### PR TITLE
fix: TS exporter — populate input on all spans

### DIFF
--- a/javascript-sdks/respan-exporter-anthropic-agents/package.json
+++ b/javascript-sdks/respan-exporter-anthropic-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@respan/exporter-anthropic-agents",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Exporter for Anthropic Agent SDK traces to Respan",
   "author": "Respan <team@respan.ai>",
   "type": "module",


### PR DESCRIPTION
## Summary
- Track `lastPrompt` across `query()`, `trackMessage()`, and `onUserPromptSubmit` hook — same fix as Python exporter (PR #48)
- Pass `lastPrompt` as `inputValue` to assistant_message and result spans (were `undefined` before)
- Remove `_is_placeholder` check (platform-side concern, not SDK)
- Remove dead `usage`/token extraction from assistant messages (tokens only exist on ResultMessage)
- Add optional `prompt` parameter to `trackMessage()` for manual usage pattern
- Bump version to 1.0.6

## Context
This is the TypeScript counterpart of the Python exporter fix in PR #48. Without this, all spans show empty `input` fields in the Respan UI.

## Test plan
- [ ] Verify input fields populate on assistant_message and result spans
- [ ] Verify tokens still appear on result spans (from ResultMessage.usage)
- [ ] Verify `exporter.query()` auto-captures prompt string