### PR TITLE
(consolidate) replace agno exporter duplicate hex ID utils with SDK imports

### DIFF
--- a/python-sdks/respan-exporter-agno/pyproject.toml
+++ b/python-sdks/respan-exporter-agno/pyproject.toml
@@ -13,7 +13,7 @@ wrapt = "^1.16.0"
 opentelemetry-sdk = "^1.20.0"
 opentelemetry-api = "^1.20.0"
 opentelemetry-instrumentation = "^0.41b0"
-respan-sdk = "^1.0.0"
+respan-sdk = ">=2.6.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.2"

--- a/python-sdks/respan-exporter-agno/src/respan_exporter_agno/utils.py
+++ b/python-sdks/respan-exporter-agno/src/respan_exporter_agno/utils.py
@@ -4,21 +4,18 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Sequence
 
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+    is_hex_string,
+)
+
+
 def ns_to_datetime(value: Optional[int]) -> Optional[datetime]:
     """Convert nanoseconds timestamp to datetime."""
     if not value:
         return None
     return datetime.fromtimestamp(value / 1e9, tz=timezone.utc)
-
-
-def format_trace_id(trace_id: int) -> str:
-    """Format trace ID as 32-char hex string."""
-    return format(trace_id, "032x")
-
-
-def format_span_id(span_id: int) -> str:
-    """Format span ID as 16-char hex string."""
-    return format(span_id, "016x")
 
 
 def is_agno_span(span: object) -> bool:
@@ -245,17 +242,6 @@ def format_rfc3339(value: Optional[datetime]) -> Optional[str]:
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def is_hex_string(value: str, length: int) -> bool:
-    """Check if string is a valid hex string of given length."""
-    if len(value) != length:
-        return False
-    try:
-        int(value, 16)
-        return True
-    except ValueError:
-        return False
 
 
 def normalize_trace_id(trace_id: str) -> str:


### PR DESCRIPTION
## Summary
- Remove duplicate `format_trace_id`, `format_span_id`, `is_hex_string` from `respan-exporter-agno/utils.py` — import from `respan_sdk.utils.data_processing.id_processing` instead
- `normalize_trace_id` and `normalize_span_id` kept locally (agno-specific UUID5 fallback) but now use imported `is_hex_string`
- Bump `respan-sdk` dependency from `^1.0.0` to `>=2.6.1`

## Test plan
- [ ] Verify agno exporter still works with imported functions (same signatures, same behavior)
- [ ] Verify `normalize_trace_id`/`normalize_span_id` UUID5 fallback still works for non-hex IDs