### PR TITLE
(fix) make HyperspellSearchMemoriesParams.query optional

### DIFF
--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "respan-sdk"
-version = "2.3.0"
+version = "2.3.1"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 
 [tool.poetry]
 name = "respan-sdk"
-version = "2.3.0"
+version = "2.3.1"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/services_types/hyperspell_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/services_types/hyperspell_types.py
@@ -25,7 +25,7 @@ class HyperspellAddMemoryParams(RespanBaseModel):
 class HyperspellSearchMemoriesParams(RespanBaseModel):
     """Schema for /memories/query payload."""
 
-    query: str
+    query: Optional[str] = None
     answer: Optional[bool] = None
     sources: Optional[List[str]] = None
     options: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- `HyperspellSearchMemoriesParams.query` was required (`str`), but the backend auto-hydrates it from the last user message in `load_integration_params()`.
- This caused `validate_and_separate_params()` to fail Pydantic validation and **silently drop** `hyperspell_params` when users send `search_memories` without an explicit `query`.
- Fix: Make `query: Optional[str] = None` — the backend fills it in later.
- Bumps `respan-sdk` from 2.3.0 → 2.3.1.

## Test plan
- [x] `validate_and_separate_params` preserves `hyperspell_params` when `search_memories` has no `query`
- [x] `validate_and_separate_params` preserves `hyperspell_params` when `search_memories` has `query`
- [x] No regression when `hyperspell_params` is absent entirely