### PR TITLE
respan-tracing 2.1.0: use shared OTLP constants from SDK

### DIFF
--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.0.2"
+version = "2.1.0"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"
@@ -14,7 +14,7 @@ python = ">=3.11,<3.14"
 typing-extensions = "^4.12.2"
 opentelemetry-api = "^1.29.0"
 opentelemetry-sdk = "^1.29.0"
-respan-sdk = ">=1.0.0"
+respan-sdk = ">=1.3.0"
 opentelemetry-instrumentation-openai = ">=0.48.0"
 opentelemetry-instrumentation-threading = ">=0.55b1"
 requests = ">=2.28.0"


### PR DESCRIPTION
## Summary
- Replaces all hardcoded OTLP JSON strings/ints in the exporter with named constants from `respan_sdk.constants.otlp_constants`
- Bumps `respan-sdk` dependency to `>=1.3.0`, version to `2.1.0`

SDK constants (PR #30) already merged to main. This PR lands the tracing exporter changes.

## Test plan
- [ ] `pip install -e` both packages, verify imports
- [ ] Existing exporter tests pass