### PR TITLE
feat(google-adk): add instrumentation package

### DIFF
--- a/python-sdks/examples/conftest.py
+++ b/python-sdks/examples/conftest.py
@@ -47,3 +47,65 @@ def _make_trace(trace_id: str, name: str):
         name=name, trace_id=trace_id,
         group_id=None, metadata=None, processor=_NoopProcessor(),
     )
+
+
+def _make_adk_spans(
+    trace_id: str = "adk-trace-001",
+    agent_name: str = "test_agent",
+    model: str = "gemini-2.5-flash",
+):
+    """Create a list of 3 ADK-style span dicts (invocation -> agent_run -> call_llm).
+
+    Uses plain dicts so no google-adk package dependency is needed in tests.
+    """
+    import time
+
+    now_ms = int(time.time() * 1000)
+
+    invocation_span = {
+        "trace_id": trace_id,
+        "span_id": "span-inv-001",
+        "parent_id": None,
+        "name": "invocation",
+        "start_time": now_ms,
+        "end_time": now_ms + 3000,
+        "attributes": {
+            "gen_ai.agent.name": agent_name,
+            "gen_ai.system": "google_genai",
+        },
+    }
+
+    agent_run_span = {
+        "trace_id": trace_id,
+        "span_id": "span-agent-001",
+        "parent_id": "span-inv-001",
+        "name": "agent_run",
+        "start_time": now_ms + 100,
+        "end_time": now_ms + 2900,
+        "attributes": {
+            "gen_ai.agent.name": agent_name,
+            "gen_ai.system": "google_genai",
+        },
+    }
+
+    call_llm_span = {
+        "trace_id": trace_id,
+        "span_id": "span-llm-001",
+        "parent_id": "span-agent-001",
+        "name": "call_llm",
+        "start_time": now_ms + 200,
+        "end_time": now_ms + 2800,
+        "attributes": {
+            "gen_ai.request.model": model,
+            "gen_ai.response.model": model,
+            "gen_ai.system": "google_genai",
+            "gen_ai.usage.prompt_tokens": 10,
+            "gen_ai.usage.completion_tokens": 25,
+            "gen_ai.prompt.0.role": "user",
+            "gen_ai.prompt.0.content": "Hello!",
+            "gen_ai.completion.0.role": "model",
+            "gen_ai.completion.0.content": "Hi there! How can I help?",
+        },
+    }
+
+    return [invocation_span, agent_run_span, call_llm_span]

--- a/python-sdks/examples/google-adk/attributes.py
+++ b/python-sdks/examples/google-adk/attributes.py
@@ -1,0 +1,80 @@
+"""Attributes — Propagate customer info and metadata to Google ADK spans.
+
+Demonstrates customer_identifier, environment, and propagate_attributes()
+for per-user scoping of traces.
+
+Prerequisites:
+    pip install respan-instrumentation-google-adk google-adk
+
+Set the RESPAN_API_KEY and GOOGLE_API_KEY environment variables before running.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+respan = Respan(
+    instrumentations=[
+        GoogleAdkInstrumentor(
+            environment="development",
+            customer_identifier="default-user",
+        )
+    ],
+    metadata={"service": "chat-api", "version": "1.0.0"},
+)
+
+os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+agent = Agent(
+    name="greeting_agent",
+    model="gemini-2.5-flash",
+    instruction="You are a friendly assistant. Greet the user and answer their questions.",
+)
+
+
+async def handle_request(user_id: str, text: str):
+    """Simulate an API request handler with per-user attributes."""
+    with respan.propagate_attributes(
+        customer_identifier=user_id,
+        session_identifier=f"session_{user_id}",
+        metadata={"plan": "pro"},
+    ):
+        runner = InMemoryRunner(agent=agent, app_name="attributes")
+        session = await runner.session_service.create_session(
+            app_name="attributes", user_id=user_id
+        )
+
+        message = types.Content(
+            role="user",
+            parts=[types.Part(text=text)],
+        )
+
+        async for event in runner.run_async(
+            user_id=session.user_id,
+            session_id=session.id,
+            new_message=message,
+        ):
+            if event.content and event.content.parts:
+                for part in event.content.parts:
+                    if part.text:
+                        print(f"[{user_id}] {part.text}")
+
+
+async def main():
+    await handle_request("user_alice", "Hello! What can you do?")
+    await handle_request("user_bob", "Tell me a joke.")
+    respan.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/examples/google-adk/callbacks.py
+++ b/python-sdks/examples/google-adk/callbacks.py
@@ -1,0 +1,90 @@
+"""Callbacks — Track agent and tool lifecycle events with ADK callbacks.
+
+Demonstrates before_agent_callback and after_agent_callback to log lifecycle
+events, with all spans traced by Respan.
+
+Prerequisites:
+    pip install respan-instrumentation-google-adk google-adk
+
+Set the RESPAN_API_KEY and GOOGLE_API_KEY environment variables before running.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+respan = Respan(instrumentations=[GoogleAdkInstrumentor(environment="development")])
+
+os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+
+def get_weather(city: str) -> dict:
+    """Get the current weather for a city."""
+    weather_data = {
+        "Tokyo": {"temp_f": 80, "condition": "Partly cloudy"},
+        "London": {"temp_f": 59, "condition": "Cloudy"},
+        "New York": {"temp_f": 72, "condition": "Sunny"},
+    }
+    return weather_data.get(city, {"temp_f": 70, "condition": "Unknown"})
+
+
+def before_agent(callback_context) -> None:
+    """Called before the agent runs."""
+    agent_name = callback_context.agent_name if hasattr(callback_context, "agent_name") else "unknown"
+    print(f">> Agent starting: {agent_name}")
+    return None
+
+
+def after_agent(callback_context) -> None:
+    """Called after the agent finishes."""
+    agent_name = callback_context.agent_name if hasattr(callback_context, "agent_name") else "unknown"
+    print(f"<< Agent finished: {agent_name}")
+    return None
+
+
+agent = Agent(
+    name="weather_agent",
+    model="gemini-2.5-flash",
+    instruction="You are a weather assistant. Use the get_weather tool to answer weather questions.",
+    tools=[get_weather],
+    before_agent_callback=before_agent,
+    after_agent_callback=after_agent,
+)
+
+
+async def main():
+    runner = InMemoryRunner(agent=agent, app_name="callbacks")
+    session = await runner.session_service.create_session(
+        app_name="callbacks", user_id="user-1"
+    )
+
+    message = types.Content(
+        role="user",
+        parts=[types.Part(text="What's the weather in Tokyo?")],
+    )
+
+    async for event in runner.run_async(
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=message,
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    print(f"Agent: {part.text}")
+
+    respan.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/examples/google-adk/multi_agent.py
+++ b/python-sdks/examples/google-adk/multi_agent.py
@@ -1,0 +1,87 @@
+"""
+Multi-agent: Trace a team of Google ADK agents with Respan.
+
+This example creates a router agent that delegates to specialist sub-agents.
+All spans -- agent runs, LLM calls, and tool executions -- are exported to Respan.
+
+Prerequisites:
+    pip install respan-instrumentation-google-adk google-adk
+
+Set the RESPAN_API_KEY and GOOGLE_API_KEY environment variables before running.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+# Enable Respan instrumentation before creating any agents
+respan = Respan(instrumentations=[
+    GoogleAdkInstrumentor(
+        environment="development",
+        customer_identifier="demo-user",
+    )
+])
+
+os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+# Define specialist sub-agents
+math_agent = Agent(
+    name="math_agent",
+    model="gemini-2.5-flash",
+    instruction="You are a math tutor. Solve math problems step by step.",
+)
+
+writing_agent = Agent(
+    name="writing_agent",
+    model="gemini-2.5-flash",
+    instruction="You are a writing assistant. Help with grammar, style, and composition.",
+)
+
+# Define the router agent that delegates to sub-agents
+router_agent = Agent(
+    name="router_agent",
+    model="gemini-2.5-flash",
+    instruction=(
+        "You are a helpful router. Delegate math questions to math_agent "
+        "and writing questions to writing_agent. For general questions, answer directly."
+    ),
+    sub_agents=[math_agent, writing_agent],
+)
+
+
+async def main():
+    runner = InMemoryRunner(agent=router_agent, app_name="multi_agent")
+    session = await runner.session_service.create_session(
+        app_name="multi_agent", user_id="user-1"
+    )
+
+    message = types.Content(
+        role="user",
+        parts=[types.Part(text="What is 42 * 58?")],
+    )
+
+    async for event in runner.run_async(
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=message,
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    print(part.text)
+
+    respan.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/examples/google-adk/multi_turn.py
+++ b/python-sdks/examples/google-adk/multi_turn.py
@@ -1,0 +1,71 @@
+"""
+Multi-turn conversation: Trace a multi-turn chat with Respan.
+
+This example sends multiple messages to a single agent within one session,
+demonstrating how Respan captures the growing conversation context across turns.
+
+Prerequisites:
+    pip install respan-instrumentation-google-adk google-adk
+
+Set the RESPAN_API_KEY and GOOGLE_API_KEY environment variables before running.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+# Enable Respan instrumentation
+respan = Respan(instrumentations=[GoogleAdkInstrumentor(environment="development")])
+
+os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+agent = Agent(
+    name="chat_agent",
+    model="gemini-2.5-flash",
+    instruction="You are a friendly assistant that remembers context from earlier in the conversation.",
+)
+
+
+async def main():
+    runner = InMemoryRunner(agent=agent, app_name="multi_turn")
+    session = await runner.session_service.create_session(
+        app_name="multi_turn", user_id="user-1"
+    )
+
+    messages = [
+        "Hi! My name is Alex.",
+        "What's my name?",
+        "Tell me a fun fact about the number 42.",
+    ]
+
+    for text in messages:
+        message = types.Content(
+            role="user",
+            parts=[types.Part(text=text)],
+        )
+        print(f"\nUser: {text}")
+        async for event in runner.run_async(
+            user_id=session.user_id,
+            session_id=session.id,
+            new_message=message,
+        ):
+            if event.content and event.content.parts:
+                for part in event.content.parts:
+                    if part.text:
+                        print(f"Agent: {part.text}")
+
+    respan.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/examples/google-adk/parallel_agents.py
+++ b/python-sdks/examples/google-adk/parallel_agents.py
@@ -1,0 +1,88 @@
+"""Parallel Agents — Run multiple ADK agents concurrently with asyncio.gather.
+
+Demonstrates running multiple translation agents in parallel, with each
+agent's spans independently traced by Respan.
+
+Prerequisites:
+    pip install respan-instrumentation-google-adk google-adk
+
+Set the RESPAN_API_KEY and GOOGLE_API_KEY environment variables before running.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+respan = Respan(instrumentations=[GoogleAdkInstrumentor(environment="development")])
+
+os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+spanish_agent = Agent(
+    name="spanish_translator",
+    model="gemini-2.5-flash",
+    instruction="Translate the user's message to Spanish. Only output the translation.",
+)
+
+french_agent = Agent(
+    name="french_translator",
+    model="gemini-2.5-flash",
+    instruction="Translate the user's message to French. Only output the translation.",
+)
+
+italian_agent = Agent(
+    name="italian_translator",
+    model="gemini-2.5-flash",
+    instruction="Translate the user's message to Italian. Only output the translation.",
+)
+
+
+async def run_agent(agent: Agent, text: str, label: str):
+    """Run a single agent and collect its output."""
+    runner = InMemoryRunner(agent=agent, app_name="parallel_agents")
+    session = await runner.session_service.create_session(
+        app_name="parallel_agents", user_id="user-1"
+    )
+
+    message = types.Content(
+        role="user",
+        parts=[types.Part(text=text)],
+    )
+
+    output_parts = []
+    async for event in runner.run_async(
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=message,
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    output_parts.append(part.text)
+
+    result = "".join(output_parts)
+    print(f"{label}: {result}")
+    return result
+
+
+async def main():
+    text = "Hello, how are you today?"
+    await asyncio.gather(
+        run_agent(spanish_agent, text, "Spanish"),
+        run_agent(french_agent, text, "French"),
+        run_agent(italian_agent, text, "Italian"),
+    )
+    respan.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/examples/google-adk/quickstart.py
+++ b/python-sdks/examples/google-adk/quickstart.py
@@ -1,0 +1,63 @@
+"""
+Quickstart: Instrument a Google ADK agent with Respan tracing.
+
+Prerequisites:
+    pip install respan-instrumentation-google-adk google-adk
+
+Set the RESPAN_API_KEY and GOOGLE_API_KEY environment variables before running.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+# Enable Respan instrumentation
+respan = Respan(instrumentations=[GoogleAdkInstrumentor(environment="development")])
+
+# Allow ADK to include message content in spans (required for input/output capture)
+os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+# Define a simple agent
+agent = Agent(
+    name="greeting_agent",
+    model="gemini-2.5-flash",
+    instruction="You are a friendly assistant. Greet the user and answer their questions.",
+)
+
+
+async def main():
+    runner = InMemoryRunner(agent=agent, app_name="quickstart")
+    session = await runner.session_service.create_session(
+        app_name="quickstart", user_id="user-1"
+    )
+
+    message = types.Content(
+        role="user",
+        parts=[types.Part(text="Hello! What can you do?")],
+    )
+
+    async for event in runner.run_async(
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=message,
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    print(part.text)
+
+    respan.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/examples/google-adk/streaming.py
+++ b/python-sdks/examples/google-adk/streaming.py
@@ -1,0 +1,71 @@
+"""
+Streaming: Trace a streaming Google ADK agent response with Respan.
+
+ADK emits OpenTelemetry spans after the stream completes, so the span
+hierarchy is identical to a non-streaming call. The key difference is
+longer output content and higher output token counts.
+
+Prerequisites:
+    pip install respan-instrumentation-google-adk google-adk
+
+Set the RESPAN_API_KEY and GOOGLE_API_KEY environment variables before running.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+# Enable Respan instrumentation
+respan = Respan(instrumentations=[GoogleAdkInstrumentor(environment="development")])
+
+os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+agent = Agent(
+    name="storyteller",
+    model="gemini-2.5-flash",
+    instruction="You are a creative storyteller. Tell vivid, detailed stories.",
+    generate_content_config=types.GenerateContentConfig(
+        temperature=0.9,
+        top_p=0.95,
+    ),
+)
+
+
+async def main():
+    runner = InMemoryRunner(agent=agent, app_name="streaming")
+    session = await runner.session_service.create_session(
+        app_name="streaming", user_id="user-1"
+    )
+
+    message = types.Content(
+        role="user",
+        parts=[types.Part(text="Tell me a short story about a robot learning to paint.")],
+    )
+
+    print("Streaming response:")
+    async for event in runner.run_async(
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=message,
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    print(part.text, end="", flush=True)
+    print()
+
+    respan.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/examples/google-adk/structured_output.py
+++ b/python-sdks/examples/google-adk/structured_output.py
@@ -1,0 +1,79 @@
+"""Structured Output — JSON mode with Google ADK's output_schema.
+
+Demonstrates using ADK Agent's output_schema parameter to get structured
+JSON responses, with all spans traced by Respan.
+
+Prerequisites:
+    pip install respan-instrumentation-google-adk google-adk
+
+Set the RESPAN_API_KEY and GOOGLE_API_KEY environment variables before running.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+respan = Respan(instrumentations=[GoogleAdkInstrumentor(environment="development")])
+
+os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+# Define a JSON schema for structured output
+movie_review_schema = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "rating": {"type": "integer"},
+        "summary": {"type": "string"},
+        "pros": {"type": "array", "items": {"type": "string"}},
+        "cons": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["title", "rating", "summary", "pros", "cons"],
+}
+
+agent = Agent(
+    name="film_critic",
+    model="gemini-2.5-flash",
+    instruction="You are a film critic. Rate movies 1-10. Return your review as structured JSON.",
+    output_schema=movie_review_schema,
+    generate_content_config=types.GenerateContentConfig(
+        response_mime_type="application/json",
+    ),
+)
+
+
+async def main():
+    runner = InMemoryRunner(agent=agent, app_name="structured_output")
+    session = await runner.session_service.create_session(
+        app_name="structured_output", user_id="user-1"
+    )
+
+    message = types.Content(
+        role="user",
+        parts=[types.Part(text="Review: The Matrix")],
+    )
+
+    async for event in runner.run_async(
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=message,
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    print(part.text)
+
+    respan.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/examples/google-adk/tool_calls.py
+++ b/python-sdks/examples/google-adk/tool_calls.py
@@ -1,0 +1,77 @@
+"""
+Tool calls: Trace an agent that uses tools with Respan.
+
+This example creates an agent with a get_weather tool. ADK produces the
+span hierarchy: invocation -> agent_run -> [call_llm, execute_tool, call_llm].
+
+Prerequisites:
+    pip install respan-instrumentation-google-adk google-adk
+
+Set the RESPAN_API_KEY and GOOGLE_API_KEY environment variables before running.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+# Enable Respan instrumentation
+respan = Respan(instrumentations=[GoogleAdkInstrumentor(environment="development")])
+
+os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+
+def get_weather(city: str) -> dict:
+    """Get the current weather for a city."""
+    # Stub implementation for demonstration
+    weather_data = {
+        "Tokyo": {"temp_f": 80, "condition": "Partly cloudy"},
+        "London": {"temp_f": 59, "condition": "Cloudy"},
+        "New York": {"temp_f": 72, "condition": "Sunny"},
+    }
+    return weather_data.get(city, {"temp_f": 70, "condition": "Unknown"})
+
+
+agent = Agent(
+    name="weather_agent",
+    model="gemini-2.5-flash",
+    instruction="You are a weather assistant. Use the get_weather tool to answer weather questions.",
+    tools=[get_weather],
+)
+
+
+async def main():
+    runner = InMemoryRunner(agent=agent, app_name="tool_calls")
+    session = await runner.session_service.create_session(
+        app_name="tool_calls", user_id="user-1"
+    )
+
+    message = types.Content(
+        role="user",
+        parts=[types.Part(text="What's the weather like in Tokyo and London?")],
+    )
+
+    async for event in runner.run_async(
+        user_id=session.user_id,
+        session_id=session.id,
+        new_message=message,
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    print(part.text)
+
+    respan.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-sdks/examples/test_e2e.py
+++ b/python-sdks/examples/test_e2e.py
@@ -10,7 +10,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-from conftest import _make_trace
+from conftest import _make_trace, _make_adk_spans
 
 
 @pytest.fixture
@@ -88,6 +88,102 @@ class TestRealBackend:
         )
         result = await Runner.run(agent, "Say hi")
         print(f"Agent output: {result.final_output}")
+
+        r.flush()
+        r.shutdown()
+
+
+@pytest.fixture
+def google_api_key():
+    key = os.getenv("GOOGLE_API_KEY")
+    if not key:
+        pytest.skip("GOOGLE_API_KEY not set")
+    return key
+
+
+class TestGoogleAdkRealBackend:
+    """Tests that send Google ADK traces to the real Respan backend."""
+
+    def test_google_adk_exporter_sends_to_respan(self, respan_api_key, respan_base_url):
+        """RespanSpanExporterV2 + AdkSpanConverter -> POST to real endpoint."""
+        from respan_tracing.exporters import RespanSpanExporterV2
+        from respan_instrumentation_google_adk.converter import AdkSpanConverter
+
+        endpoint = f"{respan_base_url.rstrip('/')}/v1/traces/ingest"
+        exp = RespanSpanExporterV2(api_key=respan_api_key, endpoint=endpoint)
+
+        converter = AdkSpanConverter(environment="test")
+        spans = _make_adk_spans()
+        payloads = converter.convert(trace_or_spans=spans)
+        assert len(payloads) == 3
+
+        exp.export(payloads)
+        exp.flush()
+        exp.shutdown()
+
+    def test_google_adk_full_pipeline(self, respan_api_key, respan_base_url):
+        """Full Respan pipeline with GoogleAdkInstrumentor: init -> convert -> flush."""
+        from respan import Respan
+        from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+        from respan_instrumentation_google_adk.converter import AdkSpanConverter
+
+        r = Respan(
+            api_key=respan_api_key,
+            base_url=respan_base_url,
+            instrumentations=[GoogleAdkInstrumentor(environment="test")],
+        )
+
+        converter = AdkSpanConverter(environment="test")
+        spans = _make_adk_spans()
+        payloads = converter.convert(trace_or_spans=spans)
+
+        r.exporter.export(payloads)
+        r.flush()
+        r.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_google_adk_real_agent_run(self, respan_api_key, respan_base_url, google_api_key):
+        """Run a real ADK agent and verify traces are sent to Respan."""
+        from google.adk.agents import Agent
+        from google.adk.runners import InMemoryRunner
+        from google.genai import types
+
+        from respan import Respan
+        from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+        os.environ["ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS"] = "true"
+
+        r = Respan(
+            api_key=respan_api_key,
+            base_url=respan_base_url,
+            instrumentations=[GoogleAdkInstrumentor(environment="test")],
+        )
+
+        agent = Agent(
+            name="TestAgent",
+            model="gemini-2.5-flash",
+            instruction="You only respond with the word 'hello'.",
+        )
+
+        runner = InMemoryRunner(agent=agent, app_name="e2e_test")
+        session = await runner.session_service.create_session(
+            app_name="e2e_test", user_id="test-user"
+        )
+
+        message = types.Content(
+            role="user",
+            parts=[types.Part(text="Say hi")],
+        )
+
+        async for event in runner.run_async(
+            user_id=session.user_id,
+            session_id=session.id,
+            new_message=message,
+        ):
+            if event.content and event.content.parts:
+                for part in event.content.parts:
+                    if part.text:
+                        print(f"Agent output: {part.text}")
 
         r.flush()
         r.shutdown()

--- a/python-sdks/examples/test_unit.py
+++ b/python-sdks/examples/test_unit.py
@@ -10,7 +10,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from conftest import _make_trace
+from conftest import _make_trace, _make_adk_spans
 
 
 # ---------------------------------------------------------------------------
@@ -286,4 +286,113 @@ class TestEndToEnd:
         assert activated_names == ["a", "b"]
         assert "fake-a" in r._instrumentations
         assert "fake-b" in r._instrumentations
+        r.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# 6. respan-instrumentation-google-adk
+# ---------------------------------------------------------------------------
+
+class TestGoogleAdkInstrumentationPackage:
+    def test_import(self):
+        from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+        from respan_instrumentation_google_adk.converter import AdkSpanConverter
+        assert GoogleAdkInstrumentor is not None
+        assert AdkSpanConverter is not None
+
+    def test_instrumentor_satisfies_protocol(self):
+        from respan import Instrumentation
+        from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+        inst = GoogleAdkInstrumentor()
+        assert isinstance(inst, Instrumentation)
+        assert inst.name == "google-adk"
+
+    def test_converter_with_spans(self):
+        from respan_instrumentation_google_adk.converter import AdkSpanConverter
+
+        converter = AdkSpanConverter(environment="test", customer_identifier="user-1")
+        spans = _make_adk_spans()
+        payloads = converter.convert(trace_or_spans=spans)
+
+        assert len(payloads) == 3
+
+        log_types = [p["log_type"] for p in payloads]
+        assert "workflow" in log_types
+        assert "agent" in log_types
+        assert "generation" in log_types
+
+        # All payloads share the same trace ID
+        trace_ids = {p["trace_unique_id"] for p in payloads}
+        assert len(trace_ids) == 1
+
+    def test_converter_environment_and_customer(self):
+        from respan_instrumentation_google_adk.converter import AdkSpanConverter
+
+        converter = AdkSpanConverter(
+            environment="staging",
+            customer_identifier="customer-42",
+        )
+        spans = _make_adk_spans()
+        payloads = converter.convert(trace_or_spans=spans)
+
+        for payload in payloads:
+            assert payload["environment"] == "staging"
+            assert payload["customer_identifier"] == "customer-42"
+
+
+# ---------------------------------------------------------------------------
+# 7. End-to-end: Google ADK instrumentations
+# ---------------------------------------------------------------------------
+
+class TestGoogleAdkEndToEnd:
+    def test_respan_with_google_adk_instrumentor(self):
+        """Respan(instrumentations=[GoogleAdkInstrumentor()]) activates the plugin."""
+        from respan import Respan
+        from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+        r = Respan(api_key="test-key", instrumentations=[GoogleAdkInstrumentor()])
+        assert "google-adk" in r._instrumentations
+        r.shutdown()
+
+    def test_end_to_end_converter_to_exporter(self):
+        """Converter → mock exporter.export → verify payload structure."""
+        from respan import Respan
+        from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+        from respan_instrumentation_google_adk.converter import AdkSpanConverter
+
+        r = Respan(api_key="test-key", instrumentations=[GoogleAdkInstrumentor()])
+
+        converter = AdkSpanConverter(environment="test")
+        spans = _make_adk_spans()
+        payloads = converter.convert(trace_or_spans=spans)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        with patch.object(r.exporter._session, "post", return_value=mock_response) as mock_post:
+            r.exporter.export(payloads)
+            r.exporter.flush()
+
+            assert mock_post.call_count == 1
+            call_kwargs = mock_post.call_args
+            posted_data = json.loads(call_kwargs.kwargs.get("data", call_kwargs[1].get("data", "")))
+            assert len(posted_data["data"]) == 3
+
+        r.shutdown()
+
+    def test_multiple_instrumentations_including_adk(self):
+        """Both FakeInstrumentor and GoogleAdkInstrumentor can be active together."""
+        from respan import Respan
+        from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+        class FakeInstrumentor:
+            name = "fake"
+            def activate(self, exporter): pass
+            def deactivate(self): pass
+
+        r = Respan(
+            api_key="test-key",
+            instrumentations=[FakeInstrumentor(), GoogleAdkInstrumentor()],
+        )
+        assert "fake" in r._instrumentations
+        assert "google-adk" in r._instrumentations
         r.shutdown()

--- a/python-sdks/respan-exporter-openai-agents/src/respan_exporter_openai_agents/respan_openai_agents_exporter.py
+++ b/python-sdks/respan-exporter-openai-agents/src/respan_exporter_openai_agents/respan_openai_agents_exporter.py
@@ -146,10 +146,8 @@ def _agent_data_to_respan_log(
     if span_data.handoffs:
         data.span_handoffs = span_data.handoffs
 
-    data.metadata = {
-        "output_type": span_data.output_type,
-        "agent_name": span_data.name,
-    }
+    if span_data.output_type:
+        data.metadata = {"output_type": span_data.output_type}
 
 
 def _guardrail_data_to_respan_log(

--- a/python-sdks/respan-instrumentation-google-adk/README.md
+++ b/python-sdks/respan-instrumentation-google-adk/README.md
@@ -1,0 +1,41 @@
+# respan-instrumentation-google-adk
+
+Respan instrumentation for [Google ADK](https://github.com/google/adk-python) traces.
+
+## Installation
+
+```bash
+pip install respan-instrumentation-google-adk
+```
+
+## Usage
+
+```python
+from respan import Respan
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+respan = Respan(instrumentations=[GoogleAdkInstrumentor(environment="development")])
+```
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `RESPAN_API_KEY` | Your Respan API key |
+| `GOOGLE_API_KEY` | Your Google Gemini API key |
+| `ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS` | Set to `true` for input/output capture |
+
+## ADK Span Mapping
+
+| ADK Span Name | Respan Log Type |
+|---|---|
+| `invocation` | `workflow` |
+| `agent_run` | `agent` |
+| `call_llm` | `generation` |
+| `execute_tool` | `tool` |
+
+## Architecture
+
+`GoogleAdkInstrumentor` implements the Respan Instrumentation protocol (`name`, `activate(exporter)`, `deactivate()`). It patches OpenTelemetry span processors to intercept ADK spans, converts them to Respan payload format via `AdkSpanConverter`, and exports them through the provided exporter. Transport (HTTP, auth, retries) is handled by the exporter, not this package.
+
+Spans for a trace are buffered until the ADK root span (`invocation`) ends so the converter can propagate fields across the full trace. On `deactivate()`, any pending buffer is flushed. If a trace grows beyond `trace_buffer_max_spans` (default `8192`, or `None` to disable the cap), that trace is flushed early with a warning.

--- a/python-sdks/respan-instrumentation-google-adk/pyproject.toml
+++ b/python-sdks/respan-instrumentation-google-adk/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.poetry]
+name = "respan-instrumentation-google-adk"
+version = "1.0.0"
+description = "Respan instrumentation for Google ADK traces"
+authors = ["Respan <team@respan.ai>"]
+license = "Apache-2.0"
+readme = "README.md"
+packages = [{include = "respan_instrumentation_google_adk", from = "src"}]
+
+[tool.poetry.dependencies]
+python = ">=3.12,<3.15"
+wrapt = "^1.16.0"
+opentelemetry-sdk = "^1.20.0"
+opentelemetry-api = "^1.20.0"
+opentelemetry-instrumentation = "^0.41b0"
+respan-sdk = ">=2.6.1"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^9.0.2"
+google-adk = ">=1.0.0"
+python-dotenv = "^1.2.2"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/respan-instrumentation-google-adk/pyproject.toml
+++ b/python-sdks/respan-instrumentation-google-adk/pyproject.toml
@@ -14,6 +14,7 @@ opentelemetry-sdk = "^1.20.0"
 opentelemetry-api = "^1.20.0"
 opentelemetry-instrumentation = "^0.41b0"
 respan-sdk = ">=2.6.1"
+respan-ai = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.2"

--- a/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/__init__.py
+++ b/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/__init__.py
@@ -1,0 +1,3 @@
+from .instrumentor import GoogleAdkInstrumentor
+
+__all__ = ["GoogleAdkInstrumentor"]

--- a/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/converter.py
+++ b/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/converter.py
@@ -25,6 +25,7 @@ from respan_instrumentation_google_adk.utils import (
 )
 from respan_sdk.constants.llm_logging import (
     LOG_TYPE_AGENT,
+    LOG_TYPE_CHAT,
     LOG_TYPE_GENERATION,
     LOG_TYPE_MAP,
     LOG_TYPE_TASK,
@@ -36,18 +37,35 @@ from respan_sdk.respan_types.log_types import RespanFullLogParams
 logger = logging.getLogger(__name__)
 
 # Mapping from ADK span names to Respan log types
+# TODO(llm_call_count): The backend does not increment llm_call_count for
+# spans arriving via /v1/traces/ingest regardless of log_type.  The OTEL
+# auto-instrumentation path (/v2/traces) counts via the llm.request.type
+# attribute which plugin instrumentations don't emit.  Once the backend is
+# updated to count from log_type (or a new field), revisit the mapping here.
 _ADK_LOG_TYPE_MAP: Dict[str, str] = {
     "invocation": LOG_TYPE_WORKFLOW,
     "agent_run": LOG_TYPE_AGENT,
     "invoke_agent": LOG_TYPE_AGENT,
-    "call_llm": LOG_TYPE_GENERATION,
-    "generate_content": LOG_TYPE_GENERATION,
+    "call_llm": LOG_TYPE_CHAT,
+    "generate_content": LOG_TYPE_CHAT,
     "execute_tool": LOG_TYPE_TOOL,
 }
 
 # ADK root run label — replaced with `adk_agent_name` when available (see
 # `_resolve_root_workflow_span_name`).
 _GENERIC_ADK_ROOT_SPAN_NAMES: frozenset[str] = frozenset({"invocation"})
+
+# Span attribute keys to extract session/thread identity from ADK spans.
+_SESSION_ATTR_KEYS: Tuple[str, ...] = (
+    "gcp.vertex.agent.session_id",
+    "gen_ai.session.id",
+)
+
+# Span attribute keys to extract customer/user identity from ADK spans.
+_CUSTOMER_ATTR_KEYS: Tuple[str, ...] = (
+    "gen_ai.user.id",
+    "gcp.vertex.agent.user_id",
+)
 
 
 class AdkSpanConverter:
@@ -95,18 +113,19 @@ class AdkSpanConverter:
         if payloads:
             self._propagate_trace_output(payloads=payloads)
             self._propagate_trace_input(payloads=payloads)
+            self._populate_span_handoffs(payloads=payloads)
             self._resolve_root_workflow_span_name(payloads=payloads)
         return payloads
 
     def _propagate_trace_output(self, payloads: List[Dict[str, Any]]) -> None:
-        """Propagate output from generation spans to workflow/agent/task spans."""
+        """Propagate output from LLM spans to workflow/agent/task spans."""
         trace_output: Optional[str] = None
         for payload in payloads:
             output_value = payload.get("output")
             if is_blank_value(value=output_value):
                 continue
             log_type = payload.get("log_type")
-            if log_type == LOG_TYPE_GENERATION:
+            if log_type in (LOG_TYPE_CHAT, LOG_TYPE_GENERATION):
                 trace_output = output_value
                 break
             if trace_output is None:
@@ -123,14 +142,14 @@ class AdkSpanConverter:
                     payload["output"] = trace_output
 
     def _propagate_trace_input(self, payloads: List[Dict[str, Any]]) -> None:
-        """Propagate input from generation spans to workflow/agent spans."""
+        """Propagate input from LLM spans to workflow/agent spans."""
         trace_input: Optional[str] = None
         for payload in payloads:
             input_value = payload.get("input")
             if is_blank_value(value=input_value):
                 continue
             log_type = payload.get("log_type")
-            if log_type == LOG_TYPE_GENERATION:
+            if log_type in (LOG_TYPE_CHAT, LOG_TYPE_GENERATION):
                 trace_input = input_value
                 break
             if trace_input is None:
@@ -145,6 +164,32 @@ class AdkSpanConverter:
                     LOG_TYPE_TASK,
                 ):
                     payload["input"] = trace_input
+
+    def _populate_span_handoffs(self, payloads: List[Dict[str, Any]]) -> None:
+        """Populate span_handoffs for invoke_agent spans."""
+        # Build span_id -> agent_name lookup
+        agent_by_span_id: Dict[str, str] = {}
+        for p in payloads:
+            sid = p.get("span_id")
+            meta = p.get("metadata") or {}
+            name = meta.get("adk_agent_name")
+            if sid and name:
+                agent_by_span_id[sid] = name
+
+        for p in payloads:
+            raw_name = p.get("span_name") or ""
+            if not raw_name.startswith("invoke_agent"):
+                continue
+            meta = p.get("metadata") or {}
+            target = meta.get("adk_agent_name")
+            if not target:
+                parts = raw_name.split(" ", 1)
+                target = parts[1] if len(parts) > 1 else None
+            if not target:
+                continue
+            parent_id = p.get("parent_id") or p.get("span_parent_id")
+            source = agent_by_span_id.get(parent_id, "") if parent_id else ""
+            p["span_handoffs"] = [f"{source} -> {target}"]
 
     def _resolve_root_workflow_span_name(self, payloads: List[Dict[str, Any]]) -> None:
         """Replace generic ADK root labels (e.g. ``invocation``) with a real agent name.
@@ -283,6 +328,46 @@ class AdkSpanConverter:
         conversation_id = root_attrs.get("gen_ai.conversation.id")
         if not session_identifier and conversation_id:
             session_identifier = conversation_id
+
+        # Extract session from ADK-specific span attributes
+        if not session_identifier:
+            for key in _SESSION_ATTR_KEYS:
+                val = root_attrs.get(key)
+                if val:
+                    session_identifier = str(val)
+                    break
+        if not session_identifier:
+            for span in spans:
+                child_attrs = as_dict(
+                    value=get_attr(span, "attributes", "metadata", "tags", "data")
+                ) or {}
+                for key in _SESSION_ATTR_KEYS:
+                    val = child_attrs.get(key)
+                    if val:
+                        session_identifier = str(val)
+                        break
+                if session_identifier:
+                    break
+
+        # Extract customer from ADK-specific span attributes
+        if not customer_identifier:
+            for key in _CUSTOMER_ATTR_KEYS:
+                val = root_attrs.get(key)
+                if val:
+                    customer_identifier = str(val)
+                    break
+        if not customer_identifier:
+            for span in spans:
+                child_attrs = as_dict(
+                    value=get_attr(span, "attributes", "metadata", "tags", "data")
+                ) or {}
+                for key in _CUSTOMER_ATTR_KEYS:
+                    val = child_attrs.get(key)
+                    if val:
+                        customer_identifier = str(val)
+                        break
+                if customer_identifier:
+                    break
 
         if not trace_start_time:
             trace_start_time = infer_trace_start_time(spans=spans)
@@ -501,6 +586,7 @@ class AdkSpanConverter:
             "environment": self.environment,
             "customer_identifier": trace_context.customer_identifier,
             "log_type": log_type,
+            "log_method": "tracing_integration",
             "start_time": format_rfc3339(value=start_time),
             "timestamp": format_rfc3339(value=end_time),
             "latency": latency,
@@ -509,6 +595,7 @@ class AdkSpanConverter:
             "model": model,
             "metadata": span_metadata or None,
             "session_identifier": trace_context.session_identifier,
+            "thread_identifier": trace_context.session_identifier,
             "trace_group_identifier": trace_context.trace_group_identifier,
         }
         if prompt_messages is not None:
@@ -537,8 +624,10 @@ class AdkSpanConverter:
         if error:
             payload["error_message"] = str(error)
             payload["status_code"] = 500
+            payload["status"] = "error"
         else:
             payload["status_code"] = get_attr(span, "status_code") or 200
+            payload["status"] = "success"
 
         # Tool info
         tool_name = (
@@ -657,7 +746,7 @@ class AdkSpanConverter:
                 if key in name_lower:
                     return value
         if model:
-            return LOG_TYPE_GENERATION
+            return LOG_TYPE_CHAT
         if parent_id is None:
             return LOG_TYPE_WORKFLOW
         return LOG_TYPE_TASK

--- a/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/converter.py
+++ b/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/converter.py
@@ -46,8 +46,8 @@ _ADK_LOG_TYPE_MAP: Dict[str, str] = {
     "invocation": LOG_TYPE_WORKFLOW,
     "agent_run": LOG_TYPE_AGENT,
     "invoke_agent": LOG_TYPE_AGENT,
-    "call_llm": LOG_TYPE_CHAT,
-    "generate_content": LOG_TYPE_CHAT,
+    "call_llm": LOG_TYPE_GENERATION,
+    "generate_content": LOG_TYPE_GENERATION,
     "execute_tool": LOG_TYPE_TOOL,
 }
 

--- a/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/converter.py
+++ b/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/converter.py
@@ -1,0 +1,663 @@
+"""Respan Google ADK Converter - Convert Google ADK traces to Respan payload format."""
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from respan_instrumentation_google_adk.types import TraceContext
+from respan_instrumentation_google_adk.utils import (
+    as_dict,
+    clean_payload,
+    coerce_datetime,
+    coerce_token_count,
+    extract_genai_messages,
+    find_root_span,
+    format_rfc3339,
+    get_attr,
+    infer_trace_start_time,
+    is_blank_value,
+    messages_to_text,
+    normalize_span_id,
+    normalize_trace_id,
+    serialize_value,
+    to_completion_message,
+    to_prompt_messages,
+)
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_AGENT,
+    LOG_TYPE_GENERATION,
+    LOG_TYPE_MAP,
+    LOG_TYPE_TASK,
+    LOG_TYPE_TOOL,
+    LOG_TYPE_WORKFLOW,
+)
+from respan_sdk.respan_types.log_types import RespanFullLogParams
+
+logger = logging.getLogger(__name__)
+
+# Mapping from ADK span names to Respan log types
+_ADK_LOG_TYPE_MAP: Dict[str, str] = {
+    "invocation": LOG_TYPE_WORKFLOW,
+    "agent_run": LOG_TYPE_AGENT,
+    "invoke_agent": LOG_TYPE_AGENT,
+    "call_llm": LOG_TYPE_GENERATION,
+    "generate_content": LOG_TYPE_GENERATION,
+    "execute_tool": LOG_TYPE_TOOL,
+}
+
+# ADK root run label — replaced with `adk_agent_name` when available (see
+# `_resolve_root_workflow_span_name`).
+_GENERIC_ADK_ROOT_SPAN_NAMES: frozenset[str] = frozenset({"invocation"})
+
+
+class AdkSpanConverter:
+    """Convert Google ADK traces/spans to Respan payload format.
+
+    The converter accepts:
+    - a trace object with a .spans collection
+    - a dict with a "spans" field
+    - a list of span objects/dicts
+    """
+
+    def __init__(
+        self,
+        environment: Optional[str] = None,
+        customer_identifier: Optional[str] = None,
+    ) -> None:
+        self.environment = environment or "production"
+        self.customer_identifier = customer_identifier
+
+    def convert(self, trace_or_spans: Any) -> List[Dict[str, Any]]:
+        """Convert trace or spans to Respan payload format."""
+        trace_obj, spans = self._normalize_trace(trace_or_spans=trace_or_spans)
+        if not spans:
+            return []
+        trace_context = self._extract_trace_context(trace_obj=trace_obj, spans=spans)
+        span_id_map: Dict[str, str] = {}
+        for span in spans:
+            raw_span_id = get_attr(span, "span_id", "id", "uid")
+            if raw_span_id is None:
+                continue
+            raw_span_id = str(raw_span_id)
+            span_id_map[raw_span_id] = normalize_span_id(
+                span_id=raw_span_id,
+                trace_id=trace_context.trace_id,
+            )
+        payloads: List[Dict[str, Any]] = []
+        for span in spans:
+            payload = self._span_to_respan(
+                span=span,
+                trace_context=trace_context,
+                span_id_map=span_id_map,
+            )
+            if payload:
+                payloads.append(payload)
+        if payloads:
+            self._propagate_trace_output(payloads=payloads)
+            self._propagate_trace_input(payloads=payloads)
+            self._resolve_root_workflow_span_name(payloads=payloads)
+        return payloads
+
+    def _propagate_trace_output(self, payloads: List[Dict[str, Any]]) -> None:
+        """Propagate output from generation spans to workflow/agent/task spans."""
+        trace_output: Optional[str] = None
+        for payload in payloads:
+            output_value = payload.get("output")
+            if is_blank_value(value=output_value):
+                continue
+            log_type = payload.get("log_type")
+            if log_type == LOG_TYPE_GENERATION:
+                trace_output = output_value
+                break
+            if trace_output is None:
+                trace_output = output_value
+        if trace_output is not None:
+            for payload in payloads:
+                if is_blank_value(value=payload.get("output")) and payload.get(
+                    "log_type"
+                ) in (
+                    LOG_TYPE_WORKFLOW,
+                    LOG_TYPE_AGENT,
+                    LOG_TYPE_TASK,
+                ):
+                    payload["output"] = trace_output
+
+    def _propagate_trace_input(self, payloads: List[Dict[str, Any]]) -> None:
+        """Propagate input from generation spans to workflow/agent spans."""
+        trace_input: Optional[str] = None
+        for payload in payloads:
+            input_value = payload.get("input")
+            if is_blank_value(value=input_value):
+                continue
+            log_type = payload.get("log_type")
+            if log_type == LOG_TYPE_GENERATION:
+                trace_input = input_value
+                break
+            if trace_input is None:
+                trace_input = input_value
+        if trace_input is not None:
+            for payload in payloads:
+                if is_blank_value(value=payload.get("input")) and payload.get(
+                    "log_type"
+                ) in (
+                    LOG_TYPE_WORKFLOW,
+                    LOG_TYPE_AGENT,
+                    LOG_TYPE_TASK,
+                ):
+                    payload["input"] = trace_input
+
+    def _resolve_root_workflow_span_name(self, payloads: List[Dict[str, Any]]) -> None:
+        """Replace generic ADK root labels (e.g. ``invocation``) with a real agent name.
+
+        Prefer ``metadata.adk_agent_name`` on the root workflow payload (from
+        ``gen_ai.agent.name`` on that span), otherwise the first agent child's
+        name. ``_map_log_type`` already ran on the raw OTel name; only the
+        emitted ``span_name`` changes here.
+        """
+        root_payload: Optional[Dict[str, Any]] = None
+        for payload in payloads:
+            if (
+                payload.get("log_type") == LOG_TYPE_WORKFLOW
+                and payload.get("parent_id") is None
+                and payload.get("span_parent_id") is None
+            ):
+                root_payload = payload
+                break
+
+        if root_payload is None:
+            return
+
+        current = root_payload.get("span_name")
+        if str(current) not in _GENERIC_ADK_ROOT_SPAN_NAMES:
+            return
+
+        root_meta = root_payload.get("metadata") or {}
+        agent_name: Optional[str] = root_meta.get("adk_agent_name")
+        if not agent_name:
+            for payload in payloads:
+                if payload.get("log_type") != LOG_TYPE_AGENT:
+                    continue
+                meta = payload.get("metadata") or {}
+                agent_name = meta.get("adk_agent_name")
+                if agent_name:
+                    break
+
+        if agent_name:
+            root_payload["span_name"] = agent_name
+
+    def _normalize_trace(self, trace_or_spans: Any) -> Tuple[Optional[Any], List[Any]]:
+        """Normalize trace input to (trace_obj, spans) tuple."""
+        if trace_or_spans is None:
+            return None, []
+        if isinstance(trace_or_spans, (list, tuple, set)):
+            return None, list(trace_or_spans)
+        if isinstance(trace_or_spans, dict):
+            spans = trace_or_spans.get("spans")
+            if spans is not None:
+                return trace_or_spans, list(spans)
+            return None, [trace_or_spans]
+        spans = get_attr(trace_or_spans, "spans", "span_events")
+        if spans is not None:
+            return trace_or_spans, list(spans)
+        return None, [trace_or_spans]
+
+    def _extract_trace_context(
+        self,
+        trace_obj: Optional[Any],
+        spans: Sequence[Any],
+    ) -> TraceContext:
+        """Extract trace context from trace object and spans."""
+        trace_id = get_attr(trace_obj, "trace_id", "id", "uid")
+        trace_name = get_attr(trace_obj, "name", "trace_name", "title")
+        workflow_name = get_attr(trace_obj, "workflow_name", "workflow")
+        session_identifier = get_attr(trace_obj, "session_identifier", "session_id")
+        conversation_id: Optional[str] = None
+        trace_group_identifier = get_attr(
+            trace_obj,
+            "trace_group_identifier",
+            "group_identifier",
+            "group_id",
+        )
+
+        trace_metadata: Dict[str, Any] = {}
+
+        customer_identifier = get_attr(
+            trace_obj,
+            "customer_identifier",
+            "customer_id",
+            "user_id",
+            "user_identifier",
+            "user",
+        )
+        if not customer_identifier:
+            customer_identifier = self.customer_identifier
+
+        trace_start_time = coerce_datetime(
+            value=get_attr(trace_obj, "start_time", "started_at", "start", "start_timestamp")
+        )
+
+        root_span = find_root_span(spans=spans)
+        root_attrs: Dict[str, Any] = {}
+        if root_span is not None:
+            root_attrs = as_dict(
+                value=get_attr(root_span, "attributes", "metadata", "tags", "data")
+            ) or {}
+
+        # Extract trace info from root span GenAI attributes
+        if not trace_name:
+            trace_name = (
+                root_attrs.get("gen_ai.agent.name")
+                or root_attrs.get("gen_ai.request.model")
+            )
+        # If root span has no agent name (e.g. bare 'invocation' span),
+        # look at child spans for the first agent name
+        if not trace_name:
+            for span in spans:
+                child_attrs = as_dict(
+                    value=get_attr(span, "attributes", "metadata", "tags", "data")
+                ) or {}
+                child_agent_name = child_attrs.get("gen_ai.agent.name")
+                if child_agent_name:
+                    trace_name = str(child_agent_name)
+                    break
+        if not trace_name:
+            root_name = get_attr(root_span, "name")
+            if root_name and str(root_name) != "invocation":
+                trace_name = str(root_name)
+
+        if not trace_id:
+            for span in spans:
+                trace_id = get_attr(span, "trace_id", "traceId")
+                if trace_id:
+                    break
+        if not trace_id:
+            trace_id = str(uuid.uuid4())
+
+        if not trace_name and trace_id:
+            trace_name = str(trace_id)
+
+        if not workflow_name:
+            workflow_name = trace_name
+
+        # Extract session/conversation from GenAI attributes
+        conversation_id = root_attrs.get("gen_ai.conversation.id")
+        if not session_identifier and conversation_id:
+            session_identifier = conversation_id
+
+        if not trace_start_time:
+            trace_start_time = infer_trace_start_time(spans=spans)
+
+        return TraceContext(
+            trace_id=str(trace_id),
+            trace_name=str(trace_name) if trace_name else None,
+            workflow_name=str(workflow_name) if workflow_name else None,
+            metadata=trace_metadata,
+            session_identifier=session_identifier,
+            trace_group_identifier=trace_group_identifier,
+            start_time=trace_start_time,
+            customer_identifier=customer_identifier,
+            conversation_id=conversation_id,
+        )
+
+    def _span_to_respan(
+        self,
+        span: Any,
+        trace_context: TraceContext,
+        span_id_map: Optional[Dict[str, str]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Convert span to Respan payload format."""
+        span_id = get_attr(span, "span_id", "id", "uid")
+        parent_id = get_attr(span, "parent_id", "parent_span_id", "parentId")
+        span_name = get_attr(span, "name", "span_name", "operation_name")
+
+        span_attrs = as_dict(
+            value=get_attr(span, "attributes", "metadata", "tags", "data")
+        ) or {}
+
+        # -- Extract GenAI semantic convention attributes --
+
+        # Model
+        model = (
+            span_attrs.get("gen_ai.response.model")
+            or span_attrs.get("gen_ai.request.model")
+        )
+
+        # Token usage (OpenLLMetry names first, then OTel GenAI semconv fallbacks)
+        prompt_tokens_raw = (
+            span_attrs.get("gen_ai.usage.prompt_tokens")
+            or span_attrs.get("gen_ai.usage.input_tokens")
+        )
+        completion_tokens_raw = (
+            span_attrs.get("gen_ai.usage.completion_tokens")
+            or span_attrs.get("gen_ai.usage.output_tokens")
+        )
+
+        # Messages (try OpenLLMetry names first, then OTel GenAI semconv,
+        # then ADK-specific attributes)
+        input_messages = extract_genai_messages(
+            attributes=span_attrs, key="gen_ai.prompt"
+        ) or extract_genai_messages(
+            attributes=span_attrs, key="gen_ai.input.messages"
+        )
+        output_messages = extract_genai_messages(
+            attributes=span_attrs, key="gen_ai.completion"
+        ) or extract_genai_messages(
+            attributes=span_attrs, key="gen_ai.output.messages"
+        )
+
+        # ADK stores full request/response in gcp.vertex.agent.llm_request/response
+        if not input_messages or not output_messages:
+            input_msgs, output_msgs = self._extract_adk_messages(span_attrs)
+            if not input_messages and input_msgs:
+                input_messages = input_msgs
+            if not output_messages and output_msgs:
+                output_messages = output_msgs
+
+        # Agent info
+        agent_name = span_attrs.get("gen_ai.agent.name")
+        agent_id = span_attrs.get("gen_ai.agent.id")
+
+        # Input/Output
+        span_input = get_attr(span, "input", "input_data", "request", "prompt")
+        if span_input is None and input_messages:
+            span_input = input_messages
+
+        span_output = get_attr(span, "output", "output_data", "response")
+        if span_output is None and output_messages:
+            output_text = messages_to_text(messages=output_messages)
+            if output_text:
+                span_output = output_text
+
+        # Build prompt_messages / completion_message
+        prompt_messages = (
+            to_prompt_messages(value=span_input) if span_input is not None else None
+        )
+        completion_message = (
+            to_completion_message(value=span_output) if span_output is not None else None
+        )
+        if prompt_messages is None and input_messages:
+            prompt_messages = input_messages
+        if completion_message is None and output_messages:
+            completion_message = output_messages[0] if output_messages else None
+
+        if is_blank_value(value=span_output) and output_messages:
+            output_text = messages_to_text(messages=output_messages)
+            if output_text:
+                span_output = output_text
+                if completion_message is None:
+                    completion_message = {"role": "assistant", "content": output_text}
+
+        if span_output is None and isinstance(completion_message, dict):
+            completion_content = completion_message.get("content")
+            if completion_content:
+                span_output = completion_content
+        if completion_message is None and isinstance(span_output, str) and span_output.strip():
+            completion_message = {"role": "assistant", "content": span_output.strip()}
+        if prompt_messages is None and isinstance(span_input, str) and span_input.strip():
+            prompt_messages = [{"role": "user", "content": span_input.strip()}]
+
+        # Error
+        error = get_attr(span, "error", "exception", "err")
+        if error is None:
+            error = span_attrs.get("error")
+
+        # Timestamps
+        start_time = coerce_datetime(
+            value=get_attr(span, "start_time", "started_at", "start", "start_timestamp"),
+            reference=trace_context.start_time,
+        )
+        end_time = coerce_datetime(
+            value=get_attr(span, "end_time", "ended_at", "end", "end_timestamp", "timestamp"),
+            reference=trace_context.start_time,
+        )
+
+        now = datetime.now(timezone.utc)
+        if start_time is None and end_time is None:
+            start_time = now
+            end_time = now
+        elif start_time is None:
+            start_time = end_time
+        elif end_time is None:
+            end_time = start_time
+        if start_time and end_time and end_time < start_time:
+            end_time = start_time
+
+        latency = get_attr(span, "latency", "duration")
+        if latency is None and start_time and end_time:
+            latency = (end_time - start_time).total_seconds()
+        if latency is not None and latency < 0:
+            latency = 0.0
+
+        if not span_id:
+            span_id = str(uuid.uuid4())
+        span_id_str = str(span_id)
+        if not span_name:
+            span_name = span_id
+
+        log_type = self._map_log_type(
+            span_name=str(span_name) if span_name else None,
+            parent_id=parent_id,
+            model=model,
+        )
+
+        # Build metadata with LLM config and agent info
+        span_metadata: Dict[str, Any] = dict(trace_context.metadata)
+        if agent_name:
+            span_metadata["adk_agent_name"] = agent_name
+        if agent_id:
+            span_metadata["adk_agent_id"] = agent_id
+
+        # LLM config
+        temperature = span_attrs.get("gen_ai.request.temperature")
+        top_k = span_attrs.get("gen_ai.request.top_k")
+        top_p = span_attrs.get("gen_ai.request.top_p")
+        max_tokens = (
+            span_attrs.get("gen_ai.request.max_tokens")
+            or span_attrs.get("gen_ai.request.max_output_tokens")
+        )
+        llm_config: Dict[str, Any] = {}
+        if temperature is not None:
+            llm_config["temperature"] = temperature
+        if top_k is not None:
+            llm_config["top_k"] = top_k
+        if top_p is not None:
+            llm_config["top_p"] = top_p
+        if max_tokens is not None:
+            llm_config["max_tokens"] = max_tokens
+        if llm_config:
+            span_metadata["llm_config"] = llm_config
+
+        trace_hex_id = normalize_trace_id(trace_id=trace_context.trace_id)
+        if span_id_map and span_id_str in span_id_map:
+            span_hex_id = span_id_map[span_id_str]
+        else:
+            span_hex_id = normalize_span_id(
+                span_id=span_id_str,
+                trace_id=trace_context.trace_id,
+            )
+        parent_hex_id = None
+        if parent_id:
+            if span_id_map:
+                parent_hex_id = span_id_map.get(str(parent_id))
+            if parent_hex_id is None:
+                parent_hex_id = normalize_span_id(
+                    span_id=str(parent_id),
+                    trace_id=trace_context.trace_id,
+                )
+
+        input_value = serialize_value(value=span_input) if span_input is not None else None
+        output_value = serialize_value(value=span_output) if span_output is not None else None
+
+        payload = {
+            "trace_unique_id": trace_hex_id,
+            "trace_name": trace_context.trace_name,
+            "span_unique_id": span_hex_id,
+            "span_parent_id": parent_hex_id,
+            "span_name": str(span_name) if span_name else None,
+            "span_workflow_name": trace_context.workflow_name,
+            "trace_id": trace_hex_id,
+            "span_id": span_hex_id,
+            "parent_id": parent_hex_id,
+            "environment": self.environment,
+            "customer_identifier": trace_context.customer_identifier,
+            "log_type": log_type,
+            "start_time": format_rfc3339(value=start_time),
+            "timestamp": format_rfc3339(value=end_time),
+            "latency": latency,
+            "input": input_value,
+            "output": output_value,
+            "model": model,
+            "metadata": span_metadata or None,
+            "session_identifier": trace_context.session_identifier,
+            "trace_group_identifier": trace_context.trace_group_identifier,
+        }
+        if prompt_messages is not None:
+            payload["prompt_messages"] = prompt_messages
+        if completion_message is not None:
+            payload["completion_message"] = completion_message
+        payload["respan_params"] = {
+            "environment": self.environment,
+            "has_webhook": False,
+        }
+        payload["disable_log"] = False
+
+        # Token usage
+        prompt_tokens_value = coerce_token_count(value=prompt_tokens_raw)
+        completion_tokens_value = coerce_token_count(value=completion_tokens_raw)
+        if prompt_tokens_value is not None or completion_tokens_value is not None:
+            payload["prompt_tokens"] = prompt_tokens_value
+            payload["completion_tokens"] = completion_tokens_value
+            total = (prompt_tokens_value or 0) + (completion_tokens_value or 0)
+            payload["total_request_tokens"] = total if total > 0 else None
+            payload["usage"] = {
+                "prompt_tokens": prompt_tokens_value or 0,
+                "completion_tokens": completion_tokens_value or 0,
+            }
+
+        if error:
+            payload["error_message"] = str(error)
+            payload["status_code"] = 500
+        else:
+            payload["status_code"] = get_attr(span, "status_code") or 200
+
+        # Tool info
+        tool_name = (
+            get_attr(span, "tool_name", "tool")
+            or span_attrs.get("gen_ai.tool.name")
+            or span_attrs.get("tool.name")
+            or span_attrs.get("tool_name")
+        )
+        if tool_name:
+            payload["span_tools"] = [str(tool_name)]
+
+        if not payload.get("span_unique_id") and payload.get("trace_unique_id"):
+            payload["span_unique_id"] = payload["trace_unique_id"]
+
+        cleaned_payload = clean_payload(payload=payload)
+
+        try:
+            RespanFullLogParams(**cleaned_payload)
+        except Exception as exc:
+            logger.warning(
+                "ADK span payload failed RespanFullLogParams validation: %s",
+                exc,
+            )
+
+        return cleaned_payload
+
+    @staticmethod
+    def _extract_adk_messages(
+        span_attrs: Dict[str, Any],
+    ) -> Tuple[Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
+        """Extract input/output messages from ADK-specific attributes.
+
+        Google ADK stores full LLM request/response JSON in
+        ``gcp.vertex.agent.llm_request`` and ``gcp.vertex.agent.llm_response``.
+        """
+        import json as _json
+
+        input_messages: Optional[List[Dict[str, Any]]] = None
+        output_messages: Optional[List[Dict[str, Any]]] = None
+
+        # Parse llm_request for input messages
+        llm_request_raw = span_attrs.get("gcp.vertex.agent.llm_request")
+        if llm_request_raw:
+            try:
+                req = _json.loads(llm_request_raw) if isinstance(llm_request_raw, str) else llm_request_raw
+                if isinstance(req, dict):
+                    # ADK request has contents array with role/parts
+                    contents = req.get("contents") or []
+                    if contents and isinstance(contents, list):
+                        msgs = []
+                        for c in contents:
+                            if isinstance(c, dict):
+                                role = c.get("role", "user")
+                                # Normalize Gemini "model" role to OpenAI "assistant"
+                                if role == "model":
+                                    role = "assistant"
+                                parts = c.get("parts") or []
+                                text_parts = []
+                                for p in parts:
+                                    if isinstance(p, dict) and p.get("text"):
+                                        text_parts.append(p["text"])
+                                if text_parts:
+                                    msgs.append({"role": role, "content": "\n".join(text_parts)})
+                        if msgs:
+                            input_messages = msgs
+            except Exception:
+                pass
+
+        # Parse llm_response for output messages
+        llm_response_raw = span_attrs.get("gcp.vertex.agent.llm_response")
+        if llm_response_raw:
+            try:
+                resp = _json.loads(llm_response_raw) if isinstance(llm_response_raw, str) else llm_response_raw
+                if isinstance(resp, dict):
+                    # ADK response has content.parts with text
+                    content = resp.get("content") or {}
+                    if isinstance(content, dict):
+                        role = content.get("role", "model")
+                        # Normalize "model" role to "assistant" for OpenAI format
+                        if role == "model":
+                            role = "assistant"
+                        parts = content.get("parts") or []
+                        text_parts = []
+                        for p in parts:
+                            if isinstance(p, dict) and p.get("text"):
+                                text_parts.append(p["text"])
+                        if text_parts:
+                            output_messages = [{"role": role, "content": "\n".join(text_parts)}]
+            except Exception:
+                pass
+
+        return input_messages, output_messages
+
+    def _map_log_type(
+        self,
+        span_name: Optional[str],
+        parent_id: Optional[str],
+        model: Optional[str],
+    ) -> str:
+        """Map ADK span name to Respan log type."""
+        if span_name:
+            # Check ADK-specific mapping first (exact match)
+            adk_type = _ADK_LOG_TYPE_MAP.get(span_name)
+            if adk_type:
+                return adk_type
+            # ADK span names can include suffixes (e.g. "invoke_agent greeting_agent",
+            # "generate_content gemini-2.5-flash") — check the prefix
+            span_prefix = span_name.split(" ")[0]
+            if span_prefix != span_name:
+                adk_type = _ADK_LOG_TYPE_MAP.get(span_prefix)
+                if adk_type:
+                    return adk_type
+            # Fall back to generic LOG_TYPE_MAP
+            name_lower = span_name.lower()
+            for key, value in LOG_TYPE_MAP.items():
+                if key in name_lower:
+                    return value
+        if model:
+            return LOG_TYPE_GENERATION
+        if parent_id is None:
+            return LOG_TYPE_WORKFLOW
+        return LOG_TYPE_TASK

--- a/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/instrumentor.py
+++ b/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/instrumentor.py
@@ -1,0 +1,305 @@
+"""Respan instrumentation for Google ADK traces.
+
+This instrumentor wraps OpenTelemetry span processors to intercept ADK spans
+and export them via a provided exporter (e.g. RespanSpanExporterV2).
+"""
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from threading import Lock
+from typing import Any, Dict, Iterable, List, Optional
+
+import wrapt
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+from respan_instrumentation_google_adk.converter import AdkSpanConverter
+from respan_instrumentation_google_adk.utils import group_spans_by_trace, is_adk_span, otel_span_to_dict
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+
+_DEFAULT_TRACE_BUFFER_MAX_SPANS = 8192
+
+
+class _SpanDedupeCache:
+    """Cache for deduplicating spans by trace_id:span_id."""
+
+    def __init__(self, max_size: int = 10000) -> None:
+        self._max_size = max_size
+        self._data: "OrderedDict[str, None]" = OrderedDict()
+        self._lock = Lock()
+
+    def add(self, trace_id: Optional[str], span_id: Optional[str]) -> bool:
+        """Add span to cache. Returns True if span was not already in cache."""
+        if not trace_id or not span_id:
+            return True
+        key = f"{trace_id}:{span_id}"
+        with self._lock:
+            if key in self._data:
+                return False
+            self._data[key] = None
+            if len(self._data) > self._max_size:
+                self._data.popitem(last=False)
+        return True
+
+
+_ACTIVE_EXPORTER: Optional[Any] = None
+_ACTIVE_CONVERTER: Optional[AdkSpanConverter] = None
+_ACTIVE_DEDUPE: Optional[_SpanDedupeCache] = _SpanDedupeCache()
+_ACTIVE_PASSTHROUGH = False
+# None = no limit (not recommended for production).
+_ACTIVE_TRACE_BUFFER_MAX_SPANS: Optional[int] = _DEFAULT_TRACE_BUFFER_MAX_SPANS
+
+# Buffer child spans per trace so the converter sees the full trace at once.
+# The ADK root span ("invocation") typically ends last; when it arrives, the
+# entire buffered trace is flushed through the converter together.
+_TRACE_BUFFER: Dict[str, List[object]] = {}
+_TRACE_BUFFER_LOCK = Lock()
+
+_ADK_ROOT_SPAN_NAMES = {"invocation"}
+
+
+def _export_adk_spans(spans: Iterable[object]) -> SpanExportResult:
+    """Export ADK spans to Respan via the active exporter."""
+    exporter = _ACTIVE_EXPORTER
+    converter = _ACTIVE_CONVERTER
+    dedupe = _ACTIVE_DEDUPE
+    if exporter is None or converter is None:
+        return SpanExportResult.SUCCESS
+
+    adk_span_dicts: List[Dict[str, object]] = []
+    for span in spans:
+        if not is_adk_span(span=span):
+            continue
+        span_dict = otel_span_to_dict(span=span)
+        if dedupe and not dedupe.add(
+            trace_id=span_dict.get("trace_id"),
+            span_id=span_dict.get("span_id"),
+        ):
+            continue
+        adk_span_dicts.append(span_dict)
+
+    if not adk_span_dicts:
+        return SpanExportResult.SUCCESS
+
+    payloads: List[Dict[str, object]] = []
+    grouped = group_spans_by_trace(spans=adk_span_dicts)
+    for trace_spans in grouped.values():
+        payloads.extend(converter.convert(trace_or_spans=trace_spans))
+
+    if not payloads:
+        return SpanExportResult.SUCCESS
+
+    exporter.export(payloads)
+    return SpanExportResult.SUCCESS
+
+
+def _flush_pending_trace_buffer() -> None:
+    """Export all pending per-trace buffers (e.g. on deactivate). Best-effort."""
+    with _TRACE_BUFFER_LOCK:
+        pending = list(_TRACE_BUFFER.items())
+        _TRACE_BUFFER.clear()
+    for _trace_id, spans in pending:
+        if not spans:
+            continue
+        try:
+            _export_adk_spans(spans=spans)
+        except Exception as exc:
+            logger.warning(
+                "Failed to export buffered ADK spans on shutdown: %s",
+                exc,
+                exc_info=True,
+            )
+
+
+def _batch_export_wrapper(wrapped, instance, args, kwargs):
+    """Wrapper for BatchSpanProcessor._export method."""
+    if _ACTIVE_EXPORTER is None:
+        return wrapped(*args, **kwargs)
+    spans = list(args[0]) if args else list(kwargs.get("spans", []))
+    if not spans:
+        return wrapped(*args, **kwargs)
+
+    adk_spans = []
+    other_spans = []
+    for span in spans:
+        if is_adk_span(span=span):
+            adk_spans.append(span)
+        else:
+            other_spans.append(span)
+
+    if not adk_spans:
+        return wrapped(*args, **kwargs)
+
+    try:
+        export_result = _export_adk_spans(spans=adk_spans)
+    except Exception as exc:
+        logger.warning("Failed to export ADK spans: %s", exc, exc_info=True)
+        export_result = SpanExportResult.FAILURE
+
+    if _ACTIVE_PASSTHROUGH:
+        return wrapped(*args, **kwargs)
+
+    if other_spans:
+        kwargs.pop("spans", None)
+        return wrapped(other_spans, **kwargs)
+
+    return export_result
+
+
+def _on_end_wrapper(wrapped, instance, args, kwargs):
+    """Wrapper for SimpleSpanProcessor.on_end method.
+
+    Buffers child spans per trace and flushes the entire trace through the
+    converter when the root "invocation" span arrives (it always ends last).
+    This ensures cross-span propagation (input/output, agent name) works.
+    """
+    if _ACTIVE_EXPORTER is None:
+        return wrapped(*args, **kwargs)
+    span = args[0] if args else kwargs.get("span")
+    if span is None or not is_adk_span(span=span):
+        return wrapped(*args, **kwargs)
+
+    # Determine trace_id and whether this is the root span
+    span_name = getattr(span, "name", None) or ""
+    ctx = getattr(span, "context", None)
+    trace_id = format(ctx.trace_id, "032x") if ctx else None
+    is_root = span_name in _ADK_ROOT_SPAN_NAMES
+
+    if trace_id:
+        all_spans: Optional[List[object]] = None
+        overflow_flush = False
+        with _TRACE_BUFFER_LOCK:
+            buf = _TRACE_BUFFER.setdefault(trace_id, [])
+            buf.append(span)
+            max_spans = _ACTIVE_TRACE_BUFFER_MAX_SPANS
+            overflow_flush = max_spans is not None and len(buf) > max_spans
+            if overflow_flush:
+                all_spans = _TRACE_BUFFER.pop(trace_id)
+            elif not is_root:
+                if _ACTIVE_PASSTHROUGH:
+                    return wrapped(*args, **kwargs)
+                return None
+            else:
+                all_spans = _TRACE_BUFFER.pop(trace_id)
+
+        if overflow_flush:
+            logger.warning(
+                "ADK trace buffer exceeded trace_buffer_max_spans (%s); "
+                "flushing partial trace %s…",
+                max_spans,
+                trace_id[:16],
+            )
+        try:
+            _export_adk_spans(spans=all_spans or [])
+        except Exception as exc:
+            logger.warning("Failed to export ADK spans: %s", exc, exc_info=True)
+    else:
+        # No trace_id — export individually (fallback)
+        try:
+            _export_adk_spans(spans=[span])
+        except Exception as exc:
+            logger.warning("Failed to export ADK span: %s", exc, exc_info=True)
+
+    if _ACTIVE_PASSTHROUGH:
+        return wrapped(*args, **kwargs)
+    return None
+
+
+class GoogleAdkInstrumentor:
+    """Instrument OpenTelemetry exporters to send Google ADK traces to Respan.
+
+    Usage::
+
+        from respan import Respan
+        from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+
+        respan = Respan(instrumentations=[GoogleAdkInstrumentor(environment="development")])
+    """
+
+    name = "google-adk"
+
+    def __init__(
+        self,
+        environment: Optional[str] = None,
+        customer_identifier: Optional[str] = None,
+        passthrough: bool = False,
+        dedupe_max_size: int = 10000,
+        trace_buffer_max_spans: Optional[int] = _DEFAULT_TRACE_BUFFER_MAX_SPANS,
+    ) -> None:
+        self._environment = environment
+        self._customer_identifier = customer_identifier
+        self._passthrough = passthrough
+        self._dedupe_max_size = dedupe_max_size
+        self._trace_buffer_max_spans = trace_buffer_max_spans
+        self._converter: Optional[AdkSpanConverter] = None
+
+    def activate(self, exporter: Any) -> None:
+        """Activate ADK instrumentation with the provided exporter.
+
+        Args:
+            exporter: A ``RespanSpanExporterV2`` instance (or compatible object
+                      with an ``export(payloads)`` method).
+        """
+        self._converter = AdkSpanConverter(
+            environment=self._environment,
+            customer_identifier=self._customer_identifier,
+        )
+
+        global _ACTIVE_EXPORTER, _ACTIVE_CONVERTER, _ACTIVE_DEDUPE, _ACTIVE_PASSTHROUGH
+        global _ACTIVE_TRACE_BUFFER_MAX_SPANS
+        _ACTIVE_EXPORTER = exporter
+        _ACTIVE_CONVERTER = self._converter
+        _ACTIVE_DEDUPE = _SpanDedupeCache(max_size=self._dedupe_max_size)
+        _ACTIVE_PASSTHROUGH = self._passthrough
+        _ACTIVE_TRACE_BUFFER_MAX_SPANS = self._trace_buffer_max_spans
+
+        self._patch_span_processors()
+        logger.info("Respan Google ADK instrumentation activated")
+
+    def deactivate(self) -> None:
+        """Deactivate ADK instrumentation."""
+        global _ACTIVE_EXPORTER, _ACTIVE_CONVERTER, _ACTIVE_DEDUPE, _ACTIVE_PASSTHROUGH
+        global _ACTIVE_TRACE_BUFFER_MAX_SPANS
+        _flush_pending_trace_buffer()
+        _ACTIVE_EXPORTER = None
+        _ACTIVE_CONVERTER = None
+        _ACTIVE_DEDUPE = None
+        _ACTIVE_PASSTHROUGH = False
+        _ACTIVE_TRACE_BUFFER_MAX_SPANS = _DEFAULT_TRACE_BUFFER_MAX_SPANS
+        self._converter = None
+        logger.info("Respan Google ADK instrumentation deactivated")
+
+    def _patch_span_processors(self) -> None:
+        global _PATCHED
+        if _PATCHED:
+            return
+
+        try:
+            from opentelemetry.sdk.trace import export as trace_export
+
+            if hasattr(trace_export.BatchSpanProcessor, "_export"):
+                wrapt.wrap_function_wrapper(
+                    module="opentelemetry.sdk.trace.export",
+                    name="BatchSpanProcessor._export",
+                    wrapper=_batch_export_wrapper,
+                )
+            else:
+                wrapt.wrap_function_wrapper(
+                    module="opentelemetry.sdk.trace.export",
+                    name="BatchSpanProcessor.on_end",
+                    wrapper=_on_end_wrapper,
+                )
+        except Exception as exc:
+            logger.debug("Failed to patch BatchSpanProcessor: %s", exc)
+
+        wrapt.wrap_function_wrapper(
+            module="opentelemetry.sdk.trace.export",
+            name="SimpleSpanProcessor.on_end",
+            wrapper=_on_end_wrapper,
+        )
+
+        _PATCHED = True
+        logger.debug("Patched OpenTelemetry span processors for ADK export")

--- a/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/instrumentor.py
+++ b/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/instrumentor.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 import wrapt
 from opentelemetry.sdk.trace.export import SpanExportResult
+from respan_tracing.exporters.span_exporter_v2 import _PROPAGATED_ATTRIBUTES
 
 from respan_instrumentation_google_adk.converter import AdkSpanConverter
 from respan_instrumentation_google_adk.utils import group_spans_by_trace, is_adk_span, otel_span_to_dict
@@ -58,10 +59,20 @@ _ACTIVE_TRACE_BUFFER_MAX_SPANS: Optional[int] = _DEFAULT_TRACE_BUFFER_MAX_SPANS
 _TRACE_BUFFER: Dict[str, List[object]] = {}
 _TRACE_BUFFER_LOCK = Lock()
 
+# Snapshot of propagated context attributes captured on the user thread.
+# Keyed by trace_id.  Without this, propagate_attributes() context would be
+# lost because BatchSpanProcessor._export runs on a background thread where
+# the ContextVar is empty.  Mirrors the pattern from the OpenAI Agents SDK
+# instrumentation (_RespanTracingProcessor._captured_ctx).
+_TRACE_CTX_CACHE: Dict[str, Dict[str, Any]] = {}
+
 _ADK_ROOT_SPAN_NAMES = {"invocation"}
 
 
-def _export_adk_spans(spans: Iterable[object]) -> SpanExportResult:
+def _export_adk_spans(
+    spans: Iterable[object],
+    captured_ctx: Optional[Dict[str, Any]] = None,
+) -> SpanExportResult:
     """Export ADK spans to Respan via the active exporter."""
     exporter = _ACTIVE_EXPORTER
     converter = _ACTIVE_CONVERTER
@@ -92,7 +103,19 @@ def _export_adk_spans(spans: Iterable[object]) -> SpanExportResult:
     if not payloads:
         return SpanExportResult.SUCCESS
 
-    exporter.export(payloads)
+    # Restore captured propagate_attributes context if the current thread
+    # doesn't have it (e.g. the context manager already exited, or we're on
+    # the BatchSpanProcessor background thread).
+    current_ctx = _PROPAGATED_ATTRIBUTES.get()
+    if captured_ctx and not current_ctx:
+        token = _PROPAGATED_ATTRIBUTES.set(captured_ctx)
+        try:
+            exporter.export(payloads)
+        finally:
+            _PROPAGATED_ATTRIBUTES.reset(token)
+    else:
+        exporter.export(payloads)
+
     return SpanExportResult.SUCCESS
 
 
@@ -101,11 +124,16 @@ def _flush_pending_trace_buffer() -> None:
     with _TRACE_BUFFER_LOCK:
         pending = list(_TRACE_BUFFER.items())
         _TRACE_BUFFER.clear()
-    for _trace_id, spans in pending:
+        pending_ctx = dict(_TRACE_CTX_CACHE)
+        _TRACE_CTX_CACHE.clear()
+    for trace_id, spans in pending:
         if not spans:
             continue
         try:
-            _export_adk_spans(spans=spans)
+            _export_adk_spans(
+                spans=spans,
+                captured_ctx=pending_ctx.get(trace_id),
+            )
         except Exception as exc:
             logger.warning(
                 "Failed to export buffered ADK spans on shutdown: %s",
@@ -115,29 +143,20 @@ def _flush_pending_trace_buffer() -> None:
 
 
 def _batch_export_wrapper(wrapped, instance, args, kwargs):
-    """Wrapper for BatchSpanProcessor._export method."""
+    """Wrapper for BatchSpanProcessor._export method.
+
+    ADK spans are normally intercepted earlier in on_end (on the user thread)
+    and never reach the batch queue.  This wrapper is a safety net that filters
+    out any ADK spans that slip through (e.g. race conditions) to prevent
+    double-export.
+    """
     if _ACTIVE_EXPORTER is None:
         return wrapped(*args, **kwargs)
     spans = list(args[0]) if args else list(kwargs.get("spans", []))
     if not spans:
         return wrapped(*args, **kwargs)
 
-    adk_spans = []
-    other_spans = []
-    for span in spans:
-        if is_adk_span(span=span):
-            adk_spans.append(span)
-        else:
-            other_spans.append(span)
-
-    if not adk_spans:
-        return wrapped(*args, **kwargs)
-
-    try:
-        export_result = _export_adk_spans(spans=adk_spans)
-    except Exception as exc:
-        logger.warning("Failed to export ADK spans: %s", exc, exc_info=True)
-        export_result = SpanExportResult.FAILURE
+    other_spans = [s for s in spans if not is_adk_span(span=s)]
 
     if _ACTIVE_PASSTHROUGH:
         return wrapped(*args, **kwargs)
@@ -146,15 +165,16 @@ def _batch_export_wrapper(wrapped, instance, args, kwargs):
         kwargs.pop("spans", None)
         return wrapped(other_spans, **kwargs)
 
-    return export_result
+    return SpanExportResult.SUCCESS
 
 
 def _on_end_wrapper(wrapped, instance, args, kwargs):
-    """Wrapper for SimpleSpanProcessor.on_end method.
+    """Wrapper for span processor on_end.
 
-    Buffers child spans per trace and flushes the entire trace through the
-    converter when the root "invocation" span arrives (it always ends last).
-    This ensures cross-span propagation (input/output, agent name) works.
+    Intercepts ADK spans on the **user thread** (where ContextVars from
+    ``propagate_attributes`` are available), buffers them per trace, and
+    flushes the entire trace through the converter when the root
+    "invocation" span arrives.
     """
     if _ACTIVE_EXPORTER is None:
         return wrapped(*args, **kwargs)
@@ -168,8 +188,17 @@ def _on_end_wrapper(wrapped, instance, args, kwargs):
     trace_id = format(ctx.trace_id, "032x") if ctx else None
     is_root = span_name in _ADK_ROOT_SPAN_NAMES
 
+    # Capture propagated attributes on the user thread.  First write wins
+    # (the outermost propagate_attributes scope is the most complete).
+    prop_ctx = _PROPAGATED_ATTRIBUTES.get()
+    if prop_ctx and trace_id:
+        with _TRACE_BUFFER_LOCK:
+            if trace_id not in _TRACE_CTX_CACHE:
+                _TRACE_CTX_CACHE[trace_id] = prop_ctx
+
     if trace_id:
         all_spans: Optional[List[object]] = None
+        captured_ctx: Optional[Dict[str, Any]] = None
         overflow_flush = False
         with _TRACE_BUFFER_LOCK:
             buf = _TRACE_BUFFER.setdefault(trace_id, [])
@@ -178,12 +207,14 @@ def _on_end_wrapper(wrapped, instance, args, kwargs):
             overflow_flush = max_spans is not None and len(buf) > max_spans
             if overflow_flush:
                 all_spans = _TRACE_BUFFER.pop(trace_id)
+                captured_ctx = _TRACE_CTX_CACHE.pop(trace_id, None)
             elif not is_root:
                 if _ACTIVE_PASSTHROUGH:
                     return wrapped(*args, **kwargs)
                 return None
             else:
                 all_spans = _TRACE_BUFFER.pop(trace_id)
+                captured_ctx = _TRACE_CTX_CACHE.pop(trace_id, None)
 
         if overflow_flush:
             logger.warning(
@@ -193,13 +224,16 @@ def _on_end_wrapper(wrapped, instance, args, kwargs):
                 trace_id[:16],
             )
         try:
-            _export_adk_spans(spans=all_spans or [])
+            _export_adk_spans(
+                spans=all_spans or [],
+                captured_ctx=captured_ctx,
+            )
         except Exception as exc:
             logger.warning("Failed to export ADK spans: %s", exc, exc_info=True)
     else:
         # No trace_id — export individually (fallback)
         try:
-            _export_adk_spans(spans=[span])
+            _export_adk_spans(spans=[span], captured_ctx=prop_ctx or None)
         except Exception as exc:
             logger.warning("Failed to export ADK span: %s", exc, exc_info=True)
 
@@ -280,17 +314,22 @@ class GoogleAdkInstrumentor:
         try:
             from opentelemetry.sdk.trace import export as trace_export
 
+            # Always patch on_end to intercept ADK spans on the user thread.
+            # This is where we capture propagate_attributes context and buffer
+            # spans per-trace.
+            wrapt.wrap_function_wrapper(
+                module="opentelemetry.sdk.trace.export",
+                name="BatchSpanProcessor.on_end",
+                wrapper=_on_end_wrapper,
+            )
+
+            # Also patch _export as a safety net: any ADK spans that somehow
+            # reach the batch queue are filtered out to prevent double-export.
             if hasattr(trace_export.BatchSpanProcessor, "_export"):
                 wrapt.wrap_function_wrapper(
                     module="opentelemetry.sdk.trace.export",
                     name="BatchSpanProcessor._export",
                     wrapper=_batch_export_wrapper,
-                )
-            else:
-                wrapt.wrap_function_wrapper(
-                    module="opentelemetry.sdk.trace.export",
-                    name="BatchSpanProcessor.on_end",
-                    wrapper=_on_end_wrapper,
                 )
         except Exception as exc:
             logger.debug("Failed to patch BatchSpanProcessor: %s", exc)

--- a/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/types.py
+++ b/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/types.py
@@ -1,0 +1,19 @@
+"""Type definitions for Respan Google ADK instrumentation."""
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
+
+from respan_sdk.respan_types.base_types import RespanBaseModel
+
+
+class TraceContext(RespanBaseModel):
+    """Context information for a trace, extracted from trace object and root span."""
+
+    trace_id: str
+    trace_name: Optional[str]
+    workflow_name: Optional[str]
+    metadata: Dict[str, Any]
+    session_identifier: Optional[Union[str, int]] = None
+    trace_group_identifier: Optional[Union[str, int]] = None
+    start_time: Optional[datetime] = None
+    customer_identifier: Optional[Union[str, int]] = None
+    conversation_id: Optional[str] = None

--- a/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/utils.py
+++ b/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/utils.py
@@ -333,34 +333,38 @@ def to_prompt_messages(value: Any) -> Optional[List[Dict[str, Any]]]:
     parsed = parse_json_value(value=value)
     if isinstance(parsed, list) and parsed and all(isinstance(item, dict) for item in parsed):
         if all("role" in item and "content" in item for item in parsed):
-            return parsed
+            return [_normalize_message_role(m) for m in parsed]
     if isinstance(parsed, dict):
         if isinstance(parsed.get("messages"), list):
             messages = parsed.get("messages") or []
             if messages and all(isinstance(item, dict) for item in messages):
-                return messages
+                return [_normalize_message_role(m) for m in messages]
         if "role" in parsed and "content" in parsed:
-            return [parsed]
+            return [_normalize_message_role(parsed)]
     return None
 
 
 def to_completion_message(value: Any) -> Optional[Dict[str, Any]]:
     """Convert value to completion message format."""
     parsed = parse_json_value(value=value)
+    result: Optional[Dict[str, Any]] = None
     if isinstance(parsed, dict):
         if "role" in parsed and "content" in parsed:
-            return parsed
-        choices = parsed.get("choices")
-        if isinstance(choices, list) and choices:
-            first = choices[0]
-            if isinstance(first, dict):
-                message = first.get("message")
-                if isinstance(message, dict) and "content" in message:
-                    return message
-    if isinstance(parsed, list) and parsed:
+            result = parsed
+        else:
+            choices = parsed.get("choices")
+            if isinstance(choices, list) and choices:
+                first = choices[0]
+                if isinstance(first, dict):
+                    message = first.get("message")
+                    if isinstance(message, dict) and "content" in message:
+                        result = message
+    if result is None and isinstance(parsed, list) and parsed:
         first = parsed[0]
         if isinstance(first, dict) and "content" in first:
-            return first
+            result = first
+    if result is not None:
+        return _normalize_message_role(result)
     return None
 
 
@@ -382,6 +386,13 @@ def messages_to_text(messages: Sequence[Dict[str, Any]]) -> Optional[str]:
     return "\n".join(parts)
 
 
+def _normalize_message_role(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize Gemini ``"model"`` role to ``"assistant"`` for OpenAI compatibility."""
+    if message.get("role") == "model":
+        message = {**message, "role": "assistant"}
+    return message
+
+
 def extract_genai_messages(
     attributes: Dict[str, Any],
     key: str,
@@ -399,9 +410,9 @@ def extract_genai_messages(
         messages = []
         for item in parsed:
             if isinstance(item, dict):
-                messages.append(item)
+                messages.append(_normalize_message_role(item))
         if messages:
             return messages
     if isinstance(parsed, dict) and ("role" in parsed or "content" in parsed):
-        return [parsed]
+        return [_normalize_message_role(parsed)]
     return None

--- a/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/utils.py
+++ b/python-sdks/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/utils.py
@@ -1,0 +1,407 @@
+"""Utility functions for Respan Google ADK instrumentation."""
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+
+def ns_to_datetime(value: Optional[int]) -> Optional[datetime]:
+    """Convert nanoseconds timestamp to datetime."""
+    if not value:
+        return None
+    return datetime.fromtimestamp(value / 1e9, tz=timezone.utc)
+
+
+def format_trace_id(trace_id: int) -> str:
+    """Format trace ID as 32-char hex string."""
+    return format(trace_id, "032x")
+
+
+def format_span_id(span_id: int) -> str:
+    """Format span ID as 16-char hex string."""
+    return format(span_id, "016x")
+
+
+_ADK_SCOPE_NAMES = {"gcp.vertex.agent", "google_adk", "google-adk"}
+_ADK_SPAN_NAMES = {"invocation", "agent_run", "call_llm", "execute_tool", "invoke_agent"}
+
+
+def is_adk_span(span: object) -> bool:
+    """Check if span is from Google ADK instrumentation."""
+    scope = getattr(span, "instrumentation_scope", None) or getattr(
+        span, "instrumentation_library", None
+    )
+    scope_name = getattr(scope, "name", "") or ""
+    if scope_name in _ADK_SCOPE_NAMES:
+        return True
+    # Fallback: check span name prefix + gen_ai attributes
+    span_name = (getattr(span, "name", "") or "").split(" ")[0]
+    if span_name in _ADK_SPAN_NAMES:
+        attributes = getattr(span, "attributes", None) or {}
+        if any(key.startswith("gen_ai.") for key in attributes):
+            return True
+    return False
+
+
+def otel_span_to_dict(span: object) -> Dict[str, object]:
+    """Convert OpenTelemetry span to dict format for ADK spans."""
+    attributes = dict(getattr(span, "attributes", None) or {})
+    span_context = getattr(span, "context", None)
+    trace_id = format_trace_id(trace_id=span_context.trace_id) if span_context else None
+    span_id = format_span_id(span_id=span_context.span_id) if span_context else None
+
+    parent = getattr(span, "parent", None)
+    parent_id = None
+    if parent is not None and getattr(parent, "span_id", None) is not None:
+        parent_id = format_span_id(span_id=parent.span_id)
+
+    span_name = getattr(span, "name", None)
+
+    raw_kind = getattr(span, "kind", None)
+    span_kind = getattr(raw_kind, "name", None) if raw_kind is not None else None
+    if span_kind is None and raw_kind is not None:
+        span_kind = str(raw_kind)
+
+    status = getattr(span, "status", None)
+    status_code = None
+    error_message = None
+    if status is not None:
+        status_enum = getattr(status, "status_code", None)
+        status_name = getattr(status_enum, "name", None)
+        if status_name == "ERROR":
+            status_code = 500
+            error_message = getattr(status, "description", None) or "error"
+        elif status_name == "OK":
+            status_code = 200
+
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_id": parent_id,
+        "name": span_name,
+        "span_type": span_kind,
+        "kind": span_kind,
+        "start_time": ns_to_datetime(value=getattr(span, "start_time", None)),
+        "end_time": ns_to_datetime(value=getattr(span, "end_time", None)),
+        "attributes": attributes,
+        "status_code": status_code,
+        "error": error_message,
+    }
+
+
+def group_spans_by_trace(
+    spans: Sequence[Dict[str, object]],
+) -> Dict[str, List[Dict[str, object]]]:
+    """Group spans by trace ID."""
+    grouped: Dict[str, List[Dict[str, object]]] = {}
+    for span in spans:
+        trace_id = span.get("trace_id")
+        if not isinstance(trace_id, str) or not trace_id:
+            continue
+        grouped.setdefault(trace_id, []).append(span)
+    return grouped
+
+
+def get_attr(obj: Any, *keys: str, default: Any = None) -> Any:
+    """Get attribute from object or dict by trying multiple keys."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        for key in keys:
+            if key in obj:
+                return obj[key]
+    for key in keys:
+        if hasattr(obj, key):
+            return getattr(obj, key)
+    return default
+
+
+def as_dict(value: Any) -> Optional[Dict[str, Any]]:
+    """Convert value to dict if possible."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        try:
+            return value.model_dump()
+        except Exception:
+            return None
+    if hasattr(value, "dict"):
+        try:
+            return value.dict()
+        except Exception:
+            return None
+    return None
+
+
+def pick_metadata_value(metadata: Optional[Dict[str, Any]], *keys: str) -> Any:
+    """Pick first available value from metadata by trying multiple keys."""
+    if not metadata:
+        return None
+    for key in keys:
+        if key in metadata:
+            return metadata[key]
+    return None
+
+
+def coerce_datetime(value: Any, reference: Optional[datetime] = None) -> Optional[datetime]:
+    """Coerce various value types to datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    if isinstance(value, (int, float)):
+        numeric_value = float(value)
+        if reference and numeric_value < 1_000_000_000:
+            return reference + timedelta(seconds=numeric_value)
+        if numeric_value > 100_000_000_000:
+            return datetime.fromtimestamp(numeric_value / 1000, tz=timezone.utc)
+        return datetime.fromtimestamp(numeric_value, tz=timezone.utc)
+    if isinstance(value, str):
+        trimmed = value.strip()
+        try:
+            return datetime.fromisoformat(trimmed.replace("Z", "+00:00"))
+        except ValueError:
+            try:
+                numeric_value = float(trimmed)
+                if reference and numeric_value < 1_000_000_000:
+                    return reference + timedelta(seconds=numeric_value)
+                if numeric_value > 100_000_000_000:
+                    return datetime.fromtimestamp(numeric_value / 1000, tz=timezone.utc)
+                return datetime.fromtimestamp(numeric_value, tz=timezone.utc)
+            except ValueError:
+                return None
+    return None
+
+
+def coerce_token_count(value: Any) -> Optional[int]:
+    """Coerce value to token count integer."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(float(stripped))
+        except ValueError:
+            return None
+    return None
+
+
+def infer_trace_start_time(spans: Sequence[Any]) -> Optional[datetime]:
+    """Infer the earliest start time from a sequence of spans."""
+    earliest: Optional[datetime] = None
+    for span in spans:
+        raw_value = get_attr(span, "start_time", "started_at", "start", "start_timestamp")
+        if isinstance(raw_value, (int, float)) and float(raw_value) < 1_000_000_000:
+            continue
+        if isinstance(raw_value, str):
+            trimmed = raw_value.strip()
+            if trimmed:
+                try:
+                    numeric_value = float(trimmed)
+                    if numeric_value < 1_000_000_000:
+                        continue
+                except ValueError:
+                    pass
+        candidate = coerce_datetime(value=raw_value)
+        if candidate and candidate.year < 2001:
+            continue
+        if candidate and (earliest is None or candidate < earliest):
+            earliest = candidate
+    return earliest
+
+
+def serialize_value(value: Any) -> Optional[str]:
+    """Serialize value to JSON string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            try:
+                json.loads(trimmed)
+                return trimmed
+            except Exception:
+                return json.dumps(value)
+        return json.dumps(value)
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return json.dumps(str(value))
+
+
+def format_rfc3339(value: Optional[datetime]) -> Optional[str]:
+    """Format datetime as RFC3339 string."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def is_hex_string(value: str, length: int) -> bool:
+    """Check if string is a valid hex string of given length."""
+    if len(value) != length:
+        return False
+    try:
+        int(value, 16)
+        return True
+    except ValueError:
+        return False
+
+
+def normalize_trace_id(trace_id: str) -> str:
+    """Normalize trace ID to 32-char hex string."""
+    if is_hex_string(value=trace_id, length=32):
+        return trace_id.lower()
+    return uuid.uuid5(uuid.NAMESPACE_DNS, trace_id).hex
+
+
+def normalize_span_id(span_id: str, trace_id: str) -> str:
+    """Normalize span ID to 16-char hex string."""
+    if is_hex_string(value=span_id, length=16):
+        return span_id.lower()
+    stable_seed = f"{trace_id}:{span_id}"
+    return uuid.uuid5(uuid.NAMESPACE_DNS, stable_seed).hex[:16]
+
+
+def clean_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove None, empty dict, and empty list values from payload."""
+    return {key: value for key, value in payload.items() if value not in (None, {}, [])}
+
+
+def parse_json_value(value: Any) -> Any:
+    """Parse JSON string value if possible."""
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            try:
+                return json.loads(trimmed)
+            except Exception:
+                return value
+        return value
+    return value
+
+
+def find_root_span(spans: Sequence[Any]) -> Optional[Any]:
+    """Find the root span (span without parent in the trace)."""
+    if not spans:
+        return None
+    span_ids = set()
+    for span in spans:
+        span_id = get_attr(span, "span_id", "id", "uid")
+        if span_id is not None:
+            span_ids.add(str(span_id))
+    for span in spans:
+        parent_id = get_attr(span, "parent_id", "parent_span_id", "parentId")
+        if not parent_id or str(parent_id) not in span_ids:
+            return span
+    return spans[0]
+
+
+def is_blank_value(value: Any) -> bool:
+    """Check if value is blank (None, empty, or null-like)."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if not trimmed:
+            return True
+        if trimmed in ("[]", "{}", "null"):
+            return True
+        try:
+            parsed = json.loads(trimmed)
+            return parsed in (None, [], {})
+        except Exception:
+            return False
+    if isinstance(value, (list, tuple, dict)) and not value:
+        return True
+    return False
+
+
+def to_prompt_messages(value: Any) -> Optional[List[Dict[str, Any]]]:
+    """Convert value to prompt messages format."""
+    parsed = parse_json_value(value=value)
+    if isinstance(parsed, list) and parsed and all(isinstance(item, dict) for item in parsed):
+        if all("role" in item and "content" in item for item in parsed):
+            return parsed
+    if isinstance(parsed, dict):
+        if isinstance(parsed.get("messages"), list):
+            messages = parsed.get("messages") or []
+            if messages and all(isinstance(item, dict) for item in messages):
+                return messages
+        if "role" in parsed and "content" in parsed:
+            return [parsed]
+    return None
+
+
+def to_completion_message(value: Any) -> Optional[Dict[str, Any]]:
+    """Convert value to completion message format."""
+    parsed = parse_json_value(value=value)
+    if isinstance(parsed, dict):
+        if "role" in parsed and "content" in parsed:
+            return parsed
+        choices = parsed.get("choices")
+        if isinstance(choices, list) and choices:
+            first = choices[0]
+            if isinstance(first, dict):
+                message = first.get("message")
+                if isinstance(message, dict) and "content" in message:
+                    return message
+    if isinstance(parsed, list) and parsed:
+        first = parsed[0]
+        if isinstance(first, dict) and "content" in first:
+            return first
+    return None
+
+
+def messages_to_text(messages: Sequence[Dict[str, Any]]) -> Optional[str]:
+    """Convert messages to text format."""
+    if not messages:
+        return None
+    parts: List[str] = []
+    for message in messages:
+        content = message.get("content")
+        if content is None:
+            continue
+        if isinstance(content, (dict, list)):
+            parts.append(json.dumps(content, default=str))
+        else:
+            parts.append(str(content))
+    if not parts:
+        return None
+    return "\n".join(parts)
+
+
+def extract_genai_messages(
+    attributes: Dict[str, Any],
+    key: str,
+) -> Optional[List[Dict[str, Any]]]:
+    """Extract messages from GenAI semantic convention attributes.
+
+    ADK stores messages as JSON strings in attributes like
+    ``gen_ai.input.messages`` and ``gen_ai.output.messages``.
+    """
+    raw = attributes.get(key)
+    if raw is None:
+        return None
+    parsed = parse_json_value(value=raw)
+    if isinstance(parsed, list):
+        messages = []
+        for item in parsed:
+            if isinstance(item, dict):
+                messages.append(item)
+        if messages:
+            return messages
+    if isinstance(parsed, dict) and ("role" in parsed or "content" in parsed):
+        return [parsed]
+    return None

--- a/python-sdks/respan-instrumentation-google-adk/tests/test_converter.py
+++ b/python-sdks/respan-instrumentation-google-adk/tests/test_converter.py
@@ -1,0 +1,618 @@
+"""Unit tests for AdkSpanConverter and utility functions."""
+
+import json
+from types import SimpleNamespace
+import pytest
+
+from respan_instrumentation_google_adk.utils import (
+    extract_genai_messages,
+    is_adk_span,
+    otel_span_to_dict,
+)
+from respan_instrumentation_google_adk.converter import AdkSpanConverter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TRACE_ID = 0xABCDEF1234567890ABCDEF1234567890
+
+
+def _make_span(
+    name="call_llm",
+    trace_id=0xABCDEF1234567890ABCDEF1234567890,
+    span_id=0x1234567890ABCDEF,
+    parent_span_id=None,
+    attributes=None,
+    scope_name="google_adk",
+    start_time=1_700_000_000_000_000_000,
+    end_time=1_700_000_001_000_000_000,
+    status_name="OK",
+):
+    """Create a mock OTel span resembling an ADK span."""
+    ctx = SimpleNamespace(trace_id=trace_id, span_id=span_id)
+    parent = None
+    if parent_span_id is not None:
+        parent = SimpleNamespace(span_id=parent_span_id, trace_id=trace_id, is_remote=False)
+    scope = SimpleNamespace(name=scope_name, version="1.0.0")
+    kind = SimpleNamespace(name="INTERNAL")
+    status_code_enum = SimpleNamespace(name=status_name)
+    status = SimpleNamespace(status_code=status_code_enum, description=None)
+    return SimpleNamespace(
+        name=name,
+        context=ctx,
+        parent=parent,
+        instrumentation_scope=scope,
+        kind=kind,
+        status=status,
+        attributes=attributes or {},
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
+def _spans_to_dicts(spans):
+    return [otel_span_to_dict(s) for s in spans]
+
+
+# ---------------------------------------------------------------------------
+# is_adk_span tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsAdkSpan:
+    def test_positive_by_scope_name(self):
+        span = _make_span(scope_name="google_adk")
+        assert is_adk_span(span) is True
+
+    def test_positive_by_scope_name_hyphen(self):
+        span = _make_span(scope_name="google-adk")
+        assert is_adk_span(span) is True
+
+    def test_positive_by_span_name_and_genai_attrs(self):
+        span = _make_span(
+            scope_name="other_lib",
+            name="call_llm",
+            attributes={"gen_ai.request.model": "gemini-2.0-flash"},
+        )
+        assert is_adk_span(span) is True
+
+    def test_negative_unknown_scope_no_genai(self):
+        span = _make_span(scope_name="some_other_lib", name="random_op", attributes={})
+        assert is_adk_span(span) is False
+
+    def test_negative_adk_name_but_no_genai_attrs(self):
+        span = _make_span(scope_name="other", name="call_llm", attributes={"foo": "bar"})
+        assert is_adk_span(span) is False
+
+
+# ---------------------------------------------------------------------------
+# otel_span_to_dict tests
+# ---------------------------------------------------------------------------
+
+
+class TestOtelSpanToDict:
+    def test_basic_conversion(self):
+        span = _make_span(
+            name="agent_run",
+            attributes={"gen_ai.agent.name": "my_agent"},
+        )
+        result = otel_span_to_dict(span)
+        assert result["name"] == "agent_run"
+        assert result["trace_id"] is not None
+        assert result["span_id"] is not None
+        assert result["parent_id"] is None
+        assert result["attributes"]["gen_ai.agent.name"] == "my_agent"
+        assert result["status_code"] == 200
+
+    def test_with_parent(self):
+        span = _make_span(parent_span_id=0xFEDCBA0987654321)
+        result = otel_span_to_dict(span)
+        assert result["parent_id"] is not None
+
+    def test_error_status(self):
+        span = _make_span(status_name="ERROR")
+        span.status.description = "Something went wrong"
+        result = otel_span_to_dict(span)
+        assert result["status_code"] == 500
+        assert result["error"] == "Something went wrong"
+
+
+# ---------------------------------------------------------------------------
+# _map_log_type tests
+# ---------------------------------------------------------------------------
+
+
+class TestMapLogType:
+    def setup_method(self):
+        self.converter = AdkSpanConverter()
+
+    def test_invocation(self):
+        assert self.converter._map_log_type("invocation", None, None) == "workflow"
+
+    def test_agent_run(self):
+        assert self.converter._map_log_type("agent_run", "parent", None) == "agent"
+
+    def test_call_llm(self):
+        assert self.converter._map_log_type("call_llm", "parent", None) == "generation"
+
+    def test_execute_tool(self):
+        assert self.converter._map_log_type("execute_tool", "parent", None) == "tool"
+
+    def test_fallback_model(self):
+        assert self.converter._map_log_type("unknown_span", None, "gemini-2.0") == "generation"
+
+    def test_fallback_no_parent(self):
+        assert self.converter._map_log_type("unknown_span", None, None) == "workflow"
+
+    def test_fallback_with_parent(self):
+        assert self.converter._map_log_type("unknown_span", "some-parent", None) == "task"
+
+
+# ---------------------------------------------------------------------------
+# extract_genai_messages tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractGenaiMessages:
+    def test_json_string_list(self):
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "model", "content": "Hi there!"},
+        ]
+        attrs = {"gen_ai.input.messages": json.dumps(messages)}
+        result = extract_genai_messages(attrs, "gen_ai.input.messages")
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["role"] == "user"
+        assert result[1]["content"] == "Hi there!"
+
+    def test_single_dict(self):
+        attrs = {"gen_ai.output.messages": json.dumps({"role": "model", "content": "Done"})}
+        result = extract_genai_messages(attrs, "gen_ai.output.messages")
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["role"] == "model"
+
+    def test_missing_key(self):
+        result = extract_genai_messages({}, "gen_ai.input.messages")
+        assert result is None
+
+    def test_none_value(self):
+        result = extract_genai_messages({"gen_ai.input.messages": None}, "gen_ai.input.messages")
+        assert result is None
+
+    def test_invalid_json(self):
+        result = extract_genai_messages(
+            {"gen_ai.input.messages": "not valid json {{"}, "gen_ai.input.messages"
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# convert tests (was build_payload)
+# ---------------------------------------------------------------------------
+
+
+class TestConvert:
+    def setup_method(self):
+        self.converter = AdkSpanConverter()
+
+    def test_single_llm_span(self):
+        span = _make_span(
+            name="call_llm",
+            attributes={
+                "gen_ai.request.model": "gemini-2.0-flash",
+                "gen_ai.response.model": "gemini-2.0-flash",
+                "gen_ai.usage.input_tokens": 10,
+                "gen_ai.usage.output_tokens": 20,
+                "gen_ai.input.messages": json.dumps(
+                    [{"role": "user", "content": "What is 2+2?"}]
+                ),
+                "gen_ai.output.messages": json.dumps(
+                    [{"role": "model", "content": "4"}]
+                ),
+            },
+        )
+        span_dict = otel_span_to_dict(span)
+        payloads = self.converter.convert(trace_or_spans=[span_dict])
+
+        assert len(payloads) == 1
+        payload = payloads[0]
+        assert payload["log_type"] == "generation"
+        assert payload["model"] == "gemini-2.0-flash"
+        assert payload["prompt_tokens"] == 10
+        assert payload["completion_tokens"] == 20
+        assert payload["total_request_tokens"] == 30
+        assert payload["prompt_messages"] is not None
+        assert payload["completion_message"] is not None
+        assert payload["trace_id"] is not None
+        assert payload["span_id"] is not None
+
+    def test_agent_run_span(self):
+        span = _make_span(
+            name="agent_run",
+            attributes={
+                "gen_ai.agent.name": "weather_agent",
+                "gen_ai.agent.id": "agent-123",
+            },
+        )
+        span_dict = otel_span_to_dict(span)
+        payloads = self.converter.convert(trace_or_spans=[span_dict])
+
+        assert len(payloads) == 1
+        payload = payloads[0]
+        assert payload["log_type"] == "agent"
+        assert payload["span_name"] == "agent_run"
+        assert payload["metadata"]["adk_agent_id"] == "agent-123"
+
+    def test_tool_span(self):
+        span = _make_span(
+            name="execute_tool",
+            parent_span_id=0xAAAABBBBCCCCDDDD,
+            attributes={
+                "gen_ai.tool.name": "get_weather",
+            },
+        )
+        span_dict = otel_span_to_dict(span)
+        payloads = self.converter.convert(trace_or_spans=[span_dict])
+
+        assert len(payloads) == 1
+        payload = payloads[0]
+        assert payload["log_type"] == "tool"
+        assert payload["span_tools"] == ["get_weather"]
+        parent_keys = ("parent_id", "span_parent_id")
+        assert any(k in payload and payload[k] is not None for k in parent_keys)
+
+    def test_llm_config_in_metadata(self):
+        span = _make_span(
+            name="call_llm",
+            attributes={
+                "gen_ai.request.model": "gemini-2.0-flash",
+                "gen_ai.request.temperature": 0.7,
+                "gen_ai.request.top_k": 40,
+                "gen_ai.request.top_p": 0.9,
+                "gen_ai.request.max_output_tokens": 1024,
+            },
+        )
+        span_dict = otel_span_to_dict(span)
+        payloads = self.converter.convert(trace_or_spans=[span_dict])
+
+        payload = payloads[0]
+        llm_config = payload["metadata"]["llm_config"]
+        assert llm_config["temperature"] == 0.7
+        assert llm_config["top_k"] == 40
+        assert llm_config["top_p"] == 0.9
+        assert llm_config["max_tokens"] == 1024
+
+    def test_conversation_id(self):
+        span = _make_span(
+            name="invocation",
+            attributes={
+                "gen_ai.conversation.id": "conv-abc-123",
+            },
+        )
+        span_dict = otel_span_to_dict(span)
+        payloads = self.converter.convert(trace_or_spans=[span_dict])
+
+        payload = payloads[0]
+        assert payload["session_identifier"] == "conv-abc-123"
+
+    def test_multi_span_trace(self):
+        """Test a realistic multi-span ADK trace."""
+        invocation = _make_span(
+            name="invocation",
+            span_id=0x1111111111111111,
+            attributes={"gen_ai.conversation.id": "session-1"},
+        )
+        agent = _make_span(
+            name="agent_run",
+            span_id=0x2222222222222222,
+            parent_span_id=0x1111111111111111,
+            attributes={"gen_ai.agent.name": "my_agent"},
+        )
+        llm = _make_span(
+            name="call_llm",
+            span_id=0x3333333333333333,
+            parent_span_id=0x2222222222222222,
+            attributes={
+                "gen_ai.request.model": "gemini-2.0-flash",
+                "gen_ai.usage.input_tokens": 50,
+                "gen_ai.usage.output_tokens": 100,
+                "gen_ai.output.messages": json.dumps(
+                    [{"role": "model", "content": "The answer is 42."}]
+                ),
+            },
+        )
+
+        span_dicts = [otel_span_to_dict(s) for s in [invocation, agent, llm]]
+        payloads = self.converter.convert(trace_or_spans=span_dicts)
+
+        assert len(payloads) == 3
+        log_types = {p["log_type"] for p in payloads}
+        assert log_types == {"workflow", "agent", "generation"}
+
+        # Output should propagate from generation to workflow/agent
+        gen_payload = next(p for p in payloads if p["log_type"] == "generation")
+        assert gen_payload["output"] is not None
+
+        wf_payload = next(p for p in payloads if p["log_type"] == "workflow")
+        assert wf_payload["output"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Example pattern tests (multi_turn, streaming, tool_calls)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTurnPattern:
+    def setup_method(self):
+        self.converter = AdkSpanConverter()
+
+    def _make_turn(self, turn_index, user_msg, assistant_msg, conv_id="session-mt-1"):
+        base_time = 1_700_000_000_000_000_000 + turn_index * 3_000_000_000
+        inv_id = 0x1000000000000000 + turn_index * 0x100
+        agent_id = inv_id + 1
+        llm_id = inv_id + 2
+
+        invocation = _make_span(
+            name="invocation",
+            span_id=inv_id,
+            attributes={"gen_ai.conversation.id": conv_id},
+            start_time=base_time,
+            end_time=base_time + 2_500_000_000,
+        )
+        agent_run = _make_span(
+            name="agent_run",
+            span_id=agent_id,
+            parent_span_id=inv_id,
+            attributes={"gen_ai.agent.name": "chat_agent"},
+            start_time=base_time + 100_000_000,
+            end_time=base_time + 2_400_000_000,
+        )
+        call_llm = _make_span(
+            name="call_llm",
+            span_id=llm_id,
+            parent_span_id=agent_id,
+            attributes={
+                "gen_ai.request.model": "gemini-2.0-flash",
+                "gen_ai.response.model": "gemini-2.0-flash",
+                "gen_ai.usage.input_tokens": 10 + turn_index * 20,
+                "gen_ai.usage.output_tokens": 15 + turn_index * 5,
+                "gen_ai.input.messages": json.dumps(
+                    [{"role": "user", "content": user_msg}]
+                ),
+                "gen_ai.output.messages": json.dumps(
+                    [{"role": "model", "content": assistant_msg}]
+                ),
+            },
+            start_time=base_time + 200_000_000,
+            end_time=base_time + 2_300_000_000,
+        )
+        return [invocation, agent_run, call_llm]
+
+    def test_single_turn_produces_correct_log_types(self):
+        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION
+        spans = self._make_turn(0, "Hi! My name is Alex.", "Hello Alex!")
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        assert len(payloads) == 3
+        log_types = {p["log_type"] for p in payloads}
+        assert log_types == {LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION}
+
+    def test_conversation_id_propagates(self):
+        conv_id = "session-mt-abc"
+        spans = self._make_turn(0, "Hello", "Hi!", conv_id=conv_id)
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        wf = next(p for p in payloads if p["log_type"] == "workflow")
+        assert wf["session_identifier"] == conv_id
+
+    def test_multi_turn_token_counts_increase(self):
+        turn0 = self._make_turn(0, "Hi! My name is Alex.", "Hello Alex!")
+        turn2 = self._make_turn(2, "Tell me a fun fact.", "42 is the answer.")
+        p0 = self.converter.convert(trace_or_spans=_spans_to_dicts(turn0))
+        p2 = self.converter.convert(trace_or_spans=_spans_to_dicts(turn2))
+        gen0 = next(p for p in p0 if p["log_type"] == "generation")
+        gen2 = next(p for p in p2 if p["log_type"] == "generation")
+        assert gen2["prompt_tokens"] > gen0["prompt_tokens"]
+
+    def test_output_propagates_to_workflow_and_agent(self):
+        spans = self._make_turn(0, "What's my name?", "Your name is Alex.")
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        wf = next(p for p in payloads if p["log_type"] == "workflow")
+        agent = next(p for p in payloads if p["log_type"] == "agent")
+        gen = next(p for p in payloads if p["log_type"] == "generation")
+        assert gen["output"] is not None
+        assert wf["output"] is not None
+        assert agent["output"] is not None
+
+    def test_parent_child_relationships(self):
+        spans = self._make_turn(0, "Hello", "Hi!")
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        wf = next(p for p in payloads if p["log_type"] == "workflow")
+        agent = next(p for p in payloads if p["log_type"] == "agent")
+        gen = next(p for p in payloads if p["log_type"] == "generation")
+        assert wf.get("parent_id") is None
+        assert agent.get("parent_id") == wf["span_id"] or agent.get("span_parent_id") == wf["span_id"]
+        assert gen.get("parent_id") == agent["span_id"] or gen.get("span_parent_id") == agent["span_id"]
+
+
+class TestStreamingPattern:
+    def setup_method(self):
+        self.converter = AdkSpanConverter()
+
+    def _make_streaming_spans(self):
+        invocation = _make_span(
+            name="invocation",
+            span_id=0xA000000000000001,
+            start_time=1_700_000_000_000_000_000,
+            end_time=1_700_000_005_000_000_000,
+        )
+        agent_run = _make_span(
+            name="agent_run",
+            span_id=0xA000000000000002,
+            parent_span_id=0xA000000000000001,
+            attributes={"gen_ai.agent.name": "storyteller"},
+            start_time=1_700_000_000_100_000_000,
+            end_time=1_700_000_004_900_000_000,
+        )
+        call_llm = _make_span(
+            name="call_llm",
+            span_id=0xA000000000000003,
+            parent_span_id=0xA000000000000002,
+            attributes={
+                "gen_ai.request.model": "gemini-2.0-flash",
+                "gen_ai.response.model": "gemini-2.0-flash",
+                "gen_ai.usage.input_tokens": 25,
+                "gen_ai.usage.output_tokens": 200,
+                "gen_ai.input.messages": json.dumps(
+                    [{"role": "user", "content": "Tell me a short story about a robot learning to paint."}]
+                ),
+                "gen_ai.output.messages": json.dumps(
+                    [{"role": "model", "content": "Once upon a time, in a lab filled with brushes and canvases..."}]
+                ),
+                "gen_ai.request.temperature": 0.9,
+                "gen_ai.request.top_p": 0.95,
+            },
+            start_time=1_700_000_000_200_000_000,
+            end_time=1_700_000_004_800_000_000,
+        )
+        return [invocation, agent_run, call_llm]
+
+    def test_streaming_produces_three_spans(self):
+        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION
+        spans = self._make_streaming_spans()
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        assert len(payloads) == 3
+        log_types = {p["log_type"] for p in payloads}
+        assert log_types == {LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION}
+
+    def test_streaming_token_counts(self):
+        spans = self._make_streaming_spans()
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        gen = next(p for p in payloads if p["log_type"] == "generation")
+        assert gen["prompt_tokens"] == 25
+        assert gen["completion_tokens"] == 200
+        assert gen["total_request_tokens"] == 225
+
+    def test_streaming_llm_config_preserved(self):
+        spans = self._make_streaming_spans()
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        gen = next(p for p in payloads if p["log_type"] == "generation")
+        llm_config = gen["metadata"]["llm_config"]
+        assert llm_config["temperature"] == 0.9
+        assert llm_config["top_p"] == 0.95
+
+    def test_streaming_latency_reflects_duration(self):
+        spans = self._make_streaming_spans()
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        gen = next(p for p in payloads if p["log_type"] == "generation")
+        assert gen["latency"] is not None
+        assert gen["latency"] > 4.0
+
+
+class TestToolCallsPattern:
+    def setup_method(self):
+        self.converter = AdkSpanConverter()
+
+    def _make_tool_call_spans(self):
+        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION, LOG_TYPE_TOOL
+        base = 1_700_000_000_000_000_000
+        invocation = _make_span(name="invocation", span_id=0xB000000000000001, start_time=base, end_time=base + 4_000_000_000)
+        agent_run = _make_span(name="agent_run", span_id=0xB000000000000002, parent_span_id=0xB000000000000001, attributes={"gen_ai.agent.name": "weather_agent"}, start_time=base + 50_000_000, end_time=base + 3_950_000_000)
+        llm_1 = _make_span(name="call_llm", span_id=0xB000000000000003, parent_span_id=0xB000000000000002, attributes={"gen_ai.request.model": "gemini-2.0-flash", "gen_ai.response.model": "gemini-2.0-flash", "gen_ai.usage.input_tokens": 30, "gen_ai.usage.output_tokens": 15, "gen_ai.input.messages": json.dumps([{"role": "user", "content": "What's the weather like in Tokyo and London?"}]), "gen_ai.output.messages": json.dumps([{"role": "model", "content": "I'll check the weather for you."}])}, start_time=base + 100_000_000, end_time=base + 1_500_000_000)
+        tool_exec = _make_span(name="execute_tool", span_id=0xB000000000000004, parent_span_id=0xB000000000000002, attributes={"gen_ai.tool.name": "get_weather"}, start_time=base + 1_600_000_000, end_time=base + 2_000_000_000)
+        llm_2 = _make_span(name="call_llm", span_id=0xB000000000000005, parent_span_id=0xB000000000000002, attributes={"gen_ai.request.model": "gemini-2.0-flash", "gen_ai.response.model": "gemini-2.0-flash", "gen_ai.usage.input_tokens": 60, "gen_ai.usage.output_tokens": 40, "gen_ai.input.messages": json.dumps([{"role": "user", "content": "What's the weather like in Tokyo and London?"}, {"role": "model", "content": "I'll check the weather for you."}, {"role": "tool", "content": json.dumps({"city": "Tokyo", "temp_f": 80})}]), "gen_ai.output.messages": json.dumps([{"role": "model", "content": "Tokyo is 80°F and partly cloudy. London is 59°F and cloudy."}])}, start_time=base + 2_100_000_000, end_time=base + 3_800_000_000)
+        return [invocation, agent_run, llm_1, tool_exec, llm_2]
+
+    def test_tool_call_produces_five_payloads(self):
+        spans = self._make_tool_call_spans()
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        assert len(payloads) == 5
+
+    def test_tool_call_log_types(self):
+        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION, LOG_TYPE_TOOL
+        spans = self._make_tool_call_spans()
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        type_counts = {}
+        for p in payloads:
+            lt = p["log_type"]
+            type_counts[lt] = type_counts.get(lt, 0) + 1
+        assert type_counts[LOG_TYPE_WORKFLOW] == 1
+        assert type_counts[LOG_TYPE_AGENT] == 1
+        assert type_counts[LOG_TYPE_GENERATION] == 2
+        assert type_counts[LOG_TYPE_TOOL] == 1
+
+    def test_tool_span_has_tool_name(self):
+        spans = self._make_tool_call_spans()
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        tool = next(p for p in payloads if p["log_type"] == "tool")
+        assert tool["span_tools"] == ["get_weather"]
+
+    def test_generation_spans_have_different_token_counts(self):
+        spans = self._make_tool_call_spans()
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        gens = [p for p in payloads if p["log_type"] == "generation"]
+        assert len(gens) == 2
+        gens.sort(key=lambda p: p.get("prompt_tokens", 0))
+        assert gens[0]["prompt_tokens"] == 30
+        assert gens[1]["prompt_tokens"] == 60
+
+    def test_all_spans_share_trace_id(self):
+        spans = self._make_tool_call_spans()
+        payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
+        trace_ids = {p["trace_id"] for p in payloads}
+        assert len(trace_ids) == 1
+
+
+# ---------------------------------------------------------------------------
+# Uninstrument passthrough tests
+# ---------------------------------------------------------------------------
+
+
+class TestUninstrumentPassthrough:
+    def test_batch_wrapper_passes_through_when_no_exporter(self):
+        import respan_instrumentation_google_adk.instrumentor as inst
+
+        original_exporter = inst._ACTIVE_EXPORTER
+        try:
+            inst._ACTIVE_EXPORTER = None
+
+            adk_span = _make_span(scope_name="google_adk", name="call_llm")
+            non_adk_span = _make_span(scope_name="other_lib", name="other_op", attributes={})
+            all_spans = [adk_span, non_adk_span]
+
+            received_args = {}
+
+            def fake_wrapped(*args, **kwargs):
+                received_args["args"] = args
+                received_args["kwargs"] = kwargs
+                return "original_result"
+
+            result = inst._batch_export_wrapper(fake_wrapped, None, (all_spans,), {})
+            assert result == "original_result"
+            assert received_args["args"] == (all_spans,)
+        finally:
+            inst._ACTIVE_EXPORTER = original_exporter
+
+    def test_on_end_wrapper_passes_through_when_no_exporter(self):
+        import respan_instrumentation_google_adk.instrumentor as inst
+
+        original_exporter = inst._ACTIVE_EXPORTER
+        try:
+            inst._ACTIVE_EXPORTER = None
+
+            adk_span = _make_span(scope_name="google_adk", name="agent_run")
+
+            received_args = {}
+
+            def fake_wrapped(*args, **kwargs):
+                received_args["args"] = args
+                received_args["kwargs"] = kwargs
+                return "original_result"
+
+            result = inst._on_end_wrapper(fake_wrapped, None, (adk_span,), {})
+            assert result == "original_result"
+            assert received_args["args"] == (adk_span,)
+        finally:
+            inst._ACTIVE_EXPORTER = original_exporter

--- a/python-sdks/respan-instrumentation-google-adk/tests/test_converter.py
+++ b/python-sdks/respan-instrumentation-google-adk/tests/test_converter.py
@@ -135,13 +135,13 @@ class TestMapLogType:
         assert self.converter._map_log_type("agent_run", "parent", None) == "agent"
 
     def test_call_llm(self):
-        assert self.converter._map_log_type("call_llm", "parent", None) == "generation"
+        assert self.converter._map_log_type("call_llm", "parent", None) == "chat"
 
     def test_execute_tool(self):
         assert self.converter._map_log_type("execute_tool", "parent", None) == "tool"
 
     def test_fallback_model(self):
-        assert self.converter._map_log_type("unknown_span", None, "gemini-2.0") == "generation"
+        assert self.converter._map_log_type("unknown_span", None, "gemini-2.0") == "chat"
 
     def test_fallback_no_parent(self):
         assert self.converter._map_log_type("unknown_span", None, None) == "workflow"
@@ -173,7 +173,7 @@ class TestExtractGenaiMessages:
         result = extract_genai_messages(attrs, "gen_ai.output.messages")
         assert result is not None
         assert len(result) == 1
-        assert result[0]["role"] == "model"
+        assert result[0]["role"] == "assistant"  # "model" normalized to "assistant"
 
     def test_missing_key(self):
         result = extract_genai_messages({}, "gen_ai.input.messages")
@@ -220,7 +220,7 @@ class TestConvert:
 
         assert len(payloads) == 1
         payload = payloads[0]
-        assert payload["log_type"] == "generation"
+        assert payload["log_type"] == "chat"
         assert payload["model"] == "gemini-2.0-flash"
         assert payload["prompt_tokens"] == 10
         assert payload["completion_tokens"] == 20
@@ -298,6 +298,82 @@ class TestConvert:
 
         payload = payloads[0]
         assert payload["session_identifier"] == "conv-abc-123"
+        assert payload["thread_identifier"] == "conv-abc-123"
+
+    def test_session_id_from_adk_attribute(self):
+        """Session extracted from gcp.vertex.agent.session_id."""
+        span = _make_span(
+            name="invocation",
+            attributes={
+                "gcp.vertex.agent.session_id": "adk-session-42",
+            },
+        )
+        span_dict = otel_span_to_dict(span)
+        payloads = self.converter.convert(trace_or_spans=[span_dict])
+
+        payload = payloads[0]
+        assert payload["session_identifier"] == "adk-session-42"
+        assert payload["thread_identifier"] == "adk-session-42"
+
+    def test_session_id_from_child_span(self):
+        """Session extracted from a child span when root lacks it."""
+        root = _make_span(
+            name="invocation",
+            span_id=0x1111111111111111,
+            attributes={},
+        )
+        child = _make_span(
+            name="agent_run",
+            span_id=0x2222222222222222,
+            parent_span_id=0x1111111111111111,
+            attributes={"gcp.vertex.agent.session_id": "child-session-99"},
+        )
+        payloads = self.converter.convert(
+            trace_or_spans=_spans_to_dicts([root, child])
+        )
+        wf = next(p for p in payloads if p["log_type"] == "workflow")
+        assert wf["session_identifier"] == "child-session-99"
+        assert wf["thread_identifier"] == "child-session-99"
+
+    def test_customer_id_from_adk_attribute(self):
+        """Customer extracted from gen_ai.user.id on root span."""
+        span = _make_span(
+            name="invocation",
+            attributes={"gen_ai.user.id": "user-abc"},
+        )
+        payloads = self.converter.convert(
+            trace_or_spans=_spans_to_dicts([span])
+        )
+        assert payloads[0]["customer_identifier"] == "user-abc"
+
+    def test_customer_id_from_child_span(self):
+        """Customer extracted from child span when root lacks it."""
+        root = _make_span(
+            name="invocation",
+            span_id=0x1111111111111111,
+            attributes={},
+        )
+        child = _make_span(
+            name="call_llm",
+            span_id=0x2222222222222222,
+            parent_span_id=0x1111111111111111,
+            attributes={"gcp.vertex.agent.user_id": "child-user-7"},
+        )
+        payloads = self.converter.convert(
+            trace_or_spans=_spans_to_dicts([root, child])
+        )
+        wf = next(p for p in payloads if p["log_type"] == "workflow")
+        assert wf["customer_identifier"] == "child-user-7"
+
+    def test_constructor_customer_not_overridden_by_span(self):
+        """Constructor customer_identifier takes precedence over span attributes."""
+        converter = AdkSpanConverter(customer_identifier="explicit-user")
+        span = _make_span(
+            name="invocation",
+            attributes={"gen_ai.user.id": "span-user"},
+        )
+        payloads = converter.convert(trace_or_spans=_spans_to_dicts([span]))
+        assert payloads[0]["customer_identifier"] == "explicit-user"
 
     def test_multi_span_trace(self):
         """Test a realistic multi-span ADK trace."""
@@ -331,10 +407,10 @@ class TestConvert:
 
         assert len(payloads) == 3
         log_types = {p["log_type"] for p in payloads}
-        assert log_types == {"workflow", "agent", "generation"}
+        assert log_types == {"workflow", "agent", "chat"}
 
         # Output should propagate from generation to workflow/agent
-        gen_payload = next(p for p in payloads if p["log_type"] == "generation")
+        gen_payload = next(p for p in payloads if p["log_type"] == "chat")
         assert gen_payload["output"] is not None
 
         wf_payload = next(p for p in payloads if p["log_type"] == "workflow")
@@ -393,12 +469,12 @@ class TestMultiTurnPattern:
         return [invocation, agent_run, call_llm]
 
     def test_single_turn_produces_correct_log_types(self):
-        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION
+        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_CHAT
         spans = self._make_turn(0, "Hi! My name is Alex.", "Hello Alex!")
         payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
         assert len(payloads) == 3
         log_types = {p["log_type"] for p in payloads}
-        assert log_types == {LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION}
+        assert log_types == {LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_CHAT}
 
     def test_conversation_id_propagates(self):
         conv_id = "session-mt-abc"
@@ -412,8 +488,8 @@ class TestMultiTurnPattern:
         turn2 = self._make_turn(2, "Tell me a fun fact.", "42 is the answer.")
         p0 = self.converter.convert(trace_or_spans=_spans_to_dicts(turn0))
         p2 = self.converter.convert(trace_or_spans=_spans_to_dicts(turn2))
-        gen0 = next(p for p in p0 if p["log_type"] == "generation")
-        gen2 = next(p for p in p2 if p["log_type"] == "generation")
+        gen0 = next(p for p in p0 if p["log_type"] == "chat")
+        gen2 = next(p for p in p2 if p["log_type"] == "chat")
         assert gen2["prompt_tokens"] > gen0["prompt_tokens"]
 
     def test_output_propagates_to_workflow_and_agent(self):
@@ -421,7 +497,7 @@ class TestMultiTurnPattern:
         payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
         wf = next(p for p in payloads if p["log_type"] == "workflow")
         agent = next(p for p in payloads if p["log_type"] == "agent")
-        gen = next(p for p in payloads if p["log_type"] == "generation")
+        gen = next(p for p in payloads if p["log_type"] == "chat")
         assert gen["output"] is not None
         assert wf["output"] is not None
         assert agent["output"] is not None
@@ -431,7 +507,7 @@ class TestMultiTurnPattern:
         payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
         wf = next(p for p in payloads if p["log_type"] == "workflow")
         agent = next(p for p in payloads if p["log_type"] == "agent")
-        gen = next(p for p in payloads if p["log_type"] == "generation")
+        gen = next(p for p in payloads if p["log_type"] == "chat")
         assert wf.get("parent_id") is None
         assert agent.get("parent_id") == wf["span_id"] or agent.get("span_parent_id") == wf["span_id"]
         assert gen.get("parent_id") == agent["span_id"] or gen.get("span_parent_id") == agent["span_id"]
@@ -480,17 +556,17 @@ class TestStreamingPattern:
         return [invocation, agent_run, call_llm]
 
     def test_streaming_produces_three_spans(self):
-        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION
+        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_CHAT
         spans = self._make_streaming_spans()
         payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
         assert len(payloads) == 3
         log_types = {p["log_type"] for p in payloads}
-        assert log_types == {LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION}
+        assert log_types == {LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_CHAT}
 
     def test_streaming_token_counts(self):
         spans = self._make_streaming_spans()
         payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
-        gen = next(p for p in payloads if p["log_type"] == "generation")
+        gen = next(p for p in payloads if p["log_type"] == "chat")
         assert gen["prompt_tokens"] == 25
         assert gen["completion_tokens"] == 200
         assert gen["total_request_tokens"] == 225
@@ -498,7 +574,7 @@ class TestStreamingPattern:
     def test_streaming_llm_config_preserved(self):
         spans = self._make_streaming_spans()
         payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
-        gen = next(p for p in payloads if p["log_type"] == "generation")
+        gen = next(p for p in payloads if p["log_type"] == "chat")
         llm_config = gen["metadata"]["llm_config"]
         assert llm_config["temperature"] == 0.9
         assert llm_config["top_p"] == 0.95
@@ -506,7 +582,7 @@ class TestStreamingPattern:
     def test_streaming_latency_reflects_duration(self):
         spans = self._make_streaming_spans()
         payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
-        gen = next(p for p in payloads if p["log_type"] == "generation")
+        gen = next(p for p in payloads if p["log_type"] == "chat")
         assert gen["latency"] is not None
         assert gen["latency"] > 4.0
 
@@ -516,7 +592,7 @@ class TestToolCallsPattern:
         self.converter = AdkSpanConverter()
 
     def _make_tool_call_spans(self):
-        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION, LOG_TYPE_TOOL
+        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_CHAT, LOG_TYPE_TOOL
         base = 1_700_000_000_000_000_000
         invocation = _make_span(name="invocation", span_id=0xB000000000000001, start_time=base, end_time=base + 4_000_000_000)
         agent_run = _make_span(name="agent_run", span_id=0xB000000000000002, parent_span_id=0xB000000000000001, attributes={"gen_ai.agent.name": "weather_agent"}, start_time=base + 50_000_000, end_time=base + 3_950_000_000)
@@ -531,7 +607,7 @@ class TestToolCallsPattern:
         assert len(payloads) == 5
 
     def test_tool_call_log_types(self):
-        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_GENERATION, LOG_TYPE_TOOL
+        from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW, LOG_TYPE_AGENT, LOG_TYPE_CHAT, LOG_TYPE_TOOL
         spans = self._make_tool_call_spans()
         payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
         type_counts = {}
@@ -540,7 +616,7 @@ class TestToolCallsPattern:
             type_counts[lt] = type_counts.get(lt, 0) + 1
         assert type_counts[LOG_TYPE_WORKFLOW] == 1
         assert type_counts[LOG_TYPE_AGENT] == 1
-        assert type_counts[LOG_TYPE_GENERATION] == 2
+        assert type_counts[LOG_TYPE_CHAT] == 2
         assert type_counts[LOG_TYPE_TOOL] == 1
 
     def test_tool_span_has_tool_name(self):
@@ -552,7 +628,7 @@ class TestToolCallsPattern:
     def test_generation_spans_have_different_token_counts(self):
         spans = self._make_tool_call_spans()
         payloads = self.converter.convert(trace_or_spans=_spans_to_dicts(spans))
-        gens = [p for p in payloads if p["log_type"] == "generation"]
+        gens = [p for p in payloads if p["log_type"] == "chat"]
         assert len(gens) == 2
         gens.sort(key=lambda p: p.get("prompt_tokens", 0))
         assert gens[0]["prompt_tokens"] == 30
@@ -569,6 +645,69 @@ class TestToolCallsPattern:
 # Uninstrument passthrough tests
 # ---------------------------------------------------------------------------
 
+
+# ---------------------------------------------------------------------------
+# Status, handoffs, and OpenLLMetry metadata tests
+# ---------------------------------------------------------------------------
+
+
+class TestStatusAndHandoffs:
+    def setup_method(self):
+        self.converter = AdkSpanConverter()
+
+    def test_success_status(self):
+        span = _make_span(name="call_llm", attributes={"gen_ai.request.model": "gemini-2.0-flash"})
+        span_dict = otel_span_to_dict(span)
+        payloads = self.converter.convert(trace_or_spans=[span_dict])
+        payload = payloads[0]
+        assert payload["status"] == "success"
+        assert payload["status_code"] == 200
+
+    def test_error_status(self):
+        span = _make_span(name="call_llm", status_name="ERROR")
+        span.status.description = "Something went wrong"
+        span_dict = otel_span_to_dict(span)
+        payloads = self.converter.convert(trace_or_spans=[span_dict])
+        payload = payloads[0]
+        assert payload["status"] == "error"
+        assert payload["status_code"] == 500
+
+    def test_invoke_agent_handoffs(self):
+        router = _make_span(
+            name="agent_run",
+            span_id=0x1111111111111111,
+            attributes={"gen_ai.agent.name": "router_agent"},
+        )
+        invoke = _make_span(
+            name="invoke_agent greeting_agent",
+            span_id=0x2222222222222222,
+            parent_span_id=0x1111111111111111,
+            attributes={"gen_ai.agent.name": "greeting_agent"},
+        )
+        span_dicts = _spans_to_dicts([router, invoke])
+        payloads = self.converter.convert(trace_or_spans=span_dicts)
+        invoke_payload = next(
+            p for p in payloads if (p.get("span_name") or "").startswith("invoke_agent")
+        )
+        assert invoke_payload["span_handoffs"] == ["router_agent -> greeting_agent"]
+
+    def test_invoke_agent_no_parent_agent(self):
+        root = _make_span(
+            name="invocation",
+            span_id=0x1111111111111111,
+        )
+        invoke = _make_span(
+            name="invoke_agent target_agent",
+            span_id=0x2222222222222222,
+            parent_span_id=0x1111111111111111,
+            attributes={"gen_ai.agent.name": "target_agent"},
+        )
+        span_dicts = _spans_to_dicts([root, invoke])
+        payloads = self.converter.convert(trace_or_spans=span_dicts)
+        invoke_payload = next(
+            p for p in payloads if (p.get("span_name") or "").startswith("invoke_agent")
+        )
+        assert invoke_payload["span_handoffs"] == [" -> target_agent"]
 
 class TestUninstrumentPassthrough:
     def test_batch_wrapper_passes_through_when_no_exporter(self):

--- a/python-sdks/respan-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python-sdks/respan-instrumentation-google-adk/tests/test_instrumentor.py
@@ -1,0 +1,688 @@
+"""Pipeline integration and end-to-end tests for GoogleAdkInstrumentor.
+
+These tests exercise the real instrumentation pipeline:
+  OTel TracerProvider -> SimpleSpanProcessor -> instrumentor wrapping -> exporter
+
+External APIs are mocked, but the instrumentation and converter code paths are real.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
+
+import respan_instrumentation_google_adk.instrumentor as inst_module
+from respan_instrumentation_google_adk import GoogleAdkInstrumentor
+from respan_instrumentation_google_adk.converter import AdkSpanConverter
+from respan_instrumentation_google_adk.utils import otel_span_to_dict
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_AGENT,
+    LOG_TYPE_GENERATION,
+    LOG_TYPE_TOOL,
+    LOG_TYPE_WORKFLOW,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_instrumentor_state():
+    """Reset global instrumentor state between tests."""
+    original_exporter = inst_module._ACTIVE_EXPORTER
+    original_converter = inst_module._ACTIVE_CONVERTER
+    original_dedupe = inst_module._ACTIVE_DEDUPE
+    original_passthrough = inst_module._ACTIVE_PASSTHROUGH
+    original_max_buf = inst_module._ACTIVE_TRACE_BUFFER_MAX_SPANS
+    yield
+    inst_module._ACTIVE_EXPORTER = original_exporter
+    inst_module._ACTIVE_CONVERTER = original_converter
+    inst_module._ACTIVE_DEDUPE = original_dedupe
+    inst_module._ACTIVE_PASSTHROUGH = original_passthrough
+    inst_module._ACTIVE_TRACE_BUFFER_MAX_SPANS = original_max_buf
+    with inst_module._TRACE_BUFFER_LOCK:
+        inst_module._TRACE_BUFFER.clear()
+
+
+@pytest.fixture
+def captured_payloads():
+    """Set up instrumentor with a mock exporter that captures payloads."""
+    captured = []
+
+    mock_exporter = SimpleNamespace(export=lambda payloads: captured.extend(payloads))
+    instrumentor = GoogleAdkInstrumentor()
+    instrumentor.activate(mock_exporter)
+
+    yield captured
+
+    instrumentor.deactivate()
+
+
+def _create_adk_tracer():
+    """Create a tracer that produces spans with google_adk scope name."""
+    provider = trace_sdk.TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    return provider.get_tracer("google_adk", "1.0.0")
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance tests
+# ---------------------------------------------------------------------------
+
+
+class TestInstrumentationProtocol:
+    """Verify GoogleAdkInstrumentor satisfies the Instrumentation protocol."""
+
+    def test_has_name_attribute(self):
+        instrumentor = GoogleAdkInstrumentor()
+        assert instrumentor.name == "google-adk"
+
+    def test_has_activate_method(self):
+        assert callable(getattr(GoogleAdkInstrumentor, "activate", None))
+
+    def test_has_deactivate_method(self):
+        assert callable(getattr(GoogleAdkInstrumentor, "deactivate", None))
+
+    def test_activate_sets_globals(self):
+        mock_exporter = SimpleNamespace(export=lambda payloads: None)
+        instrumentor = GoogleAdkInstrumentor()
+        instrumentor.activate(mock_exporter)
+
+        assert inst_module._ACTIVE_EXPORTER is mock_exporter
+        assert inst_module._ACTIVE_CONVERTER is not None
+        assert inst_module._ACTIVE_DEDUPE is not None
+
+        instrumentor.deactivate()
+
+    def test_deactivate_clears_globals(self):
+        mock_exporter = SimpleNamespace(export=lambda payloads: None)
+        instrumentor = GoogleAdkInstrumentor()
+        instrumentor.activate(mock_exporter)
+        instrumentor.deactivate()
+
+        assert inst_module._ACTIVE_EXPORTER is None
+        assert inst_module._ACTIVE_CONVERTER is None
+        assert inst_module._ACTIVE_DEDUPE is None
+
+    def test_deactivate_flushes_and_clears_trace_buffer(self):
+        mock_exporter = SimpleNamespace(export=lambda payloads: None)
+        instrumentor = GoogleAdkInstrumentor()
+        instrumentor.activate(mock_exporter)
+        with inst_module._TRACE_BUFFER_LOCK:
+            inst_module._TRACE_BUFFER["deadbeef"] = []
+        instrumentor.deactivate()
+        assert inst_module._TRACE_BUFFER == {}
+
+    def test_trace_buffer_max_spans_applied_on_activate(self):
+        mock_exporter = SimpleNamespace(export=lambda payloads: None)
+        instrumentor = GoogleAdkInstrumentor(trace_buffer_max_spans=128)
+        instrumentor.activate(mock_exporter)
+        assert inst_module._ACTIVE_TRACE_BUFFER_MAX_SPANS == 128
+        instrumentor.deactivate()
+
+    def test_constructor_params_passed_to_converter(self):
+        instrumentor = GoogleAdkInstrumentor(
+            environment="staging",
+            customer_identifier="user-42",
+        )
+        mock_exporter = SimpleNamespace(export=lambda payloads: None)
+        instrumentor.activate(mock_exporter)
+
+        converter = inst_module._ACTIVE_CONVERTER
+        assert converter.environment == "staging"
+        assert converter.customer_identifier == "user-42"
+
+        instrumentor.deactivate()
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn pipeline test
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTurnPipeline:
+    def test_multi_turn_spans_reach_exporter(self, captured_payloads):
+        tracer = _create_adk_tracer()
+
+        turns = [
+            ("Hi! My name is Alex.", "Hello Alex! Nice to meet you."),
+            ("What's my name?", "Your name is Alex!"),
+            ("Tell me a fun fact about 42.", "42 is the answer to everything."),
+        ]
+
+        for i, (user_msg, assistant_msg) in enumerate(turns):
+            inv = tracer.start_span("invocation", attributes={
+                "gen_ai.conversation.id": "session-mt-pipeline",
+            })
+            agent = tracer.start_span("agent_run", attributes={
+                "gen_ai.agent.name": "chat_agent",
+            }, context=trace_api.set_span_in_context(inv))
+            llm = tracer.start_span("call_llm", attributes={
+                "gen_ai.request.model": "gemini-2.0-flash",
+                "gen_ai.response.model": "gemini-2.0-flash",
+                "gen_ai.usage.input_tokens": 10 + i * 20,
+                "gen_ai.usage.output_tokens": 15 + i * 5,
+                "gen_ai.input.messages": json.dumps(
+                    [{"role": "user", "content": user_msg}]
+                ),
+                "gen_ai.output.messages": json.dumps(
+                    [{"role": "model", "content": assistant_msg}]
+                ),
+            }, context=trace_api.set_span_in_context(agent))
+
+            llm.end()
+            agent.end()
+            inv.end()
+
+        assert len(captured_payloads) >= 9
+
+        log_types = [p["log_type"] for p in captured_payloads]
+        assert log_types.count(LOG_TYPE_WORKFLOW) >= 3
+        assert log_types.count(LOG_TYPE_AGENT) >= 3
+        assert log_types.count(LOG_TYPE_GENERATION) >= 3
+
+    def test_multi_turn_conversation_id_preserved(self, captured_payloads):
+        tracer = _create_adk_tracer()
+
+        inv = tracer.start_span("invocation", attributes={
+            "gen_ai.conversation.id": "conv-preserved-test",
+        })
+        agent = tracer.start_span("agent_run", attributes={
+            "gen_ai.agent.name": "chat_agent",
+        }, context=trace_api.set_span_in_context(inv))
+        llm = tracer.start_span("call_llm", attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+            "gen_ai.usage.input_tokens": 10,
+            "gen_ai.usage.output_tokens": 15,
+        }, context=trace_api.set_span_in_context(agent))
+
+        llm.end()
+        agent.end()
+        inv.end()
+
+        workflows = [p for p in captured_payloads if p["log_type"] == LOG_TYPE_WORKFLOW]
+        assert len(workflows) >= 1
+        assert workflows[0].get("session_identifier") == "conv-preserved-test"
+
+    def test_multi_turn_increasing_token_counts(self, captured_payloads):
+        tracer = _create_adk_tracer()
+
+        for i in range(3):
+            inv = tracer.start_span("invocation", attributes={})
+            agent = tracer.start_span("agent_run", attributes={
+                "gen_ai.agent.name": "chat_agent",
+            }, context=trace_api.set_span_in_context(inv))
+            llm = tracer.start_span("call_llm", attributes={
+                "gen_ai.request.model": "gemini-2.0-flash",
+                "gen_ai.usage.input_tokens": 10 + i * 30,
+                "gen_ai.usage.output_tokens": 20,
+            }, context=trace_api.set_span_in_context(agent))
+            llm.end()
+            agent.end()
+            inv.end()
+
+        gens = [p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION]
+        token_counts = sorted([g.get("prompt_tokens", 0) for g in gens])
+        assert token_counts == [10, 40, 70]
+
+
+# ---------------------------------------------------------------------------
+# Streaming pipeline test
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingPipeline:
+    def test_streaming_spans_flow_through_pipeline(self, captured_payloads):
+        tracer = _create_adk_tracer()
+
+        long_story = (
+            "Once upon a time, in a lab filled with brushes and canvases, "
+            "there lived a robot named Pixel who dreamed of painting..."
+        )
+
+        inv = tracer.start_span("invocation", attributes={})
+        agent = tracer.start_span("agent_run", attributes={
+            "gen_ai.agent.name": "storyteller",
+        }, context=trace_api.set_span_in_context(inv))
+        llm = tracer.start_span("call_llm", attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+            "gen_ai.response.model": "gemini-2.0-flash",
+            "gen_ai.usage.input_tokens": 25,
+            "gen_ai.usage.output_tokens": 200,
+            "gen_ai.input.messages": json.dumps(
+                [{"role": "user", "content": "Tell me a short story about a robot learning to paint."}]
+            ),
+            "gen_ai.output.messages": json.dumps(
+                [{"role": "model", "content": long_story}]
+            ),
+            "gen_ai.request.temperature": 0.9,
+        }, context=trace_api.set_span_in_context(agent))
+
+        llm.end()
+        agent.end()
+        inv.end()
+
+        assert len(captured_payloads) >= 3
+
+        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION)
+        assert gen["prompt_tokens"] == 25
+        assert gen["completion_tokens"] == 200
+        assert gen["model"] == "gemini-2.0-flash"
+        assert "robot" in str(gen.get("output", "")).lower() or "pixel" in str(gen.get("output", "")).lower()
+
+    def test_batch_path_propagates_output(self):
+        """When spans are grouped (as in batch export), output propagates to
+        workflow and agent spans."""
+        from respan_instrumentation_google_adk.instrumentor import _export_adk_spans
+
+        captured = []
+        mock_exporter = SimpleNamespace(export=lambda payloads: captured.extend(payloads))
+        converter = AdkSpanConverter()
+
+        old_exporter = inst_module._ACTIVE_EXPORTER
+        old_converter = inst_module._ACTIVE_CONVERTER
+        old_dedupe = inst_module._ACTIVE_DEDUPE
+        inst_module._ACTIVE_EXPORTER = mock_exporter
+        inst_module._ACTIVE_CONVERTER = converter
+        inst_module._ACTIVE_DEDUPE = inst_module._SpanDedupeCache()
+
+        try:
+            trace_id = 0xABCDEF1234567890ABCDEF1234567890
+            ctx_inv = SimpleNamespace(trace_id=trace_id, span_id=0x1111111111111111)
+            ctx_agent = SimpleNamespace(trace_id=trace_id, span_id=0x2222222222222222)
+            ctx_llm = SimpleNamespace(trace_id=trace_id, span_id=0x3333333333333333)
+            scope = SimpleNamespace(name="google_adk", version="1.0.0")
+            kind = SimpleNamespace(name="INTERNAL")
+            ok_status = SimpleNamespace(
+                status_code=SimpleNamespace(name="OK"), description=None
+            )
+            base = 1_700_000_000_000_000_000
+
+            inv = SimpleNamespace(
+                name="invocation", context=ctx_inv, parent=None,
+                instrumentation_scope=scope, kind=kind, status=ok_status,
+                attributes={}, start_time=base, end_time=base + 3_000_000_000,
+            )
+            agent = SimpleNamespace(
+                name="agent_run", context=ctx_agent,
+                parent=SimpleNamespace(span_id=0x1111111111111111, trace_id=trace_id, is_remote=False),
+                instrumentation_scope=scope, kind=kind, status=ok_status,
+                attributes={"gen_ai.agent.name": "storyteller"},
+                start_time=base + 100_000_000, end_time=base + 2_900_000_000,
+            )
+            llm = SimpleNamespace(
+                name="call_llm", context=ctx_llm,
+                parent=SimpleNamespace(span_id=0x2222222222222222, trace_id=trace_id, is_remote=False),
+                instrumentation_scope=scope, kind=kind, status=ok_status,
+                attributes={
+                    "gen_ai.request.model": "gemini-2.0-flash",
+                    "gen_ai.output.messages": json.dumps(
+                        [{"role": "model", "content": "A story about painting."}]
+                    ),
+                },
+                start_time=base + 200_000_000, end_time=base + 2_800_000_000,
+            )
+
+            _export_adk_spans([inv, agent, llm])
+
+            wf = next(p for p in captured if p["log_type"] == LOG_TYPE_WORKFLOW)
+            ag = next(p for p in captured if p["log_type"] == LOG_TYPE_AGENT)
+            assert wf.get("output") is not None
+            assert ag.get("output") is not None
+        finally:
+            inst_module._ACTIVE_EXPORTER = old_exporter
+            inst_module._ACTIVE_CONVERTER = old_converter
+            inst_module._ACTIVE_DEDUPE = old_dedupe
+
+    def test_streaming_llm_config_captured(self, captured_payloads):
+        tracer = _create_adk_tracer()
+
+        inv = tracer.start_span("invocation", attributes={})
+        agent = tracer.start_span("agent_run", attributes={
+            "gen_ai.agent.name": "storyteller",
+        }, context=trace_api.set_span_in_context(inv))
+        llm = tracer.start_span("call_llm", attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+            "gen_ai.request.temperature": 0.9,
+            "gen_ai.request.top_p": 0.95,
+        }, context=trace_api.set_span_in_context(agent))
+
+        llm.end()
+        agent.end()
+        inv.end()
+
+        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION)
+        assert gen["metadata"]["llm_config"]["temperature"] == 0.9
+        assert gen["metadata"]["llm_config"]["top_p"] == 0.95
+
+
+# ---------------------------------------------------------------------------
+# Tool calls pipeline test
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallsPipeline:
+    def test_tool_call_full_pipeline(self, captured_payloads):
+        tracer = _create_adk_tracer()
+
+        inv = tracer.start_span("invocation", attributes={})
+        agent = tracer.start_span("agent_run", attributes={
+            "gen_ai.agent.name": "weather_agent",
+        }, context=trace_api.set_span_in_context(inv))
+
+        llm1 = tracer.start_span("call_llm", attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+            "gen_ai.response.model": "gemini-2.0-flash",
+            "gen_ai.usage.input_tokens": 30,
+            "gen_ai.usage.output_tokens": 15,
+            "gen_ai.input.messages": json.dumps(
+                [{"role": "user", "content": "What's the weather in Tokyo and London?"}]
+            ),
+            "gen_ai.output.messages": json.dumps(
+                [{"role": "model", "content": "I'll check the weather for you."}]
+            ),
+        }, context=trace_api.set_span_in_context(agent))
+        llm1.end()
+
+        tool = tracer.start_span("execute_tool", attributes={
+            "gen_ai.tool.name": "get_weather",
+        }, context=trace_api.set_span_in_context(agent))
+        tool.end()
+
+        llm2 = tracer.start_span("call_llm", attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+            "gen_ai.response.model": "gemini-2.0-flash",
+            "gen_ai.usage.input_tokens": 60,
+            "gen_ai.usage.output_tokens": 40,
+            "gen_ai.input.messages": json.dumps([
+                {"role": "user", "content": "What's the weather in Tokyo and London?"},
+                {"role": "model", "content": "I'll check the weather for you."},
+                {"role": "tool", "content": json.dumps({"city": "Tokyo", "temp_f": 80})},
+            ]),
+            "gen_ai.output.messages": json.dumps(
+                [{"role": "model", "content": "Tokyo is 80°F. London is 59°F."}]
+            ),
+        }, context=trace_api.set_span_in_context(agent))
+        llm2.end()
+
+        agent.end()
+        inv.end()
+
+        assert len(captured_payloads) >= 5
+
+        type_counts = {}
+        for p in captured_payloads:
+            lt = p["log_type"]
+            type_counts[lt] = type_counts.get(lt, 0) + 1
+
+        assert type_counts.get(LOG_TYPE_WORKFLOW, 0) >= 1
+        assert type_counts.get(LOG_TYPE_AGENT, 0) >= 1
+        assert type_counts.get(LOG_TYPE_GENERATION, 0) >= 2
+        assert type_counts.get(LOG_TYPE_TOOL, 0) >= 1
+
+    def test_tool_name_captured(self, captured_payloads):
+        tracer = _create_adk_tracer()
+
+        inv = tracer.start_span("invocation", attributes={})
+        agent = tracer.start_span("agent_run", attributes={
+            "gen_ai.agent.name": "weather_agent",
+        }, context=trace_api.set_span_in_context(inv))
+        tool = tracer.start_span("execute_tool", attributes={
+            "gen_ai.tool.name": "get_weather",
+        }, context=trace_api.set_span_in_context(agent))
+
+        tool.end()
+        agent.end()
+        inv.end()
+
+        tool_payloads = [p for p in captured_payloads if p["log_type"] == LOG_TYPE_TOOL]
+        assert len(tool_payloads) >= 1
+        assert tool_payloads[0]["span_tools"] == ["get_weather"]
+        assert tool_payloads[0]["log_type"] == LOG_TYPE_TOOL
+
+    def test_all_spans_share_trace_id(self, captured_payloads):
+        tracer = _create_adk_tracer()
+
+        inv = tracer.start_span("invocation", attributes={})
+        agent = tracer.start_span("agent_run", attributes={
+            "gen_ai.agent.name": "weather_agent",
+        }, context=trace_api.set_span_in_context(inv))
+        llm = tracer.start_span("call_llm", attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+        }, context=trace_api.set_span_in_context(agent))
+        tool = tracer.start_span("execute_tool", attributes={
+            "gen_ai.tool.name": "get_weather",
+        }, context=trace_api.set_span_in_context(agent))
+
+        tool.end()
+        llm.end()
+        agent.end()
+        inv.end()
+
+        trace_ids = {p["trace_id"] for p in captured_payloads}
+        assert len(trace_ids) == 1, f"Expected 1 trace_id, got {len(trace_ids)}: {trace_ids}"
+
+
+# ---------------------------------------------------------------------------
+# Deduplication test
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplication:
+    def test_same_span_not_exported_twice(self, captured_payloads):
+        tracer = _create_adk_tracer()
+
+        # Create a full trace (root + child) so the buffer flushes on root end
+        root = tracer.start_span("invocation")
+        child = tracer.start_span(
+            "call_llm",
+            context=trace_api.set_span_in_context(root),
+            attributes={
+                "gen_ai.request.model": "gemini-2.0-flash",
+            },
+        )
+        child.end()
+        root.end()
+
+        initial_count = len(captured_payloads)
+        assert initial_count > 0, "Trace should have been exported"
+
+        # Re-exporting the same spans should be deduplicated
+        from respan_instrumentation_google_adk.instrumentor import _export_adk_spans
+        _export_adk_spans([root, child])
+
+        assert len(captured_payloads) == initial_count
+
+
+# ---------------------------------------------------------------------------
+# E2E tests with OpenLLMetry conventions
+# ---------------------------------------------------------------------------
+
+
+TRACE_ID = 0xABCDEF1234567890ABCDEF1234567890
+BASE_NS = 1_700_000_000_000_000_000
+
+
+def _mock_span(
+    name,
+    span_id,
+    parent_span_id=None,
+    attributes=None,
+    start_ns=BASE_NS,
+    end_ns=None,
+):
+    end_ns = end_ns or start_ns + 1_000_000_000
+    ctx = SimpleNamespace(trace_id=TRACE_ID, span_id=span_id)
+    parent = None
+    if parent_span_id is not None:
+        parent = SimpleNamespace(
+            span_id=parent_span_id, trace_id=TRACE_ID, is_remote=False
+        )
+    return SimpleNamespace(
+        name=name,
+        context=ctx,
+        parent=parent,
+        instrumentation_scope=SimpleNamespace(name="google_adk", version="1.0.0"),
+        kind=SimpleNamespace(name="INTERNAL"),
+        status=SimpleNamespace(
+            status_code=SimpleNamespace(name="OK"), description=None
+        ),
+        attributes=attributes or {},
+        start_time=start_ns,
+        end_time=end_ns,
+    )
+
+
+def _adk_tracer():
+    provider = trace_sdk.TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    return provider.get_tracer("google_adk", "1.0.0")
+
+
+class TestMultiTurnE2E:
+    def _emit_turn(self, tracer, turn_idx, user_msg, assistant_msg, conv_id="session-e2e"):
+        inv = tracer.start_span("invocation", attributes={
+            "gen_ai.conversation.id": conv_id,
+        })
+        agent = tracer.start_span("agent_run", attributes={
+            "gen_ai.agent.name": "chat_agent",
+        }, context=trace_api.set_span_in_context(inv))
+        llm = tracer.start_span("call_llm", attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+            "gen_ai.response.model": "gemini-2.0-flash",
+            "gen_ai.usage.prompt_tokens": 10 + turn_idx * 25,
+            "gen_ai.usage.completion_tokens": 15 + turn_idx * 5,
+            "gen_ai.input.messages": json.dumps(
+                [{"role": "user", "content": user_msg}]
+            ),
+            "gen_ai.output.messages": json.dumps(
+                [{"role": "model", "content": assistant_msg}]
+            ),
+        }, context=trace_api.set_span_in_context(agent))
+        llm.end()
+        agent.end()
+        inv.end()
+
+    def test_first_class_fields_replace_traceloop_metadata(self, captured_payloads):
+        tracer = _adk_tracer()
+        self._emit_turn(tracer, 0, "Hi", "Hello")
+
+        wf = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_WORKFLOW)
+        agent = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_AGENT)
+        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION)
+
+        assert wf["log_type"] == LOG_TYPE_WORKFLOW
+        assert agent["log_type"] == LOG_TYPE_AGENT
+        assert gen["log_type"] == LOG_TYPE_GENERATION
+
+        assert agent["span_name"] is not None
+        assert wf["span_workflow_name"] is not None
+
+    def test_gen_ai_system_not_in_metadata(self, captured_payloads):
+        tracer = _adk_tracer()
+        self._emit_turn(tracer, 0, "Hi", "Hello")
+
+        for p in captured_payloads:
+            metadata = p.get("metadata") or {}
+            assert "gen_ai.system" not in metadata
+
+    def test_parent_child_chain(self, captured_payloads):
+        tracer = _adk_tracer()
+        self._emit_turn(tracer, 0, "Hi", "Hello")
+
+        wf = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_WORKFLOW)
+        agent = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_AGENT)
+        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION)
+
+        assert wf.get("parent_id") is None
+        assert agent["parent_id"] == wf["span_id"]
+        assert gen["parent_id"] == agent["span_id"]
+
+    def test_output_propagates_to_workflow_and_agent_batch(self):
+        from respan_instrumentation_google_adk.instrumentor import _export_adk_spans
+
+        captured = []
+        mock_exporter = SimpleNamespace(export=lambda payloads: captured.extend(payloads))
+        converter = AdkSpanConverter()
+
+        old_exp = inst_module._ACTIVE_EXPORTER
+        old_conv = inst_module._ACTIVE_CONVERTER
+        old_ded = inst_module._ACTIVE_DEDUPE
+        inst_module._ACTIVE_EXPORTER = mock_exporter
+        inst_module._ACTIVE_CONVERTER = converter
+        inst_module._ACTIVE_DEDUPE = inst_module._SpanDedupeCache()
+
+        try:
+            inv = _mock_span("invocation", 0x1001, attributes={
+                "gen_ai.conversation.id": "conv-batch",
+            })
+            ag = _mock_span("agent_run", 0x1002, parent_span_id=0x1001, attributes={
+                "gen_ai.agent.name": "chat_agent",
+            }, start_ns=BASE_NS + 100_000_000)
+            llm = _mock_span("call_llm", 0x1003, parent_span_id=0x1002, attributes={
+                "gen_ai.request.model": "gemini-2.0-flash",
+                "gen_ai.usage.prompt_tokens": 10,
+                "gen_ai.usage.completion_tokens": 15,
+                "gen_ai.output.messages": json.dumps(
+                    [{"role": "model", "content": "Hello Alex!"}]
+                ),
+            }, start_ns=BASE_NS + 200_000_000)
+
+            _export_adk_spans([inv, ag, llm])
+
+            wf = next(p for p in captured if p["log_type"] == LOG_TYPE_WORKFLOW)
+            agent_p = next(p for p in captured if p["log_type"] == LOG_TYPE_AGENT)
+            assert wf["output"] is not None
+            assert agent_p["output"] is not None
+            assert "Alex" in str(wf["output"])
+        finally:
+            inst_module._ACTIVE_EXPORTER = old_exp
+            inst_module._ACTIVE_CONVERTER = old_conv
+            inst_module._ACTIVE_DEDUPE = old_ded
+
+
+class TestOpenLLMetryConventionFallbacks:
+    def setup_method(self):
+        self.converter = AdkSpanConverter()
+
+    def test_prompt_tokens_convention(self):
+        span = _mock_span("call_llm", 0xC001, attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+            "gen_ai.usage.prompt_tokens": 42,
+            "gen_ai.usage.completion_tokens": 18,
+        })
+        payloads = self.converter.convert(
+            trace_or_spans=[otel_span_to_dict(span)]
+        )
+        gen = payloads[0]
+        assert gen["prompt_tokens"] == 42
+        assert gen["completion_tokens"] == 18
+
+    def test_input_tokens_fallback(self):
+        span = _mock_span("call_llm", 0xC002, attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+            "gen_ai.usage.input_tokens": 50,
+            "gen_ai.usage.output_tokens": 20,
+        })
+        payloads = self.converter.convert(
+            trace_or_spans=[otel_span_to_dict(span)]
+        )
+        gen = payloads[0]
+        assert gen["prompt_tokens"] == 50
+        assert gen["completion_tokens"] == 20
+
+    def test_total_tokens_computed(self):
+        span = _mock_span("call_llm", 0xC003, attributes={
+            "gen_ai.request.model": "gemini-2.0-flash",
+            "gen_ai.usage.prompt_tokens": 100,
+            "gen_ai.usage.completion_tokens": 50,
+        })
+        payloads = self.converter.convert(
+            trace_or_spans=[otel_span_to_dict(span)]
+        )
+        assert payloads[0]["total_request_tokens"] == 150

--- a/python-sdks/respan-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python-sdks/respan-instrumentation-google-adk/tests/test_instrumentor.py
@@ -20,7 +20,7 @@ from respan_instrumentation_google_adk.converter import AdkSpanConverter
 from respan_instrumentation_google_adk.utils import otel_span_to_dict
 from respan_sdk.constants.llm_logging import (
     LOG_TYPE_AGENT,
-    LOG_TYPE_GENERATION,
+    LOG_TYPE_CHAT,
     LOG_TYPE_TOOL,
     LOG_TYPE_WORKFLOW,
 )
@@ -184,7 +184,7 @@ class TestMultiTurnPipeline:
         log_types = [p["log_type"] for p in captured_payloads]
         assert log_types.count(LOG_TYPE_WORKFLOW) >= 3
         assert log_types.count(LOG_TYPE_AGENT) >= 3
-        assert log_types.count(LOG_TYPE_GENERATION) >= 3
+        assert log_types.count(LOG_TYPE_CHAT) >= 3
 
     def test_multi_turn_conversation_id_preserved(self, captured_payloads):
         tracer = _create_adk_tracer()
@@ -226,7 +226,7 @@ class TestMultiTurnPipeline:
             agent.end()
             inv.end()
 
-        gens = [p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION]
+        gens = [p for p in captured_payloads if p["log_type"] == LOG_TYPE_CHAT]
         token_counts = sorted([g.get("prompt_tokens", 0) for g in gens])
         assert token_counts == [10, 40, 70]
 
@@ -269,7 +269,7 @@ class TestStreamingPipeline:
 
         assert len(captured_payloads) >= 3
 
-        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION)
+        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_CHAT)
         assert gen["prompt_tokens"] == 25
         assert gen["completion_tokens"] == 200
         assert gen["model"] == "gemini-2.0-flash"
@@ -356,7 +356,7 @@ class TestStreamingPipeline:
         agent.end()
         inv.end()
 
-        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION)
+        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_CHAT)
         assert gen["metadata"]["llm_config"]["temperature"] == 0.9
         assert gen["metadata"]["llm_config"]["top_p"] == 0.95
 
@@ -422,7 +422,7 @@ class TestToolCallsPipeline:
 
         assert type_counts.get(LOG_TYPE_WORKFLOW, 0) >= 1
         assert type_counts.get(LOG_TYPE_AGENT, 0) >= 1
-        assert type_counts.get(LOG_TYPE_GENERATION, 0) >= 2
+        assert type_counts.get(LOG_TYPE_CHAT, 0) >= 2
         assert type_counts.get(LOG_TYPE_TOOL, 0) >= 1
 
     def test_tool_name_captured(self, captured_payloads):
@@ -574,11 +574,15 @@ class TestMultiTurnE2E:
 
         wf = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_WORKFLOW)
         agent = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_AGENT)
-        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION)
+        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_CHAT)
 
         assert wf["log_type"] == LOG_TYPE_WORKFLOW
         assert agent["log_type"] == LOG_TYPE_AGENT
-        assert gen["log_type"] == LOG_TYPE_GENERATION
+        assert gen["log_type"] == LOG_TYPE_CHAT
+
+        assert wf["status"] == "success"
+        assert agent["status"] == "success"
+        assert gen["status"] == "success"
 
         assert agent["span_name"] is not None
         assert wf["span_workflow_name"] is not None
@@ -597,7 +601,7 @@ class TestMultiTurnE2E:
 
         wf = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_WORKFLOW)
         agent = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_AGENT)
-        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_GENERATION)
+        gen = next(p for p in captured_payloads if p["log_type"] == LOG_TYPE_CHAT)
 
         assert wf.get("parent_id") is None
         assert agent["parent_id"] == wf["span_id"]

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/preprocessing/span_processing.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/preprocessing/span_processing.py
@@ -5,6 +5,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Instrumentation scope names that identify Google ADK spans
+# NOTE: This duplicates detection logic in respan_instrumentation_google_adk.utils.
+# We cannot import from that package here because respan_tracing is a core dependency
+# of respan_instrumentation_google_adk — importing the other direction would create a
+# circular dependency. Consider moving to respan_sdk if this grows.
 _ADK_SCOPE_NAMES = {"gcp.vertex.agent", "google_adk", "google-adk"}
 
 # Span names that indicate a Google ADK instrumented span
@@ -49,7 +53,7 @@ def is_processable_span(span: ReadableSpan) -> bool:
     # own exporters, so let them through the filter
     if _is_adk_span(span):
         logger.debug(
-            f"[Respan Debug] Processing Google ADK span: {span.name}"
+            "[Respan Debug] Processing Google ADK span: %s", span.name
         )
         return True
 

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/preprocessing/span_processing.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/preprocessing/span_processing.py
@@ -4,23 +4,40 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Instrumentation scope names that identify Google ADK spans
+_ADK_SCOPE_NAMES = {"gcp.vertex.agent", "google_adk", "google-adk"}
+
+# Span names that indicate a Google ADK instrumented span
+_ADK_SPAN_NAMES = {"invocation", "agent_run", "call_llm", "execute_tool", "invoke_agent"}
+
+
+def _is_adk_span(span: ReadableSpan) -> bool:
+    """Check if a span originates from Google ADK instrumentation."""
+    scope = getattr(span, "instrumentation_scope", None) or getattr(
+        span, "instrumentation_library", None
+    )
+    scope_name = getattr(scope, "name", "") or ""
+    if scope_name in _ADK_SCOPE_NAMES:
+        return True
+    # Fallback: check span name + gen_ai attributes
+    span_name = (getattr(span, "name", "") or "").split(" ")[0]
+    if span_name in _ADK_SPAN_NAMES:
+        attributes = getattr(span, "attributes", None) or {}
+        if any(key.startswith("gen_ai.") for key in attributes):
+            return True
+    return False
+
 
 def is_processable_span(span: ReadableSpan) -> bool:
     """
     Determine if a span should be processed based on Respan/Traceloop attributes.
 
     Logic:
+    - If span is from a known instrumentation plugin (e.g. Google ADK) → process
     - If span has TRACELOOP_SPAN_KIND: it's a user-decorated span → process
     - If span has TRACELOOP_ENTITY_PATH: it's a child span within entity context → process
     - If span has LLM_REQUEST_TYPE: it's an auto-instrumented LLM call → process
     - If span has none of the above: it's auto-instrumentation noise → filter out
-
-    GAP: The LLM_REQUEST_TYPE check is a duck-tape fix for standalone auto-instrumented
-    LLM spans. It won't cover non-LLM instrumentors (vector DB, retrieval, tool-use, etc.)
-    that also lack Traceloop decorator context. The proper fix is an allowlist of recognized
-    instrumentation scope names (e.g. "opentelemetry.instrumentation.openai") so we can
-    accept any span from a known instrumentor without requiring decorator context or
-    checking for provider-specific attributes.
 
     Args:
         span: The span to evaluate
@@ -28,6 +45,14 @@ def is_processable_span(span: ReadableSpan) -> bool:
     Returns:
         bool: True if span should be processed, False if it should be filtered out
     """
+    # Instrumentation plugin spans (e.g. Google ADK) — these are handled by their
+    # own exporters, so let them through the filter
+    if _is_adk_span(span):
+        logger.debug(
+            f"[Respan Debug] Processing Google ADK span: {span.name}"
+        )
+        return True
+
     span_kind = span.attributes.get(SpanAttributes.TRACELOOP_SPAN_KIND)
     entity_path = span.attributes.get(SpanAttributes.TRACELOOP_ENTITY_PATH, "")
 


### PR DESCRIPTION
## Summary

Adds the `respan-instrumentation-google-adk` package — an OpenTelemetry-based instrumentation layer for Google's Agent Development Kit (ADK).

- **Instrumentor**: Hooks into Google ADK's `InvocationContext` to capture agent runs, tool calls, and LLM interactions as OpenTelemetry spans with proper parent-child relationships
- **Converter**: Transforms raw ADK trace events into OpenLLMetry-compatible spans — maps LLM calls, tool invocations, agent handoffs, and session metadata into structured span attributes
- **Utilities**: Extracts session info, model parameters, token usage, and content from ADK's protobuf-based data structures; handles nested function calls and parallel agent execution
- **Examples**: 9 runnable examples covering quickstart, multi-agent, multi-turn, streaming, tool calls, structured output, callbacks, parallel agents, and custom attributes
- **Tests**: Comprehensive unit tests for the converter (~757 lines) and instrumentor (~692 lines)

### Key trace quality improvements (second commit)
- Proper LLM span mapping so model calls appear as children of their agent spans
- Session and user ID extraction from ADK invocation context
- Correct span handoff tracking for multi-agent delegation
- Fixed duplicate span export prevention

## Test plan
- [ ] `poetry install` in `python-sdks/respan-instrumentation-google-adk/` succeeds
- [ ] `poetry run pytest` passes converter and instrumentor tests
- [ ] Run quickstart example against a live ADK agent to verify end-to-end trace capture
- [ ] Verify spans appear correctly in Respan dashboard with proper hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)