### PR TITLE
feat: add client.start_span() imperative context manager with full Respan metadata

### DIFF
--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.5.1"
+version = "2.6.0"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-tracing/src/respan_tracing/core/client.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/client.py
@@ -365,9 +365,18 @@ class RespanClient:
                     # ... execute task ...
             ```
         """
+        if not self._tracer.is_enabled or not RespanTracer.is_initialized():
+            logger.warning("Respan Telemetry not initialized or disabled.")
+            yield None
+            return
+
         # Normalize kind to string
         kind_str = kind.value if hasattr(kind, "value") else str(kind)
         entity_path = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH) or ""
+
+        # Track context tokens for cleanup
+        entity_name_token = None
+        entity_path_token = None
 
         # Propagate entity name for workflow/agent spans (children inherit it
         # as TRACELOOP_WORKFLOW_NAME via RespanSpanProcessor.on_start)
@@ -375,7 +384,7 @@ class RespanClient:
             TraceloopSpanKindValues.WORKFLOW.value,
             TraceloopSpanKindValues.AGENT.value,
         ]:
-            context_api.attach(
+            entity_name_token = context_api.attach(
                 context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_NAME, name)
             )
 
@@ -385,7 +394,7 @@ class RespanClient:
             TraceloopSpanKindValues.TOOL.value,
         ]:
             entity_path = f"{entity_path}.{name}" if entity_path else name
-            context_api.attach(
+            entity_path_token = context_api.attach(
                 context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
             )
 
@@ -409,7 +418,7 @@ class RespanClient:
             RespanSpanAttributes.LOG_METHOD.value,
             LogMethodChoices.PYTHON_TRACING.value,
         )
-        if version:
+        if version is not None:
             span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_VERSION, version)
 
         # Set processors for FilteringSpanProcessor routing
@@ -437,6 +446,10 @@ class RespanClient:
         finally:
             span.end()
             context_api.detach(ctx_token)
+            if entity_path_token is not None:
+                context_api.detach(entity_path_token)
+            if entity_name_token is not None:
+                context_api.detach(entity_name_token)
 
     def get_span_buffer(self, trace_id: str) -> SpanBuffer:
         """

--- a/python-sdks/respan-tracing/src/respan_tracing/core/client.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/client.py
@@ -1,13 +1,20 @@
-from typing import Any, Dict, Optional, Union
+import json
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Generator, List, Optional, Union
 from opentelemetry import trace, context as context_api
 from opentelemetry.trace.span import Span
 from opentelemetry.trace import Status, StatusCode
+from opentelemetry.semconv_ai import TraceloopSpanKindValues, SpanAttributes
 
-from respan_sdk.respan_types.span_types import RESPAN_SPAN_ATTRIBUTES_MAP, RespanSpanAttributes
+from respan_sdk import FilterParamDict
+from respan_sdk.constants.llm_logging import LogMethodChoices
+from respan_sdk.respan_types.span_types import RESPAN_SPAN_ATTRIBUTES_MAP, RespanSpanAttributes, SpanLink
 from respan_sdk.respan_types.param_types import RespanParams
 from pydantic import ValidationError
 
 from .tracer import RespanTracer
+from ..contexts.span import span_link_to_otel, consume_span_links
+from ..constants.tracing import EXPORT_FILTER_ATTR
 from ..processors import SpanBuffer
 from ..utils.logging import get_respan_logger
 
@@ -299,7 +306,138 @@ class RespanClient:
             ```
         """
         return self._tracer.get_tracer()
-    
+
+    # Type alias for span links parameter
+    LinksParam = Optional[Union[List[SpanLink], Callable[[], List[SpanLink]]]]
+
+    @contextmanager
+    def start_span(
+        self,
+        name: str,
+        kind: str = "task",
+        processors: Optional[Union[str, List[str]]] = None,
+        export_filter: Optional[FilterParamDict] = None,
+        links: "RespanClient.LinksParam" = None,
+        version: Optional[int] = None,
+    ) -> Generator[Span, None, None]:
+        """
+        Context manager for creating spans with full Respan metadata.
+
+        This is the imperative equivalent of the @workflow/@task/@agent/@tool
+        decorators. Use it when the span name or kind must be determined at
+        runtime (e.g., dynamic task loops).
+
+        Handles all the same concerns as the decorators:
+        - ``processors`` attribute for FilteringSpanProcessor routing
+        - ``TRACELOOP_ENTITY_NAME`` attribute and OTel context propagation
+        - ``TRACELOOP_WORKFLOW_NAME`` inheritance for child spans
+        - Span links (static list or callable)
+        - Error recording and status propagation
+
+        Args:
+            name: Span name (equivalent to the decorator ``name`` parameter).
+            kind: Span kind — ``"workflow"``, ``"task"``, ``"agent"``, or
+                ``"tool"``. Controls context propagation behavior (workflow/agent
+                kinds propagate entity name to children). Defaults to ``"task"``.
+            processors: Processor name(s) to route this span to (e.g.,
+                ``"dogfood"`` or ``["dogfood", "debug"]``).
+            export_filter: Optional filter dict for conditional export.
+            links: Span links — a list of ``SpanLink`` objects or a callable
+                returning one.
+            version: Optional version number.
+
+        Yields:
+            The active ``Span`` object.
+
+        Example:
+            ```python
+            from respan_tracing import get_client
+
+            client = get_client()
+
+            # Imperative workflow span with processor routing
+            with client.start_span("workflow_execution", kind="workflow", processors="dogfood") as span:
+                span.set_attribute("workflow_count", 3)
+
+                # Child spans inherit workflow_name automatically
+                with client.start_span("step_1", kind="task", processors="dogfood") as task_span:
+                    task_span.set_attribute("task_type", "condition")
+                    # ... execute task ...
+            ```
+        """
+        # Normalize kind to string
+        kind_str = kind.value if hasattr(kind, "value") else str(kind)
+        entity_path = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH) or ""
+
+        # Propagate entity name for workflow/agent spans (children inherit it
+        # as TRACELOOP_WORKFLOW_NAME via RespanSpanProcessor.on_start)
+        if kind_str in [
+            TraceloopSpanKindValues.WORKFLOW.value,
+            TraceloopSpanKindValues.AGENT.value,
+        ]:
+            context_api.attach(
+                context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_NAME, name)
+            )
+
+        # Set entity path for task/tool spans
+        if kind_str in [
+            TraceloopSpanKindValues.TASK.value,
+            TraceloopSpanKindValues.TOOL.value,
+        ]:
+            entity_path = f"{entity_path}.{name}" if entity_path else name
+            context_api.attach(
+                context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
+            )
+
+        # Resolve span links: explicit param + context-attached
+        otel_links: List[trace.Link] = []
+        explicit_links = links() if callable(links) else (links or [])
+        for link in explicit_links:
+            otel_links.append(span_link_to_otel(link))
+        otel_links.extend(consume_span_links())
+
+        # Create span
+        tracer = self._tracer.get_tracer()
+        span_name = f"{name}.{kind_str}"
+        span = tracer.start_span(span_name, links=otel_links or None)
+
+        # Set standard Respan attributes
+        span.set_attribute(SpanAttributes.TRACELOOP_SPAN_KIND, kind_str)
+        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, name)
+        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
+        span.set_attribute(
+            RespanSpanAttributes.LOG_METHOD.value,
+            LogMethodChoices.PYTHON_TRACING.value,
+        )
+        if version:
+            span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_VERSION, version)
+
+        # Set processors for FilteringSpanProcessor routing
+        if processors:
+            processors_list = [processors] if isinstance(processors, str) else processors
+            span.set_attribute("processors", ",".join(processors_list))
+
+        # Set export filter
+        if export_filter is not None:
+            try:
+                span.set_attribute(EXPORT_FILTER_ATTR, json.dumps(export_filter))
+            except (TypeError, ValueError):
+                pass
+
+        # Activate span in context
+        ctx = trace.set_span_in_context(span)
+        ctx_token = context_api.attach(ctx)
+
+        try:
+            yield span
+        except Exception as e:
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.record_exception(e)
+            raise
+        finally:
+            span.end()
+            context_api.detach(ctx_token)
+
     def get_span_buffer(self, trace_id: str) -> SpanBuffer:
         """
         Get an OpenTelemetry-compliant context manager for buffering spans with manual export control.

--- a/python-sdks/respan-tracing/src/respan_tracing/core/client.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/client.py
@@ -1,22 +1,18 @@
-import json
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Generator, List, Optional, Union
 from opentelemetry import trace, context as context_api
 from opentelemetry.trace.span import Span
 from opentelemetry.trace import Status, StatusCode
-from opentelemetry.semconv_ai import TraceloopSpanKindValues, SpanAttributes
 
 from respan_sdk import FilterParamDict
-from respan_sdk.constants.llm_logging import LogMethodChoices
 from respan_sdk.respan_types.span_types import RESPAN_SPAN_ATTRIBUTES_MAP, RespanSpanAttributes, SpanLink
 from respan_sdk.respan_types.param_types import RespanParams
 from pydantic import ValidationError
 
 from .tracer import RespanTracer
-from ..contexts.span import span_link_to_otel, consume_span_links
-from ..constants.tracing import EXPORT_FILTER_ATTR
 from ..processors import SpanBuffer
 from ..utils.logging import get_respan_logger
+from ..utils.span_setup import setup_span, cleanup_span, LinksParam
 
 
 from ..constants.generic_constants import LOGGER_NAME_CLIENT
@@ -307,9 +303,6 @@ class RespanClient:
         """
         return self._tracer.get_tracer()
 
-    # Type alias for span links parameter
-    LinksParam = Optional[Union[List[SpanLink], Callable[[], List[SpanLink]]]]
-
     @contextmanager
     def start_span(
         self,
@@ -317,7 +310,7 @@ class RespanClient:
         kind: str = "task",
         processors: Optional[Union[str, List[str]]] = None,
         export_filter: Optional[FilterParamDict] = None,
-        links: "RespanClient.LinksParam" = None,
+        links: LinksParam = None,
         version: Optional[int] = None,
     ) -> Generator[Span, None, None]:
         """
@@ -370,72 +363,14 @@ class RespanClient:
             yield None
             return
 
-        # Normalize kind to string
-        kind_str = kind.value if hasattr(kind, "value") else str(kind)
-        entity_path = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH) or ""
-
-        # Track context tokens for cleanup
-        entity_name_token = None
-        entity_path_token = None
-
-        # Propagate entity name for workflow/agent spans (children inherit it
-        # as TRACELOOP_WORKFLOW_NAME via RespanSpanProcessor.on_start)
-        if kind_str in [
-            TraceloopSpanKindValues.WORKFLOW.value,
-            TraceloopSpanKindValues.AGENT.value,
-        ]:
-            entity_name_token = context_api.attach(
-                context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_NAME, name)
-            )
-
-        # Set entity path for task/tool spans
-        if kind_str in [
-            TraceloopSpanKindValues.TASK.value,
-            TraceloopSpanKindValues.TOOL.value,
-        ]:
-            entity_path = f"{entity_path}.{name}" if entity_path else name
-            entity_path_token = context_api.attach(
-                context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
-            )
-
-        # Resolve span links: explicit param + context-attached
-        otel_links: List[trace.Link] = []
-        explicit_links = links() if callable(links) else (links or [])
-        for link in explicit_links:
-            otel_links.append(span_link_to_otel(link))
-        otel_links.extend(consume_span_links())
-
-        # Create span
-        tracer = self._tracer.get_tracer()
-        span_name = f"{name}.{kind_str}"
-        span = tracer.start_span(span_name, links=otel_links or None)
-
-        # Set standard Respan attributes
-        span.set_attribute(SpanAttributes.TRACELOOP_SPAN_KIND, kind_str)
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, name)
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
-        span.set_attribute(
-            RespanSpanAttributes.LOG_METHOD.value,
-            LogMethodChoices.PYTHON_TRACING.value,
+        span, ctx_token, entity_name_token, entity_path_token = setup_span(
+            entity_name=name,
+            span_kind=kind,
+            version=version,
+            processors=processors,
+            export_filter=export_filter,
+            links=links,
         )
-        if version is not None:
-            span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_VERSION, version)
-
-        # Set processors for FilteringSpanProcessor routing
-        if processors:
-            processors_list = [processors] if isinstance(processors, str) else processors
-            span.set_attribute("processors", ",".join(processors_list))
-
-        # Set export filter
-        if export_filter is not None:
-            try:
-                span.set_attribute(EXPORT_FILTER_ATTR, json.dumps(export_filter))
-            except (TypeError, ValueError):
-                pass
-
-        # Activate span in context
-        ctx = trace.set_span_in_context(span)
-        ctx_token = context_api.attach(ctx)
 
         try:
             yield span
@@ -444,12 +379,7 @@ class RespanClient:
             span.record_exception(e)
             raise
         finally:
-            span.end()
-            context_api.detach(ctx_token)
-            if entity_path_token is not None:
-                context_api.detach(entity_path_token)
-            if entity_name_token is not None:
-                context_api.detach(entity_name_token)
+            cleanup_span(span, ctx_token, entity_name_token, entity_path_token)
 
     def get_span_buffer(self, trace_id: str) -> SpanBuffer:
         """

--- a/python-sdks/respan-tracing/src/respan_tracing/decorators/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/decorators/base.py
@@ -1,25 +1,15 @@
 import json
 import inspect
 from functools import wraps
-from typing import Optional, TypeVar, Callable, Any, List, ParamSpec, Awaitable, Union
-from opentelemetry import trace, context as context_api
+from typing import Optional, TypeVar, Callable, Any, ParamSpec, Awaitable
+from opentelemetry import context as context_api
 from opentelemetry.trace.status import Status, StatusCode
-from opentelemetry.semconv_ai import TraceloopSpanKindValues, SpanAttributes
-from respan_sdk.constants.llm_logging import (
-    LogMethodChoices
-)
+from opentelemetry.semconv_ai import SpanAttributes
 from respan_sdk import FilterParamDict
-from respan_sdk.respan_types.span_types import RespanSpanAttributes, SpanLink
-from respan_tracing.core import RespanTracer
-from respan_tracing.contexts.span import span_link_to_otel, consume_span_links
 from respan_tracing.constants.context_constants import (
-    WORKFLOW_NAME_KEY,
-    ENTITY_PATH_KEY,
     ENABLE_CONTENT_TRACING_KEY
 )
-from respan_tracing.constants.tracing import EXPORT_FILTER_ATTR
-
-LinksParam = Optional[Union[List[SpanLink], Callable[[], List[SpanLink]]]]
+from respan_tracing.utils.span_setup import setup_span, cleanup_span, LinksParam
 
 
 P = ParamSpec("P")
@@ -50,75 +40,24 @@ def _setup_span(
     export_filter: Optional[FilterParamDict] = None,
     links: LinksParam = None,
 ):
-    """Setup OpenTelemetry span and context"""
-    # Ensure span_kind is a string
-    span_kind_str = span_kind.value if hasattr(span_kind, "value") else str(span_kind)
-    entity_path = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH) or ""
+    """Setup OpenTelemetry span and context.
 
-    # Set workflow name for workflow spans
-    if span_kind_str in [
-        TraceloopSpanKindValues.WORKFLOW.value,
-        TraceloopSpanKindValues.AGENT.value,
-    ]:
-        context_api.attach(
-            context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
-        )
-
-    # Set entity path for task spans
-    if span_kind_str in [
-        TraceloopSpanKindValues.TASK.value,
-        TraceloopSpanKindValues.TOOL.value,
-    ]:
-        entity_path = f"{entity_path}.{entity_name}" if entity_path else entity_name
-        context_api.attach(context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path))
-
-    # Resolve span links: explicit param + context-attached
-    otel_links: List[trace.Link] = []
-    # 1. Resolve explicit links param (static list or callable)
-    explicit_links = links() if callable(links) else (links or [])
-    for link in explicit_links:
-        otel_links.append(span_link_to_otel(link))
-    # 2. Consume context-attached links (from attach_span_links())
-    otel_links.extend(consume_span_links())
-
-    # Get tracer and start span
-    tracer = RespanTracer().get_tracer()
-    span_name = f"{entity_name}.{span_kind_str}"
-    span = tracer.start_span(span_name, links=otel_links or None)
-
-    # Set span attributes
-    span.set_attribute(SpanAttributes.TRACELOOP_SPAN_KIND, span_kind_str)
-    span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
-    span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
-    span.set_attribute(
-        RespanSpanAttributes.LOG_METHOD.value, LogMethodChoices.PYTHON_TRACING.value
+    Delegates to the shared setup_span() utility.
+    Returns (span, ctx_token) for backward compatibility with existing callers.
+    Context tokens for entity_name/entity_path are tracked internally and
+    cleaned up in _cleanup_span().
+    """
+    span, ctx_token, entity_name_token, entity_path_token = setup_span(
+        entity_name=entity_name,
+        span_kind=span_kind,
+        version=version,
+        processors=processors,
+        export_filter=export_filter,
+        links=links,
     )
-    if version:
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_VERSION, version)
-
-    # Set processors attribute for routing (OTEL standard way!)
-    if processors:
-        # Normalize to list
-        if isinstance(processors, str):
-            processors_list = [processors]
-        else:
-            processors_list = processors
-
-        # Store as comma-separated string (OTEL attribute friendly)
-        span.set_attribute("processors", ",".join(processors_list))
-
-    # Store export filter as JSON string on span attribute
-    if export_filter is not None:
-        try:
-            span.set_attribute(EXPORT_FILTER_ATTR, json.dumps(export_filter))
-        except (TypeError, ValueError):
-            # Skip if serialization fails — filter won't be applied
-            pass
-
-    # Set span in context
-    ctx = trace.set_span_in_context(span)
-    ctx_token = context_api.attach(ctx)
-
+    # Store extra tokens on the span object for _cleanup_span to detach
+    span._entity_name_token = entity_name_token
+    span._entity_path_token = entity_path_token
     return span, ctx_token
 
 
@@ -146,9 +85,13 @@ def _handle_span_output(span, result):
 
 
 def _cleanup_span(span, ctx_token):
-    """End span and detach context"""
-    span.end()
-    context_api.detach(ctx_token)
+    """End span and detach all context tokens."""
+    cleanup_span(
+        span,
+        ctx_token,
+        entity_name_token=getattr(span, '_entity_name_token', None),
+        entity_path_token=getattr(span, '_entity_path_token', None),
+    )
 
 
 def _handle_generator(span, ctx_token, generator):

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/span_setup.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/span_setup.py
@@ -1,0 +1,124 @@
+"""Shared span setup and cleanup logic.
+
+Used by both the decorator API (decorators/base.py) and the imperative
+context-manager API (core/client.py) to avoid code duplication.
+"""
+import json
+from typing import List, Optional, Union, Callable, Tuple
+
+from opentelemetry import trace, context as context_api
+from opentelemetry.trace.span import Span
+from opentelemetry.semconv_ai import TraceloopSpanKindValues, SpanAttributes
+from respan_sdk import FilterParamDict
+from respan_sdk.constants.llm_logging import LogMethodChoices
+from respan_sdk.respan_types.span_types import RespanSpanAttributes, SpanLink
+
+from ..contexts.span import span_link_to_otel, consume_span_links
+from ..constants.tracing import EXPORT_FILTER_ATTR
+
+LinksParam = Optional[Union[List[SpanLink], Callable[[], List[SpanLink]]]]
+
+# Span kinds that propagate entity name to children via context
+_ENTITY_NAME_KINDS = frozenset([
+    TraceloopSpanKindValues.WORKFLOW.value,
+    TraceloopSpanKindValues.AGENT.value,
+])
+
+# Span kinds that append to entity path
+_ENTITY_PATH_KINDS = frozenset([
+    TraceloopSpanKindValues.TASK.value,
+    TraceloopSpanKindValues.TOOL.value,
+])
+
+
+def setup_span(
+    entity_name: str,
+    span_kind: str,
+    version: Optional[int] = None,
+    processors: Optional[Union[str, List[str]]] = None,
+    export_filter: Optional[FilterParamDict] = None,
+    links: LinksParam = None,
+) -> Tuple[Span, object, Optional[object], Optional[object]]:
+    """Create and configure an OpenTelemetry span with Respan metadata.
+
+    Returns:
+        Tuple of (span, ctx_token, entity_name_token, entity_path_token).
+        The caller MUST call cleanup_span() with these values in a finally block.
+    """
+    # Normalize kind to string (accepts enum or str)
+    span_kind_str = span_kind.value if hasattr(span_kind, "value") else str(span_kind)
+    entity_path = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH) or ""
+
+    entity_name_token = None
+    entity_path_token = None
+
+    # Propagate entity name for workflow/agent spans (children inherit it
+    # as TRACELOOP_WORKFLOW_NAME via RespanSpanProcessor.on_start)
+    if span_kind_str in _ENTITY_NAME_KINDS:
+        entity_name_token = context_api.attach(
+            context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
+        )
+
+    # Append to entity path for task/tool spans
+    if span_kind_str in _ENTITY_PATH_KINDS:
+        entity_path = f"{entity_path}.{entity_name}" if entity_path else entity_name
+        entity_path_token = context_api.attach(
+            context_api.set_value(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
+        )
+
+    # Resolve span links: explicit param + context-attached
+    otel_links: List[trace.Link] = []
+    explicit_links = links() if callable(links) else (links or [])
+    for link in explicit_links:
+        otel_links.append(span_link_to_otel(link))
+    otel_links.extend(consume_span_links())
+
+    # Create span
+    from ..core.tracer import RespanTracer
+    tracer = RespanTracer().get_tracer()
+    span_name = f"{entity_name}.{span_kind_str}"
+    span = tracer.start_span(span_name, links=otel_links or None)
+
+    # Set standard Respan attributes
+    span.set_attribute(SpanAttributes.TRACELOOP_SPAN_KIND, span_kind_str)
+    span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
+    span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
+    span.set_attribute(
+        RespanSpanAttributes.LOG_METHOD.value,
+        LogMethodChoices.PYTHON_TRACING.value,
+    )
+    if version is not None:
+        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_VERSION, version)
+
+    # Set processors for FilteringSpanProcessor routing
+    if processors:
+        processors_list = [processors] if isinstance(processors, str) else processors
+        span.set_attribute("processors", ",".join(processors_list))
+
+    # Set export filter
+    if export_filter is not None:
+        try:
+            span.set_attribute(EXPORT_FILTER_ATTR, json.dumps(export_filter))
+        except (TypeError, ValueError):
+            pass
+
+    # Activate span in context
+    ctx = trace.set_span_in_context(span)
+    ctx_token = context_api.attach(ctx)
+
+    return span, ctx_token, entity_name_token, entity_path_token
+
+
+def cleanup_span(
+    span: Span,
+    ctx_token: object,
+    entity_name_token: Optional[object] = None,
+    entity_path_token: Optional[object] = None,
+) -> None:
+    """End span and detach all context tokens. Must be called in a finally block."""
+    span.end()
+    context_api.detach(ctx_token)
+    if entity_path_token is not None:
+        context_api.detach(entity_path_token)
+    if entity_name_token is not None:
+        context_api.detach(entity_name_token)

--- a/python-sdks/respan-tracing/tests/test_start_span.py
+++ b/python-sdks/respan-tracing/tests/test_start_span.py
@@ -1,0 +1,310 @@
+"""Tests for client.start_span() — imperative context manager API.
+
+Covers all outcomes:
+1. Disabled/uninitialized → yields None
+2. Happy path (task kind) → span created with correct attributes
+3. Workflow kind → TRACELOOP_ENTITY_NAME propagated via context
+4. Task kind → entity path appended
+5. Processors attribute → set on span
+6. Version=0 → version attribute set (truthiness bug regression)
+7. Span links → resolved and attached
+8. Export filter → set as JSON attribute
+9. Exception inside context → error recorded, re-raised
+10. Context cleanup → all tokens detached after exit
+"""
+import pytest
+from unittest.mock import MagicMock
+from opentelemetry import trace, context as context_api
+from opentelemetry.trace import StatusCode
+from opentelemetry.semconv_ai import SpanAttributes
+
+from respan_tracing import RespanTelemetry, get_client
+from respan_tracing.constants.tracing import EXPORT_FILTER_ATTR
+from respan_sdk.respan_types.span_types import RespanSpanAttributes, SpanLink
+from respan_sdk.constants.llm_logging import LogMethodChoices
+
+
+class TestStartSpan:
+    """Tests for RespanClient.start_span()"""
+
+    def setup_method(self):
+        self.telemetry = RespanTelemetry(
+            app_name="test-start-span",
+            api_key="test-key",
+            is_enabled=True,
+        )
+        self.client = get_client()
+
+    # --- Outcome 1: Disabled/uninitialized yields None ---
+
+    def test_disabled_yields_none(self):
+        """When telemetry is disabled, start_span yields None."""
+        self.client._tracer.is_enabled = False
+        try:
+            with self.client.start_span("test_span") as span:
+                assert span is None
+        finally:
+            self.client._tracer.is_enabled = True
+
+    # --- Outcome 2: Happy path (default task kind) ---
+
+    def test_task_span_created_with_attributes(self):
+        """Default kind='task' creates span with standard Respan attributes."""
+        with self.client.start_span("my_task") as span:
+            assert span is not None
+            # Span should be the current span inside the context
+            current = trace.get_current_span()
+            assert current is span
+
+        # After exiting, span should have been ended
+        # (OTel SDK sets _end_time on end())
+        assert hasattr(span, '_end_time') or True  # span.end() was called
+
+    def test_task_span_has_correct_kind(self):
+        """Span kind attribute is set to 'task' by default."""
+        with self.client.start_span("my_task") as span:
+            attrs = dict(span.attributes)
+            assert attrs[SpanAttributes.TRACELOOP_SPAN_KIND] == "task"
+
+    def test_span_has_entity_name(self):
+        """Span has TRACELOOP_ENTITY_NAME set to the provided name."""
+        with self.client.start_span("my_task") as span:
+            attrs = dict(span.attributes)
+            assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] == "my_task"
+
+    def test_span_has_log_method(self):
+        """Span has LOG_METHOD set to python_tracing."""
+        with self.client.start_span("my_task") as span:
+            attrs = dict(span.attributes)
+            assert attrs[RespanSpanAttributes.LOG_METHOD.value] == LogMethodChoices.PYTHON_TRACING.value
+
+    def test_span_name_format(self):
+        """Span name follows the 'name.kind' format."""
+        with self.client.start_span("my_task", kind="task") as span:
+            assert span.name == "my_task.task"
+
+    # --- Outcome 3: Workflow kind propagates entity name ---
+
+    def test_workflow_kind_propagates_entity_name(self):
+        """Workflow spans set TRACELOOP_ENTITY_NAME in context for children."""
+        with self.client.start_span("my_workflow", kind="workflow") as outer:
+            # Inside the workflow context, entity name should be set
+            entity_name = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME)
+            assert entity_name == "my_workflow"
+
+        # After exiting, context should be restored
+        entity_name_after = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME)
+        assert entity_name_after is None or entity_name_after != "my_workflow"
+
+    def test_agent_kind_propagates_entity_name(self):
+        """Agent spans also propagate entity name like workflow spans."""
+        with self.client.start_span("my_agent", kind="agent") as span:
+            entity_name = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME)
+            assert entity_name == "my_agent"
+            attrs = dict(span.attributes)
+            assert attrs[SpanAttributes.TRACELOOP_SPAN_KIND] == "agent"
+
+    # --- Outcome 4: Task kind appends to entity path ---
+
+    def test_task_appends_entity_path(self):
+        """Task spans append to TRACELOOP_ENTITY_PATH."""
+        with self.client.start_span("step_1", kind="task") as span:
+            attrs = dict(span.attributes)
+            assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == "step_1"
+
+    def test_nested_task_entity_path(self):
+        """Nested task spans build a dotted entity path."""
+        with self.client.start_span("outer", kind="workflow") as _:
+            with self.client.start_span("inner", kind="task") as inner:
+                attrs = dict(inner.attributes)
+                assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == "inner"
+
+    # --- Outcome 5: Processors attribute ---
+
+    def test_processors_string(self):
+        """Single processor string sets the processors attribute."""
+        with self.client.start_span("my_task", processors="dogfood") as span:
+            attrs = dict(span.attributes)
+            assert attrs["processors"] == "dogfood"
+
+    def test_processors_list(self):
+        """List of processors is joined with commas."""
+        with self.client.start_span("my_task", processors=["dogfood", "debug"]) as span:
+            attrs = dict(span.attributes)
+            assert attrs["processors"] == "dogfood,debug"
+
+    def test_no_processors_no_attribute(self):
+        """When processors is None, no processors attribute is set."""
+        with self.client.start_span("my_task") as span:
+            attrs = dict(span.attributes)
+            assert "processors" not in attrs
+
+    # --- Outcome 6: Version=0 regression test ---
+
+    def test_version_zero_is_set(self):
+        """version=0 must be set on the span (truthiness bug regression)."""
+        with self.client.start_span("my_task", version=0) as span:
+            attrs = dict(span.attributes)
+            assert attrs[SpanAttributes.TRACELOOP_ENTITY_VERSION] == 0
+
+    def test_version_positive(self):
+        """Positive version is set correctly."""
+        with self.client.start_span("my_task", version=3) as span:
+            attrs = dict(span.attributes)
+            assert attrs[SpanAttributes.TRACELOOP_ENTITY_VERSION] == 3
+
+    def test_version_none_not_set(self):
+        """When version is None, no version attribute is set."""
+        with self.client.start_span("my_task") as span:
+            attrs = dict(span.attributes)
+            assert SpanAttributes.TRACELOOP_ENTITY_VERSION not in attrs
+
+    # --- Outcome 7: Span links ---
+
+    def test_span_links_list(self):
+        """Static list of SpanLink objects is resolved."""
+        links = [
+            SpanLink(
+                trace_id="0123456789abcdef0123456789abcdef",
+                span_id="0123456789abcdef",
+                attributes={"link.type": "test"},
+            )
+        ]
+        with self.client.start_span("my_task", links=links) as span:
+            assert span is not None
+            # Span should have links (checking the underlying OTel span)
+            if hasattr(span, '_links'):
+                assert len(span._links) == 1
+
+    def test_span_links_callable(self):
+        """Callable links are invoked at span creation time."""
+        link = SpanLink(
+            trace_id="0123456789abcdef0123456789abcdef",
+            span_id="0123456789abcdef",
+        )
+        with self.client.start_span("my_task", links=lambda: [link]) as span:
+            assert span is not None
+            if hasattr(span, '_links'):
+                assert len(span._links) == 1
+
+    def test_no_links_none(self):
+        """When links is None, no links on the span."""
+        with self.client.start_span("my_task") as span:
+            if hasattr(span, '_links'):
+                assert span._links is None or len(span._links) == 0
+
+    # --- Outcome 8: Export filter ---
+
+    def test_export_filter_set(self):
+        """Export filter is stored as JSON string attribute."""
+        ef = {"status_code": {"operator": "==", "value": "ERROR"}}
+        with self.client.start_span("my_task", export_filter=ef) as span:
+            attrs = dict(span.attributes)
+            import json
+            assert json.loads(attrs[EXPORT_FILTER_ATTR]) == ef
+
+    def test_export_filter_none_not_set(self):
+        """When export_filter is None, no attribute is set."""
+        with self.client.start_span("my_task") as span:
+            attrs = dict(span.attributes)
+            assert EXPORT_FILTER_ATTR not in attrs
+
+    # --- Outcome 9: Exception handling ---
+
+    def test_exception_records_error_and_reraises(self):
+        """Exceptions inside context set error status and re-raise."""
+        with pytest.raises(ValueError, match="test error"):
+            with self.client.start_span("my_task") as span:
+                raise ValueError("test error")
+
+        # Span should have error status
+        assert span.status.status_code == StatusCode.ERROR
+        assert "test error" in span.status.description
+
+    def test_exception_records_exception_event(self):
+        """Exceptions are recorded as events on the span."""
+        with pytest.raises(RuntimeError):
+            with self.client.start_span("my_task") as span:
+                raise RuntimeError("boom")
+
+        # Check exception was recorded (OTel adds an event)
+        if hasattr(span, '_events'):
+            exception_events = [e for e in span._events if e.name == "exception"]
+            assert len(exception_events) == 1
+
+    # --- Outcome 10: Context cleanup ---
+
+    def test_context_restored_after_exit(self):
+        """After start_span exits, the parent span is restored as current."""
+        with self.client.start_span("parent", kind="workflow") as parent:
+            with self.client.start_span("child", kind="task") as child:
+                assert trace.get_current_span() is child
+            # After child exits, parent should be current again
+            assert trace.get_current_span() is parent
+
+    def test_context_restored_after_exception(self):
+        """Context is properly restored even when an exception occurs."""
+        outer_span = trace.get_current_span()
+        try:
+            with self.client.start_span("failing_task") as span:
+                raise ValueError("fail")
+        except ValueError:
+            pass
+        # Current span should be restored to what it was before
+        assert trace.get_current_span() is not span
+
+    def test_entity_path_context_cleaned_up(self):
+        """Entity path context is cleaned up after task span exits."""
+        with self.client.start_span("task_a", kind="task") as _:
+            path_inside = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH)
+            assert path_inside == "task_a"
+
+        path_after = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH)
+        # Should be restored to parent value (None or "")
+        assert path_after is None or path_after == ""
+
+
+class TestSetupSpanShared:
+    """Tests for the shared setup_span/cleanup_span used by both decorators and client."""
+
+    def setup_method(self):
+        self.telemetry = RespanTelemetry(
+            app_name="test-setup-span",
+            api_key="test-key",
+            is_enabled=True,
+        )
+
+    def test_version_zero_via_decorator(self):
+        """Decorators using shared setup_span handle version=0 correctly (regression)."""
+        from respan_tracing import task
+
+        @task(name="versioned_task", version=0)
+        def my_versioned_fn():
+            client = get_client()
+            span = client.get_current_span()
+            if span:
+                attrs = dict(span.attributes)
+                return attrs.get(SpanAttributes.TRACELOOP_ENTITY_VERSION)
+            return None
+
+        result = my_versioned_fn()
+        assert result == 0
+
+    def test_context_cleanup_via_decorator(self):
+        """Decorators using shared cleanup_span detach context tokens (regression)."""
+        from respan_tracing import workflow, task
+
+        @workflow(name="outer_wf")
+        def outer():
+            name_inside = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME)
+            assert name_inside == "outer_wf"
+            return name_inside
+
+        outer()
+        # After decorator exits, entity name context should be cleaned up
+        name_after = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME)
+        assert name_after is None or name_after != "outer_wf"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python-sdks/respan-tracing/tests/test_start_span.py
+++ b/python-sdks/respan-tracing/tests/test_start_span.py
@@ -264,6 +264,127 @@ class TestStartSpan:
         assert path_after is None or path_after == ""
 
 
+class TestWorkflowNameInheritance:
+    """Tests for TRACELOOP_WORKFLOW_NAME propagation — the DEV-7151 fix.
+
+    The root cause of 28 fragmented traces was that imperative spans didn't
+    propagate TRACELOOP_ENTITY_NAME via context, so the RespanSpanProcessor
+    couldn't set TRACELOOP_WORKFLOW_NAME on child spans.
+    """
+
+    def setup_method(self):
+        self.telemetry = RespanTelemetry(
+            app_name="test-wf-inheritance",
+            api_key="test-key",
+            is_enabled=True,
+        )
+        self.client = get_client()
+
+    def test_child_task_inherits_workflow_name(self):
+        """Child task span gets TRACELOOP_WORKFLOW_NAME from parent workflow.
+
+        This is THE test for DEV-7151. RespanSpanProcessor.on_start reads
+        TRACELOOP_ENTITY_NAME from context and sets TRACELOOP_WORKFLOW_NAME.
+        """
+        with self.client.start_span("my_workflow", kind="workflow") as _:
+            with self.client.start_span("my_task", kind="task") as child:
+                attrs = dict(child.attributes)
+                assert attrs.get(SpanAttributes.TRACELOOP_WORKFLOW_NAME) == "my_workflow"
+
+    def test_nested_tasks_all_inherit_workflow_name(self):
+        """Multiple nested tasks all inherit the same workflow name."""
+        with self.client.start_span("executor", kind="workflow") as _:
+            with self.client.start_span("task_1", kind="task") as t1:
+                assert dict(t1.attributes).get(SpanAttributes.TRACELOOP_WORKFLOW_NAME) == "executor"
+            with self.client.start_span("task_2", kind="task") as t2:
+                assert dict(t2.attributes).get(SpanAttributes.TRACELOOP_WORKFLOW_NAME) == "executor"
+            with self.client.start_span("task_3", kind="task") as t3:
+                assert dict(t3.attributes).get(SpanAttributes.TRACELOOP_WORKFLOW_NAME) == "executor"
+
+    def test_workflow_name_not_set_without_parent_workflow(self):
+        """Without a parent workflow, TRACELOOP_WORKFLOW_NAME is absent."""
+        with self.client.start_span("orphan_task", kind="task") as span:
+            attrs = dict(span.attributes)
+            assert SpanAttributes.TRACELOOP_WORKFLOW_NAME not in attrs
+
+    def test_processors_attribute_propagated(self):
+        """Processors attribute on workflow span routes to FilteringSpanProcessor."""
+        with self.client.start_span("wf", kind="workflow", processors="dogfood") as outer:
+            assert dict(outer.attributes)["processors"] == "dogfood"
+            with self.client.start_span("t", kind="task", processors="dogfood") as inner:
+                assert dict(inner.attributes)["processors"] == "dogfood"
+
+    def test_inner_workflow_overrides_parent_workflow_name(self):
+        """Nested workflow overrides TRACELOOP_ENTITY_NAME for its children."""
+        with self.client.start_span("outer_wf", kind="workflow") as _:
+            with self.client.start_span("inner_wf", kind="workflow") as _:
+                with self.client.start_span("deep_task", kind="task") as deep:
+                    attrs = dict(deep.attributes)
+                    assert attrs.get(SpanAttributes.TRACELOOP_WORKFLOW_NAME) == "inner_wf"
+
+
+class TestEdgeCases:
+    """Edge cases and coverage gaps."""
+
+    def setup_method(self):
+        self.telemetry = RespanTelemetry(
+            app_name="test-edge-cases",
+            api_key="test-key",
+            is_enabled=True,
+        )
+        self.client = get_client()
+
+    def test_tool_kind_appends_entity_path(self):
+        """Tool kind appends to entity path, same as task."""
+        with self.client.start_span("my_tool", kind="tool") as span:
+            attrs = dict(span.attributes)
+            assert attrs[SpanAttributes.TRACELOOP_SPAN_KIND] == "tool"
+            assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == "my_tool"
+
+    def test_chained_tasks_build_entity_path(self):
+        """Nested task spans build a dotted entity path chain."""
+        with self.client.start_span("wf", kind="workflow") as _:
+            with self.client.start_span("a", kind="task") as _:
+                with self.client.start_span("b", kind="task") as inner:
+                    attrs = dict(inner.attributes)
+                    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == "a.b"
+
+    def test_enum_kind_value(self):
+        """kind parameter accepts TraceloopSpanKindValues enum."""
+        from opentelemetry.semconv_ai import TraceloopSpanKindValues
+        with self.client.start_span("my_wf", kind=TraceloopSpanKindValues.WORKFLOW) as span:
+            attrs = dict(span.attributes)
+            assert attrs[SpanAttributes.TRACELOOP_SPAN_KIND] == "workflow"
+
+    def test_non_serializable_export_filter_silently_skipped(self):
+        """Non-JSON-serializable export filter is silently skipped."""
+        class NotSerializable:
+            pass
+        with self.client.start_span("my_task", export_filter={"x": NotSerializable()}) as span:
+            attrs = dict(span.attributes)
+            assert EXPORT_FILTER_ATTR not in attrs
+
+    def test_entity_name_context_restored_after_nested_workflows(self):
+        """After nested workflow exits, parent's entity name is restored."""
+        with self.client.start_span("outer", kind="workflow") as _:
+            with self.client.start_span("inner", kind="workflow") as _:
+                assert context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME) == "inner"
+            # After inner exits, outer's entity name should be restored
+            assert context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME) == "outer"
+
+    def test_entity_path_restored_after_nested_tasks(self):
+        """After nested task exits, parent's entity path is restored."""
+        with self.client.start_span("wf", kind="workflow") as _:
+            with self.client.start_span("a", kind="task") as _:
+                with self.client.start_span("b", kind="task") as _:
+                    assert context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH) == "a.b"
+                # After b exits, a's path should be restored
+                assert context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH) == "a"
+            # After a exits, path should be empty
+            path = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH)
+            assert path is None or path == ""
+
+
 class TestSetupSpanShared:
     """Tests for the shared setup_span/cleanup_span used by both decorators and client."""
 


### PR DESCRIPTION
## Summary

- Add `RespanClient.start_span()` context manager — the imperative equivalent of `@workflow`/`@task`/`@agent`/`@tool` decorators
- Handles all the same concerns: `processors` routing, `TRACELOOP_ENTITY_NAME` context propagation, `TRACELOOP_WORKFLOW_NAME` inheritance, span links, error recording
- Use when span name or kind must be determined at runtime (e.g., dynamic task loops in workflow executors)

**Before:** Dropping to raw `tracer.start_as_current_span()` lost all Respan metadata — had to manually set 4+ attributes and context values.

**After:**
```python
with client.start_span("workflow_execution", kind="workflow", processors="dogfood") as span:
    with client.start_span("step_1", kind="task", processors="dogfood") as task_span:
        ...
```

Bumps version to 2.6.0. Backend PR: respanai/respan-backend#1031

Closes DEV-7151

## Test plan

- [ ] Verify no circular imports
- [ ] Verify `client.start_span()` sets `processors`, `TRACELOOP_ENTITY_NAME`, `TRACELOOP_SPAN_KIND` attributes
- [ ] Verify `kind="workflow"` propagates entity name via OTel context to child spans
- [ ] Verify span links (explicit + context-attached) are resolved correctly
- [ ] Verify error recording sets status and records exception