### PR TITLE
Add greptile.json with includeAuthors allowlist

### DIFF
--- a/python-sdks/greptile.json
+++ b/python-sdks/greptile.json
@@ -1,0 +1,3 @@
+{
+  "includeAuthors": ["Raymond1415926", "Nightingalelyy"]
+}


### PR DESCRIPTION
## Summary
- Adds `greptile.json` to restrict Greptile reviews to team members only
- Prevents billing for external contributors on this public repo

## Setup required
Add the `Keywords-AI/keywordsai` repo to the Greptile GitHub App:
**GitHub → Settings → Integrations → Greptile → Configure → Repository access**