### PR TITLE
respan-sdk: non-mutating payload helper for webhook signing

### DIFF
--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "respan-sdk"
-version = "2.4.3"
+version = "2.4.4"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 
 [tool.poetry]
 name = "respan-sdk"
-version = "2.4.3"
+version = "2.4.4"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-sdk/src/respan_sdk/utils/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/utils/__init__.py
@@ -1,9 +1,11 @@
 from .pre_processing import validate_and_separate_params
 from .mixins import PreprocessDataMixin
 from .retry_handler import RetryHandler
+from .payloads import with_api_key_for_signing
 
 __all__ = [
     "validate_and_separate_params",
     "PreprocessDataMixin",
     "RetryHandler",
+    "with_api_key_for_signing",
 ]

--- a/python-sdks/respan-sdk/src/respan_sdk/utils/payloads.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/utils/payloads.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict, Mapping, Optional
+
+
+def with_api_key_for_signing(
+    payload: Optional[Mapping[str, Any]],
+    api_key: Optional[str],
+) -> Dict[str, Any]:
+    """
+    Return a copy of payload with api_key attached for webhook signing.
+
+    This avoids mutating the source payload that may later be reused for
+    storage or other downstream processing.
+    """
+    copied_payload: Dict[str, Any] = dict(payload or {})
+    if api_key:
+        copied_payload["api_key"] = api_key
+    return copied_payload

--- a/python-sdks/respan-sdk/tests/core_tests/payloads_test.py
+++ b/python-sdks/respan-sdk/tests/core_tests/payloads_test.py
@@ -1,0 +1,22 @@
+from respan_sdk.utils.payloads import with_api_key_for_signing
+
+
+def test_with_api_key_for_signing_adds_api_key_without_mutating_source():
+    source = {"unique_id": "log_123", "trace_unique_id": "trace_123"}
+
+    result = with_api_key_for_signing(source, "sk_test_abc")
+
+    assert result is not source
+    assert result["api_key"] == "sk_test_abc"
+    assert "api_key" not in source
+    assert source["unique_id"] == "log_123"
+
+
+def test_with_api_key_for_signing_no_api_key_keeps_source_unmodified():
+    source = {"unique_id": "log_123"}
+
+    result = with_api_key_for_signing(source, "")
+
+    assert result is not source
+    assert result == {"unique_id": "log_123"}
+    assert "api_key" not in source


### PR DESCRIPTION
## Summary
- add `with_api_key_for_signing` utility that returns a copied payload with optional `api_key`
- export helper from `respan_sdk.utils`
- add unit tests to guarantee source payload is never mutated
- bump `respan-sdk` version to `2.4.4`

## Validation
- `poetry run pytest tests/core_tests/payloads_test.py -q`
- `poetry build`
- `poetry publish` (published `2.4.4` to PyPI)