### PR TITLE
fix: pydantic AI tracing cost extraction and metadata cleanup

### DIFF
--- a/python-sdks/respan-exporter-pydantic-ai/src/respan_exporter_pydantic_ai/constants.py
+++ b/python-sdks/respan-exporter-pydantic-ai/src/respan_exporter_pydantic_ai/constants.py
@@ -41,6 +41,11 @@ OTEL_SCOPE_NAME_ATTR = "otel.scope.name"
 OTEL_SCOPE_VERSION_ATTR = "otel.scope.version"
 MODEL_NAME_ATTR = "model_name"
 
+# Attributes emitted by pydantic-ai instrumentation (consumed or redundant)
+PYDANTIC_AI_OPERATION_COST_ATTR = "operation.cost"
+PYDANTIC_AI_USAGE_DETAILS_INPUT_TOKENS_ATTR = "gen_ai.usage.details.input_tokens"
+PYDANTIC_AI_USAGE_DETAILS_OUTPUT_TOKENS_ATTR = "gen_ai.usage.details.output_tokens"
+
 # Attributes emitted by opentelemetry-instrumentation-openai (stripped if present)
 OPENAI_LLM_HEADERS_ATTR = "llm.headers"
 OPENAI_LLM_REQUEST_REASONING_EFFORT_ATTR = "llm.request.reasoning_effort"
@@ -105,6 +110,9 @@ ENRICHMENT_STRIP_ATTRS = frozenset({
     OPENAI_RESPONSE_SERVICE_TIER_ATTR,
     OPENAI_CACHE_READ_INPUT_TOKENS_ATTR,
     OPENAI_REASONING_TOKENS_ATTR,
+    PYDANTIC_AI_OPERATION_COST_ATTR,
+    PYDANTIC_AI_USAGE_DETAILS_INPUT_TOKENS_ATTR,
+    PYDANTIC_AI_USAGE_DETAILS_OUTPUT_TOKENS_ATTR,
 })
 
 # ── Default gateway URL ────────────────────────────────────────────────────

--- a/python-sdks/respan-exporter-pydantic-ai/src/respan_exporter_pydantic_ai/instrument.py
+++ b/python-sdks/respan-exporter-pydantic-ai/src/respan_exporter_pydantic_ai/instrument.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 from pydantic_ai.agent import Agent
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from opentelemetry.sdk.trace import ReadableSpan
-from opentelemetry.semconv_ai import SpanAttributes, TraceloopSpanKindValues
+from opentelemetry.semconv_ai import SpanAttributes, TraceloopSpanKindValues, LLMRequestTypeValues
 from respan_sdk.constants.llm_logging import (
     LOG_TYPE_AGENT,
     LOG_TYPE_CHAT,
@@ -530,6 +530,11 @@ def _apply_traceloop_field_mapping(
         return
 
     if log_type == LOG_TYPE_CHAT:
+        _set_span_field(
+            attributes=enriched_attributes,
+            field_name=SpanAttributes.TRACELOOP_SPAN_KIND,
+            value=LLMRequestTypeValues.CHAT.value,
+        )
         input_messages = _extract_messages(
             attributes=attributes,
             attr_name=PYDANTIC_AI_INPUT_MESSAGES_ATTR,
@@ -604,18 +609,51 @@ def _apply_respan_field_mapping(
         value=log_type,
     )
 
-    _set_respan_log_field(
-        attributes=enriched_attributes,
-        field_name="model",
-        value=_extract_respan_model(attributes=attributes),
-    )
-
-    usage_values = _extract_respan_usage(attributes=attributes)
-    for field_name, value in usage_values.items():
+    model = _extract_respan_model(attributes=attributes)
+    if model is not None:
+        # Standard semconv attr (used by backend CHAT branch for cost calc)
+        _set_span_field(
+            attributes=enriched_attributes,
+            field_name=SpanAttributes.LLM_REQUEST_MODEL,
+            value=model,
+        )
+        # Override attr (used by backend override mechanism for non-CHAT spans)
         _set_respan_log_field(
             attributes=enriched_attributes,
-            field_name=field_name,
-            value=value,
+            field_name="model",
+            value=model,
+        )
+
+    usage_values = _extract_respan_usage(attributes=attributes)
+    prompt_tokens = usage_values.get("prompt_tokens")
+    if prompt_tokens is not None:
+        _set_span_field(
+            attributes=enriched_attributes,
+            field_name=SpanAttributes.LLM_USAGE_PROMPT_TOKENS,
+            value=prompt_tokens,
+        )
+        _set_respan_log_field(
+            attributes=enriched_attributes,
+            field_name="prompt_tokens",
+            value=prompt_tokens,
+        )
+    completion_tokens = usage_values.get("completion_tokens")
+    if completion_tokens is not None:
+        _set_span_field(
+            attributes=enriched_attributes,
+            field_name=SpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
+            value=completion_tokens,
+        )
+        _set_respan_log_field(
+            attributes=enriched_attributes,
+            field_name="completion_tokens",
+            value=completion_tokens,
+        )
+    if prompt_tokens is not None or completion_tokens is not None:
+        _set_respan_log_field(
+            attributes=enriched_attributes,
+            field_name="total_request_tokens",
+            value=(prompt_tokens or 0) + (completion_tokens or 0),
         )
 
     tool_name = attributes.get(PYDANTIC_AI_TOOL_NAME_ATTR)

--- a/python-sdks/respan-sdk/src/respan_sdk/constants/otlp_constants.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/otlp_constants.py
@@ -83,3 +83,79 @@ OTEL_SCOPE_VERSION_KEY = "otel.scope.version"
 # Error message attribute (non-standard but widely used)
 # ---------------------------------------------------------------------------
 ERROR_MESSAGE_ATTR = "error.message"
+
+# ---------------------------------------------------------------------------
+# Promoted attribute keys (Tier 1)
+#
+# Attributes that the backend extracts into typed CHLogV2 columns during
+# span-to-log conversion.  After promotion they are excluded from the
+# passthrough metadata to avoid duplication.
+#
+# This is the single source of truth — both the backend and SDK enrichment
+# layers import from here.
+# ---------------------------------------------------------------------------
+
+# Respan SDK-specific extensions (values from RespanSpanAttributes enum)
+RESPAN_PROMOTED_KEYS = frozenset({
+    "respan.span_params.custom_identifier",
+    "respan.customer_params.customer_identifier",
+    "respan.customer_params.email",
+    "respan.customer_params.name",
+    "respan.evaluation_params.evaluation_identifier",
+    "respan.threads.thread_identifier",
+    "respan.trace.trace_group_identifier",
+    "respan.metadata",
+    "respan.entity.log_method",
+    "respan.entity.log_type",
+})
+
+# Gen AI semantic conventions + OTel standard attributes
+GEN_AI_PROMOTED_KEYS = frozenset({
+    # Core LLM request/response attributes
+    "llm.request.type",
+    "gen_ai.request.model",
+    "gen_ai.response.model",
+    "gen_ai.request.temperature",
+    "gen_ai.request.max_tokens",
+    "llm.frequency_penalty",
+    "llm.presence_penalty",
+    "llm.is_streaming",
+    # Token usage
+    "gen_ai.usage.prompt_tokens",
+    "gen_ai.usage.completion_tokens",
+    "llm.usage.total_tokens",
+    # Traceloop conventions
+    "traceloop.span.kind",
+    "traceloop.entity.path",
+    "traceloop.entity.input",
+    "traceloop.entity.output",
+    "traceloop.workflow.name",
+    # Non-standard variants (Instructor telemetry, OpenAI-specific)
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.output_tokens",
+    "gen_ai.usage.total_tokens",
+    "llm.openai.chat_completions.streaming_time_to_first_token",
+    "llm.embeddings.0",
+    ERROR_MESSAGE_ATTR,
+    # OTel v2 semantic convention keys (Pydantic AI, OpenAI instrumentor).
+    # SDK enrichment remaps these to backend column names; promoted here
+    # so originals don't leak into metadata passthrough.
+    "gen_ai.usage.cache_read_input_tokens",
+    "llm.usage.reasoning_tokens",
+    "llm.request.reasoning_effort",
+    # Pydantic AI agent run span attributes — consumed by SDK enrichment,
+    # remapped to traceloop.entity.output / gen_ai.request.model.
+    "final_result",
+    "model_name",
+    "agent_name",
+    "logfire.msg",
+    # Override keys — set by SDK enrichment for the backend override mechanism.
+    # Promoted so they don't leak into passthrough metadata.
+    "model",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_request_tokens",
+})
+
+# Union of all promoted keys for quick lookup
+ALL_PROMOTED_KEYS = RESPAN_PROMOTED_KEYS | GEN_AI_PROMOTED_KEYS


### PR DESCRIPTION
## Summary

- **Cost was always 0.0 on pydantic AI tracing spans** — the SDK wasn't setting `traceloop.span.kind=chat`, so the backend never entered the CHAT branch that computes cost via `calculate_chat_llm_inference_metrics`.
- **Tokens/model leaked into metadata** — the SDK set custom override attrs (`model`, `prompt_tokens`, etc.) that weren't in `ALL_PROMOTED_KEYS`, so `collect_passthrough_attributes` dumped them into the metadata blob alongside first-class columns.

## Changes

### `respan-exporter-pydantic-ai` (instrument.py + constants.py)
- Set `traceloop.span.kind=chat` for CHAT spans → backend enters CHAT branch → computes cost
- Set semconv attrs (`gen_ai.request.model`, `gen_ai.usage.prompt_tokens`, `gen_ai.usage.completion_tokens`) alongside override attrs for backend CHAT branch
- Strip pydantic-ai internal attrs (`operation.cost`, `gen_ai.usage.details.*`) that leaked to metadata

### `respan-sdk` (otlp_constants.py)
- Add `model`, `prompt_tokens`, `completion_tokens`, `total_request_tokens` to `ALL_PROMOTED_KEYS` so they're excluded from passthrough metadata

## Verified
- Anthropic + OpenAI examples both produce `cost > 0` on tracing spans
- Metadata is clean: no duplicate tokens/model/cost
- 30/30 extraction tests pass