### PR TITLE
fix: add speed param for Anthropic fast mode passthrough

### DIFF
--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
@@ -267,6 +267,13 @@ class LiteLLMCompletionParams(BasicLLMParams):
     thinking: Optional[dict] = None
     speed: Optional[str] = None  # Anthropic fast mode: "fast" or "standard"
 
+    @field_validator("speed", mode="before")
+    @classmethod
+    def _coerce_speed(cls, v):
+        if v is not None:
+            return str(v)
+        return v
+
 
 class Usage(RespanBaseModel):
     prompt_tokens: Optional[int] = None

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
@@ -265,6 +265,7 @@ class BasicLLMParams(RespanBaseModel):
 
 class LiteLLMCompletionParams(BasicLLMParams):
     thinking: Optional[dict] = None
+    speed: Optional[str] = None  # Anthropic fast mode: "fast" or "standard"
 
 
 class Usage(RespanBaseModel):


### PR DESCRIPTION
## Summary
- Adds `speed: Optional[str] = None` to `LiteLLMCompletionParams` in respan-sdk
- Anthropic fast mode requires both `anthropic-beta: fast-mode-2026-02-01` header AND `speed: "fast"` in the request body
- The header was already passing through, but `speed` was silently dropped by Pydantic validation — fast mode never activated

## Root cause
`LiteLLMCompletionParams` didn't have `speed` as a field. During `validate_and_separate_params()`, the param was dropped before reaching litellm. Verified at httpx wire level that litellm correctly forwards `speed` to Anthropic's API body when present.

## Test plan
- [x] Unit tests confirm `speed` survives Pydantic validation
- [x] httpx spy confirms `speed` appears in outgoing HTTP body to Anthropic
- [x] httpx spy confirms `anthropic-beta` header on wire (both streaming and non-streaming)
- [x] Regression test PR for BE repo to follow