### PR TITLE
respan-tracing 2.1.0: use shared OTLP constants from SDK

### DIFF
--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.0.2"
+version = "2.1.0"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"
@@ -14,7 +14,7 @@ python = ">=3.11,<3.14"
 typing-extensions = "^4.12.2"
 opentelemetry-api = "^1.29.0"
 opentelemetry-sdk = "^1.29.0"
-respan-sdk = ">=1.0.0"
+respan-sdk = ">=1.3.0"
 opentelemetry-instrumentation-openai = ">=0.48.0"
 opentelemetry-instrumentation-threading = ">=0.55b1"
 requests = ">=2.28.0"


### PR DESCRIPTION
## Summary
- Replaces all hardcoded OTLP JSON strings/ints in `respan.py` exporter with named constants from `respan_sdk.constants.otlp_constants`
- Ensures serializer (exporter) and deserializer (backend) use identical wire-format keys
- Bumps `respan-sdk` dependency to `>=1.3.0`, version to `2.1.0`

**Depends on:** #30 (respan-sdk 1.3.0)

### Constants replaced
- `_convert_attribute_value()`: `"boolValue"` → `OTLP_BOOL_VALUE`, etc.
- `_convert_attributes()`: `"key"/"value"` → `OTLP_ATTR_KEY/OTLP_ATTR_VALUE`
- `_span_to_otlp_json()`: all structure keys + status code ints
- `_build_otlp_payload()`: all structure keys

## Test plan
- [ ] Existing exporter tests still pass
- [ ] Verify `poetry build` succeeds
- [ ] Publish to PyPI as 2.1.0 after SDK 1.3.0 is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)