### PR TITLE
fix(agno): add retry with exponential backoff to span export

### DIFF
--- a/python-sdks/respan-exporter-agno/examples/quickstart.py
+++ b/python-sdks/respan-exporter-agno/examples/quickstart.py
@@ -1,0 +1,36 @@
+"""
+Quickstart: Instrument an Agno agent with Respan tracing.
+
+Prerequisites:
+    pip install respan-exporter-agno agno openai
+
+Environment variables:
+    RESPAN_API_KEY   - Your Respan API key
+    OPENAI_API_KEY   - Your OpenAI API key
+"""
+
+import os
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+from respan_exporter_agno import RespanAgnoInstrumentor
+
+# Instrument Agno to send traces to Respan.
+# This patches OpenTelemetry span processors so that every Agno span
+# is automatically exported to the Respan tracing endpoint.
+RespanAgnoInstrumentor().instrument(
+    api_key=os.getenv("RESPAN_API_KEY"),
+    environment="development",
+)
+
+# Create a simple Agno agent backed by GPT-4o-mini.
+agent = Agent(
+    name="Quickstart Agent",
+    model=OpenAIChat(id="gpt-4o-mini", api_key=os.getenv("OPENAI_API_KEY")),
+    instructions=["You are a helpful assistant."],
+)
+
+# Run the agent -- the resulting trace is sent to Respan automatically.
+response = agent.run("What is OpenTelemetry in one sentence?")
+print(response.content)

--- a/python-sdks/respan-exporter-agno/examples/tool_usage.py
+++ b/python-sdks/respan-exporter-agno/examples/tool_usage.py
@@ -1,0 +1,48 @@
+"""
+Tool usage: Trace an Agno agent that calls a custom tool.
+
+This example shows how tool invocations appear as separate spans inside
+the Respan trace, letting you inspect inputs/outputs for each tool call.
+
+Prerequisites:
+    pip install respan-exporter-agno agno openai
+
+Environment variables:
+    RESPAN_API_KEY   - Your Respan API key
+    OPENAI_API_KEY   - Your OpenAI API key
+"""
+
+import os
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools import tool
+
+from respan_exporter_agno import RespanAgnoInstrumentor
+
+# Enable Respan instrumentation before creating any agents.
+RespanAgnoInstrumentor().instrument(
+    api_key=os.getenv("RESPAN_API_KEY"),
+    environment="development",
+)
+
+
+# Define a custom tool the agent can call.
+@tool
+def get_weather(city: str) -> str:
+    """Return the current weather for a city (stub)."""
+    return f"The weather in {city} is 22°C and sunny."
+
+
+# Create an agent with the tool registered.
+agent = Agent(
+    name="Weather Agent",
+    model=OpenAIChat(id="gpt-4o-mini", api_key=os.getenv("OPENAI_API_KEY")),
+    tools=[get_weather],
+    instructions=["Use the get_weather tool when asked about weather."],
+)
+
+# The agent will invoke get_weather, and both the LLM call and the tool
+# call will be captured as separate spans in the Respan trace.
+response = agent.run("What is the weather in San Francisco?")
+print(response.content)

--- a/python-sdks/respan-exporter-agno/src/respan_exporter_agno/exporter.py
+++ b/python-sdks/respan-exporter-agno/src/respan_exporter_agno/exporter.py
@@ -1,8 +1,6 @@
 """Respan Agno Exporter - Export Agno traces to Respan tracing endpoint."""
 import logging
 import os
-import random
-import time
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
@@ -35,6 +33,7 @@ from respan_exporter_agno.utils import (
 )
 from respan_sdk.constants.llm_logging import LOG_TYPE_MAP
 from respan_sdk.respan_types.log_types import RespanFullLogParams
+from respan_sdk.utils import RetryHandler
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +76,12 @@ class RespanAgnoExporter:
             or os.getenv("RESPAN_CUSTOMER_IDENTIFIER")
         )
         self.timeout = timeout
+        self._retry_handler = RetryHandler(
+            max_retries=3,
+            retry_delay=1.0,
+            backoff_multiplier=2.0,
+            max_delay=10.0,
+        )
 
     def _build_endpoint(self, base_url: Optional[str]) -> str:
         """Build the ingest endpoint URL from base URL."""
@@ -592,46 +597,33 @@ class RespanAgnoExporter:
 
     def _send(self, payloads: List[Dict[str, Any]]) -> None:
         """Send payloads to Respan endpoint with retry on transient errors."""
-        max_retries = 3
-        base_delay = 1.0
-        max_delay = 10.0
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
 
-        for attempt in range(max_retries):
-            try:
-                response = requests.post(
-                    url=self.endpoint,
-                    json=payloads,
-                    headers=headers,
-                    timeout=self.timeout,
-                )
-                if response.status_code in (200, 201):
-                    return
-                if response.status_code < 500:
-                    logger.warning(
-                        "Respan export failed with status %s: %s",
-                        response.status_code,
-                        response.text,
-                    )
-                    return
+        def _do_request() -> None:
+            response = requests.post(
+                url=self.endpoint,
+                json=payloads,
+                headers=headers,
+                timeout=self.timeout,
+            )
+            if response.status_code in (200, 201):
+                return
+            if response.status_code < 500:
                 logger.warning(
-                    "Respan export failed with status %s (attempt %d/%d)",
+                    "Respan export failed with status %s: %s",
                     response.status_code,
-                    attempt + 1,
-                    max_retries,
+                    response.text,
                 )
-            except Exception as exc:
-                logger.warning(
-                    "Respan export request failed (attempt %d/%d): %s",
-                    attempt + 1,
-                    max_retries,
-                    exc,
-                )
+                return
+            raise RuntimeError(
+                "Respan export server error %s: %s"
+                % (response.status_code, response.text[:200])
+            )
 
-            if attempt < max_retries - 1:
-                delay = min(base_delay * (2 ** attempt), max_delay)
-                delay += random.uniform(0, delay * 0.1)
-                time.sleep(delay)
+        try:
+            self._retry_handler.execute(_do_request, context="Respan Agno export")
+        except Exception as exc:
+            logger.error("Respan Agno export failed after retries: %s", exc)

--- a/python-sdks/respan-exporter-agno/src/respan_exporter_agno/exporter.py
+++ b/python-sdks/respan-exporter-agno/src/respan_exporter_agno/exporter.py
@@ -615,7 +615,7 @@ class RespanAgnoExporter:
                 logger.warning(
                     "Respan export failed with status %s: %s",
                     response.status_code,
-                    response.text,
+                    response.text[:200],
                 )
                 return
             raise RuntimeError(
@@ -624,6 +624,11 @@ class RespanAgnoExporter:
             )
 
         try:
+            # NOTE: RetryHandler.execute uses time.sleep for backoff, which blocks
+            # the calling thread. This is an acceptable tradeoff for a sync exporter;
+            # making retries fully configurable or async is tracked as future work.
             self._retry_handler.execute(_do_request, context="Respan Agno export")
         except Exception as exc:
-            logger.error("Respan Agno export failed after retries: %s", exc)
+            logger.exception(
+                "Respan Agno export failed after retries, giving up: %s", exc
+            )

--- a/python-sdks/respan-exporter-agno/src/respan_exporter_agno/exporter.py
+++ b/python-sdks/respan-exporter-agno/src/respan_exporter_agno/exporter.py
@@ -1,6 +1,8 @@
 """Respan Agno Exporter - Export Agno traces to Respan tracing endpoint."""
 import logging
 import os
+import random
+import time
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
@@ -589,22 +591,47 @@ class RespanAgnoExporter:
         return "task"
 
     def _send(self, payloads: List[Dict[str, Any]]) -> None:
-        """Send payloads to Respan endpoint."""
-        try:
-            response = requests.post(
-                url=self.endpoint,
-                json=payloads,
-                headers={
-                    "Authorization": f"Bearer {self.api_key}",
-                    "Content-Type": "application/json",
-                },
-                timeout=self.timeout,
-            )
-            if response.status_code not in (200, 201):
-                logger.warning(
-                    "Respan export failed with status %s: %s",
-                    response.status_code,
-                    response.text,
+        """Send payloads to Respan endpoint with retry on transient errors."""
+        max_retries = 3
+        base_delay = 1.0
+        max_delay = 10.0
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        for attempt in range(max_retries):
+            try:
+                response = requests.post(
+                    url=self.endpoint,
+                    json=payloads,
+                    headers=headers,
+                    timeout=self.timeout,
                 )
-        except Exception as exc:
-            logger.warning("Respan export request failed: %s", exc)
+                if response.status_code in (200, 201):
+                    return
+                if response.status_code < 500:
+                    logger.warning(
+                        "Respan export failed with status %s: %s",
+                        response.status_code,
+                        response.text,
+                    )
+                    return
+                logger.warning(
+                    "Respan export failed with status %s (attempt %d/%d)",
+                    response.status_code,
+                    attempt + 1,
+                    max_retries,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Respan export request failed (attempt %d/%d): %s",
+                    attempt + 1,
+                    max_retries,
+                    exc,
+                )
+
+            if attempt < max_retries - 1:
+                delay = min(base_delay * (2 ** attempt), max_delay)
+                delay += random.uniform(0, delay * 0.1)
+                time.sleep(delay)

--- a/python-sdks/respan-exporter-agno/tests/test_retry.py
+++ b/python-sdks/respan-exporter-agno/tests/test_retry.py
@@ -1,0 +1,124 @@
+"""Tests for retry behaviour in RespanAgnoExporter._send."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the exporter module directly to avoid __init__.py pulling in
+# opentelemetry.instrumentation which may not be installed in the test env.
+import respan_exporter_agno.exporter as _exporter_mod
+
+RespanAgnoExporter = _exporter_mod.RespanAgnoExporter
+
+
+def _make_exporter(**kwargs):
+    return RespanAgnoExporter(api_key="test-key", **kwargs)
+
+
+def _mock_response(status_code, text="error body"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
+
+
+class TestSendRetryOn5xx:
+    """5xx responses should raise, triggering RetryHandler retries."""
+
+    def test_retries_on_500_then_succeeds(self):
+        exporter = _make_exporter()
+        responses = [
+            _mock_response(500, "internal server error"),
+            _mock_response(200),
+        ]
+
+        with patch("respan_exporter_agno.exporter.requests.post", side_effect=responses):
+            # Should not raise: first call 500 -> retry -> second call 200
+            exporter._send(payloads=[{"test": True}])
+
+    def test_all_retries_exhausted_logs_giving_up(self):
+        exporter = _make_exporter()
+        responses = [_mock_response(500, "fail")] * 5  # more than max_retries
+
+        with patch("respan_exporter_agno.exporter.requests.post", side_effect=responses):
+            # Should not propagate, the outer except catches it
+            exporter._send(payloads=[{"test": True}])
+
+
+class TestNoRetryOn4xx:
+    """4xx responses should NOT trigger retries (they return immediately)."""
+
+    def test_400_returns_without_retry(self):
+        exporter = _make_exporter()
+        mock_post = MagicMock(return_value=_mock_response(400, "bad request"))
+
+        with patch("respan_exporter_agno.exporter.requests.post", mock_post):
+            exporter._send(payloads=[{"test": True}])
+
+        # Only one call — no retry
+        assert mock_post.call_count == 1
+
+    def test_404_returns_without_retry(self):
+        exporter = _make_exporter()
+        mock_post = MagicMock(return_value=_mock_response(404, "not found"))
+
+        with patch("respan_exporter_agno.exporter.requests.post", mock_post):
+            exporter._send(payloads=[{"test": True}])
+
+        assert mock_post.call_count == 1
+
+    def test_3xx_returns_without_retry(self):
+        exporter = _make_exporter()
+        mock_post = MagicMock(return_value=_mock_response(301, "moved"))
+
+        with patch("respan_exporter_agno.exporter.requests.post", mock_post):
+            exporter._send(payloads=[{"test": True}])
+
+        assert mock_post.call_count == 1
+
+
+class TestBackoffSleep:
+    """RetryHandler should sleep between retries with backoff."""
+
+    def test_sleep_called_on_retry(self):
+        exporter = _make_exporter()
+        responses = [
+            _mock_response(500, "err"),
+            _mock_response(200),
+        ]
+
+        with patch("respan_exporter_agno.exporter.requests.post", side_effect=responses), \
+             patch("time.sleep") as mock_sleep:
+            exporter._send(payloads=[{"test": True}])
+
+        assert mock_sleep.call_count >= 1
+
+    def test_no_sleep_on_success(self):
+        exporter = _make_exporter()
+
+        with patch("respan_exporter_agno.exporter.requests.post",
+                    return_value=_mock_response(200)), \
+             patch("time.sleep") as mock_sleep:
+            exporter._send(payloads=[{"test": True}])
+
+        assert mock_sleep.call_count == 0
+
+
+class TestResponseTextTruncation:
+    """Log messages should truncate response.text to 200 chars."""
+
+    def test_4xx_response_text_truncated_in_log(self):
+        exporter = _make_exporter()
+        long_text = "x" * 500
+
+        with patch("respan_exporter_agno.exporter.requests.post",
+                    return_value=_mock_response(400, long_text)), \
+             patch("respan_exporter_agno.exporter.logger") as mock_logger:
+            exporter._send(payloads=[{"test": True}])
+
+        # The warning call should have truncated text (200 chars)
+        call_args = mock_logger.warning.call_args
+        logged_text = call_args[0][2]  # third positional arg is response.text[:200]
+        assert len(logged_text) == 200


### PR DESCRIPTION
## Summary

- Backports retry logic from the Google ADK exporter to the Agno exporter
- Previously, a single network blip or transient 5xx would silently drop spans forever
- Now retries up to 3 times with exponential backoff + jitter
- Distinguishes client errors (4xx → fail immediately, no retry) from server errors (5xx → retry)
- Adds attempt tracking to warning logs for easier debugging

## Test plan

- [ ] Verify `poetry install && poetry run pytest` in `python-sdks/respan-exporter-agno/`
- [ ] Manually test with a flaky endpoint to confirm retry behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)