### PR TITLE
fix: standalone auto-instrumented LLM spans dropped by span filter

### DIFF
--- a/boilerplates/implementation_logs/tracing/span_filtering_gap.md
+++ b/boilerplates/implementation_logs/tracing/span_filtering_gap.md
@@ -1,0 +1,37 @@
+# Span Filtering Gap: Standalone Auto-Instrumentation
+
+**Status:** Known gap, duck-taped
+**Date:** 2026-03-02
+**Files:** `python-sdks/respan-tracing/src/respan_tracing/utils/preprocessing/span_processing.py`
+
+## Problem
+
+`is_processable_span()` was designed with only two modes:
+1. User-decorated spans (`TRACELOOP_SPAN_KIND`) — always process
+2. Child spans inside decorator context (`TRACELOOP_ENTITY_PATH`) — always process
+3. Everything else — filter as noise
+
+This dropped standalone auto-instrumented LLM spans (e.g. `openai.chat.completions.create()` without a `@workflow` wrapper) because they have neither attribute. The `gen_ai.prompt.*` attributes were set correctly but the span was silently discarded before reaching the exporter.
+
+## Current Fix (Duck-tape)
+
+Added a third check: if a span has `llm.request.type` (set by all OpenLLMetry LLM instrumentors), allow it through and root-promote it.
+
+This works for LLM instrumentors but **will not cover** future non-LLM instrumentors (vector DB, retrieval, tool-use, etc.) that also lack Traceloop decorator context.
+
+## Proper Fix
+
+Replace attribute-based detection with an **instrumentation scope allowlist**.
+
+Every OTel instrumentor tags its spans with a scope name (e.g. `opentelemetry.instrumentation.openai`). The `ReadableSpan` already carries this as `span.instrumentation_scope.name`. We should:
+
+1. Maintain an allowlist of recognized scope name prefixes (e.g. `opentelemetry.instrumentation.`)
+2. In `is_processable_span()`, check `span.instrumentation_scope.name` against the allowlist
+3. Any span from a recognized instrumentor passes through — no per-provider attribute checks needed
+4. Unknown scopes without decorator context still get filtered as noise
+
+This would handle any instrumentor (current and future) without needing attribute-specific duck-tape.
+
+## Also Affected
+
+`is_root_span_candidate()` has the same gap — standalone non-LLM spans would need root promotion too. The scope allowlist fix would apply to both functions.

--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.1.0"
+version = "2.1.1"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
@@ -44,7 +44,7 @@ from respan_sdk.constants.otlp_constants import (
 )
 
 from ..utils.logging import get_respan_logger, build_spans_export_preview
-from ..utils.preprocessing.span_processing import should_make_root_span
+from ..utils.preprocessing.span_processing import is_root_span_candidate
 from ..constants.generic_constants import LOGGER_NAME_EXPORTER
 
 logger = get_respan_logger(LOGGER_NAME_EXPORTER)
@@ -288,7 +288,7 @@ class RespanSpanExporter:
         # Apply root-span promotion logic
         modified_spans: List[ReadableSpan] = []
         for span in spans:
-            if should_make_root_span(span):
+            if is_root_span_candidate(span):
                 logger.debug("Making span a root span: %s", span.name)
                 modified_spans.append(ModifiedSpan(span))
             else:

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -14,7 +14,7 @@ from respan_tracing.constants.context_constants import (
     TRACE_GROUP_ID_KEY, 
     PARAMS_KEY
 )
-from respan_tracing.utils.preprocessing.span_processing import should_process_span
+from respan_tracing.utils.preprocessing.span_processing import is_processable_span
 from respan_tracing.utils.context import get_entity_path
 
 logger = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ class RespanSpanProcessor:
     def on_end(self, span: ReadableSpan):
         """Called when a span ends - filter spans based on Respan attributes"""
         # Apply filtering logic using shared function
-        if should_process_span(span):
+        if is_processable_span(span):
             self.processor.on_end(span)
         else:
             logger.debug(f"[Respan Debug] Skipping filtered span: {span.name}")

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/preprocessing/span_processing.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/preprocessing/span_processing.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.semconv_ai import SpanAttributes
 import logging
@@ -6,66 +5,90 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def should_process_span(span: ReadableSpan) -> bool:
+def is_processable_span(span: ReadableSpan) -> bool:
     """
     Determine if a span should be processed based on Respan/Traceloop attributes.
-    
+
     Logic:
     - If span has TRACELOOP_SPAN_KIND: it's a user-decorated span → process
-    - If span has TRACELOOP_ENTITY_PATH: it's a child span within entity context → process  
-    - If span has neither: it's auto-instrumentation noise → filter out
-    
+    - If span has TRACELOOP_ENTITY_PATH: it's a child span within entity context → process
+    - If span has LLM_REQUEST_TYPE: it's an auto-instrumented LLM call → process
+    - If span has none of the above: it's auto-instrumentation noise → filter out
+
+    GAP: The LLM_REQUEST_TYPE check is a duck-tape fix for standalone auto-instrumented
+    LLM spans. It won't cover non-LLM instrumentors (vector DB, retrieval, tool-use, etc.)
+    that also lack Traceloop decorator context. The proper fix is an allowlist of recognized
+    instrumentation scope names (e.g. "opentelemetry.instrumentation.openai") so we can
+    accept any span from a known instrumentor without requiring decorator context or
+    checking for provider-specific attributes.
+
     Args:
         span: The span to evaluate
-        
+
     Returns:
         bool: True if span should be processed, False if it should be filtered out
     """
     span_kind = span.attributes.get(SpanAttributes.TRACELOOP_SPAN_KIND)
     entity_path = span.attributes.get(SpanAttributes.TRACELOOP_ENTITY_PATH, "")
-    
+
     # User-decorated span (has TRACELOOP_SPAN_KIND)
     if span_kind:
         logger.debug(
             f"[Respan Debug] Processing user-decorated span: {span.name} (kind: {span_kind})"
         )
         return True
-    
+
     # Child span within entity context (has TRACELOOP_ENTITY_PATH)
-    elif entity_path and entity_path != "":
+    if entity_path and entity_path != "":
         logger.debug(
             f"[Respan Debug] Processing child span within entity context: {span.name} (entityPath: {entity_path})"
         )
         return True
-    
-    # Auto-instrumentation noise - filter out
-    else:
+
+    # Standalone auto-instrumented LLM span (has llm.request.type, e.g. "chat")
+    # This covers OpenAI/Anthropic/etc. calls made outside @workflow/@task decorators
+    if span.attributes.get(SpanAttributes.LLM_REQUEST_TYPE):
         logger.debug(
-            f"[Respan Debug] Filtering out auto-instrumentation span: {span.name} (no TRACELOOP_SPAN_KIND or entityPath)"
+            f"[Respan Debug] Processing standalone LLM span: {span.name} "
+            f"(llm.request.type: {span.attributes.get(SpanAttributes.LLM_REQUEST_TYPE)})"
         )
-        return False
+        return True
+
+    # Auto-instrumentation noise (HTTP, DB, etc.) - filter out
+    logger.debug(
+        f"[Respan Debug] Filtering out auto-instrumentation span: {span.name} (no TRACELOOP_SPAN_KIND, entityPath, or llm.request.type)"
+    )
+    return False
 
 
-def should_make_root_span(span: ReadableSpan) -> bool:
+def is_root_span_candidate(span: ReadableSpan) -> bool:
     """
     Determine if a span should be converted to a root span.
-    
+
     Logic:
     - User-decorated span (TRACELOOP_SPAN_KIND) without entity path should become root
-    
+    - Standalone LLM span (LLM_REQUEST_TYPE) without entity path should become root
+
     Args:
         span: The span to evaluate
-        
+
     Returns:
         bool: True if span should be made a root span
     """
     span_kind = span.attributes.get(SpanAttributes.TRACELOOP_SPAN_KIND)
     entity_path = span.attributes.get(SpanAttributes.TRACELOOP_ENTITY_PATH, "")
-    
+    llm_request_type = span.attributes.get(SpanAttributes.LLM_REQUEST_TYPE)
+
+    has_no_entity_path = not entity_path or entity_path == ""
+
     # User-decorated span without entity path should become root
-    is_root_candidate = span_kind is not None and (not entity_path or entity_path == "")
-    
-    if is_root_candidate:
-        logger.debug(f"[Respan Debug] Span should be made root: {span.name}")
-    
-    return is_root_candidate
+    if span_kind is not None and has_no_entity_path:
+        logger.debug(f"[Respan Debug] Span is root candidate (user-decorated): {span.name}")
+        return True
+
+    # Standalone LLM span without entity path should become root
+    if llm_request_type and span_kind is None and has_no_entity_path:
+        logger.debug(f"[Respan Debug] Span is root candidate (standalone LLM): {span.name}")
+        return True
+
+    return False

--- a/python-sdks/respan-tracing/tests/test_span_processing.py
+++ b/python-sdks/respan-tracing/tests/test_span_processing.py
@@ -1,0 +1,155 @@
+"""
+Unit tests for span processing functions: is_processable_span and is_root_span_candidate.
+
+Tests cover:
+- User-decorated spans (TRACELOOP_SPAN_KIND)
+- Child spans within entity context (TRACELOOP_ENTITY_PATH)
+- Standalone auto-instrumented LLM spans (LLM_REQUEST_TYPE)
+- Auto-instrumentation noise (HTTP, DB, etc.) — should be filtered
+- Root span promotion logic
+"""
+
+import pytest
+from unittest.mock import Mock
+from opentelemetry.semconv_ai import SpanAttributes
+
+from respan_tracing.utils.preprocessing.span_processing import (
+    is_processable_span,
+    is_root_span_candidate,
+)
+
+
+def _make_span(attributes: dict, name: str = "test_span") -> Mock:
+    """Create a mock ReadableSpan with given attributes."""
+    span = Mock()
+    span.name = name
+    span.attributes = attributes
+    return span
+
+
+# =============================================================================
+# is_processable_span
+# =============================================================================
+
+
+class TestIsProcessableSpan:
+    """Tests for is_processable_span()."""
+
+    def test_user_decorated_span_with_traceloop_span_kind(self):
+        """Span with TRACELOOP_SPAN_KIND should be processed."""
+        span = _make_span({SpanAttributes.TRACELOOP_SPAN_KIND: "workflow"})
+        assert is_processable_span(span) is True
+
+    def test_child_span_with_entity_path(self):
+        """Span with TRACELOOP_ENTITY_PATH should be processed."""
+        span = _make_span({SpanAttributes.TRACELOOP_ENTITY_PATH: "my_workflow.my_task"})
+        assert is_processable_span(span) is True
+
+    def test_standalone_llm_span_chat(self):
+        """Standalone auto-instrumented chat span should be processed."""
+        span = _make_span({SpanAttributes.LLM_REQUEST_TYPE: "chat"})
+        assert is_processable_span(span) is True
+
+    def test_standalone_llm_span_completion(self):
+        """Standalone auto-instrumented completion span should be processed."""
+        span = _make_span({SpanAttributes.LLM_REQUEST_TYPE: "completion"})
+        assert is_processable_span(span) is True
+
+    def test_standalone_llm_span_embedding(self):
+        """Standalone auto-instrumented embedding span should be processed."""
+        span = _make_span({SpanAttributes.LLM_REQUEST_TYPE: "embedding"})
+        assert is_processable_span(span) is True
+
+    def test_auto_instrumentation_noise_filtered(self):
+        """Span without any recognized attributes should be filtered out."""
+        span = _make_span({"http.method": "GET", "http.url": "https://api.openai.com"})
+        assert is_processable_span(span) is False
+
+    def test_empty_attributes_filtered(self):
+        """Span with empty attributes should be filtered out."""
+        span = _make_span({})
+        assert is_processable_span(span) is False
+
+    def test_empty_entity_path_filtered(self):
+        """Span with empty string entity path should be filtered out (not treated as present)."""
+        span = _make_span({SpanAttributes.TRACELOOP_ENTITY_PATH: ""})
+        assert is_processable_span(span) is False
+
+    def test_llm_span_within_decorator_context(self):
+        """LLM span inside @workflow/@task should be processed via entity_path."""
+        span = _make_span({
+            SpanAttributes.TRACELOOP_ENTITY_PATH: "my_workflow.chat_step",
+            SpanAttributes.LLM_REQUEST_TYPE: "chat",
+        })
+        assert is_processable_span(span) is True
+
+    def test_priority_traceloop_span_kind_first(self):
+        """TRACELOOP_SPAN_KIND takes priority — span is processed even if other attrs present."""
+        span = _make_span({
+            SpanAttributes.TRACELOOP_SPAN_KIND: "task",
+            SpanAttributes.TRACELOOP_ENTITY_PATH: "root.task",
+            SpanAttributes.LLM_REQUEST_TYPE: "chat",
+        })
+        assert is_processable_span(span) is True
+
+
+# =============================================================================
+# is_root_span_candidate
+# =============================================================================
+
+
+class TestIsRootSpanCandidate:
+    """Tests for is_root_span_candidate()."""
+
+    def test_user_decorated_span_without_entity_path_is_root(self):
+        """User-decorated span without entity_path should become root."""
+        span = _make_span({SpanAttributes.TRACELOOP_SPAN_KIND: "workflow"})
+        assert is_root_span_candidate(span) is True
+
+    def test_user_decorated_span_with_entity_path_not_root(self):
+        """User-decorated span WITH entity_path should NOT become root (it's a child)."""
+        span = _make_span({
+            SpanAttributes.TRACELOOP_SPAN_KIND: "task",
+            SpanAttributes.TRACELOOP_ENTITY_PATH: "parent_workflow.my_task",
+        })
+        assert is_root_span_candidate(span) is False
+
+    def test_standalone_llm_span_without_entity_path_is_root(self):
+        """Standalone LLM span without entity_path should become root."""
+        span = _make_span({SpanAttributes.LLM_REQUEST_TYPE: "chat"})
+        assert is_root_span_candidate(span) is True
+
+    def test_standalone_llm_span_with_entity_path_not_root(self):
+        """LLM span inside decorator context should NOT become root."""
+        span = _make_span({
+            SpanAttributes.LLM_REQUEST_TYPE: "chat",
+            SpanAttributes.TRACELOOP_ENTITY_PATH: "my_workflow.chat_step",
+        })
+        assert is_root_span_candidate(span) is False
+
+    def test_noise_span_not_root(self):
+        """Auto-instrumentation noise should NOT become root."""
+        span = _make_span({"http.method": "POST"})
+        assert is_root_span_candidate(span) is False
+
+    def test_empty_attributes_not_root(self):
+        """Span with empty attributes should NOT become root."""
+        span = _make_span({})
+        assert is_root_span_candidate(span) is False
+
+    def test_llm_span_with_span_kind_and_no_path_is_root_via_span_kind(self):
+        """When both TRACELOOP_SPAN_KIND and LLM_REQUEST_TYPE present, root via span_kind path."""
+        span = _make_span({
+            SpanAttributes.TRACELOOP_SPAN_KIND: "task",
+            SpanAttributes.LLM_REQUEST_TYPE: "chat",
+        })
+        # Root because span_kind is present and no entity_path
+        assert is_root_span_candidate(span) is True
+
+    def test_empty_entity_path_treated_as_absent(self):
+        """Empty string entity_path should be treated as absent (span is root candidate)."""
+        span = _make_span({
+            SpanAttributes.LLM_REQUEST_TYPE: "chat",
+            SpanAttributes.TRACELOOP_ENTITY_PATH: "",
+        })
+        assert is_root_span_candidate(span) is True


### PR DESCRIPTION
## Summary
- `is_processable_span()` was silently dropping auto-instrumented OpenAI/Anthropic/etc. spans when called **outside** `@workflow`/`@task` decorators (no `TRACELOOP_SPAN_KIND` or `TRACELOOP_ENTITY_PATH`)
- Added `llm.request.type` attribute check to recognize standalone LLM spans
- Root-promotes standalone LLM spans so they don't have dangling parent references
- Renamed `should_process_span` → `is_processable_span`, `should_make_root_span` → `is_root_span_candidate`

## Known gap
The `llm.request.type` check is specific to LLM instrumentors. Future non-LLM instrumentors (vector DB, retrieval, tool-use) would hit the same wall. Proper fix is an instrumentation scope name allowlist. Documented in `boilerplates/implementation_logs/tracing/span_filtering_gap.md`.

## Test plan
- [ ] Auto-instrumented `openai.chat.completions.create()` without `@workflow` wrapper now exports spans with full `gen_ai.prompt.*` content
- [ ] Spans inside `@workflow` context still work as before
- [ ] HTTP/DB noise spans still filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)