### PR TITLE
feat(exporters): add Microsoft Agents exporter (AutoGen + Semantic Kernel)

### DIFF
--- a/python-sdks/respan-exporter-microsoft-agents/README.md
+++ b/python-sdks/respan-exporter-microsoft-agents/README.md
@@ -1,0 +1,52 @@
+# Respan Microsoft Agents Exporter
+
+Export AutoGen and Semantic Kernel traces to Respan via OpenTelemetry span interception.
+
+## Installation
+
+```bash
+pip install respan-exporter-microsoft-agents
+```
+
+## Usage
+
+### With AutoGen
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from respan_exporter_microsoft_agents import RespanMicrosoftAgentsInstrumentor
+
+provider = TracerProvider()
+trace.set_tracer_provider(provider)
+
+# AutoGen runtime natively emits OTel spans
+# Just add Respan interception
+RespanMicrosoftAgentsInstrumentor().instrument(
+    api_key="your-respan-api-key",  # or set RESPAN_API_KEY env var
+    environment="production",
+)
+```
+
+### With Semantic Kernel
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from respan_exporter_microsoft_agents import RespanMicrosoftAgentsInstrumentor
+
+provider = TracerProvider()
+trace.set_tracer_provider(provider)
+
+# Semantic Kernel natively emits OTel spans
+RespanMicrosoftAgentsInstrumentor().instrument(
+    api_key="your-respan-api-key",
+)
+```
+
+## Environment Variables
+
+- `RESPAN_API_KEY` - API key for Respan platform
+- `RESPAN_BASE_URL` - API endpoint (default: `https://api.respan.ai/api`)
+- `RESPAN_ENVIRONMENT` - Environment name (default: `production`)
+- `RESPAN_CUSTOMER_IDENTIFIER` - Optional customer identifier

--- a/python-sdks/respan-exporter-microsoft-agents/examples/quickstart_autogen.py
+++ b/python-sdks/respan-exporter-microsoft-agents/examples/quickstart_autogen.py
@@ -1,0 +1,59 @@
+"""
+Respan Microsoft Agents Exporter - AutoGen Quick Start Example
+
+This example shows how to instrument AutoGen with Respan
+to capture traces from your agent runs.
+
+AutoGen natively emits OpenTelemetry spans. The Respan instrumentor
+intercepts those spans and forwards them to Respan for observability.
+
+Prerequisites:
+    pip install respan-exporter-microsoft-agents autogen-agentchat autogen-ext
+    export RESPAN_API_KEY=your-api-key
+    export OPENAI_API_KEY=your-openai-key
+"""
+
+import asyncio
+import os
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.messages import TextMessage
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from respan_exporter_microsoft_agents import RespanMicrosoftAgentsInstrumentor
+
+# 1. Set up OpenTelemetry (AutoGen uses it internally)
+provider = TracerProvider()
+trace.set_tracer_provider(provider)
+
+# 2. Activate Respan instrumentation to intercept AutoGen spans
+RespanMicrosoftAgentsInstrumentor().instrument(
+    api_key=os.getenv("RESPAN_API_KEY"),
+    environment="development",
+)
+
+
+async def main():
+    # 3. Create an AutoGen agent with an OpenAI model
+    model_client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+    agent = AssistantAgent(
+        name="assistant",
+        model_client=model_client,
+        system_message="You are a helpful assistant. Keep answers concise.",
+    )
+
+    # 4. Run a simple query - the trace is automatically captured by Respan
+    response = await agent.on_messages(
+        [TextMessage(content="What is the capital of France?", source="user")],
+        cancellation_token=CancellationToken(),
+    )
+    print(f"Agent response: {response.chat_message.content}")
+    print("\nTrace has been sent to Respan!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/respan-exporter-microsoft-agents/examples/quickstart_semantic_kernel.py
+++ b/python-sdks/respan-exporter-microsoft-agents/examples/quickstart_semantic_kernel.py
@@ -1,0 +1,49 @@
+"""
+Respan Microsoft Agents Exporter - Semantic Kernel Quick Start Example
+
+This example shows how to instrument Semantic Kernel with Respan
+to capture traces from your AI service calls.
+
+Semantic Kernel natively emits OpenTelemetry spans. The Respan instrumentor
+intercepts those spans and forwards them to Respan for observability.
+
+Prerequisites:
+    pip install respan-exporter-microsoft-agents semantic-kernel
+    export RESPAN_API_KEY=your-api-key
+    export OPENAI_API_KEY=your-openai-key
+"""
+
+import asyncio
+import os
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from semantic_kernel import Kernel
+from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+
+from respan_exporter_microsoft_agents import RespanMicrosoftAgentsInstrumentor
+
+# 1. Set up OpenTelemetry (Semantic Kernel uses it internally)
+provider = TracerProvider()
+trace.set_tracer_provider(provider)
+
+# 2. Activate Respan instrumentation to intercept Semantic Kernel spans
+RespanMicrosoftAgentsInstrumentor().instrument(
+    api_key=os.getenv("RESPAN_API_KEY"),
+    environment="development",
+)
+
+
+async def main():
+    # 3. Create a Semantic Kernel instance with an OpenAI chat service
+    kernel = Kernel()
+    kernel.add_service(OpenAIChatCompletion(service_id="chat", ai_model_id="gpt-4o-mini"))
+
+    # 4. Invoke a prompt - the trace is automatically captured by Respan
+    result = await kernel.invoke_prompt("What is the capital of France?")
+    print(f"Response: {result}")
+    print("\nTrace has been sent to Respan!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/respan-exporter-microsoft-agents/pyproject.toml
+++ b/python-sdks/respan-exporter-microsoft-agents/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+name = "respan-exporter-microsoft-agents"
+version = "1.0.0"
+description = "Respan exporter for Microsoft Agent Framework traces (AutoGen and Semantic Kernel)"
+authors = ["Respan <team@respan.ai>"]
+readme = "README.md"
+packages = [{include = "respan_exporter_microsoft_agents", from = "src"}]
+
+[tool.poetry.dependencies]
+python = ">=3.12,<3.14"
+requests = "^2.32.5"
+wrapt = "^1.16.0"
+opentelemetry-sdk = "^1.20.0"
+opentelemetry-api = "^1.20.0"
+opentelemetry-instrumentation = "^0.41b0"
+respan-sdk = ">=2.6.1"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^9.0.2"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/__init__.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/__init__.py
@@ -1,0 +1,4 @@
+from .exporter import RespanMicrosoftAgentsExporter
+from .instrumentor import RespanMicrosoftAgentsInstrumentor
+
+__all__ = ["RespanMicrosoftAgentsExporter", "RespanMicrosoftAgentsInstrumentor"]

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/exporter.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/exporter.py
@@ -186,8 +186,13 @@ class RespanMicrosoftAgentsExporter:
         span_name = get_attr(span, "name", "span_name", "operation_name")
         span_kind = get_attr(span, "type", "span_type", "kind")
 
+        span_path = get_attr(span, "span_path", "path")
+
         span_metadata = as_dict(value=get_attr(span, "metadata", "attributes", "tags", "data")) or {}
         span_metadata = merge_openinference_metadata(metadata=span_metadata)
+
+        if not span_path:
+            span_path = pick_metadata_value(span_metadata, "graph.node.id")
 
         if span_kind is None:
             span_kind = pick_metadata_value(span_metadata, "openinference.span.kind", "span.kind")
@@ -258,7 +263,13 @@ class RespanMicrosoftAgentsExporter:
         span_hex_id = span_id_map.get(span_id_str) if span_id_map else normalize_span_id(span_id=span_id_str, trace_id=trace_context.trace_id)
         if not span_hex_id:
             span_hex_id = normalize_span_id(span_id=span_id_str, trace_id=trace_context.trace_id)
-        parent_hex_id = span_id_map.get(str(parent_id)) if span_id_map and parent_id else (normalize_span_id(span_id=str(parent_id), trace_id=trace_context.trace_id) if parent_id else None)
+        if parent_id:
+            parent_hex_id = (
+                (span_id_map.get(str(parent_id)) if span_id_map else None)
+                or normalize_span_id(span_id=str(parent_id), trace_id=trace_context.trace_id)
+            )
+        else:
+            parent_hex_id = None
 
         if "microsoft_agents_trace_id" not in merged_metadata:
             merged_metadata["microsoft_agents_trace_id"] = trace_context.trace_id
@@ -276,6 +287,7 @@ class RespanMicrosoftAgentsExporter:
             "span_unique_id": span_hex_id,
             "span_parent_id": parent_hex_id,
             "span_name": str(span_name) if span_name else None,
+            "span_path": span_path,
             "span_workflow_name": trace_context.workflow_name,
             "trace_id": trace_hex_id,
             "span_id": span_hex_id,

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/exporter.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/exporter.py
@@ -1,0 +1,357 @@
+"""Respan microsoft_agents Exporter - Export microsoft_agents traces to Respan."""
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import requests
+
+from respan_exporter_microsoft_agents.types import TraceContext
+from respan_exporter_microsoft_agents.utils import (
+    as_dict,
+    clean_payload,
+    coerce_datetime,
+    coerce_token_count,
+    extract_openinference_messages,
+    extract_span_metadata,
+    find_root_span,
+    format_rfc3339,
+    get_attr,
+    infer_trace_start_time,
+    is_blank_value,
+    merge_openinference_metadata,
+    normalize_span_id,
+    normalize_trace_id,
+    pick_metadata_value,
+    serialize_value,
+)
+from respan_sdk.constants.llm_logging import LOG_TYPE_MAP
+from respan_sdk.respan_types.log_types import RespanFullLogParams
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENDPOINT = "https://api.respan.ai/api/v1/traces/ingest"
+
+
+class RespanMicrosoftAgentsExporter:
+    """Export microsoft_agents traces/spans to Respan."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        base_url: Optional[str] = None,
+        environment: Optional[str] = None,
+        customer_identifier: Optional[Union[str, int]] = None,
+        timeout: int = 10,
+    ) -> None:
+        self.api_key = api_key or os.getenv("RESPAN_API_KEY")
+        if base_url is None:
+            base_url = os.getenv("RESPAN_BASE_URL") or "https://api.respan.ai/api"
+        self.endpoint = endpoint or self._build_endpoint(base_url=base_url)
+        self.environment = environment or os.getenv("RESPAN_ENVIRONMENT") or "production"
+        self.customer_identifier = customer_identifier or os.getenv("RESPAN_CUSTOMER_IDENTIFIER")
+        self.timeout = timeout
+
+    def _build_endpoint(self, base_url: Optional[str]) -> str:
+        if not base_url:
+            return DEFAULT_ENDPOINT
+        base = base_url.rstrip("/")
+        if base.endswith("/v1/traces/ingest"):
+            return base
+        if base.endswith("/v1/traces"):
+            return f"{base}/ingest"
+        if base.endswith("/api"):
+            return f"{base}/v1/traces/ingest"
+        return f"{base}/api/v1/traces/ingest"
+
+    def export(self, trace_or_spans: Any) -> List[Dict[str, Any]]:
+        """Export trace or spans to Respan."""
+        payloads = self.build_payload(trace_or_spans=trace_or_spans)
+        if not payloads:
+            return payloads
+        if not self.api_key:
+            logger.warning("Respan API key is not set; skipping export")
+            return payloads
+        self._send(payloads=payloads)
+        return payloads
+
+    def build_payload(self, trace_or_spans: Any) -> List[Dict[str, Any]]:
+        """Build payload from trace or spans."""
+        trace_obj, spans = self._normalize_trace(trace_or_spans=trace_or_spans)
+        if not spans:
+            return []
+        trace_context = self._extract_trace_context(trace_obj=trace_obj, spans=spans)
+        span_id_map: Dict[str, str] = {}
+        for span in spans:
+            raw_span_id = get_attr(span, "span_id", "id", "uid")
+            if raw_span_id is None:
+                continue
+            raw_span_id = str(raw_span_id)
+            span_id_map[raw_span_id] = normalize_span_id(span_id=raw_span_id, trace_id=trace_context.trace_id)
+        payloads: List[Dict[str, Any]] = []
+        for span in spans:
+            payload = self._span_to_respan(span=span, trace_context=trace_context, span_id_map=span_id_map)
+            if payload:
+                payloads.append(payload)
+        if payloads:
+            self._propagate_trace_output(payloads=payloads)
+        return payloads
+
+    def _propagate_trace_output(self, payloads: List[Dict[str, Any]]) -> None:
+        """Propagate output from generation spans to workflow/agent/task spans."""
+        trace_output: Optional[str] = None
+        for p in payloads:
+            output = p.get("output")
+            if is_blank_value(value=output):
+                continue
+            if p.get("log_type") == "generation":
+                trace_output = output
+                break
+            if trace_output is None:
+                trace_output = output
+        if trace_output is not None:
+            for p in payloads:
+                if is_blank_value(value=p.get("output")) and p.get("log_type") in ("workflow", "agent", "task"):
+                    p["output"] = trace_output
+
+    def _normalize_trace(self, trace_or_spans: Any) -> Tuple[Optional[Any], List[Any]]:
+        if trace_or_spans is None:
+            return None, []
+        if isinstance(trace_or_spans, (list, tuple, set)):
+            return None, list(trace_or_spans)
+        if isinstance(trace_or_spans, dict):
+            spans = trace_or_spans.get("spans")
+            if spans is not None:
+                return trace_or_spans, list(spans)
+            return None, [trace_or_spans]
+        spans = get_attr(trace_or_spans, "spans", "span_events")
+        if spans is not None:
+            return trace_or_spans, list(spans)
+        return None, [trace_or_spans]
+
+    def _extract_trace_context(self, trace_obj: Optional[Any], spans: Sequence[Any]) -> TraceContext:
+        trace_id = get_attr(trace_obj, "trace_id", "id", "uid")
+        trace_name = get_attr(trace_obj, "name", "trace_name", "title")
+        workflow_name = get_attr(trace_obj, "workflow_name", "workflow")
+        session_identifier = get_attr(trace_obj, "session_identifier", "session_id")
+        trace_group_identifier = get_attr(trace_obj, "trace_group_identifier", "group_identifier", "group_id")
+
+        trace_metadata = as_dict(value=get_attr(trace_obj, "metadata", "attributes", "tags")) or {}
+        trace_metadata = merge_openinference_metadata(metadata=trace_metadata)
+
+        customer_identifier = get_attr(trace_obj, "customer_identifier", "customer_id", "user_id", "user")
+        if not customer_identifier:
+            customer_identifier = self.customer_identifier
+
+        trace_start_time = coerce_datetime(value=get_attr(trace_obj, "start_time", "started_at", "start"))
+
+        root_span = find_root_span(spans=spans)
+        root_metadata = extract_span_metadata(span=root_span) if root_span else {}
+
+        if not trace_id:
+            for span in spans:
+                trace_id = get_attr(span, "trace_id", "traceId")
+                if trace_id:
+                    break
+        if not trace_id:
+            trace_id = str(uuid.uuid4())
+
+        if not trace_name:
+            trace_name = pick_metadata_value(root_metadata, "microsoft_agents.agent.type", "agent.name")
+        if not trace_name:
+            trace_name = str(trace_id)
+
+        if not workflow_name:
+            workflow_name = trace_name
+
+        if not trace_start_time:
+            trace_start_time = infer_trace_start_time(spans=spans)
+
+        return TraceContext(
+            trace_id=str(trace_id),
+            trace_name=str(trace_name) if trace_name else None,
+            workflow_name=str(workflow_name) if workflow_name else None,
+            metadata=trace_metadata,
+            session_identifier=session_identifier,
+            trace_group_identifier=trace_group_identifier,
+            start_time=trace_start_time,
+            customer_identifier=customer_identifier,
+        )
+
+    def _span_to_respan(self, span: Any, trace_context: TraceContext, span_id_map: Optional[Dict[str, str]] = None) -> Optional[Dict[str, Any]]:
+        span_id = get_attr(span, "span_id", "id", "uid")
+        parent_id = get_attr(span, "parent_id", "parent_span_id", "parentId")
+        span_name = get_attr(span, "name", "span_name", "operation_name")
+        span_kind = get_attr(span, "type", "span_type", "kind")
+
+        span_metadata = as_dict(value=get_attr(span, "metadata", "attributes", "tags", "data")) or {}
+        span_metadata = merge_openinference_metadata(metadata=span_metadata)
+
+        if span_kind is None:
+            span_kind = pick_metadata_value(span_metadata, "openinference.span.kind", "span.kind")
+
+        span_input = get_attr(span, "input", "input_data", "request", "prompt")
+        if span_input is None:
+            for key in ("input.value", "input_value", "traceloop.entity.input"):
+                if key in span_metadata:
+                    span_input = span_metadata.get(key)
+                    break
+
+        span_output = get_attr(span, "output", "output_data", "response")
+        if span_output is None:
+            for key in ("output.value", "output_value", "traceloop.entity.output"):
+                if key in span_metadata:
+                    span_output = span_metadata.get(key)
+                    break
+
+        input_messages = extract_openinference_messages(metadata=span_metadata, prefix="llm.input_messages")
+        output_messages = extract_openinference_messages(metadata=span_metadata, prefix="llm.output_messages")
+        if span_input is None and input_messages:
+            span_input = input_messages
+        if span_output is None and output_messages:
+            span_output = output_messages
+
+        model = get_attr(span, "model", "model_name")
+        if model is None:
+            model = pick_metadata_value(span_metadata, "llm.model_name", "llm.model", "model")
+
+        usage = get_attr(span, "usage", "token_usage")
+        usage = as_dict(value=usage)
+        if usage is None:
+            prompt_tokens = span_metadata.get("llm.token_count.prompt")
+            completion_tokens = span_metadata.get("llm.token_count.completion")
+            total_tokens = span_metadata.get("llm.token_count.total")
+            if any(v is not None for v in (prompt_tokens, completion_tokens, total_tokens)):
+                usage = {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens, "total_tokens": total_tokens}
+
+        error = get_attr(span, "error", "exception", "err")
+
+        start_time = coerce_datetime(value=get_attr(span, "start_time", "started_at", "start"), reference=trace_context.start_time)
+        end_time = coerce_datetime(value=get_attr(span, "end_time", "ended_at", "end", "timestamp"), reference=trace_context.start_time)
+
+        now = datetime.now(timezone.utc)
+        if start_time is None and end_time is None:
+            start_time = end_time = now
+        elif start_time is None:
+            start_time = end_time
+        elif end_time is None:
+            end_time = start_time
+        if start_time and end_time and end_time < start_time:
+            end_time = start_time
+
+        latency = get_attr(span, "latency", "duration")
+        if latency is None and start_time and end_time:
+            latency = (end_time - start_time).total_seconds()
+
+        if not span_id:
+            span_id = str(uuid.uuid4())
+        span_id_str = str(span_id)
+        if not span_name:
+            span_name = span_id
+
+        log_type = self._map_log_type(span_kind=span_kind, parent_id=parent_id, model=model)
+
+        merged_metadata = {**trace_context.metadata, **(span_metadata or {})}
+        trace_hex_id = normalize_trace_id(trace_id=trace_context.trace_id)
+        span_hex_id = span_id_map.get(span_id_str) if span_id_map else normalize_span_id(span_id=span_id_str, trace_id=trace_context.trace_id)
+        if not span_hex_id:
+            span_hex_id = normalize_span_id(span_id=span_id_str, trace_id=trace_context.trace_id)
+        parent_hex_id = span_id_map.get(str(parent_id)) if span_id_map and parent_id else (normalize_span_id(span_id=str(parent_id), trace_id=trace_context.trace_id) if parent_id else None)
+
+        if "microsoft_agents_trace_id" not in merged_metadata:
+            merged_metadata["microsoft_agents_trace_id"] = trace_context.trace_id
+        if "microsoft_agents_span_id" not in merged_metadata:
+            merged_metadata["microsoft_agents_span_id"] = str(span_id)
+        if parent_id and "microsoft_agents_parent_id" not in merged_metadata:
+            merged_metadata["microsoft_agents_parent_id"] = str(parent_id)
+
+        input_value = serialize_value(value=span_input) if span_input is not None else None
+        output_value = serialize_value(value=span_output) if span_output is not None else None
+
+        payload = {
+            "trace_unique_id": trace_hex_id,
+            "trace_name": trace_context.trace_name,
+            "span_unique_id": span_hex_id,
+            "span_parent_id": parent_hex_id,
+            "span_name": str(span_name) if span_name else None,
+            "span_workflow_name": trace_context.workflow_name,
+            "trace_id": trace_hex_id,
+            "span_id": span_hex_id,
+            "parent_id": parent_hex_id,
+            "environment": self.environment,
+            "customer_identifier": trace_context.customer_identifier,
+            "log_type": log_type,
+            "start_time": format_rfc3339(value=start_time),
+            "timestamp": format_rfc3339(value=end_time),
+            "latency": latency,
+            "input": input_value,
+            "output": output_value,
+            "model": model,
+            "metadata": merged_metadata or None,
+            "session_identifier": trace_context.session_identifier,
+            "trace_group_identifier": trace_context.trace_group_identifier,
+            "respan_params": {"environment": self.environment, "has_webhook": False},
+            "disable_log": False,
+        }
+
+        if usage:
+            pt = usage.get("prompt_tokens") or usage.get("input_tokens")
+            ct = usage.get("completion_tokens") or usage.get("output_tokens")
+            tt = usage.get("total_tokens") or usage.get("total")
+            payload["prompt_tokens"] = pt
+            payload["completion_tokens"] = ct
+            payload["total_request_tokens"] = tt
+            coerced_total = coerce_token_count(value=tt)
+            if coerced_total is None or coerced_total == 0:
+                cp = coerce_token_count(value=pt) or 0
+                cc = coerce_token_count(value=ct) or 0
+                if cp or cc:
+                    payload["total_request_tokens"] = cp + cc
+
+        if error:
+            payload["error_message"] = str(error)
+            payload["status_code"] = 500
+        else:
+            payload["status_code"] = get_attr(span, "status_code") or 200
+
+        tool_name = get_attr(span, "tool_name", "tool") or merged_metadata.get("tool_name") or merged_metadata.get("tool.name")
+        if tool_name:
+            payload["span_tools"] = [str(tool_name)]
+
+        if not payload.get("span_unique_id") and payload.get("trace_unique_id"):
+            payload["span_unique_id"] = payload["trace_unique_id"]
+
+        cleaned = clean_payload(payload=payload)
+
+        try:
+            RespanFullLogParams(**cleaned)
+        except Exception as exc:
+            logger.warning("microsoft_agents span payload failed validation: %s", exc)
+
+        return cleaned
+
+    def _map_log_type(self, span_kind: Any, parent_id: Optional[str], model: Optional[str]) -> str:
+        if span_kind:
+            kind_str = str(span_kind).lower()
+            for key, value in LOG_TYPE_MAP.items():
+                if key in kind_str:
+                    return value
+        if model:
+            return "generation"
+        if parent_id is None:
+            return "workflow"
+        return "task"
+
+    def _send(self, payloads: List[Dict[str, Any]]) -> None:
+        try:
+            response = requests.post(
+                url=self.endpoint, json=payloads,
+                headers={"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"},
+                timeout=self.timeout,
+            )
+            if response.status_code not in (200, 201):
+                logger.warning("Respan export failed with status %s: %s", response.status_code, response.text)
+        except Exception as exc:
+            logger.warning("Respan export request failed: %s", exc)

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/instrumentor.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/instrumentor.py
@@ -85,8 +85,13 @@ def _batch_export_wrapper(wrapped, instance, args, kwargs):
     if not spans:
         return wrapped(*args, **kwargs)
 
-    microsoft_agents_spans = [s for s in spans if is_microsoft_agents_span(span=s)]
-    other_spans = [s for s in spans if not is_microsoft_agents_span(span=s)]
+    microsoft_agents_spans = []
+    other_spans = []
+    for s in spans:
+        if is_microsoft_agents_span(span=s):
+            microsoft_agents_spans.append(s)
+        else:
+            other_spans.append(s)
 
     if not microsoft_agents_spans:
         return wrapped(*args, **kwargs)
@@ -153,7 +158,7 @@ class RespanMicrosoftAgentsInstrumentor(BaseInstrumentor):
     def _uninstrument(self, **kwargs) -> None:
         global _ACTIVE_EXPORTER, _ACTIVE_DEDUPE, _ACTIVE_PASSTHROUGH
         _ACTIVE_EXPORTER = None
-        _ACTIVE_DEDUPE = None
+        _ACTIVE_DEDUPE = _SpanDedupeCache()
         _ACTIVE_PASSTHROUGH = True
         logger.info("Respan microsoft_agents instrumentation disabled")
 

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/instrumentor.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/instrumentor.py
@@ -106,7 +106,8 @@ def _batch_export_wrapper(wrapped, instance, args, kwargs):
     if _ACTIVE_PASSTHROUGH:
         return wrapped(*args, **kwargs)
     if other_spans:
-        wrapped_result = wrapped(other_spans, **kwargs)
+        fwd_kwargs = {k: v for k, v in kwargs.items() if k != "spans"}
+        wrapped_result = wrapped(other_spans, **fwd_kwargs)
         if (
             wrapped_result == SpanExportResult.FAILURE
             or export_result == SpanExportResult.FAILURE

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/instrumentor.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/instrumentor.py
@@ -96,16 +96,24 @@ def _batch_export_wrapper(wrapped, instance, args, kwargs):
     if not microsoft_agents_spans:
         return wrapped(*args, **kwargs)
 
+    export_result = SpanExportResult.SUCCESS
     try:
-        _export_microsoft_agents_spans(spans=microsoft_agents_spans)
+        export_result = _export_microsoft_agents_spans(spans=microsoft_agents_spans)
     except Exception as exc:
         logger.warning("Failed to export microsoft_agents spans: %s", exc, exc_info=True)
+        export_result = SpanExportResult.FAILURE
 
     if _ACTIVE_PASSTHROUGH:
         return wrapped(*args, **kwargs)
     if other_spans:
-        return wrapped(other_spans, **kwargs)
-    return SpanExportResult.SUCCESS
+        wrapped_result = wrapped(other_spans, **kwargs)
+        if (
+            wrapped_result == SpanExportResult.FAILURE
+            or export_result == SpanExportResult.FAILURE
+        ):
+            return SpanExportResult.FAILURE
+        return SpanExportResult.SUCCESS
+    return export_result
 
 
 def _on_end_wrapper(wrapped, instance, args, kwargs):

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/instrumentor.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/instrumentor.py
@@ -1,0 +1,177 @@
+"""Respan OpenTelemetry redirect for microsoft_agents traces."""
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from threading import Lock
+from typing import Collection, Dict, Iterable, List, Optional
+
+import wrapt
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+from respan_exporter_microsoft_agents.utils import group_spans_by_trace, is_microsoft_agents_span, otel_span_to_dict
+
+logger = logging.getLogger(__name__)
+
+_INSTRUMENTS = ("opentelemetry-sdk >= 1.20.0",)
+_PATCHED = False
+
+
+class _SpanDedupeCache:
+    """Cache for deduplicating spans."""
+
+    def __init__(self, max_size: int = 10000) -> None:
+        self._max_size = max_size
+        self._data: "OrderedDict[str, None]" = OrderedDict()
+        self._lock = Lock()
+
+    def add(self, trace_id: Optional[str], span_id: Optional[str]) -> bool:
+        if not trace_id or not span_id:
+            return True
+        key = f"{trace_id}:{span_id}"
+        with self._lock:
+            if key in self._data:
+                return False
+            self._data[key] = None
+            if len(self._data) > self._max_size:
+                self._data.popitem(last=False)
+        return True
+
+
+_ACTIVE_EXPORTER: Optional[RespanMicrosoftAgentsExporter] = None
+_ACTIVE_DEDUPE = _SpanDedupeCache()
+_ACTIVE_PASSTHROUGH = False
+
+
+def _export_microsoft_agents_spans(spans: Iterable[object]) -> SpanExportResult:
+    """Export microsoft_agents spans to Respan."""
+    exporter = _ACTIVE_EXPORTER
+    dedupe = _ACTIVE_DEDUPE
+    if exporter is None:
+        return SpanExportResult.SUCCESS
+
+    span_dicts: List[Dict[str, object]] = []
+    for span in spans:
+        if not is_microsoft_agents_span(span=span):
+            continue
+        span_dict = otel_span_to_dict(span=span)
+        if dedupe and not dedupe.add(trace_id=span_dict.get("trace_id"), span_id=span_dict.get("span_id")):
+            continue
+        span_dicts.append(span_dict)
+
+    if not span_dicts:
+        return SpanExportResult.SUCCESS
+
+    payloads: List[Dict[str, object]] = []
+    grouped = group_spans_by_trace(spans=span_dicts)
+    for trace_spans in grouped.values():
+        payloads.extend(exporter.build_payload(trace_or_spans=trace_spans))
+
+    if not payloads:
+        return SpanExportResult.SUCCESS
+
+    if not exporter.api_key:
+        logger.warning("Respan API key is not set; skipping microsoft_agents export")
+        return SpanExportResult.SUCCESS
+
+    exporter._send(payloads=payloads)
+    return SpanExportResult.SUCCESS
+
+
+def _batch_export_wrapper(wrapped, instance, args, kwargs):
+    spans = list(args[0]) if args else list(kwargs.get("spans", []))
+    if not spans:
+        return wrapped(*args, **kwargs)
+
+    microsoft_agents_spans = [s for s in spans if is_microsoft_agents_span(span=s)]
+    other_spans = [s for s in spans if not is_microsoft_agents_span(span=s)]
+
+    if not microsoft_agents_spans:
+        return wrapped(*args, **kwargs)
+
+    try:
+        _export_microsoft_agents_spans(spans=microsoft_agents_spans)
+    except Exception as exc:
+        logger.warning("Failed to export microsoft_agents spans: %s", exc, exc_info=True)
+
+    if _ACTIVE_PASSTHROUGH:
+        return wrapped(*args, **kwargs)
+    if other_spans:
+        return wrapped(other_spans, **kwargs)
+    return SpanExportResult.SUCCESS
+
+
+def _on_end_wrapper(wrapped, instance, args, kwargs):
+    span = args[0] if args else kwargs.get("span")
+    if span is None or not is_microsoft_agents_span(span=span):
+        return wrapped(*args, **kwargs)
+
+    try:
+        _export_microsoft_agents_spans(spans=[span])
+    except Exception as exc:
+        logger.warning("Failed to export microsoft_agents span: %s", exc, exc_info=True)
+
+    if _ACTIVE_PASSTHROUGH:
+        return wrapped(*args, **kwargs)
+    return None
+
+
+class RespanMicrosoftAgentsInstrumentor(BaseInstrumentor):
+    """Instrument OTel exporters to send microsoft_agents traces to Respan."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._exporter: Optional[RespanMicrosoftAgentsExporter] = None
+        self._passthrough = False
+        self._dedupe = _SpanDedupeCache()
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _INSTRUMENTS
+
+    def _instrument(self, **kwargs) -> None:
+        self._exporter = RespanMicrosoftAgentsExporter(
+            api_key=kwargs.get("api_key"),
+            endpoint=kwargs.get("endpoint"),
+            base_url=kwargs.get("base_url"),
+            environment=kwargs.get("environment"),
+            customer_identifier=kwargs.get("customer_identifier"),
+            timeout=kwargs.get("timeout", 10),
+        )
+        self._passthrough = bool(kwargs.get("passthrough", False))
+        self._dedupe = _SpanDedupeCache(max_size=kwargs.get("dedupe_max_size", 10000))
+
+        global _ACTIVE_EXPORTER, _ACTIVE_DEDUPE, _ACTIVE_PASSTHROUGH
+        _ACTIVE_EXPORTER = self._exporter
+        _ACTIVE_DEDUPE = self._dedupe
+        _ACTIVE_PASSTHROUGH = self._passthrough
+
+        self._patch_span_processors()
+        logger.info("Respan microsoft_agents instrumentation enabled")
+
+    def _uninstrument(self, **kwargs) -> None:
+        global _ACTIVE_EXPORTER, _ACTIVE_DEDUPE, _ACTIVE_PASSTHROUGH
+        _ACTIVE_EXPORTER = None
+        _ACTIVE_DEDUPE = None
+        _ACTIVE_PASSTHROUGH = True
+        logger.info("Respan microsoft_agents instrumentation disabled")
+
+    def _patch_span_processors(self) -> None:
+        global _PATCHED
+        if _PATCHED:
+            return
+
+        try:
+            from opentelemetry.sdk.trace import export as trace_export
+            if hasattr(trace_export.BatchSpanProcessor, "_export"):
+                wrapt.wrap_function_wrapper("opentelemetry.sdk.trace.export", "BatchSpanProcessor._export", _batch_export_wrapper)
+            else:
+                wrapt.wrap_function_wrapper("opentelemetry.sdk.trace.export", "BatchSpanProcessor.on_end", _on_end_wrapper)
+        except Exception as exc:
+            logger.debug("Failed to patch BatchSpanProcessor: %s", exc)
+
+        wrapt.wrap_function_wrapper("opentelemetry.sdk.trace.export", "SimpleSpanProcessor.on_end", _on_end_wrapper)
+
+        _PATCHED = True
+        logger.debug("Patched OTel span processors for microsoft_agents export")

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/types.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/types.py
@@ -1,0 +1,18 @@
+"""Type definitions for Respan Microsoft Agents exporter."""
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
+
+from respan_sdk.respan_types.base_types import RespanBaseModel
+
+
+class TraceContext(RespanBaseModel):
+    """Context information for a trace."""
+
+    trace_id: str
+    trace_name: Optional[str]
+    workflow_name: Optional[str]
+    metadata: Dict[str, Any]
+    session_identifier: Optional[Union[str, int]] = None
+    trace_group_identifier: Optional[Union[str, int]] = None
+    start_time: Optional[datetime] = None
+    customer_identifier: Optional[Union[str, int]] = None

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/utils.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/utils.py
@@ -1,0 +1,334 @@
+"""Utility functions for Respan microsoft_agents exporter."""
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+    is_hex_string,
+)
+
+
+def ns_to_datetime(value: Optional[int]) -> Optional[datetime]:
+    """Convert nanoseconds timestamp to datetime."""
+    if not value:
+        return None
+    return datetime.fromtimestamp(value / 1e9, tz=timezone.utc)
+
+
+_FRAMEWORK_SCOPE_KEYWORDS = ("autogen", "semantic_kernel", "semantic-kernel", "microsoft")
+_FRAMEWORK_ATTR_PREFIXES = ("autogen.", "semantic_kernel.", "ag.", "sk.")
+
+
+def is_microsoft_agents_span(span: object) -> bool:
+    """Check if span is from AutoGen or Semantic Kernel instrumentation."""
+    scope = getattr(span, "instrumentation_scope", None) or getattr(
+        span, "instrumentation_library", None
+    )
+    scope_name = (getattr(scope, "name", "") or "").lower()
+    if any(kw in scope_name for kw in _FRAMEWORK_SCOPE_KEYWORDS):
+        return True
+    attributes = getattr(span, "attributes", None) or {}
+    if any(key.startswith(prefix) for key in attributes for prefix in _FRAMEWORK_ATTR_PREFIXES):
+        return True
+    return False
+
+
+def otel_span_to_dict(span: object) -> Dict[str, object]:
+    """Convert OpenTelemetry span to dict format."""
+    attributes = dict(getattr(span, "attributes", None) or {})
+    span_context = getattr(span, "context", None)
+    trace_id = format_trace_id(trace_id=span_context.trace_id) if span_context else None
+    span_id = format_span_id(span_id=span_context.span_id) if span_context else None
+
+    parent = getattr(span, "parent", None)
+    parent_id = None
+    if parent is not None and getattr(parent, "span_id", None) is not None:
+        parent_id = format_span_id(span_id=parent.span_id)
+
+    span_kind = attributes.get("openinference.span.kind")
+    if not span_kind:
+        raw_kind = getattr(span, "kind", None)
+        span_kind = getattr(raw_kind, "name", None) if raw_kind is not None else None
+        if span_kind is None and raw_kind is not None:
+            span_kind = str(raw_kind)
+
+    status = getattr(span, "status", None)
+    status_code = None
+    error_message = None
+    if status is not None:
+        status_enum = getattr(status, "status_code", None)
+        status_name = getattr(status_enum, "name", None)
+        if status_name == "ERROR":
+            status_code = 500
+            error_message = getattr(status, "description", None) or "error"
+        elif status_name == "OK":
+            status_code = 200
+
+    span_path = attributes.get("graph.node.id")
+
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_id": parent_id,
+        "name": getattr(span, "name", None),
+        "span_type": span_kind,
+        "kind": span_kind,
+        "span_path": span_path,
+        "start_time": ns_to_datetime(value=getattr(span, "start_time", None)),
+        "end_time": ns_to_datetime(value=getattr(span, "end_time", None)),
+        "attributes": attributes,
+        "status_code": status_code,
+        "error": error_message,
+    }
+
+
+def group_spans_by_trace(
+    spans: Sequence[Dict[str, object]],
+) -> Dict[str, List[Dict[str, object]]]:
+    """Group spans by trace ID."""
+    grouped: Dict[str, List[Dict[str, object]]] = {}
+    for span in spans:
+        trace_id = span.get("trace_id")
+        if not isinstance(trace_id, str) or not trace_id:
+            continue
+        grouped.setdefault(trace_id, []).append(span)
+    return grouped
+
+
+def get_attr(obj: Any, *keys: str, default: Any = None) -> Any:
+    """Get attribute from object or dict by trying multiple keys."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        for key in keys:
+            if key in obj:
+                return obj[key]
+    for key in keys:
+        if hasattr(obj, key):
+            return getattr(obj, key)
+    return default
+
+
+def as_dict(value: Any) -> Optional[Dict[str, Any]]:
+    """Convert value to dict if possible."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        try:
+            return value.model_dump()
+        except Exception:
+            return None
+    if hasattr(value, "dict"):
+        try:
+            return value.dict()
+        except Exception:
+            return None
+    return None
+
+
+def pick_metadata_value(metadata: Optional[Dict[str, Any]], *keys: str) -> Any:
+    """Pick first available value from metadata."""
+    if not metadata:
+        return None
+    for key in keys:
+        if key in metadata:
+            return metadata[key]
+    return None
+
+
+def coerce_datetime(value: Any, reference: Optional[datetime] = None) -> Optional[datetime]:
+    """Coerce various value types to datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    if isinstance(value, (int, float)):
+        numeric_value = float(value)
+        if reference and numeric_value < 1_000_000_000:
+            return reference + timedelta(seconds=numeric_value)
+        if numeric_value > 100_000_000_000:
+            return datetime.fromtimestamp(numeric_value / 1000, tz=timezone.utc)
+        return datetime.fromtimestamp(numeric_value, tz=timezone.utc)
+    if isinstance(value, str):
+        trimmed = value.strip()
+        try:
+            return datetime.fromisoformat(trimmed.replace("Z", "+00:00"))
+        except ValueError:
+            try:
+                numeric_value = float(trimmed)
+                if reference and numeric_value < 1_000_000_000:
+                    return reference + timedelta(seconds=numeric_value)
+                if numeric_value > 100_000_000_000:
+                    return datetime.fromtimestamp(numeric_value / 1000, tz=timezone.utc)
+                return datetime.fromtimestamp(numeric_value, tz=timezone.utc)
+            except ValueError:
+                return None
+    return None
+
+
+def coerce_token_count(value: Any) -> Optional[int]:
+    """Coerce value to token count integer."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(float(stripped))
+        except ValueError:
+            return None
+    return None
+
+
+def infer_trace_start_time(spans: Sequence[Any]) -> Optional[datetime]:
+    """Infer the earliest start time from spans."""
+    earliest: Optional[datetime] = None
+    for span in spans:
+        raw_value = get_attr(span, "start_time", "started_at", "start", "start_timestamp")
+        if isinstance(raw_value, (int, float)) and float(raw_value) < 1_000_000_000:
+            continue
+        candidate = coerce_datetime(value=raw_value)
+        if candidate and candidate.year < 2001:
+            continue
+        if candidate and (earliest is None or candidate < earliest):
+            earliest = candidate
+    return earliest
+
+
+def serialize_value(value: Any) -> Optional[str]:
+    """Serialize value to JSON string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            try:
+                json.loads(trimmed)
+                return trimmed
+            except Exception:
+                return json.dumps(value)
+        return json.dumps(value)
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return json.dumps(str(value))
+
+
+def format_rfc3339(value: Optional[datetime]) -> Optional[str]:
+    """Format datetime as RFC3339 string."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def normalize_trace_id(trace_id: str) -> str:
+    """Normalize trace ID to 32-char hex string."""
+    if is_hex_string(value=trace_id, length=32):
+        return trace_id.lower()
+    return uuid.uuid5(uuid.NAMESPACE_DNS, trace_id).hex
+
+
+def normalize_span_id(span_id: str, trace_id: str) -> str:
+    """Normalize span ID to 16-char hex string."""
+    if is_hex_string(value=span_id, length=16):
+        return span_id.lower()
+    stable_seed = f"{trace_id}:{span_id}"
+    return uuid.uuid5(uuid.NAMESPACE_DNS, stable_seed).hex[:16]
+
+
+def clean_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove None, empty dict, and empty list values."""
+    return {key: value for key, value in payload.items() if value not in (None, {}, [])}
+
+
+def merge_openinference_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Merge OpenInference metadata format."""
+    if not metadata:
+        return {}
+    merged = dict(metadata)
+    raw_meta = merged.get("metadata")
+    if isinstance(raw_meta, dict):
+        merged.pop("metadata", None)
+        merged.update(raw_meta)
+    return merged
+
+
+def find_root_span(spans: Sequence[Any]) -> Optional[Any]:
+    """Find the root span."""
+    if not spans:
+        return None
+    span_ids = set()
+    for span in spans:
+        span_id = get_attr(span, "span_id", "id", "uid")
+        if span_id is not None:
+            span_ids.add(str(span_id))
+    for span in spans:
+        parent_id = get_attr(span, "parent_id", "parent_span_id", "parentId")
+        if not parent_id or str(parent_id) not in span_ids:
+            return span
+    return spans[0]
+
+
+def extract_span_metadata(span: Any) -> Dict[str, Any]:
+    """Extract and normalize metadata from span."""
+    raw = as_dict(value=get_attr(span, "metadata", "attributes", "tags", "data")) or {}
+    return merge_openinference_metadata(metadata=raw)
+
+
+def extract_openinference_messages(
+    metadata: Optional[Dict[str, Any]], prefix: str,
+) -> Optional[List[Dict[str, Any]]]:
+    """Extract messages from OpenInference format metadata."""
+    if not metadata:
+        return None
+    prefix_token = f"{prefix}."
+    messages: Dict[int, Dict[str, Any]] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key.startswith(prefix_token):
+            continue
+        parts = key[len(prefix_token):].split(".")
+        if len(parts) < 3:
+            continue
+        index_str, section, field = parts[0], parts[1], parts[2]
+        if not index_str.isdigit() or section != "message":
+            continue
+        index = int(index_str)
+        if field == "role":
+            messages.setdefault(index, {})["role"] = value
+        elif field == "content":
+            messages.setdefault(index, {})["content"] = value
+    if not messages:
+        return None
+    return [messages[i] for i in sorted(messages)]
+
+
+def is_blank_value(value: Any) -> bool:
+    """Check if value is blank."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if not trimmed or trimmed in ("[]", "{}", "null"):
+            return True
+        try:
+            parsed = json.loads(trimmed)
+            return parsed in (None, [], {})
+        except Exception:
+            return False
+    if isinstance(value, (list, tuple, dict)) and not value:
+        return True
+    return False

--- a/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/utils.py
+++ b/python-sdks/respan-exporter-microsoft-agents/src/respan_exporter_microsoft_agents/utils.py
@@ -13,7 +13,9 @@ from respan_sdk.utils.data_processing.id_processing import (
 
 def ns_to_datetime(value: Optional[int]) -> Optional[datetime]:
     """Convert nanoseconds timestamp to datetime."""
-    if not value:
+    if value is None:
+        return None
+    if not isinstance(value, (int, float)):
         return None
     return datetime.fromtimestamp(value / 1e9, tz=timezone.utc)
 

--- a/python-sdks/respan-exporter-microsoft-agents/tests/test_exporter.py
+++ b/python-sdks/respan-exporter-microsoft-agents/tests/test_exporter.py
@@ -1,0 +1,132 @@
+"""Tests for Microsoft Agents exporter."""
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRespanMicrosoftAgentsExporterInit:
+    def test_default_endpoint(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test")
+        assert "v1/traces/ingest" in exporter.endpoint
+
+    def test_custom_base_url(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test", base_url="https://custom.api.com/api")
+        assert exporter.endpoint == "https://custom.api.com/api/v1/traces/ingest"
+
+    def test_default_environment(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test")
+        assert exporter.environment == "production"
+
+
+class TestBuildPayload:
+    def _make_span(self, **overrides):
+        base = {
+            "trace_id": "abcdef1234567890abcdef1234567890",
+            "span_id": "1234567890abcdef",
+            "parent_id": None,
+            "name": "autogen.agent.run",
+            "span_type": "AGENT",
+            "kind": "AGENT",
+            "span_path": None,
+            "start_time": datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            "end_time": datetime(2024, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            "attributes": {},
+            "status_code": 200,
+            "error": None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_builds_payload(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test")
+        payloads = exporter.build_payload(trace_or_spans=[self._make_span()])
+        assert len(payloads) == 1
+        assert payloads[0]["span_name"] == "autogen.agent.run"
+
+    def test_maps_agent_span(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test")
+        payloads = exporter.build_payload(trace_or_spans=[self._make_span(span_type="AGENT")])
+        assert payloads[0]["log_type"] == "agent"
+
+    def test_maps_llm_span(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test")
+        payloads = exporter.build_payload(trace_or_spans=[
+            self._make_span(span_type="LLM", kind="LLM", parent_id="abc", attributes={"llm.model_name": "gpt-4"})
+        ])
+        assert payloads[0]["log_type"] == "generation"
+        assert payloads[0]["model"] == "gpt-4"
+
+    def test_maps_tool_span(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test")
+        payloads = exporter.build_payload(trace_or_spans=[
+            self._make_span(span_type="TOOL", kind="TOOL", parent_id="abc", attributes={"tool.name": "calculator"})
+        ])
+        assert payloads[0]["log_type"] == "tool"
+
+    def test_handles_error(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test")
+        payloads = exporter.build_payload(trace_or_spans=[self._make_span(error="failed")])
+        assert payloads[0]["error_message"] == "failed"
+        assert payloads[0]["status_code"] == 500
+
+    def test_empty_returns_empty(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test")
+        assert exporter.build_payload(trace_or_spans=[]) == []
+        assert exporter.build_payload(trace_or_spans=None) == []
+
+    def test_stores_framework_ids(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test")
+        payloads = exporter.build_payload(trace_or_spans=[self._make_span()])
+        metadata = payloads[0].get("metadata", {})
+        assert "microsoft_agents_trace_id" in metadata
+
+    def test_sets_customer_identifier(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test", customer_identifier="u42")
+        payloads = exporter.build_payload(trace_or_spans=[self._make_span()])
+        assert payloads[0]["customer_identifier"] == "u42"
+
+
+class TestExport:
+    def test_sends_payloads(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        exporter = RespanMicrosoftAgentsExporter(api_key="test-key")
+        span = {
+            "trace_id": "abcdef1234567890abcdef1234567890", "span_id": "1234567890abcdef",
+            "parent_id": None, "name": "T", "span_type": "AGENT", "kind": "AGENT",
+            "span_path": None,
+            "start_time": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "end_time": datetime(2024, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            "attributes": {}, "status_code": 200, "error": None,
+        }
+        with patch("respan_exporter_microsoft_agents.exporter.requests.post") as mock:
+            mock.return_value = MagicMock(status_code=200)
+            payloads = exporter.export(trace_or_spans=[span])
+            assert len(payloads) > 0
+            mock.assert_called_once()
+
+    def test_skips_without_api_key(self):
+        from respan_exporter_microsoft_agents.exporter import RespanMicrosoftAgentsExporter
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("RESPAN_API_KEY", None)
+            exporter = RespanMicrosoftAgentsExporter(api_key=None)
+            with patch("respan_exporter_microsoft_agents.exporter.requests.post") as mock:
+                exporter.export(trace_or_spans=[{
+                    "trace_id": "a" * 32, "span_id": "b" * 16, "parent_id": None,
+                    "name": "T", "span_type": "AGENT", "kind": "AGENT", "span_path": None,
+                    "start_time": datetime.now(timezone.utc), "end_time": datetime.now(timezone.utc),
+                    "attributes": {}, "status_code": 200, "error": None,
+                }])
+                mock.assert_not_called()

--- a/python-sdks/respan-exporter-microsoft-agents/tests/test_exporter.py
+++ b/python-sdks/respan-exporter-microsoft-agents/tests/test_exporter.py
@@ -3,8 +3,6 @@ import os
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestRespanMicrosoftAgentsExporterInit:
     def test_default_endpoint(self):

--- a/python-sdks/respan-exporter-microsoft-agents/tests/test_instrumentor.py
+++ b/python-sdks/respan-exporter-microsoft-agents/tests/test_instrumentor.py
@@ -1,0 +1,76 @@
+"""Tests for Microsoft Agents instrumentor."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+class TestRespanMicrosoftAgentsInstrumentor:
+    def test_instrumentation_dependencies(self):
+        from respan_exporter_microsoft_agents.instrumentor import RespanMicrosoftAgentsInstrumentor
+        instrumentor = RespanMicrosoftAgentsInstrumentor()
+        deps = instrumentor.instrumentation_dependencies()
+        assert any("opentelemetry" in dep for dep in deps)
+
+    def test_instrument_creates_exporter(self):
+        from respan_exporter_microsoft_agents.instrumentor import RespanMicrosoftAgentsInstrumentor
+        instrumentor = RespanMicrosoftAgentsInstrumentor()
+        with patch("respan_exporter_microsoft_agents.instrumentor.RespanMicrosoftAgentsExporter") as mock:
+            with patch.object(instrumentor, "_patch_span_processors"):
+                instrumentor._instrument(api_key="test-key")
+                mock.assert_called_once()
+
+
+class TestExportMicrosoftAgentsSpans:
+    def test_filters_non_microsoft_spans(self):
+        from respan_exporter_microsoft_agents import instrumentor as mod
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="openai"),
+            attributes={"http.method": "POST"},
+            context=SimpleNamespace(trace_id=123, span_id=456),
+            parent=None, name="Call", kind=SimpleNamespace(name="CLIENT"),
+            start_time=1700000000000000000, end_time=1700000001000000000,
+            status=SimpleNamespace(status_code=SimpleNamespace(name="OK"), description=None),
+        )
+        mock_exporter = MagicMock()
+        original = mod._ACTIVE_EXPORTER
+        mod._ACTIVE_EXPORTER = mock_exporter
+        try:
+            mod._export_microsoft_agents_spans(spans=[span])
+            mock_exporter.build_payload.assert_not_called()
+        finally:
+            mod._ACTIVE_EXPORTER = original
+
+    def test_exports_autogen_spans(self):
+        from respan_exporter_microsoft_agents import instrumentor as mod
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="autogen.runtime"),
+            attributes={"autogen.agent.name": "assistant"},
+            context=SimpleNamespace(trace_id=123, span_id=456),
+            parent=None, name="Agent Run", kind=SimpleNamespace(name="INTERNAL"),
+            start_time=1700000000000000000, end_time=1700000001000000000,
+            status=SimpleNamespace(status_code=SimpleNamespace(name="OK"), description=None),
+        )
+        mock_exporter = MagicMock()
+        mock_exporter.api_key = "test"
+        mock_exporter.build_payload.return_value = [{"trace_unique_id": "abc"}]
+        original = mod._ACTIVE_EXPORTER
+        mod._ACTIVE_EXPORTER = mock_exporter
+        try:
+            mod._export_microsoft_agents_spans(spans=[span])
+            mock_exporter.build_payload.assert_called_once()
+            mock_exporter._send.assert_called_once()
+        finally:
+            mod._ACTIVE_EXPORTER = original
+
+
+class TestSpanDedupeCache:
+    def test_deduplicates(self):
+        from respan_exporter_microsoft_agents.instrumentor import _SpanDedupeCache
+        cache = _SpanDedupeCache(max_size=10)
+        assert cache.add("t1", "s1") is True
+        assert cache.add("t1", "s1") is False
+
+    def test_allows_different(self):
+        from respan_exporter_microsoft_agents.instrumentor import _SpanDedupeCache
+        cache = _SpanDedupeCache(max_size=10)
+        assert cache.add("t1", "s1") is True
+        assert cache.add("t1", "s2") is True

--- a/python-sdks/respan-exporter-microsoft-agents/tests/test_utils.py
+++ b/python-sdks/respan-exporter-microsoft-agents/tests/test_utils.py
@@ -68,6 +68,24 @@ class TestIsMicrosoftAgentsSpan:
         )
         assert is_microsoft_agents_span(span=span) is False
 
+    def test_detects_ag_prefix_attributes(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="other"),
+            attributes={"ag.runtime.id": "abc"},
+        )
+        assert is_microsoft_agents_span(span=span) is True
+
+    def test_detects_sk_prefix_attributes(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="other"),
+            attributes={"sk.kernel.id": "xyz"},
+        )
+        assert is_microsoft_agents_span(span=span) is True
+
 
 class TestOtelSpanToDict:
     """Test OTel span conversion."""

--- a/python-sdks/respan-exporter-microsoft-agents/tests/test_utils.py
+++ b/python-sdks/respan-exporter-microsoft-agents/tests/test_utils.py
@@ -1,0 +1,110 @@
+"""Tests for Microsoft Agents exporter utility functions."""
+from types import SimpleNamespace
+
+
+class TestIsMicrosoftAgentsSpan:
+    """Test span detection for AutoGen and Semantic Kernel."""
+
+    def test_detects_autogen_scope(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="autogen.runtime"),
+            attributes={},
+        )
+        assert is_microsoft_agents_span(span=span) is True
+
+    def test_detects_semantic_kernel_scope(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="semantic_kernel"),
+            attributes={},
+        )
+        assert is_microsoft_agents_span(span=span) is True
+
+    def test_detects_autogen_attributes(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="other"),
+            attributes={"autogen.agent.name": "assistant"},
+        )
+        assert is_microsoft_agents_span(span=span) is True
+
+    def test_detects_semantic_kernel_attributes(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="other"),
+            attributes={"semantic_kernel.function.name": "chat"},
+        )
+        assert is_microsoft_agents_span(span=span) is True
+
+    def test_rejects_non_microsoft_span(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="openai"),
+            attributes={"http.method": "POST"},
+        )
+        assert is_microsoft_agents_span(span=span) is False
+
+    def test_handles_missing_scope(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=None,
+            attributes={"autogen.message.type": "text"},
+        )
+        assert is_microsoft_agents_span(span=span) is True
+
+    def test_handles_no_attributes(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="other"),
+            attributes=None,
+        )
+        assert is_microsoft_agents_span(span=span) is False
+
+
+class TestOtelSpanToDict:
+    """Test OTel span conversion."""
+
+    def test_converts_basic_span(self):
+        from respan_exporter_microsoft_agents.utils import otel_span_to_dict
+
+        span_context = SimpleNamespace(trace_id=1234567890, span_id=9876543210)
+        span = SimpleNamespace(
+            context=span_context,
+            parent=None,
+            name="autogen.agent.run",
+            kind=SimpleNamespace(name="INTERNAL"),
+            start_time=1700000000000000000,
+            end_time=1700000001000000000,
+            attributes={"openinference.span.kind": "AGENT"},
+            status=SimpleNamespace(status_code=SimpleNamespace(name="OK"), description=None),
+            instrumentation_scope=SimpleNamespace(name="autogen"),
+        )
+
+        result = otel_span_to_dict(span=span)
+        assert result["name"] == "autogen.agent.run"
+        assert result["trace_id"] is not None
+        assert result["status_code"] == 200
+
+
+class TestGroupSpansByTrace:
+    """Test trace grouping."""
+
+    def test_groups_correctly(self):
+        from respan_exporter_microsoft_agents.utils import group_spans_by_trace
+
+        spans = [
+            {"trace_id": "t1", "span_id": "a"},
+            {"trace_id": "t1", "span_id": "b"},
+            {"trace_id": "t2", "span_id": "c"},
+        ]
+        grouped = group_spans_by_trace(spans=spans)
+        assert len(grouped) == 2
+        assert len(grouped["t1"]) == 2

--- a/python-sdks/respan-exporter-microsoft-agents/tests/test_utils.py
+++ b/python-sdks/respan-exporter-microsoft-agents/tests/test_utils.py
@@ -68,6 +68,24 @@ class TestIsMicrosoftAgentsSpan:
         )
         assert is_microsoft_agents_span(span=span) is False
 
+    def test_detects_semantic_hyphen_kernel_scope(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="semantic-kernel.ai"),
+            attributes={},
+        )
+        assert is_microsoft_agents_span(span=span) is True
+
+    def test_detects_microsoft_scope(self):
+        from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
+
+        span = SimpleNamespace(
+            instrumentation_scope=SimpleNamespace(name="microsoft.agents"),
+            attributes={},
+        )
+        assert is_microsoft_agents_span(span=span) is True
+
     def test_detects_ag_prefix_attributes(self):
         from respan_exporter_microsoft_agents.utils import is_microsoft_agents_span
 

--- a/python-sdks/respan-exporter-microsoft-agents/tests/test_utils.py
+++ b/python-sdks/respan-exporter-microsoft-agents/tests/test_utils.py
@@ -1,5 +1,33 @@
 """Tests for Microsoft Agents exporter utility functions."""
+from datetime import datetime, timezone
 from types import SimpleNamespace
+
+
+class TestNsToDatetime:
+    """Test nanosecond timestamp conversion."""
+
+    def test_returns_none_for_none(self):
+        from respan_exporter_microsoft_agents.utils import ns_to_datetime
+
+        assert ns_to_datetime(value=None) is None
+
+    def test_converts_zero_to_epoch(self):
+        from respan_exporter_microsoft_agents.utils import ns_to_datetime
+
+        result = ns_to_datetime(value=0)
+        assert result == datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    def test_converts_valid_nanoseconds(self):
+        from respan_exporter_microsoft_agents.utils import ns_to_datetime
+
+        result = ns_to_datetime(value=1_700_000_000_000_000_000)
+        assert result is not None
+        assert result.year == 2023
+
+    def test_returns_none_for_non_numeric(self):
+        from respan_exporter_microsoft_agents.utils import ns_to_datetime
+
+        assert ns_to_datetime(value="not_a_number") is None
 
 
 class TestIsMicrosoftAgentsSpan:


### PR DESCRIPTION
## Summary
- Adds new `respan-exporter-microsoft-agents` package that intercepts OTel spans from AutoGen and Semantic Kernel
- Detects spans from both frameworks via scope names (`autogen`, `semantic_kernel`, `microsoft`) and attribute prefixes (`autogen.*`, `semantic_kernel.*`, `ag.*`, `sk.*`)
- Follows the same OTel-based interception pattern as other Respan exporters

## Key components
- `RespanMicrosoftAgentsExporter` - Builds and sends payloads to Respan
- `RespanMicrosoftAgentsInstrumentor` - Patches OTel span processors to intercept AutoGen/Semantic Kernel spans
- `is_microsoft_agents_span()` - Multi-framework span detection

## Test plan
- [x] 28 unit tests covering exporter, instrumentor, and utils
- [x] Tests verify detection of both AutoGen and Semantic Kernel spans
- [x] All tests pass (`poetry run pytest tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)