### PR TITLE
(feat) add SpanLink type and OTLP link constants to respan-sdk

### DIFF
--- a/python-sdks/respan-sdk/src/respan_sdk/constants/otlp_constants.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/otlp_constants.py
@@ -43,6 +43,14 @@ OTLP_START_TIME_KEY = "startTimeUnixNano"
 OTLP_END_TIME_KEY = "endTimeUnixNano"
 OTLP_STATUS_KEY = "status"
 OTLP_EVENTS_KEY = "events"
+OTLP_LINKS_KEY = "links"
+OTLP_FLAGS_KEY = "flags"
+OTLP_TRACE_STATE_KEY = "traceState"
+OTLP_DROPPED_ATTRIBUTES_COUNT_KEY = "droppedAttributesCount"
+
+# W3C trace context flag indicating the linked span is from a remote process.
+# See: https://www.w3.org/TR/trace-context/#trace-flags (bit 8 = HasRemoteParent)
+OTLP_REMOTE_LINK_FLAG = 0x100
 
 # OTLP attribute key/value pair keys
 OTLP_ATTR_KEY = "key"

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
@@ -28,6 +28,7 @@ from ._internal_types import (
     BasicEmbeddingParams,
 )
 from .exporter_session_types import ExporterSessionState, PendingToolState
+from .span_types import SpanLink
 
 # Filter types
 from .filter_types import (
@@ -84,6 +85,7 @@ __all__ = [
     "BasicEmbeddingParams",
     "ExporterSessionState",
     "PendingToolState",
+    "SpanLink",
 
     # Filter types (TypedDict versions)
     "MetricFilterParam",

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/span_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/span_types.py
@@ -1,4 +1,26 @@
 from enum import Enum
+from typing import Any, Dict
+
+from pydantic import ConfigDict, Field
+
+from respan_sdk.respan_types.base_types import RespanBaseModel
+
+
+class SpanLink(RespanBaseModel):
+    """Serializable link definition for attaching causal links to new spans.
+
+    A lightweight data holder with no OTel dependency.  The conversion to an
+    OpenTelemetry ``trace.Link`` is performed by ``respan_tracing`` at runtime.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    trace_id: str
+    span_id: str
+    attributes: Dict[str, Any] = Field(default_factory=dict)
+    is_remote: bool = True
+    is_sampled: bool = True
+
 
 class RespanSpanAttributes(Enum):
     # Span attributes


### PR DESCRIPTION
## Summary
- Add `SpanLink` (RespanBaseModel, frozen) to `respan_types/span_types.py` — lightweight data holder for causal span links with no OTel dependency
- Add 5 OTLP link wire-format constants to `otlp_constants.py`: `OTLP_LINKS_KEY`, `OTLP_FLAGS_KEY`, `OTLP_TRACE_STATE_KEY`, `OTLP_DROPPED_ATTRIBUTES_COUNT_KEY`, `OTLP_REMOTE_LINK_FLAG`
- Re-export `SpanLink` from `respan_types/__init__.py`

## Context
Prerequisite for PR #65 (span link support in respan-tracing span buffers). Centralizes the type and constants in respan-sdk per SDK convention Rule 1 (types in respan-sdk) and Rule 2 (constants in respan-sdk).

## Test plan
- [ ] `from respan_sdk.respan_types.span_types import SpanLink` imports cleanly
- [ ] `SpanLink(trace_id="a"*32, span_id="b"*16)` constructs correctly
- [ ] Frozen model rejects mutation
- [ ] Publish respan-sdk, then rebase PR #65 on the published version