### PR TITLE
feat: add parent context injection to SpanBuffer

### DIFF
--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.7.4"
+version = "2.8.0"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-tracing/src/respan_tracing/core/client.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/client.py
@@ -381,34 +381,46 @@ class RespanClient:
         finally:
             cleanup_span(span, ctx_token, entity_name_token, entity_path_token)
 
-    def get_span_buffer(self, trace_id: str) -> SpanBuffer:
+    def get_span_buffer(
+        self,
+        trace_id: str,
+        parent_trace_id: Optional[str] = None,
+        parent_span_id: Optional[str] = None,
+    ) -> SpanBuffer:
         """
         Get an OpenTelemetry-compliant context manager for buffering spans with manual export control.
-        
+
         This enables batch buffering of multiple spans for a single trace, allowing you to:
         - Create spans asynchronously (after execution completes)
         - Buffer multiple spans and export with single API call
         - Manually control when spans are exported
         - Inspect spans before exporting
-        
+        - Continue a pre-existing trace (workflow pause/resume)
+
         Spans created within the SpanBuffer context are isolated and only buffered
         in that buffer's local queue, without affecting other spans in the application.
-        
+
         Args:
             trace_id: Trace ID for the spans being buffered
-        
+            parent_trace_id: Optional OTel trace ID (hex string) to continue.
+                When provided with parent_span_id, spans created in this buffer
+                inherit the parent trace, making them children of the specified
+                span. Used for workflow pause/resume to keep all spans in one trace.
+            parent_span_id: Optional OTel span ID (hex string) of the parent span.
+                Must be provided together with parent_trace_id.
+
         Returns:
             SpanBuffer: Context manager for span buffering
-        
+
         Example:
             ```python
             from respan_tracing import SpanLink, get_client
-            
+
             client = get_client()
-            
+
             # Buffer spans for batch export
             collected_spans = []
-            
+
             with client.get_span_buffer("trace-123") as buffer:
                 # Create multiple spans - they go to local queue
                 buffer.create_span("step1", {"status": "completed", "latency": 100})
@@ -424,51 +436,39 @@ class RespanClient:
                         )
                     ],
                 )
-                
+
                 # Optional: inspect before extracting
                 print(f"Buffered {buffer.get_span_count()} spans")
-                
+
                 # Extract spans before context exits
                 collected_spans = buffer.get_all_spans()
-            
+
             # Export all spans as a single batch
             client.export_spans(collected_spans)
             ```
-        
-        Example (async span creation):
+
+        Example (trace continuation for workflow resume):
             ```python
-            # Phase 1: Execute workflows (no spans yet)
-            results = []
-            for workflow in workflows:
-                result = execute_workflow(workflow)
-                results.append(result)
-            
-            # Phase 2: Create spans from results 
-            collected_spans = []
-            
-            with client.get_span_buffer("exp-123") as buffer:
-                for i, result in enumerate(results):
-                    buffer.create_span(
-                        f"workflow_{i}",
-                        attributes={
-                            "input": result["input"],
-                            "output": result["output"],
-                            "latency": result["latency"],
-                        }
-                    )
-                
-                # Extract spans before context exits
-                collected_spans = buffer.get_all_spans()
-            
-            # Phase 3: Export as batch
-            client.export_spans(collected_spans)
+            # On resume, continue the pre-pause trace:
+            with client.get_span_buffer(
+                trace_id="new-run-id",
+                parent_trace_id="abcdef1234567890abcdef1234567890",
+                parent_span_id="abcdef1234567890",
+            ) as buffer:
+                # Spans inherit parent_trace_id — same trace as pre-pause
+                buffer.create_span("resumed_step", {"status": "running"})
             ```
         """
         if not self._tracer.is_enabled or not RespanTracer.is_initialized():
             logger.warning("Respan Telemetry not initialized or disabled.")
             raise RuntimeError("Respan Telemetry not initialized or disabled.")
-        
-        return SpanBuffer(trace_id=trace_id, tracer_provider=self._tracer.tracer_provider)
+
+        return SpanBuffer(
+            trace_id=trace_id,
+            tracer_provider=self._tracer.tracer_provider,
+            parent_trace_id=parent_trace_id,
+            parent_span_id=parent_span_id,
+        )
     
     def process_spans(self, spans) -> bool:
         """

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -7,6 +7,7 @@ from opentelemetry import context as context_api, trace
 from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.context import Context
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 from opentelemetry.semconv_ai import SpanAttributes
 
 from respan_sdk.respan_types.span_types import RespanSpanAttributes, SpanLink
@@ -280,7 +281,13 @@ class SpanBuffer:
     5. Thread-safe isolation (each context has its own buffer)
     """
     
-    def __init__(self, trace_id: str, tracer_provider=None):
+    def __init__(
+        self,
+        trace_id: str,
+        tracer_provider=None,
+        parent_trace_id: Optional[str] = None,
+        parent_span_id: Optional[str] = None,
+    ):
         """
         Initialize the span buffer.
 
@@ -288,34 +295,65 @@ class SpanBuffer:
             trace_id: Trace ID for the spans being buffered
             tracer_provider: Optional TracerProvider. When provided, buffered
                 spans are auto-flushed through the processor pipeline on exit.
+            parent_trace_id: Optional OTel trace ID (hex string) to continue.
+                When provided with parent_span_id, spans created in this buffer
+                inherit the parent trace, making them children of the specified
+                span. Used for workflow pause/resume to keep all spans in one trace.
+            parent_span_id: Optional OTel span ID (hex string) of the parent span.
+                Must be provided together with parent_trace_id.
         """
         self.trace_id = trace_id
         self._local_queue: List[ReadableSpan] = []
         self._seen_span_ids: set = set()
         self._is_buffering = False
         self._context_token = None
+        self._parent_context_token = None
         self._tracer_provider = tracer_provider
+        self._parent_trace_id = parent_trace_id
+        self._parent_span_id = parent_span_id
     
     def __enter__(self):
         """
         Enter context: Set this buffer as active in the current context.
-        
+
         Spans created within this context will be routed to this buffer's
         local queue instead of being exported immediately.
-        
+
+        When parent_trace_id and parent_span_id are set, injects a
+        NonRecordingSpan as the current context so that all spans created
+        in this buffer inherit the parent's trace_id and become children
+        of the specified span. This enables workflow resume to continue
+        the pre-pause trace instead of starting a new one.
+
         Returns:
             self for context manager usage
         """
         logger.debug(f"[SpanBuffer] Entering buffering context for trace {self.trace_id}")
-        
+
+        # Inject parent context for trace continuation (workflow resume)
+        if self._parent_trace_id and self._parent_span_id:
+            parent_ctx = SpanContext(
+                trace_id=int(self._parent_trace_id, 16),
+                span_id=int(self._parent_span_id, 16),
+                is_remote=True,
+                trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            )
+            parent_span = NonRecordingSpan(parent_ctx)
+            ctx = trace.set_span_in_context(parent_span)
+            self._parent_context_token = context_api.attach(ctx)
+            logger.debug(
+                f"[SpanBuffer] Injected parent context: "
+                f"trace_id={self._parent_trace_id}, span_id={self._parent_span_id}"
+            )
+
         # Mark as buffering
         self._is_buffering = True
-        
+
         # Set this buffer as active in the context variable
         self._context_token = _active_span_buffer.set(self)
-        
+
         logger.debug(f"[SpanBuffer] Activated buffer for trace {self.trace_id}")
-        
+
         return self
     
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -340,6 +378,11 @@ class SpanBuffer:
         # Auto-flush: replay buffered spans through the processor pipeline
         if self._tracer_provider is not None and self._local_queue:
             self.process_spans(self._tracer_provider)
+
+        # Detach parent context (must happen after flush so spans keep the parent)
+        if self._parent_context_token is not None:
+            context_api.detach(self._parent_context_token)
+            self._parent_context_token = None
 
         logger.debug(f"[SpanBuffer] Deactivated buffer for trace {self.trace_id}")
     

--- a/python-sdks/respan-tracing/tests/test_parent_context_injection.py
+++ b/python-sdks/respan-tracing/tests/test_parent_context_injection.py
@@ -9,8 +9,9 @@ This is the SDK side of Phase 6 (Continue-Trace-on-Resume) from
 span_mv_and_trace_evolution.md.
 """
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+from opentelemetry import trace
 from respan_tracing import RespanTelemetry, get_client
 from respan_tracing.processors.base import SpanBuffer
 
@@ -88,8 +89,6 @@ class TestParentContextInjection:
 
     def test_parent_context_detached_after_exit(self):
         """Parent context is properly detached after buffer exits."""
-        from opentelemetry import trace
-
         # Get trace_id before entering buffer
         pre_span = trace.get_current_span()
 

--- a/python-sdks/respan-tracing/tests/test_parent_context_injection.py
+++ b/python-sdks/respan-tracing/tests/test_parent_context_injection.py
@@ -1,0 +1,163 @@
+"""Tests for SpanBuffer parent context injection (trace continuation).
+
+When a workflow pauses and resumes, we want the post-resume spans to
+share the pre-pause trace_id. SpanBuffer achieves this by injecting a
+NonRecordingSpan parent context so all child spans inherit the parent's
+trace_id.
+
+This is the SDK side of Phase 6 (Continue-Trace-on-Resume) from
+span_mv_and_trace_evolution.md.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from respan_tracing import RespanTelemetry, get_client
+from respan_tracing.processors.base import SpanBuffer
+
+
+# Valid OTel hex IDs for testing
+PARENT_TRACE_ID = "0123456789abcdef0123456789abcdef"
+PARENT_SPAN_ID = "fedcba9876543210"
+
+
+class TestParentContextInjection:
+    """Tests for SpanBuffer with parent_trace_id/parent_span_id."""
+
+    def setup_method(self):
+        self.telemetry = RespanTelemetry(
+            app_name="test-parent-ctx",
+            api_key="test-key",
+            is_enabled=True,
+        )
+        self.client = get_client()
+
+    def test_spans_inherit_parent_trace_id(self):
+        """Spans created in a buffer with parent context inherit the parent trace_id."""
+        with self.client.get_span_buffer(
+            trace_id="run-abc",
+            parent_trace_id=PARENT_TRACE_ID,
+            parent_span_id=PARENT_SPAN_ID,
+        ) as buffer:
+            buffer.create_span("resumed_step", {"status": "running"})
+            buffer.create_span("resumed_step_2", {"status": "done"})
+
+        spans = buffer.get_all_spans()
+        assert len(spans) == 2
+
+        expected_trace_id = int(PARENT_TRACE_ID, 16)
+        for span in spans:
+            actual_trace_id = span.get_span_context().trace_id
+            assert actual_trace_id == expected_trace_id, (
+                f"Span '{span.name}' has trace_id {actual_trace_id:#034x}, "
+                f"expected {expected_trace_id:#034x}"
+            )
+
+    def test_spans_are_children_of_parent_span(self):
+        """Spans created in buffer are children of the injected parent span."""
+        with self.client.get_span_buffer(
+            trace_id="run-def",
+            parent_trace_id=PARENT_TRACE_ID,
+            parent_span_id=PARENT_SPAN_ID,
+        ) as buffer:
+            buffer.create_span("child_step", {"x": 1})
+
+        spans = buffer.get_all_spans()
+        assert len(spans) == 1
+        span = spans[0]
+
+        expected_parent = int(PARENT_SPAN_ID, 16)
+        assert span.parent is not None, "Span should have a parent"
+        actual_parent = span.parent.span_id
+        assert actual_parent == expected_parent, (
+            f"Span parent_span_id is {actual_parent:#018x}, "
+            f"expected {expected_parent:#018x}"
+        )
+
+    def test_no_parent_context_creates_new_trace(self):
+        """Without parent context, spans get a new auto-generated trace_id (backward compat)."""
+        with self.client.get_span_buffer(trace_id="run-ghi") as buffer:
+            buffer.create_span("independent_step", {"status": "ok"})
+
+        spans = buffer.get_all_spans()
+        assert len(spans) == 1
+
+        # Should NOT have the parent trace_id
+        actual_trace_id = spans[0].get_span_context().trace_id
+        assert actual_trace_id != int(PARENT_TRACE_ID, 16)
+        assert actual_trace_id != 0  # Should have some valid trace_id
+
+    def test_parent_context_detached_after_exit(self):
+        """Parent context is properly detached after buffer exits."""
+        from opentelemetry import trace
+
+        # Get trace_id before entering buffer
+        pre_span = trace.get_current_span()
+
+        with self.client.get_span_buffer(
+            trace_id="run-jkl",
+            parent_trace_id=PARENT_TRACE_ID,
+            parent_span_id=PARENT_SPAN_ID,
+        ) as buffer:
+            buffer.create_span("step", {"x": 1})
+
+        # After exit, current span should be back to what it was before
+        post_span = trace.get_current_span()
+        # The parent NonRecordingSpan should not leak into outer context
+        post_trace_id = post_span.get_span_context().trace_id
+        assert post_trace_id != int(PARENT_TRACE_ID, 16), (
+            "Parent context leaked — trace_id still active after buffer exit"
+        )
+
+    def test_partial_parent_context_ignored(self):
+        """If only parent_trace_id is provided (no parent_span_id), no injection happens."""
+        buffer = SpanBuffer(
+            trace_id="run-mno",
+            parent_trace_id=PARENT_TRACE_ID,
+            # parent_span_id intentionally omitted
+        )
+        assert buffer._parent_trace_id == PARENT_TRACE_ID
+        assert buffer._parent_span_id is None
+
+        # __enter__ should not inject parent context
+        buffer.__enter__()
+        assert buffer._parent_context_token is None
+        buffer.__exit__(None, None, None)
+
+    def test_client_get_span_buffer_passes_parent_params(self):
+        """client.get_span_buffer() correctly passes parent_trace_id/parent_span_id."""
+        buffer = self.client.get_span_buffer(
+            trace_id="run-pqr",
+            parent_trace_id=PARENT_TRACE_ID,
+            parent_span_id=PARENT_SPAN_ID,
+        )
+        assert buffer._parent_trace_id == PARENT_TRACE_ID
+        assert buffer._parent_span_id == PARENT_SPAN_ID
+        assert buffer._tracer_provider is not None
+
+    def test_multiple_spans_share_trace_but_have_unique_span_ids(self):
+        """All spans in a parent-context buffer share trace_id but have distinct span_ids."""
+        with self.client.get_span_buffer(
+            trace_id="run-stu",
+            parent_trace_id=PARENT_TRACE_ID,
+            parent_span_id=PARENT_SPAN_ID,
+        ) as buffer:
+            buffer.create_span("step_a", {})
+            buffer.create_span("step_b", {})
+            buffer.create_span("step_c", {})
+
+        spans = buffer.get_all_spans()
+        assert len(spans) == 3
+
+        trace_ids = {s.get_span_context().trace_id for s in spans}
+        span_ids = {s.get_span_context().span_id for s in spans}
+
+        # All same trace_id
+        assert len(trace_ids) == 1
+        assert trace_ids.pop() == int(PARENT_TRACE_ID, 16)
+
+        # All different span_ids
+        assert len(span_ids) == 3
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- `SpanBuffer` now accepts `parent_trace_id` and `parent_span_id` params
- When provided, injects a `NonRecordingSpan` as OTel parent context — all child spans inherit the parent's `trace_id` and become children of the specified span
- `RespanClient.get_span_buffer()` passes through the new params
- Backward compatible — omitting the params preserves current behavior (new trace)

## Why

Workflow pause/resume currently creates disconnected traces. This enables Phase 6 (Continue-Trace-on-Resume): the resume executor passes the pre-pause `trace_id` + root `span_id`, so post-resume spans land in the same trace.

## Test plan

- [x] `test_spans_inherit_parent_trace_id` — spans share parent's trace_id
- [x] `test_spans_are_children_of_parent_span` — parent_span_id set correctly
- [x] `test_no_parent_context_creates_new_trace` — backward compat
- [x] `test_parent_context_detached_after_exit` — no context leak
- [x] `test_partial_parent_context_ignored` — only trace_id without span_id = no injection
- [x] `test_client_get_span_buffer_passes_parent_params` — client passthrough
- [x] `test_multiple_spans_share_trace_but_have_unique_span_ids` — correct semantics
- [x] All 11 existing SpanBuffer tests still pass