### PR TITLE
feat: errors_only and sample_rate for tracing decorators

### DIFF
--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.1.3"
+version = "2.2.0"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-tracing/src/respan_tracing/constants/tracing.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/constants/tracing.py
@@ -1,1 +1,4 @@
 TRACER_NAME = "respan.tracer"
+
+# Span attribute key for errors_only filtering (checked by processors)
+ERRORS_ONLY_ATTR = "respan.errors_only"

--- a/python-sdks/respan-tracing/src/respan_tracing/decorators/__init__.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/decorators/__init__.py
@@ -8,15 +8,21 @@ def workflow(
     version: Optional[int] = None,
     method_name: Optional[str] = None,
     processors: Optional[Union[str, List[str]]] = None,
+    errors_only: bool = False,
+    sample_rate: Optional[float] = None,
 ):
     """Respan workflow decorator
-    
+
     Args:
         name: Optional name for the workflow
         version: Optional version number
         method_name: Optional method name for class decorators
         processors: Optional processor name(s) to route this workflow's spans to.
                    Can be a single string or list of strings (e.g., "debug" or ["debug", "analytics"])
+        errors_only: If True, only export spans where the function raised an exception.
+                    Useful for high-volume paths where you only care about failures.
+        sample_rate: Sample rate between 0.0 and 1.0. If set, only this fraction of
+                    calls will produce spans. None means 100% (default behavior).
     """
     return create_entity_method(
         name=name,
@@ -24,6 +30,8 @@ def workflow(
         method_name=method_name,
         span_kind=TraceloopSpanKindValues.WORKFLOW,
         processors=processors,
+        errors_only=errors_only,
+        sample_rate=sample_rate,
     )
 
 
@@ -32,15 +40,21 @@ def task(
     version: Optional[int] = None,
     method_name: Optional[str] = None,
     processors: Optional[Union[str, List[str]]] = None,
+    errors_only: bool = False,
+    sample_rate: Optional[float] = None,
 ):
     """Respan task decorator
-    
+
     Args:
         name: Optional name for the task
         version: Optional version number
         method_name: Optional method name for class decorators
         processors: Optional processor name(s) to route this task's spans to.
                    Can be a single string or list of strings (e.g., "debug" or ["debug", "analytics"])
+        errors_only: If True, only export spans where the function raised an exception.
+                    Useful for high-volume paths where you only care about failures.
+        sample_rate: Sample rate between 0.0 and 1.0. If set, only this fraction of
+                    calls will produce spans. None means 100% (default behavior).
     """
     return create_entity_method(
         name=name,
@@ -48,6 +62,8 @@ def task(
         method_name=method_name,
         span_kind=TraceloopSpanKindValues.TASK,
         processors=processors,
+        errors_only=errors_only,
+        sample_rate=sample_rate,
     )
 
 
@@ -56,15 +72,21 @@ def agent(
     version: Optional[int] = None,
     method_name: Optional[str] = None,
     processors: Optional[Union[str, List[str]]] = None,
+    errors_only: bool = False,
+    sample_rate: Optional[float] = None,
 ):
     """Respan agent decorator
-    
+
     Args:
         name: Optional name for the agent
         version: Optional version number
         method_name: Optional method name for class decorators
         processors: Optional processor name(s) to route this agent's spans to.
                    Can be a single string or list of strings (e.g., "debug" or ["debug", "analytics"])
+        errors_only: If True, only export spans where the function raised an exception.
+                    Useful for high-volume paths where you only care about failures.
+        sample_rate: Sample rate between 0.0 and 1.0. If set, only this fraction of
+                    calls will produce spans. None means 100% (default behavior).
     """
     return create_entity_method(
         name=name,
@@ -72,6 +94,8 @@ def agent(
         method_name=method_name,
         span_kind=TraceloopSpanKindValues.AGENT,
         processors=processors,
+        errors_only=errors_only,
+        sample_rate=sample_rate,
     )
 
 
@@ -80,15 +104,21 @@ def tool(
     version: Optional[int] = None,
     method_name: Optional[str] = None,
     processors: Optional[Union[str, List[str]]] = None,
+    errors_only: bool = False,
+    sample_rate: Optional[float] = None,
 ):
     """Respan tool decorator
-    
+
     Args:
         name: Optional name for the tool
         version: Optional version number
         method_name: Optional method name for class decorators
         processors: Optional processor name(s) to route this tool's spans to.
                    Can be a single string or list of strings (e.g., "debug" or ["debug", "analytics"])
+        errors_only: If True, only export spans where the function raised an exception.
+                    Useful for high-volume paths where you only care about failures.
+        sample_rate: Sample rate between 0.0 and 1.0. If set, only this fraction of
+                    calls will produce spans. None means 100% (default behavior).
     """
     return create_entity_method(
         name=name,
@@ -96,4 +126,6 @@ def tool(
         method_name=method_name,
         span_kind=TraceloopSpanKindValues.TOOL,
         processors=processors,
+        errors_only=errors_only,
+        sample_rate=sample_rate,
     )

--- a/python-sdks/respan-tracing/src/respan_tracing/decorators/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/decorators/base.py
@@ -1,5 +1,6 @@
 import json
 import inspect
+import random
 from functools import wraps
 from typing import Optional, TypeVar, Callable, Any, ParamSpec, Awaitable
 from opentelemetry import trace, context as context_api
@@ -11,11 +12,11 @@ from respan_sdk.constants.llm_logging import (
 from respan_sdk.respan_types.span_types import RespanSpanAttributes
 from respan_tracing.core import RespanTracer
 from respan_tracing.constants.context_constants import (
-    WORKFLOW_NAME_KEY, 
+    WORKFLOW_NAME_KEY,
     ENTITY_PATH_KEY,
     ENABLE_CONTENT_TRACING_KEY
 )
-
+from respan_tracing.constants.tracing import ERRORS_ONLY_ATTR
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -37,7 +38,20 @@ def _is_async_method(fn):
     return inspect.iscoroutinefunction(fn) or inspect.isasyncgenfunction(fn)
 
 
-def _setup_span(entity_name: str, span_kind: str, version: Optional[int] = None, processors=None):
+def _is_sampled(sample_rate: Optional[float]) -> bool:
+    """Check if this call should be sampled.
+
+    Returns True if the call should produce a span.
+    None or 1.0 = always sampled, 0.0 = never sampled.
+    """
+    if sample_rate is None or sample_rate >= 1.0:
+        return True
+    if sample_rate <= 0.0:
+        return False
+    return random.random() < sample_rate
+
+
+def _setup_span(entity_name: str, span_kind: str, version: Optional[int] = None, processors=None, errors_only: bool = False):
     """Setup OpenTelemetry span and context"""
     # Ensure span_kind is a string
     span_kind_str = span_kind.value if hasattr(span_kind, "value") else str(span_kind)
@@ -74,7 +88,7 @@ def _setup_span(entity_name: str, span_kind: str, version: Optional[int] = None,
     )
     if version:
         span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_VERSION, version)
-    
+
     # Set processors attribute for routing (OTEL standard way!)
     if processors:
         # Normalize to list
@@ -82,9 +96,13 @@ def _setup_span(entity_name: str, span_kind: str, version: Optional[int] = None,
             processors_list = [processors]
         else:
             processors_list = processors
-        
+
         # Store as comma-separated string (OTEL attribute friendly)
         span.set_attribute("processors", ",".join(processors_list))
+
+    # Mark span for errors-only filtering (processor checks this at export time)
+    if errors_only:
+        span.set_attribute(ERRORS_ONLY_ATTR, True)
 
     # Set span in context
     ctx = trace.set_span_in_context(span)
@@ -154,25 +172,31 @@ def create_entity_method(
     method_name: Optional[str] = None,
     span_kind: str = "task",
     processors=None,
+    errors_only: bool = False,
+    sample_rate: Optional[float] = None,
 ) -> Callable[[F], F]:
     """Create entity decorator for methods or classes"""
 
     if method_name is not None:
         # Class decorator
         return _create_entity_class(
-            name=name, 
-            version=version, 
-            method_name=method_name, 
-            span_kind=span_kind, 
-            processors=processors
+            name=name,
+            version=version,
+            method_name=method_name,
+            span_kind=span_kind,
+            processors=processors,
+            errors_only=errors_only,
+            sample_rate=sample_rate,
         )
     else:
         # Method decorator
         return _create_entity_method_decorator(
-            name=name, 
-            version=version, 
-            span_kind=span_kind, 
-            processors=processors
+            name=name,
+            version=version,
+            span_kind=span_kind,
+            processors=processors,
+            errors_only=errors_only,
+            sample_rate=sample_rate,
         )
 
 
@@ -181,6 +205,8 @@ def _create_entity_method_decorator(
     version: Optional[int] = None,
     span_kind: str = "task",
     processors=None,
+    errors_only: bool = False,
+    sample_rate: Optional[float] = None,
 ) -> Callable[[F], F]:
     """Create method decorator"""
 
@@ -192,11 +218,17 @@ def _create_entity_method_decorator(
                 # Async generator
                 @wraps(fn)
                 async def async_gen_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    if not _is_sampled(sample_rate):
+                        async for item in fn(*args, **kwargs):
+                            yield item
+                        return
+
                     span, ctx_token = _setup_span(
-                        entity_name=entity_name, 
-                        span_kind=span_kind, 
-                        version=version, 
-                        processors=processors
+                        entity_name=entity_name,
+                        span_kind=span_kind,
+                        version=version,
+                        processors=processors,
+                        errors_only=errors_only,
                     )
                     _handle_span_input(span, args, kwargs)
 
@@ -215,11 +247,15 @@ def _create_entity_method_decorator(
                 # Regular async function
                 @wraps(fn)
                 async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    if not _is_sampled(sample_rate):
+                        return await fn(*args, **kwargs)
+
                     span, ctx_token = _setup_span(
-                        entity_name=entity_name, 
-                        span_kind=span_kind, 
-                        version=version, 
-                        processors=processors
+                        entity_name=entity_name,
+                        span_kind=span_kind,
+                        version=version,
+                        processors=processors,
+                        errors_only=errors_only,
                     )
                     _handle_span_input(span, args, kwargs)
 
@@ -239,7 +275,10 @@ def _create_entity_method_decorator(
             # Sync function
             @wraps(fn)
             def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
-                span, ctx_token = _setup_span(entity_name, span_kind, version, processors)
+                if not _is_sampled(sample_rate):
+                    return fn(*args, **kwargs)
+
+                span, ctx_token = _setup_span(entity_name, span_kind, version, processors, errors_only)
                 _handle_span_input(span, args, kwargs)
 
                 try:
@@ -270,6 +309,8 @@ def _create_entity_class(
     method_name: str,
     span_kind: str = "task",
     processors=None,
+    errors_only: bool = False,
+    sample_rate: Optional[float] = None,
 ):
     """Create class decorator"""
 
@@ -281,10 +322,12 @@ def _create_entity_class(
 
         # Create decorated method
         decorated_method = _create_entity_method_decorator(
-            name=entity_name, 
-            version=version, 
-            span_kind=span_kind, 
-            processors=processors
+            name=entity_name,
+            version=version,
+            span_kind=span_kind,
+            processors=processors,
+            errors_only=errors_only,
+            sample_rate=sample_rate,
         )(original_method)
 
         # Replace the method

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -7,6 +7,7 @@ from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.context import Context
 from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace.status import StatusCode
 
 from respan_sdk.respan_types.span_types import RespanSpanAttributes
 from respan_tracing.constants.generic_constants import SDK_PREFIX
@@ -14,6 +15,7 @@ from respan_tracing.constants.context_constants import (
     TRACE_GROUP_ID_KEY, 
     PARAMS_KEY
 )
+from respan_tracing.constants.tracing import ERRORS_ONLY_ATTR
 from respan_tracing.utils.preprocessing.span_processing import is_processable_span
 from respan_tracing.utils.context import get_entity_path
 
@@ -80,6 +82,12 @@ class RespanSpanProcessor:
 
     def on_end(self, span: ReadableSpan):
         """Called when a span ends - filter spans based on Respan attributes"""
+        # errors_only: drop non-error spans that opted into errors-only mode
+        if span.attributes.get(ERRORS_ONLY_ATTR):
+            if span.status.status_code != StatusCode.ERROR:
+                logger.debug(f"[Respan Debug] Dropping non-error span (errors_only): {span.name}")
+                return
+
         # Apply filtering logic using shared function
         if is_processable_span(span):
             self.processor.on_end(span)


### PR DESCRIPTION
## Summary
- Adds `errors_only` and `sample_rate` parameters to all 4 decorator types (`workflow`, `task`, `agent`, `tool`)
- `errors_only=True` sets a span attribute; processor drops non-error spans at export time
- `sample_rate` (0.0–1.0) skips span creation entirely when not sampled — zero overhead on unsampled calls
- Shared `ERRORS_ONLY_ATTR` constant in `constants/tracing.py` avoids circular imports between decorators and processors
- Bumps `respan-tracing` to **2.2.0**

## Usage
```python
from respan_tracing.decorators import task, workflow

@task(processors="dogfood", errors_only=True)
def hot_path_function():
    """Only traces when this function raises an exception"""
    ...

@workflow(sample_rate=0.1)
def high_volume_workflow():
    """Only 10% of calls produce a trace"""
    ...
```

## Test plan
- [ ] Unit test: `errors_only=True` + success → span NOT exported
- [ ] Unit test: `errors_only=True` + exception → span exported with ERROR status
- [ ] Unit test: `sample_rate=0.0` → no span created
- [ ] Unit test: `sample_rate=1.0` → span always created
- [ ] Integration: decorate a function, verify span attributes include `respan.errors_only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)