### PR TITLE
fix: inherit customer_identifier for tool call subspans

### DIFF
--- a/javascript-sdks/respan-exporter-vercel/src/respan-vercel-trace-exporter.ts
+++ b/javascript-sdks/respan-exporter-vercel/src/respan-vercel-trace-exporter.ts
@@ -138,13 +138,16 @@ export class RespanExporter implements SpanExporter {
     const toolCalls = this.parseToolCalls(span);
     const messages = this.parseCompletionMessages(span, toolCalls);
 
+    // Resolve customer identity: own span → parent span → default
+    const customerParams = this.resolveCustomerParams(span, relatedSpans);
+
     const payload: RespanPayload = {
       model,
       start_time: this.formatTimestamp(span.startTime),
       timestamp: this.formatTimestamp(span.endTime),
       prompt_messages: this.parsePromptMessages(span),
       completion_message: messages[0],
-      customer_identifier: metadata.userId || "default_user",
+      customer_identifier: customerParams?.customer_identifier || metadata.userId || "default_user",
       thread_identifier: metadata.userId,
       prompt_tokens: this.parsePromptTokens(span),
       completion_tokens: this.parseCompletionTokens(span),
@@ -192,7 +195,7 @@ export class RespanExporter implements SpanExporter {
       disable_log: false,
       request_breakdown: false,
       disable_fallback: false,
-      ...this.parseCustomerParams(span),
+      ...(customerParams || {}),
     };
 
     return payload;
@@ -531,6 +534,36 @@ export class RespanExporter implements SpanExporter {
   private compareHrTime(a: [number, number], b: [number, number]): number {
     if (a[0] !== b[0]) return a[0] - b[0];
     return a[1] - b[1];
+  }
+
+  private findParentSpan(
+    span: ReadableSpan,
+    spans: ReadableSpan[]
+  ): ReadableSpan | undefined {
+    const parentId = span.parentSpanId;
+    if (!parentId) return undefined;
+    return spans.find((s) => s.spanContext().spanId === parentId);
+  }
+
+  private resolveCustomerParams(
+    span: ReadableSpan,
+    relatedSpans: ReadableSpan[]
+  ): ReturnType<typeof this.parseCustomerParams> {
+    // Try own span first
+    const own = this.parseCustomerParams(span);
+    if (own) return own;
+
+    // Walk up the parent chain to inherit customer identity
+    let current: ReadableSpan | undefined = span;
+    while (current) {
+      const parent = this.findParentSpan(current, relatedSpans);
+      if (!parent) break;
+      const parentParams = this.parseCustomerParams(parent);
+      if (parentParams) return parentParams;
+      current = parent;
+    }
+
+    return undefined;
   }
 
   private findRootSpan(

--- a/javascript-sdks/respan-exporter-vercel/src/respan-vercel-trace-exporter.ts
+++ b/javascript-sdks/respan-exporter-vercel/src/respan-vercel-trace-exporter.ts
@@ -148,7 +148,7 @@ export class RespanExporter implements SpanExporter {
       prompt_messages: this.parsePromptMessages(span),
       completion_message: messages[0],
       customer_identifier: customerParams?.customer_identifier || metadata.userId || "default_user",
-      thread_identifier: metadata.userId,
+      thread_identifier: customerParams?.customer_identifier || metadata.userId,
       prompt_tokens: this.parsePromptTokens(span),
       completion_tokens: this.parseCompletionTokens(span),
       cost: this.parseCost(span),
@@ -555,9 +555,14 @@ export class RespanExporter implements SpanExporter {
 
     // Walk up the parent chain to inherit customer identity
     let current: ReadableSpan | undefined = span;
+    const visited = new Set<string>();
+    visited.add(span.spanContext().spanId);
     while (current) {
       const parent = this.findParentSpan(current, relatedSpans);
       if (!parent) break;
+      const parentId = parent.spanContext().spanId;
+      if (visited.has(parentId)) break;
+      visited.add(parentId);
       const parentParams = this.parseCustomerParams(parent);
       if (parentParams) return parentParams;
       current = parent;

--- a/javascript-sdks/respan-exporter-vercel/src/respan-vercel-trace-exporter.ts
+++ b/javascript-sdks/respan-exporter-vercel/src/respan-vercel-trace-exporter.ts
@@ -148,7 +148,7 @@ export class RespanExporter implements SpanExporter {
       prompt_messages: this.parsePromptMessages(span),
       completion_message: messages[0],
       customer_identifier: customerParams?.customer_identifier || metadata.userId || "default_user",
-      thread_identifier: customerParams?.customer_identifier || metadata.userId,
+      thread_identifier: metadata.threadId,
       prompt_tokens: this.parsePromptTokens(span),
       completion_tokens: this.parseCompletionTokens(span),
       cost: this.parseCost(span),

--- a/javascript-sdks/respan-exporter-vercel/src/respan-vercel-trace-exporter.ts
+++ b/javascript-sdks/respan-exporter-vercel/src/respan-vercel-trace-exporter.ts
@@ -148,7 +148,7 @@ export class RespanExporter implements SpanExporter {
       prompt_messages: this.parsePromptMessages(span),
       completion_message: messages[0],
       customer_identifier: customerParams?.customer_identifier || metadata.userId || "default_user",
-      thread_identifier: metadata.threadId,
+      thread_identifier: metadata.thread_identifier,
       prompt_tokens: this.parsePromptTokens(span),
       completion_tokens: this.parseCompletionTokens(span),
       cost: this.parseCost(span),


### PR DESCRIPTION
## Summary
- Tool call spans (`ai.toolCall`) don't carry `ai.telemetry.metadata.*` attributes from the parent generation span, so `customer_identifier` falls back to `"default_user"`
- Adds `resolveCustomerParams()` that walks the parent span chain to inherit customer identity when the current span lacks it
- Adds `findParentSpan()` helper using OTel's native `parentSpanId`

## Test plan
- [ ] Verify tool call spans now show the correct `customer_identifier` instead of `default_user`
- [ ] Verify spans with their own `customer_identifier` still use their own value (no regression)
- [ ] Verify deeply nested spans (tool call → subtool) inherit correctly