### PR TITLE
fix: SpanBuffer auto-flush on exit — spans were silently dropped

### DIFF
--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.6.0"
+version = "2.6.1"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-tracing/src/respan_tracing/core/client.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/client.py
@@ -468,7 +468,7 @@ class RespanClient:
             logger.warning("Respan Telemetry not initialized or disabled.")
             raise RuntimeError("Respan Telemetry not initialized or disabled.")
         
-        return SpanBuffer(trace_id=trace_id)
+        return SpanBuffer(trace_id=trace_id, tracer_provider=self._tracer.tracer_provider)
     
     def process_spans(self, spans) -> bool:
         """

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -284,17 +284,20 @@ class SpanBuffer:
     5. Thread-safe isolation (each context has its own buffer)
     """
     
-    def __init__(self, trace_id: str):
+    def __init__(self, trace_id: str, tracer_provider=None):
         """
         Initialize the span buffer.
-        
+
         Args:
             trace_id: Trace ID for the spans being buffered
+            tracer_provider: Optional TracerProvider. When provided, buffered
+                spans are auto-flushed through the processor pipeline on exit.
         """
         self.trace_id = trace_id
         self._local_queue: List[ReadableSpan] = []
         self._is_buffering = False
         self._context_token = None
+        self._tracer_provider = tracer_provider
     
     def __enter__(self):
         """
@@ -320,27 +323,28 @@ class SpanBuffer:
     
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
-        Exit context: Deactivate this buffer in the current context.
-        
-        Args:
-            exc_type: Exception type if an exception was raised
-            exc_val: Exception value if an exception was raised
-            exc_tb: Exception traceback if an exception was raised
+        Exit context: Deactivate this buffer and auto-flush spans.
+
+        Buffered spans are replayed through the tracer provider's processor
+        pipeline so they reach the OTLP exporter. This does NOT clear the
+        local queue — ``get_all_spans()`` still works after exit for read-only
+        use cases (e.g., converting spans to unified logs).
         """
         logger.debug(f"[SpanBuffer] Exiting buffering context for trace {self.trace_id}")
-        
-        # Mark as not buffering
+
+        # Mark as not buffering FIRST so replayed spans don't re-enter the buffer
         self._is_buffering = False
-        
+
         # Reset the context variable
         if self._context_token is not None:
             _active_span_buffer.reset(self._context_token)
             self._context_token = None
-        
+
+        # Auto-flush: replay buffered spans through the processor pipeline
+        if self._tracer_provider is not None and self._local_queue:
+            self.process_spans(self._tracer_provider)
+
         logger.debug(f"[SpanBuffer] Deactivated buffer for trace {self.trace_id}")
-        
-        # Note: Local queue persists for manual export or inspection
-        # It will be cleaned up by garbage collection when this object is destroyed
     
     def create_span(
         self, 

--- a/python-sdks/respan-tracing/tests/test_span_buffer_flush.py
+++ b/python-sdks/respan-tracing/tests/test_span_buffer_flush.py
@@ -1,0 +1,105 @@
+"""Tests for SpanBuffer auto-flush on exit.
+
+The bug: SpanBuffer.__exit__() didn't flush. Spans went into _local_queue,
+buffer deactivated, spans got GC'd. process_spans() existed but nobody
+called it. This test ensures auto-flush happens when tracer_provider is set.
+"""
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+from respan_tracing import RespanTelemetry, get_client
+from respan_tracing.processors.base import SpanBuffer
+
+
+class TestSpanBufferAutoFlush:
+    """Tests for SpanBuffer auto-flush on __exit__."""
+
+    def setup_method(self):
+        self.telemetry = RespanTelemetry(
+            app_name="test-buffer-flush",
+            api_key="test-key",
+            is_enabled=True,
+        )
+        self.client = get_client()
+
+    def test_auto_flush_on_exit(self):
+        """Spans are auto-flushed through processor pipeline on context exit."""
+        with self.client.get_span_buffer("trace-123") as buffer:
+            buffer.create_span("step_1", {"status": "ok"})
+            buffer.create_span("step_2", {"status": "ok"})
+            span_count = buffer.get_span_count()
+            assert span_count == 2
+
+        # After exit, spans should still be readable (queue not cleared)
+        assert len(buffer.get_all_spans()) == 2
+
+    def test_auto_flush_calls_process_spans(self):
+        """__exit__ calls process_spans when tracer_provider is set."""
+        buffer = SpanBuffer(trace_id="trace-456", tracer_provider=MagicMock())
+        buffer._local_queue = [MagicMock(), MagicMock()]
+
+        with patch.object(buffer, 'process_spans', return_value=2) as mock_process:
+            buffer.__enter__()
+            buffer.__exit__(None, None, None)
+            mock_process.assert_called_once_with(buffer._tracer_provider)
+
+    def test_no_auto_flush_without_tracer_provider(self):
+        """Without tracer_provider, no auto-flush (backward compatible)."""
+        buffer = SpanBuffer(trace_id="trace-789")
+        buffer._local_queue = [MagicMock()]
+
+        with patch.object(buffer, 'process_spans') as mock_process:
+            buffer.__enter__()
+            buffer.__exit__(None, None, None)
+            mock_process.assert_not_called()
+
+    def test_no_auto_flush_on_empty_queue(self):
+        """No process_spans call when queue is empty."""
+        buffer = SpanBuffer(trace_id="trace-000", tracer_provider=MagicMock())
+
+        with patch.object(buffer, 'process_spans') as mock_process:
+            buffer.__enter__()
+            buffer.__exit__(None, None, None)
+            mock_process.assert_not_called()
+
+    def test_get_all_spans_works_after_exit(self):
+        """get_all_spans() still returns spans after auto-flush (read-only use case)."""
+        with self.client.get_span_buffer("trace-read") as buffer:
+            buffer.create_span("s1", {"x": 1})
+            buffer.create_span("s2", {"x": 2})
+
+        # Post-exit: spans still readable for unified log conversion
+        spans = buffer.get_all_spans()
+        assert len(spans) == 2
+        assert spans[0].name == "s1"
+        assert spans[1].name == "s2"
+
+    def test_client_get_span_buffer_passes_tracer_provider(self):
+        """client.get_span_buffer() passes tracer_provider for auto-flush."""
+        buffer = self.client.get_span_buffer("trace-auto")
+        assert buffer._tracer_provider is not None
+        assert buffer._tracer_provider is self.client._tracer.tracer_provider
+
+    def test_buffering_deactivated_before_flush(self):
+        """_is_buffering is False before flush to prevent re-entry."""
+        flush_order = []
+
+        buffer = SpanBuffer(trace_id="trace-order", tracer_provider=MagicMock())
+        original_process = buffer.process_spans
+
+        def tracking_process(tp):
+            flush_order.append(("process", buffer._is_buffering))
+            return 0
+
+        buffer.process_spans = tracking_process
+        buffer._local_queue = [MagicMock()]
+
+        buffer.__enter__()
+        buffer.__exit__(None, None, None)
+
+        # process_spans should have been called with _is_buffering=False
+        assert flush_order == [("process", False)]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- SpanBuffer.__exit__() didn't flush buffered spans through the processor pipeline — spans went into `_local_queue`, buffer deactivated, spans got GC'd
- Fix: `__exit__` now auto-flushes by calling `process_spans(tracer_provider)` to replay buffered spans through OTLP exporter
- `get_all_spans()` still works after exit for read-only use (unified log conversion)
- Backward compatible: SpanBuffer without `tracer_provider` skips auto-flush
- Bumps to 2.6.1

## Test plan

- [x] 7 new tests in `test_span_buffer_flush.py`
- [x] All 46 tests pass (39 start_span + 7 buffer)
- [x] Verified `_is_buffering=False` before flush (prevents re-entry)
- [x] Verified `get_all_spans()` works after exit (queue not cleared)