### PR TITLE
feat: inherit processors attribute from parent span to child spans

### DIFF
--- a/python-sdks/respan-tracing/src/respan_tracing/constants/tracing.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/constants/tracing.py
@@ -1,3 +1,4 @@
 TRACER_NAME = "respan.tracer"
 SPAN_BUFFER_TRACER_NAME = "respan.span_buffer"
 EXPORT_FILTER_ATTR = "respan.export_filter"
+PROCESSORS_ATTR = "processors"

--- a/python-sdks/respan-tracing/src/respan_tracing/constants/tracing.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/constants/tracing.py
@@ -1,4 +1,4 @@
 TRACER_NAME = "respan.tracer"
 SPAN_BUFFER_TRACER_NAME = "respan.span_buffer"
 EXPORT_FILTER_ATTR = "respan.export_filter"
-PROCESSORS_ATTR = "processors"
+PROCESSORS_ATTR = "respan.processors"

--- a/python-sdks/respan-tracing/src/respan_tracing/core/tracer.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/tracer.py
@@ -21,7 +21,7 @@ from ..utils.notebook import is_notebook
 from ..utils.instrumentation import init_instrumentations
 from ..utils.imports import import_from_string
 from ..utils.logging import get_respan_logger
-from ..constants.tracing import TRACER_NAME
+from ..constants.tracing import TRACER_NAME, PROCESSORS_ATTR
 from ..constants.generic_constants import LOGGER_NAME_TRACER
 
 # Use Respan logger for all logging in this module
@@ -190,7 +190,7 @@ class RespanTracer:
         # Create combined filter: name-based + custom filter
         if name is not None:
             # Name-based filter (always applied when name is provided)
-            name_filter = lambda span: name in (span.attributes.get("processors") or "").split(",")
+            name_filter = lambda span: name in (span.attributes.get(PROCESSORS_ATTR) or "").split(",")
             
             if filter_fn is not None:
                 # Combine: BOTH name filter AND custom filter must pass

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -79,8 +79,10 @@ class RespanSpanProcessor:
         # This enables a parent @workflow(processors="dogfood,production") to
         # automatically route all child @task spans to the same processors,
         # without each child needing to repeat the processors param.
+        # Uses parent_context (not ambient context) for correctness in async
+        # and explicit-context scenarios.
         if not span.attributes.get(PROCESSORS_ATTR):
-            parent_span = trace.get_current_span()
+            parent_span = trace.get_current_span(parent_context)
             if parent_span and hasattr(parent_span, "attributes"):
                 parent_processors = (parent_span.attributes or {}).get(PROCESSORS_ATTR)
                 if parent_processors:

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -14,7 +14,7 @@ from respan_sdk.respan_types.span_types import RespanSpanAttributes, SpanLink
 from respan_sdk.utils.data_processing.id_processing import format_span_id
 from respan_tracing.contexts.span import span_link_to_otel
 from respan_tracing.constants.generic_constants import SDK_PREFIX
-from respan_tracing.constants.tracing import EXPORT_FILTER_ATTR, SPAN_BUFFER_TRACER_NAME
+from respan_tracing.constants.tracing import EXPORT_FILTER_ATTR, PROCESSORS_ATTR, SPAN_BUFFER_TRACER_NAME
 from respan_tracing.constants.context_constants import (
     TRACE_GROUP_ID_KEY,
     PARAMS_KEY
@@ -74,6 +74,17 @@ class RespanSpanProcessor:
             span.set_attribute(
                 RespanSpanAttributes.RESPAN_TRACE_GROUP_ID.value, trace_group_id
             )
+
+        # Inherit processors from parent span when child doesn't have its own.
+        # This enables a parent @workflow(processors="dogfood,production") to
+        # automatically route all child @task spans to the same processors,
+        # without each child needing to repeat the processors param.
+        if not span.attributes.get(PROCESSORS_ATTR):
+            parent_span = trace.get_current_span()
+            if parent_span and hasattr(parent_span, "attributes"):
+                parent_processors = (parent_span.attributes or {}).get(PROCESSORS_ATTR)
+                if parent_processors:
+                    span.set_attribute(PROCESSORS_ATTR, parent_processors)
 
         # Add custom parameters if present
         respan_params = context_api.get_value(PARAMS_KEY)

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/span_setup.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/span_setup.py
@@ -73,11 +73,20 @@ def setup_span(
         otel_links.append(span_link_to_otel(link))
     otel_links.extend(consume_span_links())
 
-    # Create span
+    # Build initial attributes — processors must be set BEFORE start_span()
+    # so that on_start's inheritance guard can distinguish explicit processors
+    # from spans that should inherit from their parent.
     from ..core.tracer import RespanTracer
     tracer = RespanTracer().get_tracer()
     span_name = f"{entity_name}.{span_kind_str}"
-    span = tracer.start_span(span_name, links=otel_links or None)
+    initial_attributes = {}
+    if processors:
+        processors_list = [processors] if isinstance(processors, str) else processors
+        initial_attributes[PROCESSORS_ATTR] = ",".join(processors_list)
+
+    span = tracer.start_span(
+        span_name, attributes=initial_attributes, links=otel_links or None,
+    )
 
     # Set standard Respan attributes
     span.set_attribute(SpanAttributes.TRACELOOP_SPAN_KIND, span_kind_str)
@@ -89,11 +98,6 @@ def setup_span(
     )
     if version is not None:
         span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_VERSION, version)
-
-    # Set processors for FilteringSpanProcessor routing
-    if processors:
-        processors_list = [processors] if isinstance(processors, str) else processors
-        span.set_attribute(PROCESSORS_ATTR, ",".join(processors_list))
 
     # Set export filter
     if export_filter is not None:

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/span_setup.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/span_setup.py
@@ -14,7 +14,7 @@ from respan_sdk.constants.llm_logging import LogMethodChoices
 from respan_sdk.respan_types.span_types import RespanSpanAttributes, SpanLink
 
 from ..contexts.span import span_link_to_otel, consume_span_links
-from ..constants.tracing import EXPORT_FILTER_ATTR
+from ..constants.tracing import EXPORT_FILTER_ATTR, PROCESSORS_ATTR
 
 LinksParam = Optional[Union[List[SpanLink], Callable[[], List[SpanLink]]]]
 
@@ -93,7 +93,7 @@ def setup_span(
     # Set processors for FilteringSpanProcessor routing
     if processors:
         processors_list = [processors] if isinstance(processors, str) else processors
-        span.set_attribute("processors", ",".join(processors_list))
+        span.set_attribute(PROCESSORS_ATTR, ",".join(processors_list))
 
     # Set export filter
     if export_filter is not None:

--- a/python-sdks/respan-tracing/tests/test_processors_inheritance.py
+++ b/python-sdks/respan-tracing/tests/test_processors_inheritance.py
@@ -1,0 +1,112 @@
+"""Tests for processors attribute inheritance from parent spans.
+
+When a parent span has processors="dogfood,production" and a child span
+doesn't explicitly set processors, the child should inherit the parent's
+processors attribute. This enables a single @workflow(processors=...) to
+route all child @task spans to the same processors automatically.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from respan_tracing import RespanTelemetry, get_client
+from respan_tracing.constants.tracing import PROCESSORS_ATTR
+from respan_tracing.decorators import workflow, task
+
+
+class TestProcessorsInheritance:
+    """Tests for processors inheritance from parent to child spans."""
+
+    def setup_method(self):
+        self.telemetry = RespanTelemetry(
+            app_name="test-processors-inheritance",
+            api_key="test-key",
+            is_enabled=True,
+        )
+        self.client = get_client()
+
+    def test_child_inherits_processors_from_parent(self):
+        """Child span without explicit processors inherits parent's processors."""
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood,production",
+        ) as parent_span:
+            with self.client.start_span("child_task", kind="task") as child_span:
+                assert child_span.attributes.get(PROCESSORS_ATTR) == "dogfood,production"
+
+    def test_child_with_explicit_processors_not_overridden(self):
+        """Child span with its own processors keeps them (no override)."""
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood,production",
+        ) as parent_span:
+            with self.client.start_span(
+                "child_task",
+                kind="task",
+                processors="debug",
+            ) as child_span:
+                assert child_span.attributes.get(PROCESSORS_ATTR) == "debug"
+
+    def test_no_inheritance_when_parent_has_no_processors(self):
+        """Child span stays without processors when parent has none."""
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+        ) as parent_span:
+            with self.client.start_span("child_task", kind="task") as child_span:
+                assert child_span.attributes.get(PROCESSORS_ATTR) is None
+
+    def test_deep_nesting_inherits_through_chain(self):
+        """Processors propagate through multiple nesting levels."""
+        with self.client.start_span(
+            "root",
+            kind="workflow",
+            processors="dogfood",
+        ) as root:
+            with self.client.start_span("mid", kind="task") as mid:
+                # mid inherited "dogfood" from root
+                assert mid.attributes.get(PROCESSORS_ATTR) == "dogfood"
+                with self.client.start_span("leaf", kind="task") as leaf:
+                    # leaf inherits "dogfood" from mid (which inherited from root)
+                    assert leaf.attributes.get(PROCESSORS_ATTR) == "dogfood"
+
+    def test_span_buffer_children_inherit_processors(self):
+        """Spans created inside SpanBuffer inherit processors from parent context."""
+        # When SpanBuffer is used with parent context, child spans should
+        # inherit processors from whatever span is in context
+        with self.client.start_span(
+            "outer_workflow",
+            kind="workflow",
+            processors="dogfood,production",
+        ) as outer:
+            with self.client.get_span_buffer("trace-123") as buffer:
+                # Spans created in buffer should inherit from outer_workflow
+                span_id = buffer.create_span("buffered_step", {"status": "ok"})
+
+            # Check the buffered span got processors inherited
+            spans = buffer.get_all_spans()
+            assert len(spans) == 1
+            assert spans[0].attributes.get(PROCESSORS_ATTR) == "dogfood,production"
+
+    def test_decorator_processors_inheritance(self):
+        """@task inside @workflow inherits processors via decorator."""
+        collected_spans = []
+
+        @workflow(name="test_wf", processors="dogfood")
+        def my_workflow():
+            @task(name="test_task")
+            def my_task():
+                return "done"
+            return my_task()
+
+        # Patch to collect spans
+        my_workflow()
+        # We can't easily inspect spans from decorators in a unit test,
+        # but the mechanism is the same as start_span (both go through
+        # setup_span → on_start). The start_span tests above cover the
+        # core inheritance logic.
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python-sdks/respan-tracing/tests/test_processors_inheritance.py
+++ b/python-sdks/respan-tracing/tests/test_processors_inheritance.py
@@ -91,7 +91,13 @@ class TestProcessorsInheritance:
 
     def test_decorator_processors_inheritance(self):
         """@task inside @workflow inherits processors via decorator."""
-        collected_spans = []
+        from opentelemetry import trace as trace_api
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+        exporter = InMemorySpanExporter()
+        provider = trace_api.get_tracer_provider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
 
         @workflow(name="test_wf", processors="dogfood")
         def my_workflow():
@@ -100,12 +106,13 @@ class TestProcessorsInheritance:
                 return "done"
             return my_task()
 
-        # Patch to collect spans
         my_workflow()
-        # We can't easily inspect spans from decorators in a unit test,
-        # but the mechanism is the same as start_span (both go through
-        # setup_span → on_start). The start_span tests above cover the
-        # core inheritance logic.
+        provider.force_flush()
+
+        spans = exporter.get_finished_spans()
+        task_spans = [s for s in spans if "test_task" in s.name]
+        assert len(task_spans) >= 1, f"Expected task span, got: {[s.name for s in spans]}"
+        assert task_spans[0].attributes.get(PROCESSORS_ATTR) == "dogfood"
 
 
 if __name__ == "__main__":

--- a/python-sdks/respan-tracing/tests/test_start_span.py
+++ b/python-sdks/respan-tracing/tests/test_start_span.py
@@ -19,7 +19,7 @@ from opentelemetry.trace import StatusCode
 from opentelemetry.semconv_ai import SpanAttributes
 
 from respan_tracing import RespanTelemetry, get_client
-from respan_tracing.constants.tracing import EXPORT_FILTER_ATTR
+from respan_tracing.constants.tracing import EXPORT_FILTER_ATTR, PROCESSORS_ATTR
 from respan_sdk.respan_types.span_types import RespanSpanAttributes, SpanLink
 from respan_sdk.constants.llm_logging import LogMethodChoices
 
@@ -125,19 +125,19 @@ class TestStartSpan:
         """Single processor string sets the processors attribute."""
         with self.client.start_span("my_task", processors="dogfood") as span:
             attrs = dict(span.attributes)
-            assert attrs["processors"] == "dogfood"
+            assert attrs[PROCESSORS_ATTR] == "dogfood"
 
     def test_processors_list(self):
         """List of processors is joined with commas."""
         with self.client.start_span("my_task", processors=["dogfood", "debug"]) as span:
             attrs = dict(span.attributes)
-            assert attrs["processors"] == "dogfood,debug"
+            assert attrs[PROCESSORS_ATTR] == "dogfood,debug"
 
     def test_no_processors_no_attribute(self):
         """When processors is None, no processors attribute is set."""
         with self.client.start_span("my_task") as span:
             attrs = dict(span.attributes)
-            assert "processors" not in attrs
+            assert PROCESSORS_ATTR not in attrs
 
     # --- Outcome 6: Version=0 regression test ---
 
@@ -310,9 +310,9 @@ class TestWorkflowNameInheritance:
     def test_processors_attribute_propagated(self):
         """Processors attribute on workflow span routes to FilteringSpanProcessor."""
         with self.client.start_span("wf", kind="workflow", processors="dogfood") as outer:
-            assert dict(outer.attributes)["processors"] == "dogfood"
+            assert dict(outer.attributes)[PROCESSORS_ATTR] == "dogfood"
             with self.client.start_span("t", kind="task", processors="dogfood") as inner:
-                assert dict(inner.attributes)["processors"] == "dogfood"
+                assert dict(inner.attributes)[PROCESSORS_ATTR] == "dogfood"
 
     def test_inner_workflow_overrides_parent_workflow_name(self):
         """Nested workflow overrides TRACELOOP_ENTITY_NAME for its children."""


### PR DESCRIPTION
## Summary

- Child spans without explicit `processors` now inherit the parent span's `processors` attribute
- Enables `@workflow(processors="dogfood,production")` to automatically route all child `@task` spans to the same processors without each child repeating the param
- Extracts `PROCESSORS_ATTR` constant to replace `"processors"` magic string across 3 files

**Use case:** Backend experiment workflows need to route spans through both `dogfood` (external export) and `production` (auto-ingestion) processors. Currently each `@task` mixin hardcodes `processors="dogfood"`. With this change, the parent `WorkflowExecutor` can set `processors="dogfood,production"` once and all child task spans inherit it.

## Test plan
- [x] 6 new tests pass (`test_processors_inheritance.py`)
- [x] 11 existing SpanBuffer tests pass (`test_span_buffer_flush.py`)
- [ ] Backend integration: PR respanai/respan-backend#1160 (Phase 2) + future Phase 4