### PR TITLE
feat(exporters): add CrewAI exporter

### DIFF
--- a/python-sdks/respan-exporter-crewai/README.md
+++ b/python-sdks/respan-exporter-crewai/README.md
@@ -2,7 +2,15 @@
 
 **[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-exporter-crewai/)**
 
-Export CrewAI traces to Respan via OpenTelemetry span interception.
+Export CrewAI traces to Respan via OpenTelemetry span interception. This exporter hooks into the OpenTelemetry span pipeline to capture CrewAI spans (crews, agents, tasks, tool calls, LLM generations) and send them to the Respan tracing endpoint.
+
+## Features
+
+- Automatic interception of CrewAI spans from OpenTelemetry processors
+- Span deduplication to avoid duplicate exports
+- Passthrough mode to forward spans to other exporters simultaneously
+- Maps CrewAI span kinds (CHAIN, AGENT, TOOL, LLM) to Respan log types
+- Extracts token usage, model info, input/output, and metadata from OpenInference attributes
 
 ## Installation
 
@@ -10,31 +18,68 @@ Export CrewAI traces to Respan via OpenTelemetry span interception.
 pip install respan-exporter-crewai
 ```
 
-## Usage
+### Prerequisites
+
+CrewAI must be instrumented with [OpenInference](https://github.com/Arize-ai/openinference) so that spans flow through OpenTelemetry:
+
+```bash
+pip install crewai openinference-instrumentation-crewai
+```
+
+## Quick Start
 
 ```python
 from openinference.instrumentation.crewai import CrewAIInstrumentor
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from respan_exporter_crewai import RespanCrewAIInstrumentor
 
-# Set up OTel provider
+# 1. Set up an OpenTelemetry TracerProvider with at least one processor
 provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
 trace.set_tracer_provider(provider)
 
-# Instrument CrewAI with OpenInference
+# 2. Instrument CrewAI with OpenInference
 CrewAIInstrumentor().instrument(tracer_provider=provider)
 
-# Add Respan interception
+# 3. Add Respan interception (intercepts CrewAI spans from the processor)
 RespanCrewAIInstrumentor().instrument(
     api_key="your-respan-api-key",  # or set RESPAN_API_KEY env var
     environment="production",
 )
+
+# 4. Run your CrewAI crew as usual -- spans are exported automatically
+```
+
+### Disabling the Exporter
+
+```python
+instrumentor = RespanCrewAIInstrumentor()
+instrumentor.instrument(api_key="your-key")
+
+# Later, to disable:
+instrumentor.uninstrument()
 ```
 
 ## Environment Variables
 
-- `RESPAN_API_KEY` - API key for Respan platform
-- `RESPAN_BASE_URL` - API endpoint (default: `https://api.respan.ai/api`)
-- `RESPAN_ENVIRONMENT` - Environment name (default: `production`)
-- `RESPAN_CUSTOMER_IDENTIFIER` - Optional customer identifier
+| Variable | Description | Default |
+|---|---|---|
+| `RESPAN_API_KEY` | API key for Respan platform | (required) |
+| `RESPAN_BASE_URL` | API endpoint | `https://api.respan.ai/api` |
+| `RESPAN_ENVIRONMENT` | Environment name | `production` |
+| `RESPAN_CUSTOMER_IDENTIFIER` | Optional customer/user identifier | |
+
+## Requirements
+
+- Python >= 3.12, < 3.14
+- `crewai >= 0.80.0`
+- `openinference-instrumentation-crewai >= 0.1.0`
+- `opentelemetry-sdk >= 1.20.0`
+
+## Support
+
+- **Documentation:** https://docs.respan.ai/
+- **Dashboard:** https://platform.respan.ai/
+- **Issues:** [GitHub Issues](https://github.com/respanai/respan/issues)

--- a/python-sdks/respan-exporter-crewai/README.md
+++ b/python-sdks/respan-exporter-crewai/README.md
@@ -1,4 +1,6 @@
-# Respan CrewAI Exporter
+# Respan Exporter for CrewAI
+
+**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-exporter-crewai/)**
 
 Export CrewAI traces to Respan via OpenTelemetry span interception.
 

--- a/python-sdks/respan-exporter-crewai/README.md
+++ b/python-sdks/respan-exporter-crewai/README.md
@@ -1,3 +1,38 @@
 # Respan CrewAI Exporter
 
-Export CrewAI traces to Respan.
+Export CrewAI traces to Respan via OpenTelemetry span interception.
+
+## Installation
+
+```bash
+pip install respan-exporter-crewai
+```
+
+## Usage
+
+```python
+from openinference.instrumentation.crewai import CrewAIInstrumentor
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from respan_exporter_crewai import RespanCrewAIInstrumentor
+
+# Set up OTel provider
+provider = TracerProvider()
+trace.set_tracer_provider(provider)
+
+# Instrument CrewAI with OpenInference
+CrewAIInstrumentor().instrument(tracer_provider=provider)
+
+# Add Respan interception
+RespanCrewAIInstrumentor().instrument(
+    api_key="your-respan-api-key",  # or set RESPAN_API_KEY env var
+    environment="production",
+)
+```
+
+## Environment Variables
+
+- `RESPAN_API_KEY` - API key for Respan platform
+- `RESPAN_BASE_URL` - API endpoint (default: `https://api.respan.ai/api`)
+- `RESPAN_ENVIRONMENT` - Environment name (default: `production`)
+- `RESPAN_CUSTOMER_IDENTIFIER` - Optional customer identifier

--- a/python-sdks/respan-exporter-crewai/README.md
+++ b/python-sdks/respan-exporter-crewai/README.md
@@ -1,0 +1,3 @@
+# Respan CrewAI Exporter
+
+Export CrewAI traces to Respan.

--- a/python-sdks/respan-exporter-crewai/examples/multi_agent_crew.py
+++ b/python-sdks/respan-exporter-crewai/examples/multi_agent_crew.py
@@ -1,0 +1,78 @@
+# multi_agent_crew.py - Multi-agent CrewAI crew with Respan tracing
+#
+# Demonstrates tracing a crew with multiple collaborating agents.
+#
+# Prerequisites:
+#   pip install crewai openinference-instrumentation-crewai respan-exporter-crewai
+#
+# Set your API key:
+#   export RESPAN_API_KEY="your-respan-api-key"
+
+from crewai import Agent, Crew, Task
+from openinference.instrumentation.crewai import CrewAIInstrumentor
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+from respan_exporter_crewai import RespanCrewAIInstrumentor
+
+# --- OpenTelemetry + Respan setup ---
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(provider)
+
+CrewAIInstrumentor().instrument(tracer_provider=provider)
+
+RespanCrewAIInstrumentor().instrument(
+    api_key=None,  # uses RESPAN_API_KEY env var
+    environment="development",
+    passthrough=True,  # also forward spans to other exporters
+)
+
+# --- Define agents ---
+planner = Agent(
+    role="Content Planner",
+    goal="Create an outline for a blog post",
+    backstory="You are an experienced content strategist.",
+)
+
+writer = Agent(
+    role="Content Writer",
+    goal="Write a short blog post based on the provided outline",
+    backstory="You are a skilled technical writer.",
+)
+
+reviewer = Agent(
+    role="Editor",
+    goal="Review the blog post for clarity and correctness",
+    backstory="You are a meticulous editor with an eye for detail.",
+)
+
+# --- Define tasks (sequential handoff) ---
+plan_task = Task(
+    description="Create a three-section outline for a blog post about AI observability.",
+    expected_output="A numbered outline with section titles and one-sentence summaries.",
+    agent=planner,
+)
+
+write_task = Task(
+    description="Write a short blog post following the outline from the planner.",
+    expected_output="A blog post of roughly 200 words.",
+    agent=writer,
+)
+
+review_task = Task(
+    description="Review the blog post and suggest improvements.",
+    expected_output="The revised blog post with inline comments.",
+    agent=reviewer,
+)
+
+# --- Run the crew ---
+crew = Crew(
+    agents=[planner, writer, reviewer],
+    tasks=[plan_task, write_task, review_task],
+    verbose=True,
+)
+
+result = crew.kickoff()
+print(result)

--- a/python-sdks/respan-exporter-crewai/examples/quickstart.py
+++ b/python-sdks/respan-exporter-crewai/examples/quickstart.py
@@ -1,0 +1,47 @@
+# quickstart.py - Basic CrewAI instrumentation with Respan
+#
+# Prerequisites:
+#   pip install crewai openinference-instrumentation-crewai respan-exporter-crewai
+#
+# Set your API key:
+#   export RESPAN_API_KEY="your-respan-api-key"
+
+from crewai import Agent, Crew, Task
+from openinference.instrumentation.crewai import CrewAIInstrumentor
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+from respan_exporter_crewai import RespanCrewAIInstrumentor
+
+# 1. Set up OpenTelemetry with a TracerProvider and at least one processor
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(provider)
+
+# 2. Instrument CrewAI with OpenInference so spans flow through OpenTelemetry
+CrewAIInstrumentor().instrument(tracer_provider=provider)
+
+# 3. Enable Respan interception to capture CrewAI spans
+RespanCrewAIInstrumentor().instrument(
+    api_key=None,  # uses RESPAN_API_KEY env var
+    environment="development",
+)
+
+# 4. Define a simple agent and task
+researcher = Agent(
+    role="Researcher",
+    goal="Find concise answers to questions",
+    backstory="You are a helpful research assistant.",
+)
+
+task = Task(
+    description="What are three benefits of OpenTelemetry tracing?",
+    expected_output="A short bullet-point list.",
+    agent=researcher,
+)
+
+# 5. Run the crew -- spans are automatically exported to Respan
+crew = Crew(agents=[researcher], tasks=[task], verbose=True)
+result = crew.kickoff()
+print(result)

--- a/python-sdks/respan-exporter-crewai/pyproject.toml
+++ b/python-sdks/respan-exporter-crewai/pyproject.toml
@@ -17,7 +17,6 @@ respan-sdk = ">=2.6.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.2"
-setuptools = "<81"
 crewai = ">=0.80.0"
 openinference-instrumentation-crewai = ">=0.1.0"
 openai = "^1.0.0"

--- a/python-sdks/respan-exporter-crewai/pyproject.toml
+++ b/python-sdks/respan-exporter-crewai/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "respan-exporter-crewai"
+version = "1.0.0"
+description = "Respan exporter for CrewAI traces"
+authors = ["Respan <team@respan.ai>"]
+readme = "README.md"
+packages = [{include = "respan_exporter_crewai", from = "src"}]
+
+[tool.poetry.dependencies]
+python = ">=3.12,<3.14"
+requests = "^2.32.5"
+wrapt = "^1.16.0"
+opentelemetry-sdk = "^1.20.0"
+opentelemetry-api = "^1.20.0"
+opentelemetry-instrumentation = "^0.41b0"
+respan-sdk = ">=2.6.1"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^9.0.2"
+setuptools = "<81"
+crewai = ">=0.80.0"
+openinference-instrumentation-crewai = ">=0.1.0"
+openai = "^1.0.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/__init__.py
+++ b/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/__init__.py
@@ -1,0 +1,4 @@
+from .exporter import RespanCrewAIExporter
+from .instrumentor import RespanCrewAIInstrumentor
+
+__all__ = ["RespanCrewAIExporter", "RespanCrewAIInstrumentor"]

--- a/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/exporter.py
+++ b/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/exporter.py
@@ -1,0 +1,611 @@
+"""Respan CrewAI Exporter - Export CrewAI traces to Respan tracing endpoint."""
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import requests
+
+from respan_exporter_crewai.types import TraceContext
+from respan_exporter_crewai.utils import (
+    as_dict,
+    clean_payload,
+    coerce_datetime,
+    coerce_token_count,
+    extract_metadata_payload,
+    extract_openinference_choice_texts,
+    extract_openinference_messages,
+    extract_span_metadata,
+    find_root_span,
+    format_rfc3339,
+    get_attr,
+    infer_trace_start_time,
+    is_blank_value,
+    merge_openinference_metadata,
+    messages_to_text,
+    normalize_span_id,
+    normalize_trace_id,
+    pick_metadata_value,
+    serialize_value,
+    to_completion_message,
+    to_prompt_messages,
+)
+from respan_sdk.constants.llm_logging import LOG_TYPE_MAP
+from respan_sdk.respan_types.log_types import RespanFullLogParams
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENDPOINT = "https://api.respan.ai/api/v1/traces/ingest"
+
+
+class RespanCrewAIExporter:
+    """
+    Export CrewAI traces/spans to Respan tracing endpoint.
+
+    The exporter accepts:
+    - a trace object with a .spans collection
+    - a dict with a "spans" field
+    - a list of span objects/dicts
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        base_url: Optional[str] = None,
+        environment: Optional[str] = None,
+        customer_identifier: Optional[Union[str, int]] = None,
+        timeout: int = 10,
+    ) -> None:
+        self.api_key = api_key or os.getenv("RESPAN_API_KEY")
+        if base_url is None:
+            base_url = (
+                os.getenv("RESPAN_BASE_URL")
+                or "https://api.respan.ai/api"
+            )
+        self.endpoint = endpoint or self._build_endpoint(base_url=base_url)
+        self.environment = (
+            environment
+            or os.getenv("RESPAN_ENVIRONMENT")
+            or "production"
+        )
+        self.customer_identifier = (
+            customer_identifier
+            or os.getenv("RESPAN_CUSTOMER_IDENTIFIER")
+        )
+        self.timeout = timeout
+
+    def _build_endpoint(self, base_url: Optional[str]) -> str:
+        """Build the ingest endpoint URL from base URL."""
+        if not base_url:
+            return DEFAULT_ENDPOINT
+        base = base_url.rstrip("/")
+        if base.endswith("/v1/traces/ingest"):
+            return base
+        if base.endswith("/v1/traces"):
+            return f"{base}/ingest"
+        if base.endswith("/api"):
+            return f"{base}/v1/traces/ingest"
+        return f"{base}/api/v1/traces/ingest"
+
+    def export(self, trace_or_spans: Any) -> List[Dict[str, Any]]:
+        """Export trace or spans to Respan."""
+        payloads = self.build_payload(trace_or_spans=trace_or_spans)
+        if not payloads:
+            return payloads
+        if not self.api_key:
+            logger.warning(
+                "Respan API key is not set; skipping export to %s",
+                self.endpoint,
+            )
+            return payloads
+        self._send(payloads=payloads)
+        return payloads
+
+    def export_trace(self, trace_or_spans: Any) -> List[Dict[str, Any]]:
+        """Alias for export method."""
+        return self.export(trace_or_spans=trace_or_spans)
+
+    def build_payload(self, trace_or_spans: Any) -> List[Dict[str, Any]]:
+        """Build payload from trace or spans."""
+        trace_obj, spans = self._normalize_trace(trace_or_spans=trace_or_spans)
+        if not spans:
+            return []
+        trace_context = self._extract_trace_context(trace_obj=trace_obj, spans=spans)
+        span_id_map: Dict[str, str] = {}
+        for span in spans:
+            raw_span_id = get_attr(span, "span_id", "id", "uid")
+            if raw_span_id is None:
+                continue
+            raw_span_id = str(raw_span_id)
+            span_id_map[raw_span_id] = normalize_span_id(
+                span_id=raw_span_id,
+                trace_id=trace_context.trace_id,
+            )
+        payloads: List[Dict[str, Any]] = []
+        for span in spans:
+            payload = self._span_to_respan(
+                span=span,
+                trace_context=trace_context,
+                span_id_map=span_id_map,
+            )
+            if payload:
+                payloads.append(payload)
+        if payloads:
+            self._propagate_trace_output(payloads=payloads)
+        return payloads
+
+    def _propagate_trace_output(self, payloads: List[Dict[str, Any]]) -> None:
+        """Propagate output from generation spans to workflow/agent/task spans."""
+        trace_output: Optional[str] = None
+        for payload in payloads:
+            output_value = payload.get("output")
+            if is_blank_value(value=output_value):
+                continue
+            log_type = payload.get("log_type")
+            if log_type == "generation":
+                trace_output = output_value
+                break
+            if trace_output is None:
+                trace_output = output_value
+        if trace_output is not None:
+            for payload in payloads:
+                if is_blank_value(value=payload.get("output")) and payload.get(
+                    "log_type"
+                ) in (
+                    "workflow",
+                    "agent",
+                    "task",
+                ):
+                    payload["output"] = trace_output
+
+    def _normalize_trace(self, trace_or_spans: Any) -> Tuple[Optional[Any], List[Any]]:
+        """Normalize trace input to (trace_obj, spans) tuple."""
+        if trace_or_spans is None:
+            return None, []
+        if isinstance(trace_or_spans, (list, tuple, set)):
+            return None, list(trace_or_spans)
+        if isinstance(trace_or_spans, dict):
+            spans = trace_or_spans.get("spans")
+            if spans is not None:
+                return trace_or_spans, list(spans)
+            return None, [trace_or_spans]
+        spans = get_attr(trace_or_spans, "spans", "span_events")
+        if spans is not None:
+            return trace_or_spans, list(spans)
+        return None, [trace_or_spans]
+
+    def _extract_trace_context(
+        self,
+        trace_obj: Optional[Any],
+        spans: Sequence[Any],
+    ) -> TraceContext:
+        """Extract trace context from trace object and spans."""
+        trace_id = get_attr(trace_obj, "trace_id", "id", "uid")
+        trace_name = get_attr(trace_obj, "name", "trace_name", "title")
+        workflow_name = get_attr(trace_obj, "workflow_name", "workflow")
+        session_identifier = get_attr(trace_obj, "session_identifier", "session_id")
+        trace_group_identifier = get_attr(
+            trace_obj,
+            "trace_group_identifier",
+            "group_identifier",
+            "group_id",
+        )
+
+        trace_metadata = as_dict(
+            value=get_attr(trace_obj, "metadata", "attributes", "tags")
+        ) or {}
+        trace_metadata = merge_openinference_metadata(metadata=trace_metadata)
+
+        customer_identifier = get_attr(
+            trace_obj,
+            "customer_identifier",
+            "customer_id",
+            "user_id",
+            "user_identifier",
+            "user",
+        )
+        if not customer_identifier and isinstance(trace_metadata, dict):
+            for key in ("customer_identifier", "customer_id", "user_id", "user"):
+                if key in trace_metadata:
+                    customer_identifier = trace_metadata.get(key)
+                    break
+        if not customer_identifier:
+            customer_identifier = self.customer_identifier
+
+        trace_start_time = coerce_datetime(
+            value=get_attr(trace_obj, "start_time", "started_at", "start", "start_timestamp")
+        )
+
+        root_span = find_root_span(spans=spans)
+        root_metadata = extract_span_metadata(span=root_span) if root_span is not None else {}
+        if root_metadata:
+            root_user_metadata = extract_metadata_payload(metadata=root_metadata)
+            if root_user_metadata:
+                trace_metadata = {**root_user_metadata, **trace_metadata}
+
+        if not trace_id:
+            for span in spans:
+                trace_id = get_attr(span, "trace_id", "traceId")
+                if trace_id:
+                    break
+        if not trace_id:
+            trace_id = str(uuid.uuid4())
+
+        if not trace_name:
+            trace_name = pick_metadata_value(
+                root_metadata,
+                "graph.node.name",
+                "crewai.crew.name",
+                "crewai.task.name",
+                "agent.name",
+            )
+        if not trace_name and trace_id:
+            trace_name = str(trace_id)
+
+        if not workflow_name:
+            workflow_name = trace_name
+
+        if not session_identifier:
+            session_identifier = pick_metadata_value(
+                root_metadata,
+                "session.id",
+                "session_id",
+                "session",
+            )
+
+        if not customer_identifier:
+            customer_identifier = (
+                pick_metadata_value(
+                    root_metadata,
+                    "user.id",
+                    "user_id",
+                    "customer_identifier",
+                    "customer_id",
+                    "user",
+                )
+                or customer_identifier
+            )
+
+        if not trace_start_time:
+            trace_start_time = infer_trace_start_time(spans=spans)
+
+        return TraceContext(
+            trace_id=str(trace_id),
+            trace_name=str(trace_name) if trace_name else None,
+            workflow_name=str(workflow_name) if workflow_name else None,
+            metadata=trace_metadata,
+            session_identifier=session_identifier,
+            trace_group_identifier=trace_group_identifier,
+            start_time=trace_start_time,
+            customer_identifier=customer_identifier,
+        )
+
+    def _span_to_respan(
+        self,
+        span: Any,
+        trace_context: TraceContext,
+        span_id_map: Optional[Dict[str, str]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Convert span to Respan payload format."""
+        span_id = get_attr(span, "span_id", "id", "uid")
+        parent_id = get_attr(span, "parent_id", "parent_span_id", "parentId")
+        span_name = get_attr(span, "name", "span_name", "operation_name")
+        span_kind = get_attr(span, "type", "span_type", "kind")
+        span_path = get_attr(span, "span_path", "path")
+
+        span_metadata = as_dict(
+            value=get_attr(span, "metadata", "attributes", "tags", "data")
+        ) or {}
+        span_metadata = merge_openinference_metadata(metadata=span_metadata)
+
+        if span_kind is None and isinstance(span_metadata, dict):
+            span_kind = pick_metadata_value(
+                span_metadata,
+                "openinference.span.kind",
+                "span.kind",
+            )
+
+        if not span_name and isinstance(span_metadata, dict):
+            span_name = pick_metadata_value(
+                span_metadata,
+                "graph.node.name",
+                "crewai.crew.name",
+                "crewai.agent.name",
+                "crewai.task.name",
+            )
+
+        if not span_path and isinstance(span_metadata, dict):
+            span_path = pick_metadata_value(span_metadata, "graph.node.id")
+
+        span_input = get_attr(span, "input", "input_data", "request", "prompt")
+        if span_input is None and isinstance(span_metadata, dict) and "input" in span_metadata:
+            span_input = span_metadata.pop("input")
+        if span_input is None and isinstance(span_metadata, dict):
+            for key in ("input.value", "input_value", "traceloop.entity.input"):
+                if key in span_metadata:
+                    span_input = span_metadata.get(key)
+                    break
+
+        span_output = get_attr(span, "output", "output_data", "response")
+        if span_output is None and isinstance(span_metadata, dict) and "output" in span_metadata:
+            span_output = span_metadata.pop("output")
+        if span_output is None and isinstance(span_metadata, dict):
+            for key in ("output.value", "output_value", "traceloop.entity.output"):
+                if key in span_metadata:
+                    span_output = span_metadata.get(key)
+                    break
+
+        input_messages = None
+        output_messages = None
+        if isinstance(span_metadata, dict):
+            input_messages = extract_openinference_messages(
+                metadata=span_metadata,
+                prefix="llm.input_messages",
+            )
+            output_messages = extract_openinference_messages(
+                metadata=span_metadata,
+                prefix="llm.output_messages",
+            )
+            if span_input is None and input_messages:
+                span_input = input_messages
+            if span_output is None and output_messages:
+                span_output = output_messages
+
+        prompt_messages = (
+            to_prompt_messages(value=span_input) if span_input is not None else None
+        )
+        completion_message = (
+            to_completion_message(value=span_output) if span_output is not None else None
+        )
+        if prompt_messages is None and input_messages:
+            prompt_messages = input_messages
+        if completion_message is None and output_messages:
+            completion_message = output_messages[0] if output_messages else None
+
+        if is_blank_value(value=span_output):
+            choice_texts = extract_openinference_choice_texts(metadata=span_metadata)
+            if choice_texts:
+                span_output = "\n".join(choice_texts)
+                if completion_message is None:
+                    completion_message = {"role": "assistant", "content": span_output}
+            elif output_messages:
+                output_text = messages_to_text(messages=output_messages)
+                if output_text:
+                    span_output = output_text
+                    if completion_message is None:
+                        completion_message = {"role": "assistant", "content": output_text}
+        if span_output is None and isinstance(completion_message, dict):
+            completion_content = completion_message.get("content")
+            if completion_content:
+                span_output = completion_content
+        if completion_message is None and isinstance(span_output, str) and span_output.strip():
+            completion_message = {"role": "assistant", "content": span_output.strip()}
+        if prompt_messages is None and isinstance(span_input, str) and span_input.strip():
+            prompt_messages = [{"role": "user", "content": span_input.strip()}]
+
+        model = get_attr(span, "model", "model_name")
+        if model is None and isinstance(span_metadata, dict) and "model" in span_metadata:
+            model = span_metadata.pop("model")
+        if model is None and isinstance(span_metadata, dict):
+            model = pick_metadata_value(
+                span_metadata,
+                "llm.model_name",
+                "llm.model",
+                "embedding.model_name",
+            )
+
+        usage = get_attr(span, "usage", "token_usage")
+        if usage is None and isinstance(span_metadata, dict) and "usage" in span_metadata:
+            usage = span_metadata.pop("usage")
+        usage = as_dict(value=usage)
+        prompt_tokens_value: Optional[int] = None
+        completion_tokens_value: Optional[int] = None
+        if usage is None and isinstance(span_metadata, dict):
+            prompt_tokens = span_metadata.get("llm.token_count.prompt")
+            completion_tokens = span_metadata.get("llm.token_count.completion")
+            total_tokens = span_metadata.get("llm.token_count.total")
+            if any(
+                value is not None
+                for value in (prompt_tokens, completion_tokens, total_tokens)
+            ):
+                usage = {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": total_tokens,
+                }
+
+        error = get_attr(span, "error", "exception", "err")
+        if error is None and isinstance(span_metadata, dict) and "error" in span_metadata:
+            error = span_metadata.pop("error")
+
+        start_time = coerce_datetime(
+            value=get_attr(span, "start_time", "started_at", "start", "start_timestamp"),
+            reference=trace_context.start_time,
+        )
+        end_time = coerce_datetime(
+            value=get_attr(span, "end_time", "ended_at", "end", "end_timestamp", "timestamp"),
+            reference=trace_context.start_time,
+        )
+
+        now = datetime.now(timezone.utc)
+        if start_time is None and end_time is None:
+            start_time = now
+            end_time = now
+        elif start_time is None:
+            start_time = end_time
+        elif end_time is None:
+            end_time = start_time
+        if start_time and end_time and end_time < start_time:
+            end_time = start_time
+
+        latency = get_attr(span, "latency", "duration")
+        if latency is None and start_time and end_time:
+            latency = (end_time - start_time).total_seconds()
+        if latency is not None and latency < 0:
+            latency = 0.0
+
+        if not span_id:
+            span_id = str(uuid.uuid4())
+        span_id_str = str(span_id)
+        if not span_name:
+            span_name = span_id
+
+        log_type = self._map_log_type(
+            span_kind=span_kind,
+            parent_id=parent_id,
+            model=model,
+        )
+
+        merged_metadata = {**trace_context.metadata, **(span_metadata or {})}
+        trace_hex_id = normalize_trace_id(trace_id=trace_context.trace_id)
+        if span_id_map and span_id_str in span_id_map:
+            span_hex_id = span_id_map[span_id_str]
+        else:
+            span_hex_id = normalize_span_id(
+                span_id=span_id_str,
+                trace_id=trace_context.trace_id,
+            )
+        parent_hex_id = (
+            span_id_map.get(str(parent_id))
+            if span_id_map and parent_id is not None
+            else normalize_span_id(span_id=str(parent_id), trace_id=trace_context.trace_id)
+            if parent_id
+            else None
+        )
+
+        if "crewai_trace_id" not in merged_metadata:
+            merged_metadata["crewai_trace_id"] = trace_context.trace_id
+        if "crewai_span_id" not in merged_metadata:
+            merged_metadata["crewai_span_id"] = str(span_id)
+        if parent_id and "crewai_parent_id" not in merged_metadata:
+            merged_metadata["crewai_parent_id"] = str(parent_id)
+
+        input_value = serialize_value(value=span_input) if span_input is not None else None
+        output_value = serialize_value(value=span_output) if span_output is not None else None
+
+        payload = {
+            "trace_unique_id": trace_hex_id,
+            "trace_name": trace_context.trace_name,
+            "span_unique_id": span_hex_id,
+            "span_parent_id": parent_hex_id,
+            "span_name": str(span_name) if span_name else None,
+            "span_path": span_path,
+            "span_workflow_name": trace_context.workflow_name,
+            "trace_id": trace_hex_id,
+            "span_id": span_hex_id,
+            "parent_id": parent_hex_id,
+            "environment": self.environment,
+            "customer_identifier": trace_context.customer_identifier,
+            "log_type": log_type,
+            "start_time": format_rfc3339(value=start_time),
+            "timestamp": format_rfc3339(value=end_time),
+            "latency": latency,
+            "input": input_value,
+            "output": output_value,
+            "model": model,
+            "metadata": merged_metadata or None,
+            "session_identifier": trace_context.session_identifier,
+            "trace_group_identifier": trace_context.trace_group_identifier,
+        }
+        if prompt_messages is not None:
+            payload["prompt_messages"] = prompt_messages
+        if completion_message is not None:
+            payload["completion_message"] = completion_message
+        payload["respan_params"] = {
+            "environment": self.environment,
+            "has_webhook": False,
+        }
+        payload["disable_log"] = False
+
+        if usage:
+            prompt_tokens = usage.get("prompt_tokens") or usage.get("input_tokens")
+            completion_tokens = usage.get("completion_tokens") or usage.get("output_tokens")
+            total_tokens = usage.get("total_tokens") or usage.get("total")
+
+            payload["prompt_tokens"] = prompt_tokens
+            payload["completion_tokens"] = completion_tokens
+            payload["total_request_tokens"] = total_tokens
+
+            coerced_total = coerce_token_count(value=total_tokens)
+            if coerced_total is None or coerced_total == 0:
+                prompt_tokens_value = coerce_token_count(value=prompt_tokens)
+                completion_tokens_value = coerce_token_count(value=completion_tokens)
+                coerced_prompt = prompt_tokens_value or 0
+                coerced_completion = completion_tokens_value or 0
+                if coerced_prompt or coerced_completion:
+                    payload["total_request_tokens"] = coerced_prompt + coerced_completion
+            else:
+                prompt_tokens_value = coerce_token_count(value=prompt_tokens)
+                completion_tokens_value = coerce_token_count(value=completion_tokens)
+
+        if error:
+            payload["error_message"] = str(error)
+            payload["status_code"] = 500
+        else:
+            payload["status_code"] = get_attr(span, "status_code") or 200
+
+        tool_name = (
+            get_attr(span, "tool_name", "tool")
+            or merged_metadata.get("tool_name")
+            or merged_metadata.get("tool.name")
+        )
+        if tool_name:
+            payload["span_tools"] = [str(tool_name)]
+
+        if not payload.get("span_unique_id") and payload.get("trace_unique_id"):
+            payload["span_unique_id"] = payload["trace_unique_id"]
+
+        cleaned_payload = clean_payload(payload=payload)
+
+        try:
+            RespanFullLogParams(**cleaned_payload)
+        except Exception as exc:
+            logger.warning(
+                "CrewAI span payload failed RespanFullLogParams validation: %s",
+                exc,
+            )
+
+        return cleaned_payload
+
+    def _map_log_type(
+        self,
+        span_kind: Any,
+        parent_id: Optional[str],
+        model: Optional[str],
+    ) -> str:
+        """Map span kind to Respan log type."""
+        if span_kind:
+            kind_str = str(span_kind).lower()
+            if kind_str == "chain" and parent_id is None:
+                return "workflow"
+            for key, value in LOG_TYPE_MAP.items():
+                if key in kind_str:
+                    return value
+        if model:
+            return "generation"
+        if parent_id is None:
+            return "workflow"
+        return "task"
+
+    def _send(self, payloads: List[Dict[str, Any]]) -> None:
+        """Send payloads to Respan endpoint."""
+        try:
+            response = requests.post(
+                url=self.endpoint,
+                json=payloads,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=self.timeout,
+            )
+            if response.status_code not in (200, 201):
+                logger.warning(
+                    "Respan export failed with status %s: %s",
+                    response.status_code,
+                    response.text,
+                )
+        except Exception as exc:
+            logger.warning("Respan export request failed: %s", exc)

--- a/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/exporter.py
+++ b/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/exporter.py
@@ -467,13 +467,13 @@ class RespanCrewAIExporter:
                 span_id=span_id_str,
                 trace_id=trace_context.trace_id,
             )
-        parent_hex_id = (
-            span_id_map.get(str(parent_id))
-            if span_id_map and parent_id is not None
-            else normalize_span_id(span_id=str(parent_id), trace_id=trace_context.trace_id)
-            if parent_id
-            else None
-        )
+        if parent_id is not None:
+            parent_str = str(parent_id)
+            parent_hex_id = (
+                span_id_map.get(parent_str) if span_id_map else None
+            ) or normalize_span_id(span_id=parent_str, trace_id=trace_context.trace_id)
+        else:
+            parent_hex_id = None
 
         if "crewai_trace_id" not in merged_metadata:
             merged_metadata["crewai_trace_id"] = trace_context.trace_id

--- a/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/instrumentor.py
+++ b/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/instrumentor.py
@@ -1,0 +1,207 @@
+"""Respan OpenTelemetry redirect for CrewAI traces.
+
+This instrumentor wraps OpenTelemetry span processors to intercept CrewAI spans
+and export them to the Respan tracing ingest endpoint.
+"""
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from threading import Lock
+from typing import Collection, Dict, Iterable, List, Optional, Sequence
+
+import wrapt
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+from respan_exporter_crewai.exporter import RespanCrewAIExporter
+from respan_exporter_crewai.utils import group_spans_by_trace, is_crewai_span, otel_span_to_dict
+
+logger = logging.getLogger(__name__)
+
+_INSTRUMENTS = ("crewai >= 0.80.0", "openinference-instrumentation-crewai >= 0.1.0")
+
+_PATCHED = False
+
+
+class _SpanDedupeCache:
+    """Cache for deduplicating spans by trace_id:span_id."""
+
+    def __init__(self, max_size: int = 10000) -> None:
+        self._max_size = max_size
+        self._data: "OrderedDict[str, None]" = OrderedDict()
+        self._lock = Lock()
+
+    def add(self, trace_id: Optional[str], span_id: Optional[str]) -> bool:
+        """Add span to cache. Returns True if span was not already in cache."""
+        if not trace_id or not span_id:
+            return True
+        key = f"{trace_id}:{span_id}"
+        with self._lock:
+            if key in self._data:
+                return False
+            self._data[key] = None
+            if len(self._data) > self._max_size:
+                self._data.popitem(last=False)
+        return True
+
+
+_ACTIVE_EXPORTER: Optional[RespanCrewAIExporter] = None
+_ACTIVE_DEDUPE = _SpanDedupeCache()
+_ACTIVE_PASSTHROUGH = False
+
+
+def _export_crewai_spans(spans: Iterable[object]) -> SpanExportResult:
+    """Export CrewAI spans to Respan."""
+    exporter = _ACTIVE_EXPORTER
+    dedupe = _ACTIVE_DEDUPE
+    if exporter is None:
+        return SpanExportResult.SUCCESS
+
+    crewai_span_dicts: List[Dict[str, object]] = []
+    for span in spans:
+        if not is_crewai_span(span=span):
+            continue
+        span_dict = otel_span_to_dict(span=span)
+        if dedupe and not dedupe.add(
+            trace_id=span_dict.get("trace_id"),
+            span_id=span_dict.get("span_id"),
+        ):
+            continue
+        crewai_span_dicts.append(span_dict)
+
+    if not crewai_span_dicts:
+        return SpanExportResult.SUCCESS
+
+    payloads: List[Dict[str, object]] = []
+    grouped = group_spans_by_trace(spans=crewai_span_dicts)
+    for trace_spans in grouped.values():
+        payloads.extend(exporter.build_payload(trace_or_spans=trace_spans))
+
+    if not payloads:
+        return SpanExportResult.SUCCESS
+
+    if not exporter.api_key:
+        logger.warning("Respan API key is not set; skipping CrewAI export")
+        return SpanExportResult.SUCCESS
+
+    exporter._send(payloads=payloads)
+    return SpanExportResult.SUCCESS
+
+
+def _batch_export_wrapper(wrapped, instance, args, kwargs):
+    """Wrapper for BatchSpanProcessor._export method."""
+    spans = list(args[0]) if args else list(kwargs.get("spans", []))
+    if not spans:
+        return wrapped(*args, **kwargs)
+
+    crewai_spans = []
+    other_spans = []
+    for span in spans:
+        if is_crewai_span(span=span):
+            crewai_spans.append(span)
+        else:
+            other_spans.append(span)
+
+    if not crewai_spans:
+        return wrapped(*args, **kwargs)
+
+    try:
+        export_result = _export_crewai_spans(spans=crewai_spans)
+    except Exception as exc:
+        logger.warning("Failed to export CrewAI spans: %s", exc, exc_info=True)
+        export_result = SpanExportResult.FAILURE
+
+    if _ACTIVE_PASSTHROUGH:
+        return wrapped(*args, **kwargs)
+
+    if other_spans:
+        return wrapped(other_spans, **kwargs)
+
+    return export_result
+
+
+def _on_end_wrapper(wrapped, instance, args, kwargs):
+    """Wrapper for SimpleSpanProcessor.on_end method."""
+    span = args[0] if args else kwargs.get("span")
+    if span is None or not is_crewai_span(span=span):
+        return wrapped(*args, **kwargs)
+
+    try:
+        _export_crewai_spans(spans=[span])
+    except Exception as exc:
+        logger.warning("Failed to export CrewAI span: %s", exc, exc_info=True)
+
+    if _ACTIVE_PASSTHROUGH:
+        return wrapped(*args, **kwargs)
+    return None
+
+
+class RespanCrewAIInstrumentor(BaseInstrumentor):
+    """Instrument OpenTelemetry exporters to send CrewAI traces to Respan."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._exporter: Optional[RespanCrewAIExporter] = None
+        self._passthrough = False
+        self._dedupe = _SpanDedupeCache()
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _INSTRUMENTS
+
+    def _instrument(self, **kwargs) -> None:
+        self._exporter = RespanCrewAIExporter(
+            api_key=kwargs.get("api_key"),
+            endpoint=kwargs.get("endpoint"),
+            base_url=kwargs.get("base_url"),
+            environment=kwargs.get("environment"),
+            customer_identifier=kwargs.get("customer_identifier"),
+            timeout=kwargs.get("timeout", 10),
+        )
+        self._passthrough = bool(kwargs.get("passthrough", False))
+        self._dedupe = _SpanDedupeCache(max_size=kwargs.get("dedupe_max_size", 10000))
+
+        global _ACTIVE_EXPORTER, _ACTIVE_DEDUPE, _ACTIVE_PASSTHROUGH
+        _ACTIVE_EXPORTER = self._exporter
+        _ACTIVE_DEDUPE = self._dedupe
+        _ACTIVE_PASSTHROUGH = self._passthrough
+
+        self._patch_span_processors()
+        logger.info("Respan CrewAI instrumentation enabled")
+
+    def _uninstrument(self, **kwargs) -> None:
+        global _ACTIVE_EXPORTER
+        _ACTIVE_EXPORTER = None
+        logger.info("Respan CrewAI instrumentation disabled")
+
+    def _patch_span_processors(self) -> None:
+        global _PATCHED
+        if _PATCHED:
+            return
+
+        try:
+            from opentelemetry.sdk.trace import export as trace_export
+
+            if hasattr(trace_export.BatchSpanProcessor, "_export"):
+                wrapt.wrap_function_wrapper(
+                    module="opentelemetry.sdk.trace.export",
+                    name="BatchSpanProcessor._export",
+                    wrapper=_batch_export_wrapper,
+                )
+            else:
+                wrapt.wrap_function_wrapper(
+                    module="opentelemetry.sdk.trace.export",
+                    name="BatchSpanProcessor.on_end",
+                    wrapper=_on_end_wrapper,
+                )
+        except Exception as exc:
+            logger.debug("Failed to patch BatchSpanProcessor: %s", exc)
+
+        wrapt.wrap_function_wrapper(
+            module="opentelemetry.sdk.trace.export",
+            name="SimpleSpanProcessor.on_end",
+            wrapper=_on_end_wrapper,
+        )
+
+        _PATCHED = True
+        logger.debug("Patched OpenTelemetry span processors for CrewAI export")

--- a/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/instrumentor.py
+++ b/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/instrumentor.py
@@ -170,8 +170,10 @@ class RespanCrewAIInstrumentor(BaseInstrumentor):
         logger.info("Respan CrewAI instrumentation enabled")
 
     def _uninstrument(self, **kwargs) -> None:
-        global _ACTIVE_EXPORTER
+        global _ACTIVE_EXPORTER, _ACTIVE_DEDUPE, _ACTIVE_PASSTHROUGH
         _ACTIVE_EXPORTER = None
+        _ACTIVE_DEDUPE = None
+        _ACTIVE_PASSTHROUGH = True
         logger.info("Respan CrewAI instrumentation disabled")
 
     def _patch_span_processors(self) -> None:

--- a/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/types.py
+++ b/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/types.py
@@ -1,0 +1,18 @@
+"""Type definitions for Respan CrewAI exporter."""
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
+
+from respan_sdk.respan_types.base_types import RespanBaseModel
+
+
+class TraceContext(RespanBaseModel):
+    """Context information for a trace, extracted from trace object and root span."""
+
+    trace_id: str
+    trace_name: Optional[str]
+    workflow_name: Optional[str]
+    metadata: Dict[str, Any]
+    session_identifier: Optional[Union[str, int]] = None
+    trace_group_identifier: Optional[Union[str, int]] = None
+    start_time: Optional[datetime] = None
+    customer_identifier: Optional[Union[str, int]] = None

--- a/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/utils.py
+++ b/python-sdks/respan-exporter-crewai/src/respan_exporter_crewai/utils.py
@@ -1,0 +1,459 @@
+"""Utility functions for Respan CrewAI exporter."""
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+    is_hex_string,
+)
+
+
+def ns_to_datetime(value: Optional[int]) -> Optional[datetime]:
+    """Convert nanoseconds timestamp to datetime."""
+    if not value:
+        return None
+    return datetime.fromtimestamp(value / 1e9, tz=timezone.utc)
+
+
+def is_crewai_span(span: object) -> bool:
+    """Check if span is from CrewAI instrumentation."""
+    scope = getattr(span, "instrumentation_scope", None) or getattr(
+        span, "instrumentation_library", None
+    )
+    scope_name = getattr(scope, "name", "") or ""
+    if "crewai" in scope_name:
+        return True
+    attributes = getattr(span, "attributes", None) or {}
+    if any(key.startswith("crewai.") for key in attributes):
+        return True
+    return False
+
+
+def otel_span_to_dict(span: object) -> Dict[str, object]:
+    """Convert OpenTelemetry span to dict format."""
+    attributes = dict(getattr(span, "attributes", None) or {})
+    span_context = getattr(span, "context", None)
+    trace_id = format_trace_id(trace_id=span_context.trace_id) if span_context else None
+    span_id = format_span_id(span_id=span_context.span_id) if span_context else None
+
+    parent = getattr(span, "parent", None)
+    parent_id = None
+    if parent is not None and getattr(parent, "span_id", None) is not None:
+        parent_id = format_span_id(span_id=parent.span_id)
+
+    span_kind = attributes.get("openinference.span.kind")
+    if not span_kind:
+        raw_kind = getattr(span, "kind", None)
+        span_kind = getattr(raw_kind, "name", None) if raw_kind is not None else None
+        if span_kind is None and raw_kind is not None:
+            span_kind = str(raw_kind)
+
+    status = getattr(span, "status", None)
+    status_code = None
+    error_message = None
+    if status is not None:
+        status_enum = getattr(status, "status_code", None)
+        status_name = getattr(status_enum, "name", None)
+        if status_name == "ERROR":
+            status_code = 500
+            error_message = getattr(status, "description", None) or "error"
+        elif status_name == "OK":
+            status_code = 200
+
+    span_path = attributes.get("graph.node.id")
+
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_id": parent_id,
+        "name": getattr(span, "name", None),
+        "span_type": span_kind,
+        "kind": span_kind,
+        "span_path": span_path,
+        "start_time": ns_to_datetime(value=getattr(span, "start_time", None)),
+        "end_time": ns_to_datetime(value=getattr(span, "end_time", None)),
+        "attributes": attributes,
+        "status_code": status_code,
+        "error": error_message,
+    }
+
+
+def group_spans_by_trace(
+    spans: Sequence[Dict[str, object]],
+) -> Dict[str, List[Dict[str, object]]]:
+    """Group spans by trace ID."""
+    grouped: Dict[str, List[Dict[str, object]]] = {}
+    for span in spans:
+        trace_id = span.get("trace_id")
+        if not isinstance(trace_id, str) or not trace_id:
+            continue
+        grouped.setdefault(trace_id, []).append(span)
+    return grouped
+
+
+def get_attr(obj: Any, *keys: str, default: Any = None) -> Any:
+    """Get attribute from object or dict by trying multiple keys."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        for key in keys:
+            if key in obj:
+                return obj[key]
+    for key in keys:
+        if hasattr(obj, key):
+            return getattr(obj, key)
+    return default
+
+
+def as_dict(value: Any) -> Optional[Dict[str, Any]]:
+    """Convert value to dict if possible."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        try:
+            return value.model_dump()
+        except Exception:
+            return None
+    if hasattr(value, "dict"):
+        try:
+            return value.dict()
+        except Exception:
+            return None
+    return None
+
+
+def pick_metadata_value(metadata: Optional[Dict[str, Any]], *keys: str) -> Any:
+    """Pick first available value from metadata by trying multiple keys."""
+    if not metadata:
+        return None
+    for key in keys:
+        if key in metadata:
+            return metadata[key]
+    return None
+
+
+def coerce_datetime(value: Any, reference: Optional[datetime] = None) -> Optional[datetime]:
+    """Coerce various value types to datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    if isinstance(value, (int, float)):
+        numeric_value = float(value)
+        if reference and numeric_value < 1_000_000_000:
+            return reference + timedelta(seconds=numeric_value)
+        if numeric_value > 100_000_000_000:
+            return datetime.fromtimestamp(numeric_value / 1000, tz=timezone.utc)
+        return datetime.fromtimestamp(numeric_value, tz=timezone.utc)
+    if isinstance(value, str):
+        trimmed = value.strip()
+        try:
+            return datetime.fromisoformat(trimmed.replace("Z", "+00:00"))
+        except ValueError:
+            try:
+                numeric_value = float(trimmed)
+                if reference and numeric_value < 1_000_000_000:
+                    return reference + timedelta(seconds=numeric_value)
+                if numeric_value > 100_000_000_000:
+                    return datetime.fromtimestamp(numeric_value / 1000, tz=timezone.utc)
+                return datetime.fromtimestamp(numeric_value, tz=timezone.utc)
+            except ValueError:
+                return None
+    return None
+
+
+def coerce_token_count(value: Any) -> Optional[int]:
+    """Coerce value to token count integer."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(float(stripped))
+        except ValueError:
+            return None
+    return None
+
+
+def infer_trace_start_time(spans: Sequence[Any]) -> Optional[datetime]:
+    """Infer the earliest start time from a sequence of spans."""
+    earliest: Optional[datetime] = None
+    for span in spans:
+        raw_value = get_attr(span, "start_time", "started_at", "start", "start_timestamp")
+        if isinstance(raw_value, (int, float)) and float(raw_value) < 1_000_000_000:
+            continue
+        if isinstance(raw_value, str):
+            trimmed = raw_value.strip()
+            if trimmed:
+                try:
+                    numeric_value = float(trimmed)
+                    if numeric_value < 1_000_000_000:
+                        continue
+                except ValueError:
+                    pass
+        candidate = coerce_datetime(value=raw_value)
+        if candidate and candidate.year < 2001:
+            continue
+        if candidate and (earliest is None or candidate < earliest):
+            earliest = candidate
+    return earliest
+
+
+def serialize_value(value: Any) -> Optional[str]:
+    """Serialize value to JSON string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            try:
+                json.loads(trimmed)
+                return trimmed
+            except Exception:
+                return json.dumps(value)
+        return json.dumps(value)
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return json.dumps(str(value))
+
+
+def format_rfc3339(value: Optional[datetime]) -> Optional[str]:
+    """Format datetime as RFC3339 string."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def normalize_trace_id(trace_id: str) -> str:
+    """Normalize trace ID to 32-char hex string."""
+    if is_hex_string(value=trace_id, length=32):
+        return trace_id.lower()
+    return uuid.uuid5(uuid.NAMESPACE_DNS, trace_id).hex
+
+
+def normalize_span_id(span_id: str, trace_id: str) -> str:
+    """Normalize span ID to 16-char hex string."""
+    if is_hex_string(value=span_id, length=16):
+        return span_id.lower()
+    stable_seed = f"{trace_id}:{span_id}"
+    return uuid.uuid5(uuid.NAMESPACE_DNS, stable_seed).hex[:16]
+
+
+def clean_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove None, empty dict, and empty list values from payload."""
+    return {key: value for key, value in payload.items() if value not in (None, {}, [])}
+
+
+def parse_json_value(value: Any) -> Any:
+    """Parse JSON string value if possible."""
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            try:
+                return json.loads(trimmed)
+            except Exception:
+                return value
+        return value
+    return value
+
+
+def extract_metadata_payload(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Extract nested metadata payload from metadata dict."""
+    if not metadata:
+        return {}
+    raw_meta = metadata.get("metadata")
+    if isinstance(raw_meta, dict):
+        return dict(raw_meta)
+    if isinstance(raw_meta, str):
+        parsed = parse_json_value(value=raw_meta)
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def merge_openinference_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Merge OpenInference metadata format with extracted nested metadata."""
+    if not metadata:
+        return {}
+    merged = dict(metadata)
+    extracted = extract_metadata_payload(metadata=merged)
+    if extracted:
+        merged.pop("metadata", None)
+        merged.update(extracted)
+    return merged
+
+
+def find_root_span(spans: Sequence[Any]) -> Optional[Any]:
+    """Find the root span (span without parent in the trace)."""
+    if not spans:
+        return None
+    span_ids = set()
+    for span in spans:
+        span_id = get_attr(span, "span_id", "id", "uid")
+        if span_id is not None:
+            span_ids.add(str(span_id))
+    for span in spans:
+        parent_id = get_attr(span, "parent_id", "parent_span_id", "parentId")
+        if not parent_id or str(parent_id) not in span_ids:
+            return span
+    return spans[0]
+
+
+def extract_span_metadata(span: Any) -> Dict[str, Any]:
+    """Extract and normalize metadata from span."""
+    raw_metadata = as_dict(value=get_attr(span, "metadata", "attributes", "tags", "data")) or {}
+    return merge_openinference_metadata(metadata=raw_metadata)
+
+
+def to_prompt_messages(value: Any) -> Optional[List[Dict[str, Any]]]:
+    """Convert value to prompt messages format."""
+    parsed = parse_json_value(value=value)
+    if isinstance(parsed, list) and parsed and all(isinstance(item, dict) for item in parsed):
+        if all("role" in item and "content" in item for item in parsed):
+            return parsed
+    if isinstance(parsed, dict):
+        if isinstance(parsed.get("messages"), list):
+            messages = parsed.get("messages") or []
+            if messages and all(isinstance(item, dict) for item in messages):
+                return messages
+        if "role" in parsed and "content" in parsed:
+            return [parsed]
+    return None
+
+
+def to_completion_message(value: Any) -> Optional[Dict[str, Any]]:
+    """Convert value to completion message format."""
+    parsed = parse_json_value(value=value)
+    if isinstance(parsed, dict):
+        if "role" in parsed and "content" in parsed:
+            return parsed
+        choices = parsed.get("choices")
+        if isinstance(choices, list) and choices:
+            first = choices[0]
+            if isinstance(first, dict):
+                message = first.get("message")
+                if isinstance(message, dict) and "content" in message:
+                    return message
+    if isinstance(parsed, list) and parsed:
+        first = parsed[0]
+        if isinstance(first, dict) and "content" in first:
+            return first
+    return None
+
+
+def extract_openinference_messages(
+    metadata: Optional[Dict[str, Any]],
+    prefix: str,
+) -> Optional[List[Dict[str, Any]]]:
+    """Extract messages from OpenInference format metadata."""
+    if not metadata:
+        return None
+    prefix_token = f"{prefix}."
+    messages: Dict[int, Dict[str, Any]] = {}
+    message_contents: Dict[int, List[str]] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key.startswith(prefix_token):
+            continue
+        remainder = key[len(prefix_token):]
+        parts = remainder.split(".")
+        if len(parts) < 3:
+            continue
+        index_str, section, field = parts[0], parts[1], parts[2]
+        if not index_str.isdigit() or section != "message":
+            continue
+        index = int(index_str)
+        if field == "role":
+            messages.setdefault(index, {})["role"] = value
+        elif field == "content":
+            messages.setdefault(index, {})["content"] = value
+        elif field == "contents" and len(parts) >= 6:
+            if parts[-2] == "message_content" and parts[-1] == "text":
+                message_contents.setdefault(index, []).append(str(value))
+    if not messages:
+        if not message_contents:
+            return None
+        messages = {index: {} for index in message_contents.keys()}
+    if message_contents:
+        for index, contents in message_contents.items():
+            if contents and not messages.setdefault(index, {}).get("content"):
+                messages[index]["content"] = "\n".join(contents)
+    return [messages[index] for index in sorted(messages)]
+
+
+def extract_openinference_choice_texts(
+    metadata: Optional[Dict[str, Any]],
+) -> Optional[List[str]]:
+    """Extract choice texts from OpenInference format metadata."""
+    if not metadata:
+        return None
+    prefix_token = "llm.choices."
+    choices: Dict[int, str] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key.startswith(prefix_token):
+            continue
+        parts = key.split(".")
+        if len(parts) < 4:
+            continue
+        index_str = parts[1]
+        if not index_str.isdigit():
+            continue
+        if parts[2] != "completion" or parts[3] != "text":
+            continue
+        choices[int(index_str)] = str(value)
+    if not choices:
+        return None
+    return [choices[index] for index in sorted(choices)]
+
+
+def messages_to_text(messages: Sequence[Dict[str, Any]]) -> Optional[str]:
+    """Convert messages to text format."""
+    if not messages:
+        return None
+    parts: List[str] = []
+    for message in messages:
+        content = message.get("content")
+        if content is None:
+            continue
+        if isinstance(content, (dict, list)):
+            parts.append(json.dumps(content, default=str))
+        else:
+            parts.append(str(content))
+    if not parts:
+        return None
+    return "\n".join(parts)
+
+
+def is_blank_value(value: Any) -> bool:
+    """Check if value is blank (None, empty, or null-like)."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if not trimmed:
+            return True
+        if trimmed in ("[]", "{}", "null"):
+            return True
+        try:
+            parsed = json.loads(trimmed)
+            return parsed in (None, [], {})
+        except Exception:
+            return False
+    if isinstance(value, (list, tuple, dict)) and not value:
+        return True
+    return False

--- a/python-sdks/respan-exporter-crewai/tests/test_exporter.py
+++ b/python-sdks/respan-exporter-crewai/tests/test_exporter.py
@@ -248,6 +248,26 @@ class TestBuildPayload:
 
         assert payloads[0]["customer_identifier"] == "user-42"
 
+    def test_parent_id_fallback_when_parent_not_in_trace(self):
+        """parent_id should fall back to normalize_span_id when the parent span is not in trace_or_spans."""
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        # Child span whose parent_id does NOT appear as any span's span_id
+        child_span = self._make_span_dict(
+            span_id="aaaaaaaaaaaaaaaa",
+            parent_id="missing_parent_id_123",
+            name="Orphan Task",
+            span_type="CHAIN",
+            kind="CHAIN",
+        )
+        payloads = exporter.build_payload(trace_or_spans=[child_span])
+
+        assert len(payloads) == 1
+        # parent_id must not be None; it should be a normalized hex value
+        assert payloads[0]["parent_id"] is not None
+        assert len(payloads[0]["parent_id"]) > 0
+
 
 class TestExport:
     """Test the export (send) functionality."""

--- a/python-sdks/respan-exporter-crewai/tests/test_exporter.py
+++ b/python-sdks/respan-exporter-crewai/tests/test_exporter.py
@@ -1,0 +1,336 @@
+"""Tests for CrewAI exporter."""
+import json
+import os
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRespanCrewAIExporterInit:
+    """Test exporter initialization."""
+
+    def test_uses_env_api_key(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        with patch.dict(os.environ, {"RESPAN_API_KEY": "test-key-123"}):
+            exporter = RespanCrewAIExporter()
+            assert exporter.api_key == "test-key-123"
+
+    def test_explicit_api_key_overrides_env(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        with patch.dict(os.environ, {"RESPAN_API_KEY": "env-key"}):
+            exporter = RespanCrewAIExporter(api_key="explicit-key")
+            assert exporter.api_key == "explicit-key"
+
+    def test_default_endpoint(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        assert "v1/traces/ingest" in exporter.endpoint
+
+    def test_custom_base_url(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(
+            api_key="test",
+            base_url="https://custom.api.com/api",
+        )
+        assert exporter.endpoint == "https://custom.api.com/api/v1/traces/ingest"
+
+    def test_default_environment(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        assert exporter.environment == "production"
+
+    def test_custom_environment(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test", environment="staging")
+        assert exporter.environment == "staging"
+
+
+class TestBuildPayload:
+    """Test payload construction from spans."""
+
+    def _make_span_dict(self, **overrides):
+        """Create a minimal span dict for testing."""
+        base = {
+            "trace_id": "abcdef1234567890abcdef1234567890",
+            "span_id": "1234567890abcdef",
+            "parent_id": None,
+            "name": "CrewAI Crew",
+            "span_type": "CHAIN",
+            "kind": "CHAIN",
+            "span_path": None,
+            "start_time": datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            "end_time": datetime(2024, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            "attributes": {},
+            "status_code": 200,
+            "error": None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_builds_payload_from_single_span(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        span = self._make_span_dict()
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        assert len(payloads) == 1
+        payload = payloads[0]
+        assert payload["trace_unique_id"] is not None
+        assert payload["span_unique_id"] is not None
+        assert payload["span_name"] == "CrewAI Crew"
+        assert payload["log_type"] == "workflow"  # root span with no parent
+        assert payload["environment"] == "production"
+
+    def test_builds_payload_with_generation_span(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        span = self._make_span_dict(
+            name="LLM Call",
+            span_type="LLM",
+            kind="LLM",
+            parent_id="abcdef1234567890",
+            attributes={
+                "llm.model_name": "gpt-4",
+                "llm.token_count.prompt": 100,
+                "llm.token_count.completion": 50,
+                "llm.token_count.total": 150,
+            },
+        )
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        assert len(payloads) == 1
+        payload = payloads[0]
+        assert payload["log_type"] == "generation"
+        assert payload["model"] == "gpt-4"
+        assert payload["prompt_tokens"] == 100
+        assert payload["completion_tokens"] == 50
+        assert payload["total_request_tokens"] == 150
+
+    def test_builds_payload_with_agent_span(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        span = self._make_span_dict(
+            name="Research Agent",
+            span_type="AGENT",
+            kind="AGENT",
+            parent_id="abcdef1234567890",
+        )
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        assert len(payloads) == 1
+        assert payloads[0]["log_type"] == "agent"
+
+    def test_builds_payload_with_tool_span(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        span = self._make_span_dict(
+            name="Search Tool",
+            span_type="TOOL",
+            kind="TOOL",
+            parent_id="abcdef1234567890",
+            attributes={"tool.name": "web_search"},
+        )
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        assert len(payloads) == 1
+        assert payloads[0]["log_type"] == "tool"
+        assert payloads[0].get("span_tools") == ["web_search"]
+
+    def test_builds_payload_with_task_span(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        span = self._make_span_dict(
+            name="Research Task",
+            span_type="CHAIN",
+            kind="CHAIN",
+            parent_id="abcdef1234567890",
+        )
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        assert len(payloads) == 1
+        assert payloads[0]["log_type"] == "task"  # child CHAIN = task
+
+    def test_extracts_input_output(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        span = self._make_span_dict(
+            attributes={
+                "input.value": "Research AI trends",
+                "output.value": "AI is growing rapidly...",
+            },
+        )
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        assert len(payloads) == 1
+        payload = payloads[0]
+        assert "Research AI trends" in payload["input"]
+        assert "AI is growing rapidly" in payload["output"]
+
+    def test_calculates_latency(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        span = self._make_span_dict(
+            start_time=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            end_time=datetime(2024, 1, 1, 0, 0, 5, tzinfo=timezone.utc),
+        )
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        assert payloads[0]["latency"] == 5.0
+
+    def test_handles_error_span(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        span = self._make_span_dict(
+            error="Task execution failed",
+            status_code=500,
+        )
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        assert payloads[0]["error_message"] == "Task execution failed"
+        assert payloads[0]["status_code"] == 500
+
+    def test_empty_spans_returns_empty(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        assert exporter.build_payload(trace_or_spans=[]) == []
+        assert exporter.build_payload(trace_or_spans=None) == []
+
+    def test_multiple_spans_in_trace(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        crew_span = self._make_span_dict(name="My Crew")
+        agent_span = self._make_span_dict(
+            name="Agent",
+            span_id="aaaaaaaaaaaaaaaa",
+            parent_id="1234567890abcdef",
+            span_type="AGENT",
+            kind="AGENT",
+        )
+        payloads = exporter.build_payload(trace_or_spans=[crew_span, agent_span])
+
+        assert len(payloads) == 2
+
+    def test_stores_crewai_ids_in_metadata(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        span = self._make_span_dict()
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        metadata = payloads[0].get("metadata", {})
+        assert "crewai_trace_id" in metadata
+        assert "crewai_span_id" in metadata
+
+    def test_sets_customer_identifier(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test", customer_identifier="user-42")
+        span = self._make_span_dict()
+        payloads = exporter.build_payload(trace_or_spans=[span])
+
+        assert payloads[0]["customer_identifier"] == "user-42"
+
+
+class TestExport:
+    """Test the export (send) functionality."""
+
+    def test_export_sends_payloads(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test-key")
+        span = {
+            "trace_id": "abcdef1234567890abcdef1234567890",
+            "span_id": "1234567890abcdef",
+            "parent_id": None,
+            "name": "Test Crew",
+            "span_type": "CHAIN",
+            "kind": "CHAIN",
+            "span_path": None,
+            "start_time": datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            "end_time": datetime(2024, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            "attributes": {},
+            "status_code": 200,
+            "error": None,
+        }
+
+        with patch("respan_exporter_crewai.exporter.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            payloads = exporter.export(trace_or_spans=[span])
+
+            assert len(payloads) > 0
+            mock_post.assert_called_once()
+            call_kwargs = mock_post.call_args
+            assert "Bearer test-key" in call_kwargs.kwargs.get("headers", {}).get("Authorization", "")
+
+    def test_export_skips_when_no_api_key(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        with patch.dict(os.environ, {}, clear=True):
+            env_vars_to_remove = ["RESPAN_API_KEY"]
+            for var in env_vars_to_remove:
+                os.environ.pop(var, None)
+
+            exporter = RespanCrewAIExporter(api_key=None)
+            span = {
+                "trace_id": "abcdef1234567890abcdef1234567890",
+                "span_id": "1234567890abcdef",
+                "parent_id": None,
+                "name": "Test",
+                "span_type": "CHAIN",
+                "kind": "CHAIN",
+                "span_path": None,
+                "start_time": datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                "end_time": datetime(2024, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+                "attributes": {},
+                "status_code": 200,
+                "error": None,
+            }
+
+            with patch("respan_exporter_crewai.exporter.requests.post") as mock_post:
+                payloads = exporter.export(trace_or_spans=[span])
+                mock_post.assert_not_called()
+                assert len(payloads) > 0  # payloads are built but not sent
+
+
+class TestPropagateTraceOutput:
+    """Test output propagation from generation spans to workflow/agent/task spans."""
+
+    def test_propagates_generation_output_to_workflow(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        payloads = [
+            {"log_type": "workflow", "output": None},
+            {"log_type": "generation", "output": "Generated answer"},
+        ]
+        exporter._propagate_trace_output(payloads=payloads)
+        assert payloads[0]["output"] == "Generated answer"
+
+    def test_does_not_overwrite_existing_output(self):
+        from respan_exporter_crewai.exporter import RespanCrewAIExporter
+
+        exporter = RespanCrewAIExporter(api_key="test")
+        payloads = [
+            {"log_type": "workflow", "output": "Existing output"},
+            {"log_type": "generation", "output": "Generated answer"},
+        ]
+        exporter._propagate_trace_output(payloads=payloads)
+        assert payloads[0]["output"] == "Existing output"

--- a/python-sdks/respan-exporter-crewai/tests/test_instrumentor.py
+++ b/python-sdks/respan-exporter-crewai/tests/test_instrumentor.py
@@ -1,0 +1,138 @@
+"""Tests for CrewAI OTel instrumentor."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRespanCrewAIInstrumentor:
+    """Test instrumentor setup and configuration."""
+
+    def test_instrumentation_dependencies(self):
+        from respan_exporter_crewai.instrumentor import RespanCrewAIInstrumentor
+
+        instrumentor = RespanCrewAIInstrumentor()
+        deps = instrumentor.instrumentation_dependencies()
+        assert any("crewai" in dep for dep in deps)
+        assert any("openinference-instrumentation-crewai" in dep for dep in deps)
+
+    def test_instrument_creates_exporter(self):
+        from respan_exporter_crewai.instrumentor import RespanCrewAIInstrumentor
+
+        instrumentor = RespanCrewAIInstrumentor()
+
+        with patch("respan_exporter_crewai.instrumentor.RespanCrewAIExporter") as mock_cls:
+            with patch.object(instrumentor, "_patch_span_processors"):
+                instrumentor._instrument(
+                    api_key="test-key",
+                    environment="staging",
+                )
+                mock_cls.assert_called_once_with(
+                    api_key="test-key",
+                    endpoint=None,
+                    base_url=None,
+                    environment="staging",
+                    customer_identifier=None,
+                    timeout=10,
+                )
+
+    def test_instrument_with_passthrough(self):
+        from respan_exporter_crewai.instrumentor import RespanCrewAIInstrumentor
+
+        instrumentor = RespanCrewAIInstrumentor()
+
+        with patch("respan_exporter_crewai.instrumentor.RespanCrewAIExporter"):
+            with patch.object(instrumentor, "_patch_span_processors"):
+                instrumentor._instrument(
+                    api_key="test-key",
+                    passthrough=True,
+                )
+                assert instrumentor._passthrough is True
+
+
+class TestExportCrewAISpans:
+    """Test the span export function used by wrappers."""
+
+    def test_filters_non_crewai_spans(self):
+        from respan_exporter_crewai import instrumentor as mod
+
+        non_crewai_span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="openai"),
+            attributes={"http.method": "POST"},
+            context=SimpleNamespace(trace_id=123, span_id=456),
+            parent=None,
+            name="OpenAI Call",
+            kind=SimpleNamespace(name="CLIENT"),
+            start_time=1700000000000000000,
+            end_time=1700000001000000000,
+            status=SimpleNamespace(
+                status_code=SimpleNamespace(name="OK"),
+                description=None,
+            ),
+        )
+
+        mock_exporter = MagicMock()
+        original_exporter = mod._ACTIVE_EXPORTER
+        mod._ACTIVE_EXPORTER = mock_exporter
+        try:
+            mod._export_crewai_spans(spans=[non_crewai_span])
+            mock_exporter.build_payload.assert_not_called()
+        finally:
+            mod._ACTIVE_EXPORTER = original_exporter
+
+    def test_exports_crewai_spans(self):
+        from respan_exporter_crewai import instrumentor as mod
+
+        crewai_span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.crewai"),
+            attributes={"openinference.span.kind": "CHAIN"},
+            context=SimpleNamespace(trace_id=123, span_id=456),
+            parent=None,
+            name="CrewAI Crew",
+            kind=SimpleNamespace(name="INTERNAL"),
+            start_time=1700000000000000000,
+            end_time=1700000001000000000,
+            status=SimpleNamespace(
+                status_code=SimpleNamespace(name="OK"),
+                description=None,
+            ),
+        )
+
+        mock_exporter = MagicMock()
+        mock_exporter.api_key = "test"
+        mock_exporter.build_payload.return_value = [{"trace_unique_id": "abc"}]
+        original_exporter = mod._ACTIVE_EXPORTER
+        mod._ACTIVE_EXPORTER = mock_exporter
+        try:
+            mod._export_crewai_spans(spans=[crewai_span])
+            mock_exporter.build_payload.assert_called_once()
+            mock_exporter._send.assert_called_once()
+        finally:
+            mod._ACTIVE_EXPORTER = original_exporter
+
+
+class TestSpanDedupeCache:
+    """Test span deduplication cache."""
+
+    def test_deduplicates_same_span(self):
+        from respan_exporter_crewai.instrumentor import _SpanDedupeCache
+
+        cache = _SpanDedupeCache(max_size=10)
+        assert cache.add("trace1", "span1") is True
+        assert cache.add("trace1", "span1") is False
+
+    def test_allows_different_spans(self):
+        from respan_exporter_crewai.instrumentor import _SpanDedupeCache
+
+        cache = _SpanDedupeCache(max_size=10)
+        assert cache.add("trace1", "span1") is True
+        assert cache.add("trace1", "span2") is True
+
+    def test_evicts_oldest_when_full(self):
+        from respan_exporter_crewai.instrumentor import _SpanDedupeCache
+
+        cache = _SpanDedupeCache(max_size=2)
+        cache.add("t1", "s1")
+        cache.add("t1", "s2")
+        cache.add("t1", "s3")  # evicts s1
+        assert cache.add("t1", "s1") is True  # s1 was evicted, can add again

--- a/python-sdks/respan-exporter-crewai/tests/test_utils.py
+++ b/python-sdks/respan-exporter-crewai/tests/test_utils.py
@@ -1,0 +1,168 @@
+"""Tests for CrewAI exporter utility functions."""
+import pytest
+from types import SimpleNamespace
+
+
+class TestIsCrewAISpan:
+    """Test is_crewai_span detection logic."""
+
+    def test_detects_crewai_instrumentation_scope(self):
+        from respan_exporter_crewai.utils import is_crewai_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.crewai"),
+            attributes={},
+        )
+        assert is_crewai_span(span=span) is True
+
+    def test_detects_crewai_attribute_prefix(self):
+        from respan_exporter_crewai.utils import is_crewai_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="other"),
+            attributes={"crewai.crew.id": "123", "crewai.task.id": "456"},
+        )
+        assert is_crewai_span(span=span) is True
+
+    def test_rejects_non_crewai_span(self):
+        from respan_exporter_crewai.utils import is_crewai_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="openai"),
+            attributes={"http.method": "POST"},
+        )
+        assert is_crewai_span(span=span) is False
+
+    def test_detects_crewai_via_openinference_span_kind(self):
+        """CrewAI spans from openinference have openinference.span.kind attribute."""
+        from respan_exporter_crewai.utils import is_crewai_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.crewai"),
+            attributes={"openinference.span.kind": "CHAIN"},
+        )
+        assert is_crewai_span(span=span) is True
+
+    def test_handles_missing_instrumentation_scope(self):
+        from respan_exporter_crewai.utils import is_crewai_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=None,
+            attributes={"crewai.crew.id": "abc"},
+        )
+        assert is_crewai_span(span=span) is True
+
+    def test_handles_no_attributes(self):
+        from respan_exporter_crewai.utils import is_crewai_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="other"),
+            attributes=None,
+        )
+        assert is_crewai_span(span=span) is False
+
+
+class TestOtelSpanToDict:
+    """Test conversion of OTel spans to dict format."""
+
+    def test_converts_basic_span(self):
+        from respan_exporter_crewai.utils import otel_span_to_dict
+
+        span_context = SimpleNamespace(trace_id=1234567890, span_id=9876543210)
+        span = SimpleNamespace(
+            context=span_context,
+            parent=None,
+            name="CrewAI Task",
+            kind=SimpleNamespace(name="INTERNAL"),
+            start_time=1700000000000000000,
+            end_time=1700000001000000000,
+            attributes={"openinference.span.kind": "CHAIN"},
+            status=SimpleNamespace(
+                status_code=SimpleNamespace(name="OK"),
+                description=None,
+            ),
+            instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.crewai"),
+        )
+
+        result = otel_span_to_dict(span=span)
+        assert result["name"] == "CrewAI Task"
+        assert result["trace_id"] is not None
+        assert result["span_id"] is not None
+        assert result["parent_id"] is None
+        assert result["start_time"] is not None
+        assert result["end_time"] is not None
+        assert result["status_code"] == 200
+
+    def test_converts_span_with_parent(self):
+        from respan_exporter_crewai.utils import otel_span_to_dict
+
+        parent_context = SimpleNamespace(span_id=1111111111)
+        span_context = SimpleNamespace(trace_id=1234567890, span_id=9876543210)
+        span = SimpleNamespace(
+            context=span_context,
+            parent=parent_context,
+            name="CrewAI Agent",
+            kind=SimpleNamespace(name="INTERNAL"),
+            start_time=1700000000000000000,
+            end_time=1700000001000000000,
+            attributes={"openinference.span.kind": "AGENT"},
+            status=SimpleNamespace(
+                status_code=SimpleNamespace(name="OK"),
+                description=None,
+            ),
+            instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.crewai"),
+        )
+
+        result = otel_span_to_dict(span=span)
+        assert result["parent_id"] is not None
+
+    def test_converts_error_span(self):
+        from respan_exporter_crewai.utils import otel_span_to_dict
+
+        span_context = SimpleNamespace(trace_id=1234567890, span_id=9876543210)
+        span = SimpleNamespace(
+            context=span_context,
+            parent=None,
+            name="Failed Task",
+            kind=SimpleNamespace(name="INTERNAL"),
+            start_time=1700000000000000000,
+            end_time=1700000001000000000,
+            attributes={},
+            status=SimpleNamespace(
+                status_code=SimpleNamespace(name="ERROR"),
+                description="task failed",
+            ),
+            instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.crewai"),
+        )
+
+        result = otel_span_to_dict(span=span)
+        assert result["status_code"] == 500
+        assert result["error"] == "task failed"
+
+
+class TestGroupSpansByTrace:
+    """Test grouping spans by trace ID."""
+
+    def test_groups_correctly(self):
+        from respan_exporter_crewai.utils import group_spans_by_trace
+
+        spans = [
+            {"trace_id": "trace1", "span_id": "a"},
+            {"trace_id": "trace1", "span_id": "b"},
+            {"trace_id": "trace2", "span_id": "c"},
+        ]
+        grouped = group_spans_by_trace(spans=spans)
+        assert len(grouped) == 2
+        assert len(grouped["trace1"]) == 2
+        assert len(grouped["trace2"]) == 1
+
+    def test_skips_missing_trace_id(self):
+        from respan_exporter_crewai.utils import group_spans_by_trace
+
+        spans = [
+            {"trace_id": "trace1", "span_id": "a"},
+            {"span_id": "b"},
+            {"trace_id": "", "span_id": "c"},
+        ]
+        grouped = group_spans_by_trace(spans=spans)
+        assert len(grouped) == 1


### PR DESCRIPTION
## Summary
- Adds new `respan-exporter-crewai` package that intercepts OTel spans from `openinference-instrumentation-crewai`
- Converts CrewAI traces (Crew/Agent/Task/Tool/LLM spans) to Respan format and exports to the trace ingestion endpoint
- Follows the same OTel-based interception pattern as the existing Agno exporter (`RespanCrewAIInstrumentor` wraps OTel span processors via `wrapt`)

## Key components
- `RespanCrewAIExporter` - Builds and sends payloads to Respan
- `RespanCrewAIInstrumentor` - Patches `BatchSpanProcessor` and `SimpleSpanProcessor` to intercept CrewAI spans
- `is_crewai_span()` - Detects CrewAI spans by instrumentation scope name or `crewai.*` attribute keys

## Test plan
- [x] 41 unit tests covering exporter, instrumentor, and utils
- [x] Tests verify span detection, payload construction, log type mapping, token extraction, error handling, deduplication, and export behavior
- [x] All tests pass (`poetry run pytest tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)