### PR TITLE
feat: add optional timestamp to SpanLink

### DIFF
--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/span_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/span_types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pydantic import ConfigDict, Field
 
@@ -11,6 +11,18 @@ class SpanLink(RespanBaseModel):
 
     A lightweight data holder with no OTel dependency.  The conversion to an
     OpenTelemetry ``trace.Link`` is performed by ``respan_tracing`` at runtime.
+
+    Args:
+        trace_id: Hex trace ID of the linked span.
+        span_id: Hex span ID of the linked span.
+        attributes: Extra key-value pairs to attach to the OTel link.
+        timestamp: Optional ISO 8601 timestamp of the linked trace. When set,
+            automatically merged into link attributes as
+            ``respan.link.timestamp``. This enables efficient ClickHouse
+            point-lookups when navigating to the linked trace (the primary
+            key includes timestamp).
+        is_remote: Whether the linked span is remote (default True).
+        is_sampled: Whether the linked span was sampled (default True).
     """
 
     model_config = ConfigDict(frozen=True)
@@ -18,6 +30,7 @@ class SpanLink(RespanBaseModel):
     trace_id: str
     span_id: str
     attributes: Dict[str, Any] = Field(default_factory=dict)
+    timestamp: Optional[str] = None
     is_remote: bool = True
     is_sampled: bool = True
 

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/span_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/span_types.py
@@ -56,6 +56,9 @@ class RespanSpanAttributes(Enum):
     # Metadata
     RESPAN_METADATA = "respan.metadata" # This is a pattern, it can be  any "respan.metadata.key" where key is customizable
 
+    # Span links
+    LINK_TIMESTAMP = "respan.link.timestamp"
+
     # Logging
     LOG_METHOD = "respan.entity.log_method"
     LOG_TYPE = "respan.entity.log_type"

--- a/python-sdks/respan-tracing/src/respan_tracing/contexts/span.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/contexts/span.py
@@ -9,6 +9,7 @@ from respan_sdk.respan_types.span_types import (
     RespanSpanAttributes,
     SpanLink,
 )
+LINK_TIMESTAMP_ATTR = RespanSpanAttributes.LINK_TIMESTAMP.value
 from respan_sdk.respan_types.param_types import RespanParams
 from respan_sdk.utils.data_processing.id_processing import (
     SPAN_ID_HEX_LENGTH,
@@ -44,7 +45,7 @@ def span_link_to_otel(link: SpanLink) -> trace.Link:
     # Merge timestamp into attributes if provided (enables efficient CH lookups)
     attrs = dict(link.attributes)
     if link.timestamp:
-        attrs["respan.link.timestamp"] = link.timestamp
+        attrs[LINK_TIMESTAMP_ATTR] = link.timestamp
     return trace.Link(context=span_context, attributes=attrs)
 
 

--- a/python-sdks/respan-tracing/src/respan_tracing/contexts/span.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/contexts/span.py
@@ -41,7 +41,11 @@ def span_link_to_otel(link: SpanLink) -> trace.Link:
         trace_flags=trace_flags,
         trace_state=trace.TraceState(),
     )
-    return trace.Link(context=span_context, attributes=link.attributes)
+    # Merge timestamp into attributes if provided (enables efficient CH lookups)
+    attrs = dict(link.attributes)
+    if link.timestamp:
+        attrs["respan.link.timestamp"] = link.timestamp
+    return trace.Link(context=span_context, attributes=attrs)
 
 
 def attach_span_links(links: List[SpanLink]) -> None:

--- a/python-sdks/respan-tracing/tests/test_span_links.py
+++ b/python-sdks/respan-tracing/tests/test_span_links.py
@@ -11,6 +11,9 @@ from respan_sdk.constants.otlp_constants import (
     OTLP_STRING_VALUE,
     OTLP_TRACE_ID_KEY,
 )
+from respan_sdk.respan_types.span_types import RespanSpanAttributes
+
+LINK_TIMESTAMP_ATTR = RespanSpanAttributes.LINK_TIMESTAMP.value
 from respan_tracing import RespanTelemetry, SpanLink, span_link_to_otel, get_client
 from respan_tracing.core.tracer import RespanTracer
 from respan_tracing.exporters.respan import _span_to_otlp_json
@@ -179,7 +182,7 @@ def test_span_link_timestamp_merged_into_attributes():
         timestamp="2026-03-08T12:00:00Z",
     )
     otel_link = span_link_to_otel(link)
-    assert otel_link.attributes["respan.link.timestamp"] == "2026-03-08T12:00:00Z"
+    assert otel_link.attributes[LINK_TIMESTAMP_ATTR] == "2026-03-08T12:00:00Z"
     assert otel_link.attributes["link.type"] == "resume"
 
 
@@ -191,7 +194,7 @@ def test_span_link_no_timestamp_no_extra_attribute():
         attributes={"link.type": "resume"},
     )
     otel_link = span_link_to_otel(link)
-    assert "respan.link.timestamp" not in otel_link.attributes
+    assert LINK_TIMESTAMP_ATTR not in otel_link.attributes
     assert otel_link.attributes == {"link.type": "resume"}
 
 
@@ -205,4 +208,4 @@ def test_span_link_timestamp_does_not_mutate_original_attributes():
         timestamp="2026-03-08T12:00:00Z",
     )
     span_link_to_otel(link)
-    assert "respan.link.timestamp" not in original_attrs
+    assert LINK_TIMESTAMP_ATTR not in original_attrs

--- a/python-sdks/respan-tracing/tests/test_span_links.py
+++ b/python-sdks/respan-tracing/tests/test_span_links.py
@@ -168,3 +168,41 @@ def test_otlp_json_serializes_span_links(clean_exporter):
         for item in link_payload["attributes"]
     }
     assert serialized_attributes == {"link.type": "resume"}
+
+
+def test_span_link_timestamp_merged_into_attributes():
+    """SpanLink.timestamp should be auto-merged into OTel link attributes."""
+    link = SpanLink(
+        trace_id="a" * 32,
+        span_id="b" * 16,
+        attributes={"link.type": "resume"},
+        timestamp="2026-03-08T12:00:00Z",
+    )
+    otel_link = span_link_to_otel(link)
+    assert otel_link.attributes["respan.link.timestamp"] == "2026-03-08T12:00:00Z"
+    assert otel_link.attributes["link.type"] == "resume"
+
+
+def test_span_link_no_timestamp_no_extra_attribute():
+    """SpanLink without timestamp should not add respan.link.timestamp."""
+    link = SpanLink(
+        trace_id="a" * 32,
+        span_id="b" * 16,
+        attributes={"link.type": "resume"},
+    )
+    otel_link = span_link_to_otel(link)
+    assert "respan.link.timestamp" not in otel_link.attributes
+    assert otel_link.attributes == {"link.type": "resume"}
+
+
+def test_span_link_timestamp_does_not_mutate_original_attributes():
+    """Merging timestamp must not mutate the original SpanLink.attributes dict."""
+    original_attrs = {"link.type": "resume"}
+    link = SpanLink(
+        trace_id="a" * 32,
+        span_id="b" * 16,
+        attributes=original_attrs,
+        timestamp="2026-03-08T12:00:00Z",
+    )
+    span_link_to_otel(link)
+    assert "respan.link.timestamp" not in original_attrs


### PR DESCRIPTION
## Summary
- Adds optional `timestamp` param to `SpanLink` (respan-sdk)
- When set, auto-merged into OTel link attributes as `respan.link.timestamp` (respan-tracing)
- Enables efficient ClickHouse point-lookups when UI navigates to linked traces (timestamp hits the primary key instead of scanning all granules)

## Motivation
CHLogV2's primary key is `(org_id, timestamp, id)`. Point lookups by `trace_id` without timestamp scan all granules for the org. By embedding the linked trace's timestamp in the span link, the UI can include it in the query for O(log N) lookups.

This is a zero-infrastructure alternative to projections or mapping tables — documented as Option C in `tracing_architecture.md`.

## Changes
- `respan-sdk`: `SpanLink.timestamp: Optional[str]` field added
- `respan-tracing`: `span_link_to_otel()` merges timestamp into link attributes
- 3 new tests: timestamp merge, no-timestamp no-attribute, no mutation of original attrs

## Test plan
- [x] `test_span_link_timestamp_merged_into_attributes` — timestamp appears in OTel link attributes
- [x] `test_span_link_no_timestamp_no_extra_attribute` — no timestamp = no extra attribute
- [x] `test_span_link_timestamp_does_not_mutate_original_attributes` — original dict unchanged