### PR TITLE
fix: cross-cutting trace quality fixes

### DIFF
--- a/python-sdks/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_instrumentation.py
+++ b/python-sdks/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_instrumentation.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from agents.tracing.processor_interface import TracingProcessor
 from agents.tracing.spans import Span
 from agents.tracing.traces import Trace
+from respan_tracing.exporters.span_exporter_v2 import _PROPAGATED_ATTRIBUTES
 
 from ._converter import convert_to_respan_log
 
@@ -14,26 +15,62 @@ logger = logging.getLogger(__name__)
 
 
 class _RespanTracingProcessor(TracingProcessor):
-    """OpenAI Agents SDK TracingProcessor that forwards spans to RespanSpanExporterV2."""
+    """OpenAI Agents SDK TracingProcessor that forwards spans to RespanSpanExporterV2.
+
+    Captures context-propagated attributes (customer_identifier, thread_identifier,
+    etc.) at span/trace *start* time.  This ensures the attributes are available at
+    *end* time even when ``propagate_attributes`` is nested inside the trace scope
+    and has already exited by the time ``on_trace_end`` fires.
+    """
 
     def __init__(self, exporter: Any) -> None:
         self._exporter = exporter
+        # Snapshot of propagated attributes captured at start, keyed by object id
+        self._captured_ctx: Dict[int, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
 
     def on_trace_start(self, trace: Trace) -> None:
-        pass
+        ctx = _PROPAGATED_ATTRIBUTES.get()
+        if ctx:
+            with self._lock:
+                self._captured_ctx[id(trace)] = ctx
 
     def on_trace_end(self, trace: Trace) -> None:
+        with self._lock:
+            captured = self._captured_ctx.pop(id(trace), None)
         data = convert_to_respan_log(trace)
         if data:
-            self._exporter.export([data])
+            self._export_with_ctx(data, captured)
 
     def on_span_start(self, span: Span[Any]) -> None:
-        pass
+        ctx = _PROPAGATED_ATTRIBUTES.get()
+        if ctx:
+            with self._lock:
+                self._captured_ctx[id(span)] = ctx
 
     def on_span_end(self, span: Span[Any]) -> None:
+        with self._lock:
+            captured = self._captured_ctx.pop(id(span), None)
         data = convert_to_respan_log(span)
         if data:
+            self._export_with_ctx(data, captured)
+
+    def _export_with_ctx(
+        self, data: Dict[str, Any], captured: Optional[Dict[str, Any]]
+    ) -> None:
+        """Export data, restoring the captured context if the current one is empty."""
+        current = _PROPAGATED_ATTRIBUTES.get()
+        if current or not captured:
+            # Context is still active (normal on_span_end) or nothing was captured
             self._exporter.export([data])
+            return
+        # Context was lost (e.g. on_trace_end after propagate_attributes exited).
+        # Temporarily restore the snapshot so the exporter can merge attributes.
+        token = _PROPAGATED_ATTRIBUTES.set(captured)
+        try:
+            self._exporter.export([data])
+        finally:
+            _PROPAGATED_ATTRIBUTES.reset(token)
 
     def shutdown(self) -> None:
         pass

--- a/python-sdks/respan-tracing/src/respan_tracing/core/tracer.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/tracer.py
@@ -85,9 +85,11 @@ class RespanTracer:
         if auto_instrument:
             self._setup_instrumentations(instruments, block_instruments)
         
-        # Add default Respan processor for backward compatibility
-        # Only if api_key is provided (user wants to send to Respan)
-        if api_key:
+        # Add default Respan processor for backward compatibility.
+        # Only when api_key is provided AND auto_instrument is enabled.
+        # When auto_instrument is False, plugins handle tracing via their own
+        # exporter — the default OTEL processor would cause duplicate exports.
+        if api_key and auto_instrument:
             self._setup_default_processor()
         
         # Register cleanup

--- a/python-sdks/respan-tracing/src/respan_tracing/exporters/span_exporter_v2.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/exporters/span_exporter_v2.py
@@ -37,7 +37,9 @@ _SUPPORTED_ATTRIBUTE_KEYS = frozenset({
     "customer_identifier",
     "customer_email",
     "customer_name",
+    "evaluation_identifier",
     "thread_identifier",
+    "session_identifier",
     "custom_identifier",
     "group_identifier",
     "environment",
@@ -56,8 +58,8 @@ def propagate_attributes(**kwargs):
 
     Supported attributes:
         customer_identifier, customer_email, customer_name,
-        thread_identifier, custom_identifier, group_identifier,
-        environment, metadata (dict — merged, not replaced),
+        evaluation_identifier, thread_identifier, custom_identifier,
+        group_identifier, environment, metadata (dict — merged, not replaced),
         prompt (dict with prompt_id + variables — triggers server-side
         template resolution).
 

--- a/python-sdks/respan/src/respan/_core.py
+++ b/python-sdks/respan/src/respan/_core.py
@@ -43,6 +43,7 @@ class Respan:
             via OTEL.  Defaults to ``True`` when no plugins are provided,
             ``False`` when plugins are provided (to avoid duplicate spans).
         customer_identifier: Default customer/user identifier for all spans.
+        evaluation_identifier: Default evaluation identifier for all spans.
         thread_identifier: Default conversation thread ID for all spans.
         metadata: Default metadata dict merged into all spans.
         environment: Default environment (e.g. ``"production"``).
@@ -67,6 +68,7 @@ class Respan:
         instrumentations: Optional[Sequence[object]] = None,
         auto_instrument: Optional[bool] = None,
         customer_identifier: Optional[str] = None,
+        evaluation_identifier: Optional[str] = None,
         thread_identifier: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         environment: Optional[str] = None,
@@ -81,6 +83,8 @@ class Respan:
         default_attributes: Dict[str, Any] = {}
         if customer_identifier:
             default_attributes["customer_identifier"] = customer_identifier
+        if evaluation_identifier:
+            default_attributes["evaluation_identifier"] = evaluation_identifier
         if thread_identifier:
             default_attributes["thread_identifier"] = thread_identifier
         if metadata:
@@ -137,6 +141,7 @@ class Respan:
             customer_identifier: User/customer identifier.
             customer_email: Customer email address.
             customer_name: Customer display name.
+            evaluation_identifier: Evaluation run identifier.
             thread_identifier: Conversation thread ID.
             custom_identifier: Indexed custom identifier.
             group_identifier: Group related traces.


### PR DESCRIPTION
## Summary

Extracts three cross-cutting fixes that were mixed into the Google ADK instrumentation commit (`de43f45`) and applies them cleanly against `feat/unified-respan-instrumentation`.

### 1. Capture `propagate_attributes` context on user thread (OpenAI Agents)
- **File:** `python-sdks/respan-instrumentation-openai-agents/.../_instrumentation.py`
- The `_RespanTracingProcessor` now snapshots `_PROPAGATED_ATTRIBUTES` at span/trace **start** time and restores the snapshot at **end** time if the context has been lost (e.g. when `on_trace_end` fires on a background thread after `propagate_attributes` has already exited).
- Prevents `customer_identifier`, `thread_identifier`, and other propagated fields from silently disappearing on exported spans.

### 2. Add `evaluation_identifier` and `session_identifier` to `propagate_attributes`
- **File:** `python-sdks/respan-tracing/.../exporters/span_exporter_v2.py` — adds both keys to `_SUPPORTED_ATTRIBUTE_KEYS` and updates the docstring.
- **File:** `python-sdks/respan/src/respan/_core.py` — adds `evaluation_identifier` parameter to the `Respan` constructor and wires it into `default_attributes`. Updates the `propagate_attributes` docstring.

### 3. Fix duplicate span exports when `auto_instrument=False`
- **File:** `python-sdks/respan-tracing/.../core/tracer.py`
- The default OTEL processor is now only added when **both** `api_key` is set **and** `auto_instrument` is `True`. When `auto_instrument=False` (i.e. plugins handle tracing via their own exporter), the default processor was causing every span to be exported twice.

## Test plan
- [ ] Verify `propagate_attributes(customer_identifier=...)` fields appear on exported spans when using the OpenAI Agents instrumentor
- [ ] Verify `evaluation_identifier` and `session_identifier` are accepted by `propagate_attributes()` and appear in exported payloads
- [ ] Verify `Respan(evaluation_identifier="eval_1")` sets the field as a default attribute
- [ ] Verify that `Respan(instrumentations=[...])` no longer produces duplicate span exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)