### PR TITLE
(fix) anthropic exporter: extract content + propagate input

### DIFF
--- a/javascript-sdks/respan-exporter-anthropic-agents/package.json
+++ b/javascript-sdks/respan-exporter-anthropic-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@respan/exporter-anthropic-agents",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Exporter for Anthropic Agent SDK traces to Respan",
   "author": "Respan <team@respan.ai>",
   "type": "module",

--- a/javascript-sdks/respan-sdk/package.json
+++ b/javascript-sdks/respan-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/respan-sdk",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Respan typing SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/javascript-sdks/respan-sdk/src/types/exporterSessionTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/exporterSessionTypes.ts
@@ -19,7 +19,6 @@ export type SessionState = {
   startedAt: Date;
   pendingTools: Map<string, PendingToolState>;
   isRootEmitted: boolean;
-  prompt?: unknown;
 };
 
 /** Alias for cross-language consistency with Python ExporterSessionState. */

--- a/python-sdks/respan-exporter-anthropic-agents/pyproject.toml
+++ b/python-sdks/respan-exporter-anthropic-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-exporter-anthropic-agents"
-version = "1.0.2"
+version = "1.0.4"
 description = "Exporter for Anthropic Agent SDK telemetry to Respan"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"

--- a/python-sdks/respan-exporter-anthropic-agents/pyproject.toml
+++ b/python-sdks/respan-exporter-anthropic-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-exporter-anthropic-agents"
-version = "1.0.4"
+version = "1.0.5"
 description = "Exporter for Anthropic Agent SDK telemetry to Respan"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"

--- a/python-sdks/respan-exporter-anthropic-agents/pyproject.toml
+++ b/python-sdks/respan-exporter-anthropic-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-exporter-anthropic-agents"
-version = "1.0.6"
+version = "1.0.7"
 description = "Exporter for Anthropic Agent SDK telemetry to Respan"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"

--- a/python-sdks/respan-exporter-anthropic-agents/pyproject.toml
+++ b/python-sdks/respan-exporter-anthropic-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-exporter-anthropic-agents"
-version = "1.0.5"
+version = "1.0.6"
 description = "Exporter for Anthropic Agent SDK telemetry to Respan"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"

--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "respan-sdk"
-version = "2.4.1"
+version = "2.4.3"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 
 [tool.poetry]
 name = "respan-sdk"
-version = "2.4.1"
+version = "2.4.3"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/exporter_session_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/exporter_session_types.py
@@ -30,4 +30,3 @@ class ExporterSessionState(RespanBaseModel):
     started_at: datetime
     pending_tools: Dict[str, PendingToolState] = Field(default_factory=dict)
     is_root_emitted: bool = False
-    prompt: Any = None


### PR DESCRIPTION
## Summary

Fixes the Python Anthropic Agent SDK exporter to produce meaningful trace data instead of raw SDK object blobs.

### Problems fixed:
1. **Output was empty/placeholder** — SDK TextBlock/ToolUseBlock are typed dataclasses with no type field. Old code used getattr(block, "type") which always returned None, so text extraction silently failed.
2. **Input was empty** — User prompt was never propagated to assistant_message or result:success spans.
3. **Tokens on wrong span** — AssistantMessage has no usage field; tokens live exclusively on ResultMessage.

### Fixes:
- Use isinstance(block, TextBlock) / isinstance(block, ToolUseBlock) for content extraction
- Track self._last_prompt from hooks, query() wrapper, and new track_message(prompt=...) param
- Pass prompt as input_value on assistant_message and result spans
- Remove dead usage extraction from AssistantMessage

### Verified output (debug_exporter.py):
```
--- PAYLOAD: assistant_message ---
  input: What is 2 + 2? Reply in one word.
  output: Four
  model: claude-sonnet-4-6

--- PAYLOAD: result:success ---
  input: What is 2 + 2? Reply in one word.
  output: Four
  prompt_tokens: 3
  completion_tokens: 4
  prompt_cache_hit_tokens: 16472
```

### Published versions:
- respan-exporter-anthropic-agents **1.0.7** (PyPI)

## Test plan
- [x] Run debug_exporter.py — verify input + output on assistant_message and result spans
- [x] Run debug_messages.py — verify SDK message types and fields
- [ ] TS exporter needs same isinstance fix (deferred)