### PR TITLE
Add LocalSpanCollector for in-process span collection

### DIFF
--- a/python-sdks/respan-exporter-openai-agents/pyproject.toml
+++ b/python-sdks/respan-exporter-openai-agents/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">3.10,<3.13"
 openai-agents = ">=0.3.1"
-respan-sdk = "^1.0.0"
+respan-sdk = ">=1.0.0"
 
 
 [build-system]

--- a/python-sdks/respan-exporter-openai-agents/pyproject.toml
+++ b/python-sdks/respan-exporter-openai-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-exporter-openai-agents"
-version = "1.0.2"
+version = "1.1.0"
 description = "Exporter for Respan OpenAI Agents SDK"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">3.10,<3.13"
-openai-agents = "^0.3.1"
+openai-agents = ">=0.3.1"
 respan-sdk = "^1.0.0"
 
 

--- a/python-sdks/respan-exporter-openai-agents/src/respan_exporter_openai_agents/__init__.py
+++ b/python-sdks/respan-exporter-openai-agents/src/respan_exporter_openai_agents/__init__.py
@@ -1,3 +1,13 @@
-from .respan_openai_agents_exporter import RespanSpanExporter, RespanTraceProcessor
+from .respan_openai_agents_exporter import (
+    LocalSpanCollector,
+    RespanSpanExporter,
+    RespanTraceProcessor,
+    convert_to_respan_log,
+)
 
-__all__ = ["RespanSpanExporter", "RespanTraceProcessor"]
+__all__ = [
+    "LocalSpanCollector",
+    "RespanSpanExporter",
+    "RespanTraceProcessor",
+    "convert_to_respan_log",
+]


### PR DESCRIPTION
## Summary
- Extract span conversion into standalone `convert_to_respan_log()` function
- Add `LocalSpanCollector(TracingProcessor)` — thread-safe, in-memory span collection keyed by `trace_id`
- Enables self-hosted deployments to dogfood the SDK without HTTP round-trips
- `RespanSpanExporter._respan_export()` now delegates to the standalone function
- Widen `openai-agents` dependency from `^0.3.1` to `>=0.3.1` (tested with 0.9.3)
- Bump version 1.0.2 → 1.1.0

## Use case
When the agent service IS the Respan backend, making HTTP calls to itself is wasteful. `LocalSpanCollector` collects spans in-process, and the caller retrieves them via `pop_trace(trace_id)` to feed directly to `log_request()`.

## Test plan
- [x] All imports pass on agents SDK 0.9.3
- [x] All 7 span data types + Trace type still compatible
- [x] `LocalSpanCollector` instantiates and implements `TracingProcessor`
- [x] `pop_trace()` returns empty list for unknown trace_id
- [ ] Integration test with actual agent run (backend PR #587)