### PR TITLE
feat(respan-sdk): add batch to LogType

### DIFF
--- a/python-sdks/respan-sdk/src/respan_sdk/constants/llm_logging.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/llm_logging.py
@@ -29,6 +29,7 @@ LOG_TYPE_CUSTOM = "custom"
 LOG_TYPE_GENERATION = "generation"
 LOG_TYPE_UNKNOWN = "unknown"
 LOG_TYPE_SCORE = "score"
+LOG_TYPE_BATCH = "batch"
 
 
 class LogTypeChoices(Enum):
@@ -50,6 +51,7 @@ class LogTypeChoices(Enum):
     GENERATION = LOG_TYPE_GENERATION  # OpenAI Agent
     UNKNOWN = LOG_TYPE_UNKNOWN
     SCORE = LOG_TYPE_SCORE
+    BATCH = LOG_TYPE_BATCH
 
 LogType = Literal[
     "text",
@@ -70,4 +72,5 @@ LogType = Literal[
     "generation",
     "unknown",
     "score",
+    "batch",
 ]


### PR DESCRIPTION
## Summary
- Add `LOG_TYPE_BATCH = "batch"` constant
- Add `BATCH` to `LogTypeChoices` enum
- Add `"batch"` to `LogType` Literal

Backend batch API operations use `log_type="batch"` but this value was missing from the SDK's `LogType` Literal, causing Pydantic `model_validate()` failures in the Celery worker. The backend has a ducktape override in `KeywordsAIFullLogParams` (PR #198) until this SDK change is installed.

## Test plan
- [ ] Verify `LogTypeChoices.BATCH.value == "batch"`
- [ ] Verify `"batch"` is accepted by Pydantic fields typed as `LogType`