### PR TITLE
feat(exporters): add LangChain exporter using BaseCallbackHandler

### DIFF
--- a/python-sdks/respan-exporter-langchain/README.md
+++ b/python-sdks/respan-exporter-langchain/README.md
@@ -1,0 +1,75 @@
+# Respan Exporter for LangChain
+
+**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-exporter-langchain/)**
+
+Respan exporter for LangChain traces using the native `BaseCallbackHandler` API.
+
+## Installation
+
+```bash
+pip install respan-exporter-langchain
+```
+
+## Usage
+
+```python
+from langchain_openai import ChatOpenAI
+from respan_exporter_langchain import RespanCallbackHandler
+
+# Create the callback handler
+handler = RespanCallbackHandler(api_key="your-respan-api-key")
+
+# Use it with any LangChain component
+llm = ChatOpenAI(model="gpt-4o-mini")
+result = llm.invoke("Hello!", config={"callbacks": [handler]})
+
+# Or pass it globally
+from langchain_core.globals import set_llm_cache
+chain = prompt | llm | parser
+chain.invoke({"input": "Hello!"}, config={"callbacks": [handler]})
+```
+
+### Additional Options
+
+```python
+handler = RespanCallbackHandler(
+    api_key="your-respan-api-key",
+    environment="staging",
+    customer_identifier="user-123",
+    session_identifier="session-abc",
+    trace_name="my-chain",
+)
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `RESPAN_API_KEY` | Your Respan API key | — |
+| `RESPAN_BASE_URL` | Respan API base URL | `https://api.respan.ai/api` |
+| `RESPAN_ENVIRONMENT` | Environment tag for traces | `production` |
+| `RESPAN_CUSTOMER_IDENTIFIER` | Customer identifier for traces | — |
+
+## How It Works
+
+This exporter uses LangChain's native `BaseCallbackHandler` API to capture trace events — the stable, framework-endorsed approach used by Langfuse, LangSmith, and other observability tools. Unlike OTel-based patching, this approach is resilient across LangChain version upgrades.
+
+### Captured Events
+
+| LangChain Event | Respan Log Type |
+|---|---|
+| Chain (root) | `workflow` |
+| Chain (nested) | `task` |
+| Agent chain | `agent` |
+| LLM / Chat model | `generation` |
+| Tool | `tool` |
+| Retriever | `tool` |
+
+### Features
+
+- Automatic span hierarchy from LangChain's `run_id` / `parent_run_id`
+- Token usage extraction from LLM responses
+- Prompt messages and completion message capture
+- Retry with exponential backoff on transient server errors
+- Thread-safe span accumulation with background export
+- Support for chains, agents, tools, retrievers, and chat models

--- a/python-sdks/respan-exporter-langchain/README.md
+++ b/python-sdks/respan-exporter-langchain/README.md
@@ -23,8 +23,7 @@ handler = RespanCallbackHandler(api_key="your-respan-api-key")
 llm = ChatOpenAI(model="gpt-4o-mini")
 result = llm.invoke("Hello!", config={"callbacks": [handler]})
 
-# Or pass it globally
-from langchain_core.globals import set_llm_cache
+# Or pass it to a chain
 chain = prompt | llm | parser
 chain.invoke({"input": "Hello!"}, config={"callbacks": [handler]})
 ```

--- a/python-sdks/respan-exporter-langchain/examples/chain_with_tools.py
+++ b/python-sdks/respan-exporter-langchain/examples/chain_with_tools.py
@@ -1,0 +1,50 @@
+"""
+Chain with Tools: Trace a LangChain agent that uses tool calling with Respan.
+
+This example creates an agent with custom tools and traces the full
+workflow — including tool invocations — to Respan.
+
+Prerequisites:
+    pip install respan-exporter-langchain langchain-openai
+
+Environment variables:
+    RESPAN_API_KEY   - Your Respan API key
+    OPENAI_API_KEY   - Your OpenAI API key
+"""
+
+from langchain_openai import ChatOpenAI
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+
+from respan_exporter_langchain import RespanCallbackHandler
+
+# 1. Define custom tools
+@tool
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    return f"The weather in {city} is 72°F and sunny."
+
+@tool
+def get_population(city: str) -> str:
+    """Get the population of a city."""
+    populations = {"new york": "8.3 million", "london": "8.8 million"}
+    return populations.get(city.lower(), "Unknown")
+
+# 2. Create the Respan callback handler
+handler = RespanCallbackHandler(
+    api_key="your-respan-api-key",          # or set RESPAN_API_KEY env var
+    trace_name="tool-calling-agent",
+)
+
+# 3. Build a tool-calling agent
+llm = ChatOpenAI(model="gpt-4o-mini")
+agent = create_react_agent(llm, tools=[get_weather, get_population])
+
+# 4. Invoke the agent with the Respan callback
+result = agent.invoke(
+    {"messages": [("human", "What is the weather and population of New York?")]},
+    config={"callbacks": [handler]},
+)
+
+for message in result["messages"]:
+    print(f"{message.type}: {message.content}")

--- a/python-sdks/respan-exporter-langchain/examples/quickstart.py
+++ b/python-sdks/respan-exporter-langchain/examples/quickstart.py
@@ -1,0 +1,41 @@
+"""
+Quickstart: Trace a LangChain LLM call with Respan.
+
+Prerequisites:
+    pip install respan-exporter-langchain langchain-openai
+
+Environment variables:
+    RESPAN_API_KEY   - Your Respan API key
+    OPENAI_API_KEY   - Your OpenAI API key
+"""
+
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+from respan_exporter_langchain import RespanCallbackHandler
+
+# 1. Create the Respan callback handler
+handler = RespanCallbackHandler(
+    api_key="your-respan-api-key",          # or set RESPAN_API_KEY env var
+    environment="development",
+    customer_identifier="user-123",
+    session_identifier="session-abc",
+    trace_name="quickstart-chain",
+)
+
+# 2. Build a simple prompt -> LLM -> parser chain
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful assistant."),
+    ("human", "{question}"),
+])
+llm = ChatOpenAI(model="gpt-4o-mini")
+chain = prompt | llm | StrOutputParser()
+
+# 3. Invoke the chain with the Respan callback
+result = chain.invoke(
+    {"question": "What is LangChain in one sentence?"},
+    config={"callbacks": [handler]},
+)
+
+print(result)

--- a/python-sdks/respan-exporter-langchain/pyproject.toml
+++ b/python-sdks/respan-exporter-langchain/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "respan-exporter-langchain"
+version = "1.0.0"
+description = "Respan exporter for LangChain traces"
+authors = ["Respan <team@respan.ai>"]
+readme = "README.md"
+packages = [{include = "respan_exporter_langchain", from = "src"}]
+
+[tool.poetry.dependencies]
+python = ">=3.12,<3.15"
+requests = "^2.32.5"
+langchain-core = ">=0.2.0"
+respan-sdk = ">=2.6.1"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^9.0.2"
+langchain = ">=0.2.0"
+langchain-openai = ">=0.1.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/__init__.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/__init__.py
@@ -1,0 +1,4 @@
+from .callback_handler import RespanCallbackHandler
+from .exporter import RespanLangchainExporter
+
+__all__ = ["RespanCallbackHandler", "RespanLangchainExporter"]

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/callback_handler.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/callback_handler.py
@@ -2,6 +2,7 @@
 import logging
 import threading
 import uuid
+from collections import deque
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Union
 
@@ -155,9 +156,9 @@ class RespanCallbackHandler(BaseCallbackHandler):
             if span.parent_run_id is not None:
                 children_map.setdefault(span.parent_run_id, []).append(span.run_id)
         result.append(root)
-        queue = [root_run_id]
+        queue = deque([root_run_id])
         while queue:
-            parent = queue.pop(0)
+            parent = queue.popleft()
             for child_id in children_map.get(parent, []):
                 child = self._spans.get(child_id)
                 if child is not None and child not in result:
@@ -423,11 +424,7 @@ class RespanCallbackHandler(BaseCallbackHandler):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        name = serialized.get("name")
-        if not name:
-            id_list = serialized.get("id")
-            if isinstance(id_list, list) and id_list:
-                name = str(id_list[-1])
+        name = self._extract_chain_name(serialized)
         self._register_span(
             run_id=run_id,
             parent_run_id=parent_run_id,

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/callback_handler.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/callback_handler.py
@@ -332,8 +332,25 @@ class RespanCallbackHandler(BaseCallbackHandler):
         for group in messages:
             flat_messages.extend(group)
         prompt_messages = langchain_messages_to_dicts(flat_messages)
+        def _content_to_str(content: Any) -> str:
+            """Coerce message content to a plain string."""
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                # Handle structured content (list of dicts with "text" key)
+                parts: List[str] = []
+                for item in content:
+                    if isinstance(item, dict):
+                        parts.append(str(item.get("text", "")))
+                    elif isinstance(item, str):
+                        parts.append(item)
+                    else:
+                        parts.append(str(item))
+                return " ".join(parts)
+            return str(content) if content is not None else ""
+
         input_text = "\n".join(
-            m.get("content", "") for m in prompt_messages if isinstance(m, dict)
+            _content_to_str(m.get("content", "")) for m in prompt_messages if isinstance(m, dict)
         )
         self._register_span(
             run_id=run_id,

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/callback_handler.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/callback_handler.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 from langchain_core.callbacks import BaseCallbackHandler
-from langchain_core.outputs import ChatGenerationChunk, GenerationChunk, LLMResult
+from langchain_core.outputs import LLMResult
 
 from respan_exporter_langchain.types import SpanRecord
 from respan_exporter_langchain.utils import langchain_messages_to_dicts
@@ -149,15 +149,20 @@ class RespanCallbackHandler(BaseCallbackHandler):
         root = self._spans.get(root_run_id)
         if root is None:
             return result
+        # Build parent→children index for O(n) traversal
+        children_map: Dict[str, List[str]] = {}
+        for span in self._spans.values():
+            if span.parent_run_id is not None:
+                children_map.setdefault(span.parent_run_id, []).append(span.run_id)
         result.append(root)
-        # BFS to find all children
         queue = [root_run_id]
         while queue:
             parent = queue.pop(0)
-            for span in self._spans.values():
-                if span.parent_run_id == parent and span not in result:
-                    result.append(span)
-                    queue.append(span.run_id)
+            for child_id in children_map.get(parent, []):
+                child = self._spans.get(child_id)
+                if child is not None and child not in result:
+                    result.append(child)
+                    queue.append(child_id)
         return result
 
     def _do_export(self, spans: List[SpanRecord]) -> None:
@@ -418,9 +423,11 @@ class RespanCallbackHandler(BaseCallbackHandler):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        name = serialized.get("name") or serialized.get("id", [None])[-1] if serialized.get("id") else None
-        if name is None:
-            name = serialized.get("name")
+        name = serialized.get("name")
+        if not name:
+            id_list = serialized.get("id")
+            if isinstance(id_list, list) and id_list:
+                name = str(id_list[-1])
         self._register_span(
             run_id=run_id,
             parent_run_id=parent_run_id,

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/callback_handler.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/callback_handler.py
@@ -1,0 +1,521 @@
+"""Respan callback handler for LangChain."""
+import logging
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.outputs import ChatGenerationChunk, GenerationChunk, LLMResult
+
+from respan_exporter_langchain.types import SpanRecord
+from respan_exporter_langchain.utils import langchain_messages_to_dicts
+
+logger = logging.getLogger(__name__)
+
+
+class RespanCallbackHandler(BaseCallbackHandler):
+    """
+    LangChain callback handler that captures trace spans and exports them to Respan.
+
+    Usage::
+
+        from respan_exporter_langchain import RespanCallbackHandler
+
+        handler = RespanCallbackHandler(api_key="your-respan-api-key")
+        chain.invoke({"input": "hello"}, config={"callbacks": [handler]})
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        base_url: Optional[str] = None,
+        environment: Optional[str] = None,
+        customer_identifier: Optional[Union[str, int]] = None,
+        session_identifier: Optional[Union[str, int]] = None,
+        trace_group_identifier: Optional[Union[str, int]] = None,
+        trace_name: Optional[str] = None,
+        timeout: int = 10,
+    ) -> None:
+        super().__init__()
+        # Lazy import to avoid circular dependency
+        from respan_exporter_langchain.exporter import RespanLangchainExporter
+
+        self._exporter = RespanLangchainExporter(
+            api_key=api_key,
+            endpoint=endpoint,
+            base_url=base_url,
+            environment=environment,
+            customer_identifier=customer_identifier,
+            timeout=timeout,
+        )
+        self.session_identifier = session_identifier
+        self.trace_group_identifier = trace_group_identifier
+        self.trace_name = trace_name
+
+        # Thread-safe storage: run_id → SpanRecord
+        self._lock = threading.Lock()
+        self._spans: Dict[str, SpanRecord] = {}
+        # Track which run_ids are root chains (no parent)
+        self._root_run_ids: set = set()
+
+    def _run_id_str(self, run_id: Any) -> str:
+        return str(run_id) if run_id else str(uuid.uuid4())
+
+    def _register_span(
+        self,
+        run_id: Any,
+        parent_run_id: Any,
+        span_type: str,
+        name: Optional[str] = None,
+        input_data: Any = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+        model: Optional[str] = None,
+        prompt_messages: Any = None,
+    ) -> None:
+        rid = self._run_id_str(run_id)
+        pid = self._run_id_str(parent_run_id) if parent_run_id else None
+        span = SpanRecord(
+            run_id=rid,
+            parent_run_id=pid,
+            span_type=span_type,
+            name=name,
+            input=input_data,
+            start_time=datetime.now(timezone.utc),
+            metadata=metadata or {},
+            tags=tags or [],
+            model=model,
+            prompt_messages=prompt_messages,
+        )
+        with self._lock:
+            self._spans[rid] = span
+            if pid is None:
+                self._root_run_ids.add(rid)
+
+    def _finish_span(
+        self,
+        run_id: Any,
+        output: Any = None,
+        error: Optional[str] = None,
+        token_usage: Optional[Dict[str, Any]] = None,
+        completion_message: Any = None,
+    ) -> None:
+        rid = self._run_id_str(run_id)
+        with self._lock:
+            span = self._spans.get(rid)
+            if span is None:
+                return
+            span.end_time = datetime.now(timezone.utc)
+            if output is not None:
+                span.output = output
+            if error is not None:
+                span.error = error
+            if completion_message is not None:
+                span.completion_message = completion_message
+            if token_usage:
+                span.prompt_tokens = token_usage.get("prompt_tokens") or token_usage.get("input_tokens")
+                span.completion_tokens = token_usage.get("completion_tokens") or token_usage.get("output_tokens")
+                span.total_tokens = token_usage.get("total_tokens") or token_usage.get("total")
+
+            # If this is a root span, flush the entire trace
+            if rid in self._root_run_ids:
+                self._flush_trace(root_run_id=rid)
+
+    def _flush_trace(self, root_run_id: str) -> None:
+        """Flush all spans belonging to this trace. Must be called under self._lock."""
+        # Collect all spans in this trace tree
+        trace_spans = self._collect_trace_spans(root_run_id=root_run_id)
+        # Remove from storage
+        for span in trace_spans:
+            self._spans.pop(span.run_id, None)
+        self._root_run_ids.discard(root_run_id)
+
+        if not trace_spans:
+            return
+
+        # Export in a separate thread to not block the chain
+        thread = threading.Thread(
+            target=self._do_export,
+            args=(trace_spans,),
+            daemon=True,
+        )
+        thread.start()
+
+    def _collect_trace_spans(self, root_run_id: str) -> List[SpanRecord]:
+        """Collect all spans belonging to a trace tree rooted at root_run_id."""
+        result: List[SpanRecord] = []
+        root = self._spans.get(root_run_id)
+        if root is None:
+            return result
+        result.append(root)
+        # BFS to find all children
+        queue = [root_run_id]
+        while queue:
+            parent = queue.pop(0)
+            for span in self._spans.values():
+                if span.parent_run_id == parent and span not in result:
+                    result.append(span)
+                    queue.append(span.run_id)
+        return result
+
+    def _do_export(self, spans: List[SpanRecord]) -> None:
+        """Export spans to Respan (runs in background thread)."""
+        try:
+            span_dicts = [self._span_record_to_dict(span=s) for s in spans]
+            self._exporter.export(
+                spans=span_dicts,
+                trace_name=self.trace_name,
+                session_identifier=self.session_identifier,
+                trace_group_identifier=self.trace_group_identifier,
+            )
+        except Exception as exc:
+            logger.warning("Respan LangChain export failed: %s", exc)
+
+    @staticmethod
+    def _span_record_to_dict(span: SpanRecord) -> Dict[str, Any]:
+        """Convert SpanRecord to dict for the exporter."""
+        return {
+            "span_id": span.run_id,
+            "parent_id": span.parent_run_id,
+            "name": span.name,
+            "span_type": span.span_type,
+            "input": span.input,
+            "output": span.output,
+            "error": span.error,
+            "start_time": span.start_time,
+            "end_time": span.end_time,
+            "model": span.model,
+            "prompt_tokens": span.prompt_tokens,
+            "completion_tokens": span.completion_tokens,
+            "total_tokens": span.total_tokens,
+            "prompt_messages": span.prompt_messages,
+            "completion_message": span.completion_message,
+            "metadata": span.metadata,
+            "tags": span.tags,
+        }
+
+    # ── Extract model name from serialized dict ─────────────────────────
+
+    @staticmethod
+    def _extract_model_name(serialized: Dict[str, Any]) -> Optional[str]:
+        """Extract model name from LangChain serialized dict."""
+        kwargs = serialized.get("kwargs", {})
+        for key in ("model_name", "model", "model_id"):
+            val = kwargs.get(key)
+            if val:
+                return str(val)
+        name = serialized.get("name", "")
+        id_list = serialized.get("id", [])
+        if id_list and isinstance(id_list, list):
+            last = id_list[-1]
+            if isinstance(last, str) and "chat" in last.lower():
+                return name or last
+        return None
+
+    @staticmethod
+    def _extract_chain_name(serialized: Dict[str, Any]) -> Optional[str]:
+        """Extract chain/agent name from serialized dict."""
+        name = serialized.get("name")
+        if name:
+            return str(name)
+        id_list = serialized.get("id", [])
+        if id_list and isinstance(id_list, list):
+            return str(id_list[-1])
+        return None
+
+    # ── LangChain callback methods ──────────────────────────────────────
+
+    def on_chain_start(
+        self,
+        serialized: Dict[str, Any],
+        inputs: Dict[str, Any],
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        name = self._extract_chain_name(serialized)
+        # Determine if this is an agent chain
+        id_list = serialized.get("id", [])
+        is_agent = any(
+            "agent" in str(part).lower()
+            for part in (id_list if isinstance(id_list, list) else [])
+        )
+        if parent_run_id is None:
+            span_type = "workflow"
+        elif is_agent:
+            span_type = "agent"
+        else:
+            span_type = "task"
+
+        self._register_span(
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            span_type=span_type,
+            name=name,
+            input_data=inputs,
+            metadata=metadata,
+            tags=tags,
+        )
+
+    def on_chain_end(
+        self,
+        outputs: Dict[str, Any],
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._finish_span(run_id=run_id, output=outputs)
+
+    def on_chain_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._finish_span(run_id=run_id, error=str(error))
+
+    def on_llm_start(
+        self,
+        serialized: Dict[str, Any],
+        prompts: List[str],
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        model = self._extract_model_name(serialized)
+        name = self._extract_chain_name(serialized) or model
+        prompt_messages = [{"role": "user", "content": p} for p in prompts] if prompts else None
+        self._register_span(
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            span_type="generation",
+            name=name,
+            input_data=prompts,
+            metadata=metadata,
+            tags=tags,
+            model=model,
+            prompt_messages=prompt_messages,
+        )
+
+    def on_chat_model_start(
+        self,
+        serialized: Dict[str, Any],
+        messages: List[List[Any]],
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        model = self._extract_model_name(serialized)
+        name = self._extract_chain_name(serialized) or model
+        # Flatten message groups and convert to dicts
+        flat_messages: List[Any] = []
+        for group in messages:
+            flat_messages.extend(group)
+        prompt_messages = langchain_messages_to_dicts(flat_messages)
+        input_text = "\n".join(
+            m.get("content", "") for m in prompt_messages if isinstance(m, dict)
+        )
+        self._register_span(
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            span_type="generation",
+            name=name,
+            input_data=input_text or prompt_messages,
+            metadata=metadata,
+            tags=tags,
+            model=model,
+            prompt_messages=prompt_messages,
+        )
+
+    def on_llm_end(
+        self,
+        response: LLMResult,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        output_text = None
+        completion_message = None
+        token_usage: Optional[Dict[str, Any]] = None
+
+        if response.llm_output:
+            token_usage = response.llm_output.get("token_usage")
+            if token_usage is None:
+                token_usage = response.llm_output.get("usage")
+
+        # Extract output from generations
+        if response.generations:
+            first_gen_list = response.generations[0]
+            if first_gen_list:
+                gen = first_gen_list[0]
+                if hasattr(gen, "message"):
+                    msg = gen.message
+                    content = getattr(msg, "content", None)
+                    role = getattr(msg, "type", "assistant")
+                    role_map = {"ai": "assistant", "human": "user"}
+                    role = role_map.get(role, role)
+                    output_text = content
+                    completion_message = {"role": role, "content": content}
+                    # Extract token usage from AIMessage usage_metadata
+                    usage_meta = getattr(msg, "usage_metadata", None)
+                    if usage_meta and token_usage is None:
+                        if isinstance(usage_meta, dict):
+                            token_usage = {
+                                "prompt_tokens": usage_meta.get("input_tokens"),
+                                "completion_tokens": usage_meta.get("output_tokens"),
+                                "total_tokens": usage_meta.get("total_tokens"),
+                            }
+                        elif hasattr(usage_meta, "input_tokens"):
+                            token_usage = {
+                                "prompt_tokens": getattr(usage_meta, "input_tokens", None),
+                                "completion_tokens": getattr(usage_meta, "output_tokens", None),
+                                "total_tokens": getattr(usage_meta, "total_tokens", None),
+                            }
+                elif hasattr(gen, "text"):
+                    output_text = gen.text
+                    completion_message = {"role": "assistant", "content": gen.text}
+
+        self._finish_span(
+            run_id=run_id,
+            output=output_text,
+            token_usage=token_usage,
+            completion_message=completion_message,
+        )
+
+    def on_llm_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._finish_span(run_id=run_id, error=str(error))
+
+    def on_tool_start(
+        self,
+        serialized: Dict[str, Any],
+        input_str: str,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        name = serialized.get("name") or serialized.get("id", [None])[-1] if serialized.get("id") else None
+        if name is None:
+            name = serialized.get("name")
+        self._register_span(
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            span_type="tool",
+            name=name,
+            input_data=input_str,
+            metadata=metadata,
+            tags=tags,
+        )
+
+    def on_tool_end(
+        self,
+        output: Any,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        output_str = str(output) if output is not None else None
+        self._finish_span(run_id=run_id, output=output_str)
+
+    def on_tool_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._finish_span(run_id=run_id, error=str(error))
+
+    def on_retriever_start(
+        self,
+        serialized: Dict[str, Any],
+        query: str,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        name = self._extract_chain_name(serialized) or "retriever"
+        self._register_span(
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            span_type="tool",
+            name=name,
+            input_data=query,
+            metadata=metadata,
+            tags=tags,
+        )
+
+    def on_retriever_end(
+        self,
+        documents: Sequence[Any],
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        doc_list = []
+        for doc in documents:
+            if hasattr(doc, "page_content"):
+                doc_list.append({
+                    "page_content": doc.page_content,
+                    "metadata": getattr(doc, "metadata", {}),
+                })
+            else:
+                doc_list.append(str(doc))
+        self._finish_span(run_id=run_id, output=doc_list)
+
+    def on_retriever_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: Optional[uuid.UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._finish_span(run_id=run_id, error=str(error))
+
+    # agent_action and agent_finish are informational; the actual chain
+    # start/end already captures agent spans, so we skip these to avoid dupes.
+    def on_agent_action(self, action: Any, **kwargs: Any) -> None:
+        pass
+
+    def on_agent_finish(self, finish: Any, **kwargs: Any) -> None:
+        pass
+
+    def on_text(self, text: str, **kwargs: Any) -> None:
+        pass
+
+    def flush(self) -> None:
+        """Force flush any pending spans (e.g. on shutdown)."""
+        with self._lock:
+            for root_id in list(self._root_run_ids):
+                self._flush_trace(root_run_id=root_id)

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/exporter.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/exporter.py
@@ -180,7 +180,7 @@ class RespanLangchainExporter:
         workflow_name = trace_name
 
         # Extract metadata from root span
-        trace_metadata = dict(root_span.get("metadata", {})) if root_span else {}
+        trace_metadata = dict(root_span.get("metadata") or {}) if root_span else {}
 
         # Try to extract customer_identifier from metadata
         customer_identifier = None
@@ -281,7 +281,7 @@ class RespanLangchainExporter:
             model=model,
         )
 
-        span_metadata = dict(span.get("metadata", {}))
+        span_metadata = dict(span.get("metadata") or {})
         tags = span.get("tags", [])
         if tags:
             span_metadata["langchain_tags"] = tags

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/exporter.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/exporter.py
@@ -1,0 +1,459 @@
+"""Respan LangChain Exporter - Export LangChain traces to Respan tracing endpoint."""
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
+
+import requests
+
+from respan_exporter_langchain.types import TraceContext
+from respan_exporter_langchain.utils import (
+    clean_payload,
+    format_rfc3339,
+    is_blank_value,
+    normalize_span_id,
+    normalize_trace_id,
+    serialize_value,
+    to_completion_message,
+    to_prompt_messages,
+)
+from respan_sdk.constants.llm_logging import LOG_TYPE_MAP
+from respan_sdk.respan_types.log_types import RespanFullLogParams
+from respan_sdk.utils import RetryHandler
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENDPOINT = "https://api.respan.ai/api/v1/traces/ingest"
+
+
+class RespanLangchainExporter:
+    """
+    Export LangChain traces/spans to Respan tracing endpoint.
+
+    This exporter is used internally by RespanCallbackHandler. It accepts a
+    list of span dicts (built from callback events) and converts them to
+    Respan ingest payloads.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        base_url: Optional[str] = None,
+        environment: Optional[str] = None,
+        customer_identifier: Optional[Union[str, int]] = None,
+        timeout: int = 10,
+    ) -> None:
+        self.api_key = api_key or os.getenv("RESPAN_API_KEY")
+        if base_url is None:
+            base_url = (
+                os.getenv("RESPAN_BASE_URL")
+                or "https://api.respan.ai/api"
+            )
+        self.endpoint = endpoint or self._build_endpoint(base_url=base_url)
+        self.environment = (
+            environment
+            or os.getenv("RESPAN_ENVIRONMENT")
+            or "production"
+        )
+        self.customer_identifier = (
+            customer_identifier
+            or os.getenv("RESPAN_CUSTOMER_IDENTIFIER")
+        )
+        self.timeout = timeout
+        self._retry_handler = RetryHandler(
+            max_retries=3,
+            retry_delay=1.0,
+            backoff_multiplier=2.0,
+            max_delay=10.0,
+        )
+
+    def _build_endpoint(self, base_url: Optional[str]) -> str:
+        """Build the ingest endpoint URL from base URL."""
+        if not base_url:
+            return DEFAULT_ENDPOINT
+        base = base_url.rstrip("/")
+        if base.endswith("/v1/traces/ingest"):
+            return base
+        if base.endswith("/v1/traces"):
+            return f"{base}/ingest"
+        if base.endswith("/api"):
+            return f"{base}/v1/traces/ingest"
+        return f"{base}/api/v1/traces/ingest"
+
+    def export(
+        self,
+        spans: List[Dict[str, Any]],
+        trace_name: Optional[str] = None,
+        session_identifier: Optional[Union[str, int]] = None,
+        trace_group_identifier: Optional[Union[str, int]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Export spans to Respan."""
+        payloads = self.build_payload(
+            spans=spans,
+            trace_name=trace_name,
+            session_identifier=session_identifier,
+            trace_group_identifier=trace_group_identifier,
+        )
+        if not payloads:
+            return payloads
+        if not self.api_key:
+            logger.warning(
+                "Respan API key is not set; skipping export to %s",
+                self.endpoint,
+            )
+            return payloads
+        self._send(payloads=payloads)
+        return payloads
+
+    def build_payload(
+        self,
+        spans: List[Dict[str, Any]],
+        trace_name: Optional[str] = None,
+        session_identifier: Optional[Union[str, int]] = None,
+        trace_group_identifier: Optional[Union[str, int]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Build Respan payloads from span dicts."""
+        if not spans:
+            return []
+
+        trace_context = self._extract_trace_context(
+            spans=spans,
+            trace_name=trace_name,
+            session_identifier=session_identifier,
+            trace_group_identifier=trace_group_identifier,
+        )
+
+        # Build span ID normalization map
+        span_id_map: Dict[str, str] = {}
+        for span in spans:
+            raw_span_id = span.get("span_id")
+            if raw_span_id is None:
+                continue
+            raw_span_id = str(raw_span_id)
+            span_id_map[raw_span_id] = normalize_span_id(
+                span_id=raw_span_id,
+                trace_id=trace_context.trace_id,
+            )
+
+        payloads: List[Dict[str, Any]] = []
+        for span in spans:
+            payload = self._span_to_respan(
+                span=span,
+                trace_context=trace_context,
+                span_id_map=span_id_map,
+            )
+            if payload:
+                payloads.append(payload)
+
+        if payloads:
+            self._propagate_trace_output(payloads=payloads)
+
+        return payloads
+
+    def _extract_trace_context(
+        self,
+        spans: List[Dict[str, Any]],
+        trace_name: Optional[str] = None,
+        session_identifier: Optional[Union[str, int]] = None,
+        trace_group_identifier: Optional[Union[str, int]] = None,
+    ) -> TraceContext:
+        """Extract trace context from spans."""
+        # Find root span (no parent)
+        root_span = None
+        for span in spans:
+            if span.get("parent_id") is None:
+                root_span = span
+                break
+        if root_span is None and spans:
+            root_span = spans[0]
+
+        # Use root span's run_id as trace_id
+        trace_id = str(root_span.get("span_id", uuid.uuid4())) if root_span else str(uuid.uuid4())
+
+        if not trace_name and root_span:
+            trace_name = root_span.get("name")
+        if not trace_name:
+            trace_name = trace_id
+
+        workflow_name = trace_name
+
+        # Extract metadata from root span
+        trace_metadata = dict(root_span.get("metadata", {})) if root_span else {}
+
+        # Try to extract customer_identifier from metadata
+        customer_identifier = None
+        for key in ("customer_identifier", "customer_id", "user_id", "user"):
+            if key in trace_metadata:
+                customer_identifier = trace_metadata.get(key)
+                break
+        if not customer_identifier:
+            customer_identifier = self.customer_identifier
+
+        # Session identifier from metadata
+        if not session_identifier:
+            for key in ("session_id", "session_identifier", "session"):
+                if key in trace_metadata:
+                    session_identifier = trace_metadata.get(key)
+                    break
+
+        # Find earliest start time
+        start_time = None
+        for span in spans:
+            st = span.get("start_time")
+            if isinstance(st, datetime):
+                if start_time is None or st < start_time:
+                    start_time = st
+
+        return TraceContext(
+            trace_id=trace_id,
+            trace_name=trace_name,
+            workflow_name=workflow_name,
+            metadata=trace_metadata,
+            session_identifier=session_identifier,
+            trace_group_identifier=trace_group_identifier,
+            start_time=start_time,
+            customer_identifier=customer_identifier,
+        )
+
+    def _span_to_respan(
+        self,
+        span: Dict[str, Any],
+        trace_context: TraceContext,
+        span_id_map: Dict[str, str],
+    ) -> Optional[Dict[str, Any]]:
+        """Convert a span dict to Respan payload format."""
+        span_id = span.get("span_id")
+        parent_id = span.get("parent_id")
+        span_name = span.get("name")
+        span_type = span.get("span_type", "task")
+        model = span.get("model")
+        error = span.get("error")
+
+        span_input = span.get("input")
+        span_output = span.get("output")
+
+        prompt_messages = span.get("prompt_messages")
+        completion_message = span.get("completion_message")
+
+        # Build prompt_messages and completion_message if not provided
+        if prompt_messages is None and span_input is not None:
+            prompt_messages = to_prompt_messages(value=span_input)
+        if completion_message is None and span_output is not None:
+            completion_message = to_completion_message(value=span_output)
+
+        # Fallback: create simple message wrappers
+        if prompt_messages is None and isinstance(span_input, str) and span_input.strip():
+            prompt_messages = [{"role": "user", "content": span_input.strip()}]
+        if completion_message is None and isinstance(span_output, str) and span_output.strip():
+            completion_message = {"role": "assistant", "content": span_output.strip()}
+
+        start_time = span.get("start_time")
+        end_time = span.get("end_time")
+
+        now = datetime.now(timezone.utc)
+        if start_time is None and end_time is None:
+            start_time = now
+            end_time = now
+        elif start_time is None:
+            start_time = end_time
+        elif end_time is None:
+            end_time = start_time
+        if start_time and end_time and end_time < start_time:
+            end_time = start_time
+
+        latency = None
+        if start_time and end_time:
+            latency = (end_time - start_time).total_seconds()
+        if latency is not None and latency < 0:
+            latency = 0.0
+
+        if not span_id:
+            span_id = str(uuid.uuid4())
+        span_id_str = str(span_id)
+        if not span_name:
+            span_name = span_id_str
+
+        log_type = self._map_log_type(
+            span_type=span_type,
+            parent_id=parent_id,
+            model=model,
+        )
+
+        span_metadata = dict(span.get("metadata", {}))
+        tags = span.get("tags", [])
+        if tags:
+            span_metadata["langchain_tags"] = tags
+        merged_metadata = {**trace_context.metadata, **span_metadata}
+
+        trace_hex_id = normalize_trace_id(trace_id=trace_context.trace_id)
+        span_hex_id = span_id_map.get(span_id_str) or normalize_span_id(
+            span_id=span_id_str,
+            trace_id=trace_context.trace_id,
+        )
+        parent_hex_id = (
+            span_id_map.get(str(parent_id))
+            if parent_id is not None
+            else None
+        )
+        if parent_hex_id is None and parent_id is not None:
+            parent_hex_id = normalize_span_id(
+                span_id=str(parent_id),
+                trace_id=trace_context.trace_id,
+            )
+
+        # Store original LangChain IDs in metadata
+        if "langchain_run_id" not in merged_metadata:
+            merged_metadata["langchain_run_id"] = span_id_str
+        if parent_id and "langchain_parent_run_id" not in merged_metadata:
+            merged_metadata["langchain_parent_run_id"] = str(parent_id)
+
+        input_value = serialize_value(value=span_input) if span_input is not None else None
+        output_value = serialize_value(value=span_output) if span_output is not None else None
+
+        payload: Dict[str, Any] = {
+            "trace_unique_id": trace_hex_id,
+            "trace_name": trace_context.trace_name,
+            "span_unique_id": span_hex_id,
+            "span_parent_id": parent_hex_id,
+            "span_name": str(span_name) if span_name else None,
+            "span_workflow_name": trace_context.workflow_name,
+            "trace_id": trace_hex_id,
+            "span_id": span_hex_id,
+            "parent_id": parent_hex_id,
+            "environment": self.environment,
+            "customer_identifier": trace_context.customer_identifier,
+            "log_type": log_type,
+            "start_time": format_rfc3339(value=start_time),
+            "timestamp": format_rfc3339(value=end_time),
+            "latency": latency,
+            "input": input_value,
+            "output": output_value,
+            "model": model,
+            "metadata": merged_metadata or None,
+            "session_identifier": trace_context.session_identifier,
+            "trace_group_identifier": trace_context.trace_group_identifier,
+        }
+
+        if prompt_messages is not None:
+            payload["prompt_messages"] = prompt_messages
+        if completion_message is not None:
+            payload["completion_message"] = completion_message
+
+        payload["respan_params"] = {
+            "environment": self.environment,
+            "has_webhook": False,
+        }
+        payload["disable_log"] = False
+
+        # Token usage
+        prompt_tokens = span.get("prompt_tokens")
+        completion_tokens = span.get("completion_tokens")
+        total_tokens = span.get("total_tokens")
+        if any(v is not None for v in (prompt_tokens, completion_tokens, total_tokens)):
+            payload["prompt_tokens"] = prompt_tokens
+            payload["completion_tokens"] = completion_tokens
+            payload["total_request_tokens"] = total_tokens
+            # Calculate total if missing
+            if total_tokens is None or total_tokens == 0:
+                pt = int(prompt_tokens or 0)
+                ct = int(completion_tokens or 0)
+                if pt or ct:
+                    payload["total_request_tokens"] = pt + ct
+
+        if error:
+            payload["error_message"] = str(error)
+            payload["status_code"] = 500
+        else:
+            payload["status_code"] = 200
+
+        if not payload.get("span_unique_id") and payload.get("trace_unique_id"):
+            payload["span_unique_id"] = payload["trace_unique_id"]
+
+        cleaned_payload = clean_payload(payload=payload)
+
+        try:
+            RespanFullLogParams(**cleaned_payload)
+        except Exception as exc:
+            logger.warning(
+                "LangChain span payload failed RespanFullLogParams validation: %s",
+                exc,
+            )
+
+        return cleaned_payload
+
+    def _propagate_trace_output(self, payloads: List[Dict[str, Any]]) -> None:
+        """Propagate output from generation spans to workflow/agent/task spans."""
+        trace_output: Optional[str] = None
+        for payload in payloads:
+            output_value = payload.get("output")
+            if is_blank_value(value=output_value):
+                continue
+            log_type = payload.get("log_type")
+            if log_type == "generation":
+                trace_output = output_value
+                break
+            if trace_output is None:
+                trace_output = output_value
+        if trace_output is not None:
+            for payload in payloads:
+                if is_blank_value(value=payload.get("output")) and payload.get(
+                    "log_type"
+                ) in (
+                    "workflow",
+                    "agent",
+                    "task",
+                ):
+                    payload["output"] = trace_output
+
+    def _map_log_type(
+        self,
+        span_type: str,
+        parent_id: Optional[str],
+        model: Optional[str],
+    ) -> str:
+        """Map span type to Respan log type."""
+        if span_type:
+            type_str = str(span_type).lower()
+            for key, value in LOG_TYPE_MAP.items():
+                if key in type_str:
+                    return value
+        if model:
+            return "generation"
+        if parent_id is None:
+            return "workflow"
+        return "task"
+
+    def _send(self, payloads: List[Dict[str, Any]]) -> None:
+        """Send payloads to Respan endpoint with retry on transient errors."""
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        def _do_request() -> None:
+            response = requests.post(
+                url=self.endpoint,
+                json=payloads,
+                headers=headers,
+                timeout=self.timeout,
+            )
+            if response.status_code in (200, 201):
+                return
+            if response.status_code < 500:
+                logger.warning(
+                    "Respan export failed with status %s: %s",
+                    response.status_code,
+                    response.text,
+                )
+                return
+            raise RuntimeError(
+                "Respan export server error %s: %s"
+                % (response.status_code, response.text[:200])
+            )
+
+        try:
+            self._retry_handler.execute(_do_request, context="Respan LangChain export")
+        except Exception as exc:
+            logger.error("Respan LangChain export failed after retries: %s", exc)

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/exporter.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/exporter.py
@@ -347,6 +347,10 @@ class RespanLangchainExporter:
         }
         payload["disable_log"] = False
 
+        # Populate span_tools for tool spans (matches Agno exporter pattern)
+        if log_type == "tool" and span_name:
+            payload["span_tools"] = [str(span_name)]
+
         # Token usage
         prompt_tokens = span.get("prompt_tokens")
         completion_tokens = span.get("completion_tokens")

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/exporter.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/exporter.py
@@ -170,7 +170,7 @@ class RespanLangchainExporter:
             root_span = spans[0]
 
         # Use root span's run_id as trace_id
-        trace_id = str(root_span.get("span_id", uuid.uuid4())) if root_span else str(uuid.uuid4())
+        trace_id = str(root_span.get("span_id") or uuid.uuid4()) if root_span else str(uuid.uuid4())
 
         if not trace_name and root_span:
             trace_name = root_span.get("name")

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/types.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/types.py
@@ -1,0 +1,40 @@
+"""Type definitions for Respan LangChain exporter."""
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
+
+from respan_sdk.respan_types.base_types import RespanBaseModel
+
+
+class TraceContext(RespanBaseModel):
+    """Context information for a trace, extracted from root chain span."""
+
+    trace_id: str
+    trace_name: Optional[str]
+    workflow_name: Optional[str]
+    metadata: Dict[str, Any]
+    session_identifier: Optional[Union[str, int]] = None
+    trace_group_identifier: Optional[Union[str, int]] = None
+    start_time: Optional[datetime] = None
+    customer_identifier: Optional[Union[str, int]] = None
+
+
+class SpanRecord(RespanBaseModel):
+    """Internal record for a LangChain callback span."""
+
+    run_id: str
+    parent_run_id: Optional[str] = None
+    span_type: str  # workflow, agent, task, tool, generation
+    name: Optional[str] = None
+    input: Any = None
+    output: Any = None
+    error: Optional[str] = None
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+    model: Optional[str] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    prompt_messages: Any = None
+    completion_message: Any = None
+    metadata: Dict[str, Any] = {}
+    tags: list = []

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/types.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/types.py
@@ -1,7 +1,8 @@
 """Type definitions for Respan LangChain exporter."""
 from datetime import datetime
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
+from pydantic import Field
 from respan_sdk.respan_types.base_types import RespanBaseModel
 
 
@@ -36,5 +37,5 @@ class SpanRecord(RespanBaseModel):
     total_tokens: Optional[int] = None
     prompt_messages: Any = None
     completion_message: Any = None
-    metadata: Dict[str, Any] = {}
-    tags: list = []
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    tags: List[str] = Field(default_factory=list)

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/utils.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/utils.py
@@ -1,0 +1,156 @@
+"""Utility functions for Respan LangChain exporter."""
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+from respan_sdk.utils.data_processing.id_processing import is_hex_string
+
+
+def normalize_trace_id(trace_id: str) -> str:
+    """Normalize trace ID to 32-char hex string."""
+    if is_hex_string(value=trace_id, length=32):
+        return trace_id.lower()
+    return uuid.uuid5(uuid.NAMESPACE_DNS, trace_id).hex
+
+
+def normalize_span_id(span_id: str, trace_id: str) -> str:
+    """Normalize span ID to 16-char hex string."""
+    if is_hex_string(value=span_id, length=16):
+        return span_id.lower()
+    stable_seed = f"{trace_id}:{span_id}"
+    return uuid.uuid5(uuid.NAMESPACE_DNS, stable_seed).hex[:16]
+
+
+def serialize_value(value: Any) -> Optional[str]:
+    """Serialize value to JSON string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            try:
+                json.loads(trimmed)
+                return trimmed
+            except Exception:
+                return json.dumps(value)
+        return json.dumps(value)
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return json.dumps(str(value))
+
+
+def format_rfc3339(value: Optional[datetime]) -> Optional[str]:
+    """Format datetime as RFC3339 string."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def clean_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove None, empty dict, and empty list values from payload."""
+    return {key: value for key, value in payload.items() if value not in (None, {}, [])}
+
+
+def is_blank_value(value: Any) -> bool:
+    """Check if value is blank (None, empty, or null-like)."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if not trimmed:
+            return True
+        if trimmed in ("[]", "{}", "null"):
+            return True
+        try:
+            parsed = json.loads(trimmed)
+            return parsed in (None, [], {})
+        except Exception:
+            return False
+    if isinstance(value, (list, tuple, dict)) and not value:
+        return True
+    return False
+
+
+def to_prompt_messages(value: Any) -> Optional[List[Dict[str, Any]]]:
+    """Convert value to prompt messages format."""
+    parsed = _parse_json_value(value=value)
+    if isinstance(parsed, list) and parsed and all(isinstance(item, dict) for item in parsed):
+        if all("role" in item and "content" in item for item in parsed):
+            return parsed
+    if isinstance(parsed, dict):
+        if isinstance(parsed.get("messages"), list):
+            messages = parsed.get("messages") or []
+            if messages and all(isinstance(item, dict) for item in messages):
+                return messages
+        if "role" in parsed and "content" in parsed:
+            return [parsed]
+    return None
+
+
+def to_completion_message(value: Any) -> Optional[Dict[str, Any]]:
+    """Convert value to completion message format."""
+    parsed = _parse_json_value(value=value)
+    if isinstance(parsed, dict):
+        if "role" in parsed and "content" in parsed:
+            return parsed
+        choices = parsed.get("choices")
+        if isinstance(choices, list) and choices:
+            first = choices[0]
+            if isinstance(first, dict):
+                message = first.get("message")
+                if isinstance(message, dict) and "content" in message:
+                    return message
+    if isinstance(parsed, list) and parsed:
+        first = parsed[0]
+        if isinstance(first, dict) and "content" in first:
+            return first
+    return None
+
+
+def _parse_json_value(value: Any) -> Any:
+    """Parse JSON string value if possible."""
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            try:
+                return json.loads(trimmed)
+            except Exception:
+                return value
+        return value
+    return value
+
+
+def langchain_messages_to_dicts(messages: Sequence[Any]) -> List[Dict[str, Any]]:
+    """Convert LangChain BaseMessage objects to dicts."""
+    result: List[Dict[str, Any]] = []
+    for msg in messages:
+        if isinstance(msg, dict):
+            result.append(msg)
+            continue
+        role = getattr(msg, "type", "unknown")
+        # Map LangChain message types to standard roles
+        role_map = {
+            "human": "user",
+            "ai": "assistant",
+            "system": "system",
+            "function": "function",
+            "tool": "tool",
+        }
+        content = getattr(msg, "content", str(msg))
+        entry: Dict[str, Any] = {
+            "role": role_map.get(role, role),
+            "content": content,
+        }
+        # Include tool_calls if present
+        tool_calls = getattr(msg, "tool_calls", None)
+        if tool_calls:
+            entry["tool_calls"] = [
+                tc if isinstance(tc, dict) else tc.dict()
+                for tc in tool_calls
+            ]
+        result.append(entry)
+    return result

--- a/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/utils.py
+++ b/python-sdks/respan-exporter-langchain/src/respan_exporter_langchain/utils.py
@@ -149,7 +149,10 @@ def langchain_messages_to_dicts(messages: Sequence[Any]) -> List[Dict[str, Any]]
         tool_calls = getattr(msg, "tool_calls", None)
         if tool_calls:
             entry["tool_calls"] = [
-                tc if isinstance(tc, dict) else tc.dict()
+                tc if isinstance(tc, dict)
+                else tc.model_dump() if hasattr(tc, "model_dump")
+                else tc.dict() if hasattr(tc, "dict")
+                else str(tc)
                 for tc in tool_calls
             ]
         result.append(entry)

--- a/python-sdks/respan-exporter-langchain/tests/test_basic_langchain.py
+++ b/python-sdks/respan-exporter-langchain/tests/test_basic_langchain.py
@@ -1,0 +1,40 @@
+"""Basic LangChain tracing test for Respan exporter."""
+
+import os
+
+import pytest
+
+pytest.importorskip("langchain")
+pytest.importorskip("langchain_openai")
+
+from langchain_openai import ChatOpenAI
+
+from respan_exporter_langchain import RespanCallbackHandler
+
+
+def test_langchain_tracing_exporter_basic():
+    """Run a LangChain chain and send traces to Respan."""
+
+    respan_api_key = os.getenv("RESPAN_API_KEY")
+    if not respan_api_key:
+        pytest.skip("RESPAN_API_KEY not set")
+
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    if not openai_api_key:
+        pytest.skip("OPENAI_API_KEY not set")
+
+    handler = RespanCallbackHandler(
+        api_key=respan_api_key,
+        base_url=os.getenv("RESPAN_BASE_URL"),
+    )
+
+    model_id = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    llm = ChatOpenAI(model=model_id, api_key=openai_api_key)
+
+    result = llm.invoke(
+        "Hello from Respan LangChain exporter test",
+        config={"callbacks": [handler]},
+    )
+
+    assert result is not None
+    assert result.content

--- a/python-sdks/respan-exporter-langchain/tests/test_unit.py
+++ b/python-sdks/respan-exporter-langchain/tests/test_unit.py
@@ -1,0 +1,273 @@
+"""Unit tests for the LangChain exporter - no external API calls needed."""
+
+import json
+import time
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from respan_exporter_langchain import RespanCallbackHandler, RespanLangchainExporter
+
+
+class TestRespanLangchainExporter:
+    """Tests for the exporter payload building."""
+
+    def test_build_payload_basic(self):
+        exporter = RespanLangchainExporter(api_key="test-key")
+        spans = [
+            {
+                "span_id": "root-1",
+                "parent_id": None,
+                "name": "TestChain",
+                "span_type": "workflow",
+                "input": "hello",
+                "output": "world",
+                "start_time": datetime(2025, 1, 1, tzinfo=timezone.utc),
+                "end_time": datetime(2025, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+                "metadata": {},
+            },
+        ]
+        payloads = exporter.build_payload(spans=spans)
+        assert len(payloads) == 1
+        payload = payloads[0]
+        assert payload["trace_name"] == "TestChain"
+        assert payload["log_type"] == "workflow"
+        assert payload["span_name"] == "TestChain"
+        assert payload["status_code"] == 200
+        assert payload["latency"] == 1.0
+
+    def test_build_payload_with_generation(self):
+        exporter = RespanLangchainExporter(api_key="test-key")
+        spans = [
+            {
+                "span_id": "root-1",
+                "parent_id": None,
+                "name": "RunnableSequence",
+                "span_type": "workflow",
+                "input": "hello",
+                "output": None,
+                "start_time": datetime(2025, 1, 1, tzinfo=timezone.utc),
+                "end_time": datetime(2025, 1, 1, 0, 0, 2, tzinfo=timezone.utc),
+                "metadata": {},
+            },
+            {
+                "span_id": "llm-1",
+                "parent_id": "root-1",
+                "name": "ChatOpenAI",
+                "span_type": "generation",
+                "model": "gpt-4o-mini",
+                "input": "hello",
+                "output": "Hi there!",
+                "start_time": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                "end_time": datetime(2025, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "prompt_messages": [{"role": "user", "content": "hello"}],
+                "completion_message": {"role": "assistant", "content": "Hi there!"},
+                "metadata": {},
+            },
+        ]
+        payloads = exporter.build_payload(spans=spans)
+        assert len(payloads) == 2
+
+        workflow_payload = payloads[0]
+        llm_payload = payloads[1]
+
+        assert workflow_payload["log_type"] == "workflow"
+        # Output should be propagated from generation to workflow
+        assert workflow_payload["output"] is not None
+
+        assert llm_payload["log_type"] == "generation"
+        assert llm_payload["model"] == "gpt-4o-mini"
+        assert llm_payload["prompt_tokens"] == 10
+        assert llm_payload["completion_tokens"] == 5
+        assert llm_payload["total_request_tokens"] == 15
+
+    def test_build_payload_error_span(self):
+        exporter = RespanLangchainExporter(api_key="test-key")
+        spans = [
+            {
+                "span_id": "root-1",
+                "parent_id": None,
+                "name": "TestChain",
+                "span_type": "workflow",
+                "input": "hello",
+                "output": None,
+                "error": "Something went wrong",
+                "start_time": datetime(2025, 1, 1, tzinfo=timezone.utc),
+                "end_time": datetime(2025, 1, 1, tzinfo=timezone.utc),
+                "metadata": {},
+            },
+        ]
+        payloads = exporter.build_payload(spans=spans)
+        assert len(payloads) == 1
+        assert payloads[0]["status_code"] == 500
+        assert payloads[0]["error_message"] == "Something went wrong"
+
+    def test_endpoint_building(self):
+        e1 = RespanLangchainExporter(base_url="https://example.com/api")
+        assert e1.endpoint == "https://example.com/api/v1/traces/ingest"
+
+        e2 = RespanLangchainExporter(base_url="https://example.com/api/v1/traces/ingest")
+        assert e2.endpoint == "https://example.com/api/v1/traces/ingest"
+
+        e3 = RespanLangchainExporter(base_url="https://example.com")
+        assert e3.endpoint == "https://example.com/api/v1/traces/ingest"
+
+    def test_id_normalization(self):
+        exporter = RespanLangchainExporter(api_key="test-key")
+        spans = [
+            {
+                "span_id": "some-uuid-string",
+                "parent_id": None,
+                "name": "Test",
+                "span_type": "workflow",
+                "input": "x",
+                "start_time": datetime(2025, 1, 1, tzinfo=timezone.utc),
+                "end_time": datetime(2025, 1, 1, tzinfo=timezone.utc),
+                "metadata": {},
+            },
+        ]
+        payloads = exporter.build_payload(spans=spans)
+        # IDs should be normalized to hex strings
+        assert len(payloads[0]["trace_unique_id"]) == 32
+        assert len(payloads[0]["span_unique_id"]) == 16
+
+
+class TestRespanCallbackHandler:
+    """Tests for the callback handler."""
+
+    @patch("respan_exporter_langchain.exporter.requests.post")
+    def test_chain_lifecycle(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        handler = RespanCallbackHandler(api_key="test-key")
+
+        root_id = uuid.uuid4()
+        handler.on_chain_start(
+            serialized={"name": "TestChain", "id": ["langchain", "chains", "TestChain"]},
+            inputs={"input": "hello"},
+            run_id=root_id,
+        )
+
+        handler.on_chain_end(
+            outputs={"output": "world"},
+            run_id=root_id,
+        )
+
+        # Wait for background thread
+        time.sleep(0.5)
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        payloads = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert len(payloads) == 1
+        assert payloads[0]["log_type"] == "workflow"
+        assert payloads[0]["span_name"] == "TestChain"
+
+    @patch("respan_exporter_langchain.exporter.requests.post")
+    def test_llm_span(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        handler = RespanCallbackHandler(api_key="test-key")
+
+        root_id = uuid.uuid4()
+        llm_id = uuid.uuid4()
+
+        handler.on_chain_start(
+            serialized={"name": "RunnableSequence", "id": ["langchain", "RunnableSequence"]},
+            inputs={"input": "hello"},
+            run_id=root_id,
+        )
+
+        handler.on_llm_start(
+            serialized={"name": "ChatOpenAI", "id": ["langchain", "ChatOpenAI"], "kwargs": {"model_name": "gpt-4o-mini"}},
+            prompts=["hello"],
+            run_id=llm_id,
+            parent_run_id=root_id,
+        )
+
+        # Simulate LLMResult
+        from langchain_core.outputs import LLMResult, Generation
+        result = LLMResult(
+            generations=[[Generation(text="Hi there!")]],
+            llm_output={"token_usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}},
+        )
+        handler.on_llm_end(response=result, run_id=llm_id, parent_run_id=root_id)
+        handler.on_chain_end(outputs={"output": "Hi there!"}, run_id=root_id)
+
+        time.sleep(0.5)
+        mock_post.assert_called_once()
+        payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert len(payloads) == 2
+
+        # Find generation payload
+        gen_payload = next(p for p in payloads if p["log_type"] == "generation")
+        assert gen_payload["model"] == "gpt-4o-mini"
+        assert gen_payload["prompt_tokens"] == 5
+        assert gen_payload["completion_tokens"] == 3
+
+    @patch("respan_exporter_langchain.exporter.requests.post")
+    def test_tool_span(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        handler = RespanCallbackHandler(api_key="test-key")
+
+        root_id = uuid.uuid4()
+        tool_id = uuid.uuid4()
+
+        handler.on_chain_start(
+            serialized={"name": "AgentExecutor", "id": ["langchain", "agents", "AgentExecutor"]},
+            inputs={"input": "what's the weather?"},
+            run_id=root_id,
+        )
+
+        handler.on_tool_start(
+            serialized={"name": "weather_tool"},
+            input_str='{"city": "SF"}',
+            run_id=tool_id,
+            parent_run_id=root_id,
+        )
+
+        handler.on_tool_end(output="Sunny, 72F", run_id=tool_id, parent_run_id=root_id)
+        handler.on_chain_end(outputs={"output": "It's sunny"}, run_id=root_id)
+
+        time.sleep(0.5)
+        mock_post.assert_called_once()
+        payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+
+        tool_payload = next(p for p in payloads if p["log_type"] == "tool")
+        assert tool_payload["span_name"] == "weather_tool"
+
+    @patch("respan_exporter_langchain.exporter.requests.post")
+    def test_error_handling(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        handler = RespanCallbackHandler(api_key="test-key")
+
+        root_id = uuid.uuid4()
+        handler.on_chain_start(
+            serialized={"name": "TestChain"},
+            inputs={"input": "hello"},
+            run_id=root_id,
+        )
+        handler.on_chain_error(
+            error=ValueError("test error"),
+            run_id=root_id,
+        )
+
+        time.sleep(0.5)
+        mock_post.assert_called_once()
+        payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payloads[0]["status_code"] == 500
+        assert "test error" in payloads[0]["error_message"]
+
+    def test_no_api_key_skips_export(self):
+        handler = RespanCallbackHandler()  # no api key
+        root_id = uuid.uuid4()
+        handler.on_chain_start(
+            serialized={"name": "Test"},
+            inputs={"input": "hello"},
+            run_id=root_id,
+        )
+        handler.on_chain_end(outputs={"output": "world"}, run_id=root_id)
+        time.sleep(0.5)
+        # Should not raise, just skip

--- a/python-sdks/respan-exporter-langchain/tests/test_unit.py
+++ b/python-sdks/respan-exporter-langchain/tests/test_unit.py
@@ -1,7 +1,7 @@
 """Unit tests for the LangChain exporter - no external API calls needed."""
 
 import json
-import time
+import os
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
@@ -9,6 +9,30 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from respan_exporter_langchain import RespanCallbackHandler, RespanLangchainExporter
+
+
+class _InlineThread:
+    """Replacement for threading.Thread that runs target inline on start()."""
+
+    def __init__(self, target=None, args=None, kwargs=None, **_):
+        self._target = target
+        self._args = args or ()
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+    def join(self, timeout=None):
+        pass
+
+
+def _patch_inline_thread():
+    """Patch threading.Thread in the callback handler to run inline."""
+    return patch(
+        "respan_exporter_langchain.callback_handler.threading.Thread",
+        side_effect=_InlineThread,
+    )
 
 
 class TestRespanLangchainExporter:
@@ -143,22 +167,21 @@ class TestRespanCallbackHandler:
     @patch("respan_exporter_langchain.exporter.requests.post")
     def test_chain_lifecycle(self, mock_post):
         mock_post.return_value = MagicMock(status_code=200)
-        handler = RespanCallbackHandler(api_key="test-key")
+        with _patch_inline_thread():
+            handler = RespanCallbackHandler(api_key="test-key")
 
-        root_id = uuid.uuid4()
-        handler.on_chain_start(
-            serialized={"name": "TestChain", "id": ["langchain", "chains", "TestChain"]},
-            inputs={"input": "hello"},
-            run_id=root_id,
-        )
+            root_id = uuid.uuid4()
+            handler.on_chain_start(
+                serialized={"name": "TestChain", "id": ["langchain", "chains", "TestChain"]},
+                inputs={"input": "hello"},
+                run_id=root_id,
+            )
 
-        handler.on_chain_end(
-            outputs={"output": "world"},
-            run_id=root_id,
-        )
+            handler.on_chain_end(
+                outputs={"output": "world"},
+                run_id=root_id,
+            )
 
-        # Wait for background thread
-        time.sleep(0.5)
         mock_post.assert_called_once()
         call_args = mock_post.call_args
         payloads = call_args.kwargs.get("json") or call_args[1].get("json")
@@ -169,34 +192,34 @@ class TestRespanCallbackHandler:
     @patch("respan_exporter_langchain.exporter.requests.post")
     def test_llm_span(self, mock_post):
         mock_post.return_value = MagicMock(status_code=200)
-        handler = RespanCallbackHandler(api_key="test-key")
+        with _patch_inline_thread():
+            handler = RespanCallbackHandler(api_key="test-key")
 
-        root_id = uuid.uuid4()
-        llm_id = uuid.uuid4()
+            root_id = uuid.uuid4()
+            llm_id = uuid.uuid4()
 
-        handler.on_chain_start(
-            serialized={"name": "RunnableSequence", "id": ["langchain", "RunnableSequence"]},
-            inputs={"input": "hello"},
-            run_id=root_id,
-        )
+            handler.on_chain_start(
+                serialized={"name": "RunnableSequence", "id": ["langchain", "RunnableSequence"]},
+                inputs={"input": "hello"},
+                run_id=root_id,
+            )
 
-        handler.on_llm_start(
-            serialized={"name": "ChatOpenAI", "id": ["langchain", "ChatOpenAI"], "kwargs": {"model_name": "gpt-4o-mini"}},
-            prompts=["hello"],
-            run_id=llm_id,
-            parent_run_id=root_id,
-        )
+            handler.on_llm_start(
+                serialized={"name": "ChatOpenAI", "id": ["langchain", "ChatOpenAI"], "kwargs": {"model_name": "gpt-4o-mini"}},
+                prompts=["hello"],
+                run_id=llm_id,
+                parent_run_id=root_id,
+            )
 
-        # Simulate LLMResult
-        from langchain_core.outputs import LLMResult, Generation
-        result = LLMResult(
-            generations=[[Generation(text="Hi there!")]],
-            llm_output={"token_usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}},
-        )
-        handler.on_llm_end(response=result, run_id=llm_id, parent_run_id=root_id)
-        handler.on_chain_end(outputs={"output": "Hi there!"}, run_id=root_id)
+            # Simulate LLMResult
+            from langchain_core.outputs import LLMResult, Generation
+            result = LLMResult(
+                generations=[[Generation(text="Hi there!")]],
+                llm_output={"token_usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}},
+            )
+            handler.on_llm_end(response=result, run_id=llm_id, parent_run_id=root_id)
+            handler.on_chain_end(outputs={"output": "Hi there!"}, run_id=root_id)
 
-        time.sleep(0.5)
         mock_post.assert_called_once()
         payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
         assert len(payloads) == 2
@@ -210,28 +233,28 @@ class TestRespanCallbackHandler:
     @patch("respan_exporter_langchain.exporter.requests.post")
     def test_tool_span(self, mock_post):
         mock_post.return_value = MagicMock(status_code=200)
-        handler = RespanCallbackHandler(api_key="test-key")
+        with _patch_inline_thread():
+            handler = RespanCallbackHandler(api_key="test-key")
 
-        root_id = uuid.uuid4()
-        tool_id = uuid.uuid4()
+            root_id = uuid.uuid4()
+            tool_id = uuid.uuid4()
 
-        handler.on_chain_start(
-            serialized={"name": "AgentExecutor", "id": ["langchain", "agents", "AgentExecutor"]},
-            inputs={"input": "what's the weather?"},
-            run_id=root_id,
-        )
+            handler.on_chain_start(
+                serialized={"name": "AgentExecutor", "id": ["langchain", "agents", "AgentExecutor"]},
+                inputs={"input": "what's the weather?"},
+                run_id=root_id,
+            )
 
-        handler.on_tool_start(
-            serialized={"name": "weather_tool"},
-            input_str='{"city": "SF"}',
-            run_id=tool_id,
-            parent_run_id=root_id,
-        )
+            handler.on_tool_start(
+                serialized={"name": "weather_tool"},
+                input_str='{"city": "SF"}',
+                run_id=tool_id,
+                parent_run_id=root_id,
+            )
 
-        handler.on_tool_end(output="Sunny, 72F", run_id=tool_id, parent_run_id=root_id)
-        handler.on_chain_end(outputs={"output": "It's sunny"}, run_id=root_id)
+            handler.on_tool_end(output="Sunny, 72F", run_id=tool_id, parent_run_id=root_id)
+            handler.on_chain_end(outputs={"output": "It's sunny"}, run_id=root_id)
 
-        time.sleep(0.5)
         mock_post.assert_called_once()
         payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
 
@@ -241,20 +264,20 @@ class TestRespanCallbackHandler:
     @patch("respan_exporter_langchain.exporter.requests.post")
     def test_error_handling(self, mock_post):
         mock_post.return_value = MagicMock(status_code=200)
-        handler = RespanCallbackHandler(api_key="test-key")
+        with _patch_inline_thread():
+            handler = RespanCallbackHandler(api_key="test-key")
 
-        root_id = uuid.uuid4()
-        handler.on_chain_start(
-            serialized={"name": "TestChain"},
-            inputs={"input": "hello"},
-            run_id=root_id,
-        )
-        handler.on_chain_error(
-            error=ValueError("test error"),
-            run_id=root_id,
-        )
+            root_id = uuid.uuid4()
+            handler.on_chain_start(
+                serialized={"name": "TestChain"},
+                inputs={"input": "hello"},
+                run_id=root_id,
+            )
+            handler.on_chain_error(
+                error=ValueError("test error"),
+                run_id=root_id,
+            )
 
-        time.sleep(0.5)
         mock_post.assert_called_once()
         payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
         assert payloads[0]["status_code"] == 500
@@ -263,37 +286,37 @@ class TestRespanCallbackHandler:
     @patch("respan_exporter_langchain.exporter.requests.post")
     def test_retriever_span(self, mock_post):
         mock_post.return_value = MagicMock(status_code=200)
-        handler = RespanCallbackHandler(api_key="test-key")
+        with _patch_inline_thread():
+            handler = RespanCallbackHandler(api_key="test-key")
 
-        root_id = uuid.uuid4()
-        retriever_id = uuid.uuid4()
+            root_id = uuid.uuid4()
+            retriever_id = uuid.uuid4()
 
-        handler.on_chain_start(
-            serialized={"name": "RAGChain", "id": ["langchain", "RAGChain"]},
-            inputs={"input": "what is respan?"},
-            run_id=root_id,
-        )
-        handler.on_retriever_start(
-            serialized={"name": "VectorStoreRetriever"},
-            query="what is respan?",
-            run_id=retriever_id,
-            parent_run_id=root_id,
-        )
+            handler.on_chain_start(
+                serialized={"name": "RAGChain", "id": ["langchain", "RAGChain"]},
+                inputs={"input": "what is respan?"},
+                run_id=root_id,
+            )
+            handler.on_retriever_start(
+                serialized={"name": "VectorStoreRetriever"},
+                query="what is respan?",
+                run_id=retriever_id,
+                parent_run_id=root_id,
+            )
 
-        # Simulate Document objects
-        class FakeDoc:
-            def __init__(self, content, metadata):
-                self.page_content = content
-                self.metadata = metadata
+            # Simulate Document objects
+            class FakeDoc:
+                def __init__(self, content, metadata):
+                    self.page_content = content
+                    self.metadata = metadata
 
-        handler.on_retriever_end(
-            documents=[FakeDoc("Respan is an observability platform", {"source": "docs"})],
-            run_id=retriever_id,
-            parent_run_id=root_id,
-        )
-        handler.on_chain_end(outputs={"output": "Respan is..."}, run_id=root_id)
+            handler.on_retriever_end(
+                documents=[FakeDoc("Respan is an observability platform", {"source": "docs"})],
+                run_id=retriever_id,
+                parent_run_id=root_id,
+            )
+            handler.on_chain_end(outputs={"output": "Respan is..."}, run_id=root_id)
 
-        time.sleep(0.5)
         mock_post.assert_called_once()
         payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
 
@@ -303,38 +326,45 @@ class TestRespanCallbackHandler:
     @patch("respan_exporter_langchain.exporter.requests.post")
     def test_tool_span_has_span_tools(self, mock_post):
         mock_post.return_value = MagicMock(status_code=200)
-        handler = RespanCallbackHandler(api_key="test-key")
+        with _patch_inline_thread():
+            handler = RespanCallbackHandler(api_key="test-key")
 
-        root_id = uuid.uuid4()
-        tool_id = uuid.uuid4()
+            root_id = uuid.uuid4()
+            tool_id = uuid.uuid4()
 
-        handler.on_chain_start(
-            serialized={"name": "Chain"},
-            inputs={"input": "test"},
-            run_id=root_id,
-        )
-        handler.on_tool_start(
-            serialized={"name": "calculator"},
-            input_str="2+2",
-            run_id=tool_id,
-            parent_run_id=root_id,
-        )
-        handler.on_tool_end(output="4", run_id=tool_id, parent_run_id=root_id)
-        handler.on_chain_end(outputs={"output": "4"}, run_id=root_id)
+            handler.on_chain_start(
+                serialized={"name": "Chain"},
+                inputs={"input": "test"},
+                run_id=root_id,
+            )
+            handler.on_tool_start(
+                serialized={"name": "calculator"},
+                input_str="2+2",
+                run_id=tool_id,
+                parent_run_id=root_id,
+            )
+            handler.on_tool_end(output="4", run_id=tool_id, parent_run_id=root_id)
+            handler.on_chain_end(outputs={"output": "4"}, run_id=root_id)
 
-        time.sleep(0.5)
         payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
         tool_payload = next(p for p in payloads if p["log_type"] == "tool")
         assert tool_payload["span_tools"] == ["calculator"]
 
-    def test_no_api_key_skips_export(self):
-        handler = RespanCallbackHandler()  # no api key
-        root_id = uuid.uuid4()
-        handler.on_chain_start(
-            serialized={"name": "Test"},
-            inputs={"input": "hello"},
-            run_id=root_id,
-        )
-        handler.on_chain_end(outputs={"output": "world"}, run_id=root_id)
-        time.sleep(0.5)
-        # Should not raise, just skip
+    @patch.dict(os.environ, {}, clear=False)
+    @patch("respan_exporter_langchain.exporter.requests.post")
+    def test_no_api_key_skips_export(self, mock_post):
+        # Ensure RESPAN_API_KEY is not set so the handler truly has no key
+        env = os.environ.copy()
+        env.pop("RESPAN_API_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            with _patch_inline_thread():
+                handler = RespanCallbackHandler()  # no api key
+                root_id = uuid.uuid4()
+                handler.on_chain_start(
+                    serialized={"name": "Test"},
+                    inputs={"input": "hello"},
+                    run_id=root_id,
+                )
+                handler.on_chain_end(outputs={"output": "world"}, run_id=root_id)
+            # Should not have made any network call
+            mock_post.assert_not_called()

--- a/python-sdks/respan-exporter-langchain/tests/test_unit.py
+++ b/python-sdks/respan-exporter-langchain/tests/test_unit.py
@@ -260,6 +260,73 @@ class TestRespanCallbackHandler:
         assert payloads[0]["status_code"] == 500
         assert "test error" in payloads[0]["error_message"]
 
+    @patch("respan_exporter_langchain.exporter.requests.post")
+    def test_retriever_span(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        handler = RespanCallbackHandler(api_key="test-key")
+
+        root_id = uuid.uuid4()
+        retriever_id = uuid.uuid4()
+
+        handler.on_chain_start(
+            serialized={"name": "RAGChain", "id": ["langchain", "RAGChain"]},
+            inputs={"input": "what is respan?"},
+            run_id=root_id,
+        )
+        handler.on_retriever_start(
+            serialized={"name": "VectorStoreRetriever"},
+            query="what is respan?",
+            run_id=retriever_id,
+            parent_run_id=root_id,
+        )
+
+        # Simulate Document objects
+        class FakeDoc:
+            def __init__(self, content, metadata):
+                self.page_content = content
+                self.metadata = metadata
+
+        handler.on_retriever_end(
+            documents=[FakeDoc("Respan is an observability platform", {"source": "docs"})],
+            run_id=retriever_id,
+            parent_run_id=root_id,
+        )
+        handler.on_chain_end(outputs={"output": "Respan is..."}, run_id=root_id)
+
+        time.sleep(0.5)
+        mock_post.assert_called_once()
+        payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+
+        retriever_payload = next(p for p in payloads if p["span_name"] == "VectorStoreRetriever")
+        assert retriever_payload["log_type"] == "tool"
+
+    @patch("respan_exporter_langchain.exporter.requests.post")
+    def test_tool_span_has_span_tools(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        handler = RespanCallbackHandler(api_key="test-key")
+
+        root_id = uuid.uuid4()
+        tool_id = uuid.uuid4()
+
+        handler.on_chain_start(
+            serialized={"name": "Chain"},
+            inputs={"input": "test"},
+            run_id=root_id,
+        )
+        handler.on_tool_start(
+            serialized={"name": "calculator"},
+            input_str="2+2",
+            run_id=tool_id,
+            parent_run_id=root_id,
+        )
+        handler.on_tool_end(output="4", run_id=tool_id, parent_run_id=root_id)
+        handler.on_chain_end(outputs={"output": "4"}, run_id=root_id)
+
+        time.sleep(0.5)
+        payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        tool_payload = next(p for p in payloads if p["log_type"] == "tool")
+        assert tool_payload["span_tools"] == ["calculator"]
+
     def test_no_api_key_skips_export(self):
         handler = RespanCallbackHandler()  # no api key
         root_id = uuid.uuid4()

--- a/python-sdks/respan-exporter-langchain/tests/test_unit.py
+++ b/python-sdks/respan-exporter-langchain/tests/test_unit.py
@@ -350,6 +350,52 @@ class TestRespanCallbackHandler:
         tool_payload = next(p for p in payloads if p["log_type"] == "tool")
         assert tool_payload["span_tools"] == ["calculator"]
 
+    @patch("respan_exporter_langchain.exporter.requests.post")
+    def test_token_usage_from_usage_metadata(self, mock_post):
+        """Token usage extracted from AIMessage.usage_metadata should populate payload."""
+        mock_post.return_value = MagicMock(status_code=200)
+        with _patch_inline_thread():
+            handler = RespanCallbackHandler(api_key="test-key")
+
+            root_id = uuid.uuid4()
+            llm_id = uuid.uuid4()
+
+            handler.on_chain_start(
+                serialized={"name": "Chain", "id": ["langchain", "Chain"]},
+                inputs={"input": "hi"},
+                run_id=root_id,
+            )
+            handler.on_chat_model_start(
+                serialized={"name": "ChatOpenAI", "id": ["langchain", "ChatOpenAI"], "kwargs": {"model_name": "gpt-4o"}},
+                messages=[[MagicMock(type="human", content="hi")]],
+                run_id=llm_id,
+                parent_run_id=root_id,
+            )
+
+            # Build an LLMResult whose AIMessage carries usage_metadata
+            from langchain_core.outputs import LLMResult, ChatGeneration
+            from langchain_core.messages import AIMessage
+
+            ai_msg = AIMessage(content="hello back")
+            ai_msg.usage_metadata = {
+                "input_tokens": 12,
+                "output_tokens": 8,
+                "total_tokens": 20,
+            }
+            result = LLMResult(
+                generations=[[ChatGeneration(message=ai_msg)]],
+                llm_output={},  # no token_usage here
+            )
+            handler.on_llm_end(response=result, run_id=llm_id, parent_run_id=root_id)
+            handler.on_chain_end(outputs={"output": "hello back"}, run_id=root_id)
+
+        mock_post.assert_called_once()
+        payloads = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        gen_payload = next(p for p in payloads if p["log_type"] == "generation")
+        assert gen_payload["prompt_tokens"] == 12
+        assert gen_payload["completion_tokens"] == 8
+        assert gen_payload["total_request_tokens"] == 20
+
     @patch.dict(os.environ, {}, clear=False)
     @patch("respan_exporter_langchain.exporter.requests.post")
     def test_no_api_key_skips_export(self, mock_post):


### PR DESCRIPTION
## Summary

- Adds `respan-exporter-langchain` package that uses LangChain's native `BaseCallbackHandler` from `langchain_core.callbacks` instead of OTel auto-instrumentation
- The callback API is the stable, framework-endorsed approach used by Langfuse and LangSmith, and is resilient across LangChain version upgrades (unlike OTel patching which breaks across versions)
- Follows existing exporter patterns (Google ADK, Agno) for package structure, payload building, ID normalization, and Respan ingest

### Features
- `RespanCallbackHandler` — drop-in LangChain callback handler that captures chains, LLMs, chat models, tools, and retrievers
- `RespanLangchainExporter` — converts captured spans to Respan ingest format with full payload validation
- Automatic span hierarchy from LangChain's `run_id`/`parent_run_id`
- Token usage extraction from LLM responses (including `usage_metadata` from AIMessage)
- RetryHandler with exponential backoff for transient server errors
- Thread-safe span accumulation with background export
- Output propagation from generation spans to workflow/agent/task spans

## Test plan

- [x] All 10 unit tests pass (`poetry run pytest tests/test_unit.py -v`)
- [x] Package imports and instantiates correctly
- [x] Package builds successfully (`poetry build`)
- [ ] Integration test with real LangChain + OpenAI (requires API keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)