### PR TITLE
deprecate separate_params() in favor of validate_and_separate_params()

### DIFF
--- a/python-sdks/respan-sdk/src/respan_sdk/utils/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/utils/__init__.py
@@ -1,2 +1,2 @@
-from .pre_processing import separate_params
+from .pre_processing import validate_and_separate_params
 from .mixins import PreprocessDataMixin

--- a/python-sdks/respan-sdk/src/respan_sdk/utils/pre_processing.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/utils/pre_processing.py
@@ -50,15 +50,22 @@ def assign_with_validation(
 
 def separate_params(params: dict, remove_none=True, raise_exception=False):
     """
-    Separate the params into llm_params and respan_params
-    If the params are falsely, they are removed from the dictionary (no params are valid with value 0)
+    .. deprecated::
+        Use ``validate_and_separate_params()`` instead. This function manually pops
+        fields and is not kept in sync with new RespanParams fields. It will be
+        removed in a future release.
+
+    Separate the params into llm_params and respan_params.
     Returns:
     llm_params: dict
     respan_params: dict
-
-    RULES:
-        1. For cleanliness, all params that are default as False should end with "or None" as fallback so that they get removed
     """
+    import warnings
+    warnings.warn(
+        "separate_params() is deprecated. Use validate_and_separate_params() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     respan_params = {}
     respan_params["cache_enabled"] = params.pop("cache_enabled", None) or None


### PR DESCRIPTION
## Summary
- Remove `separate_params` from `utils/__init__.py` public export
- Add `DeprecationWarning` to `separate_params()` function body
- `validate_and_separate_params()` uses Pydantic models (`LiteLLMCompletionParams`, `RespanParams`) and stays in sync with field changes automatically, unlike the manual field-popping in `separate_params()`

## Context
All backend test files and production code have been migrated to `validate_and_separate_params()` in backend PR #331. This SDK change makes the deprecation official.

## Test plan
- [x] Backend tests updated to use `validate_and_separate_params` + `.model_dump()`
- [ ] Verify existing imports `from respan_sdk.utils.pre_processing import separate_params` still work (function is not removed, just deprecated)
- [ ] Verify `from respan_sdk.utils import validate_and_separate_params` works as the new public export