### PR TITLE
fix: respan-instrumentation-openai-agents payload problems

### DIFF
--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
@@ -233,12 +233,12 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
 
             tool_calls = _extract_tool_calls(resp.output)
             if tool_calls:
-                attrs["tool_calls"] = tool_calls
+                attrs["tool_calls"] = _safe_json(tool_calls)
 
         if hasattr(resp, "tools") and resp.tools:
             tools_list = _extract_tools(resp.tools)
             if tools_list:
-                attrs["tools"] = tools_list
+                attrs["tools"] = _safe_json(tools_list)
 
         usage = getattr(resp, "usage", None)
         if usage:

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
@@ -107,6 +107,47 @@ def _safe_json(obj: Any) -> str:
         return str(obj)
 
 
+def _extract_tools(tools: list) -> list:
+    """Convert Response API tool definitions to Chat Completions format."""
+    result = []
+    for tool in tools:
+        tool_dict = serialize_value(tool)
+        if not isinstance(tool_dict, dict):
+            continue
+        tool_type = tool_dict.get("type", "")
+        if tool_type == "function":
+            func = {
+                "name": tool_dict.get("name", ""),
+            }
+            desc = tool_dict.get("description")
+            if desc:
+                func["description"] = desc
+            params = tool_dict.get("parameters")
+            if params:
+                func["parameters"] = params
+            result.append({"type": "function", "function": func})
+        else:
+            result.append(tool_dict)
+    return result
+
+
+def _extract_tool_calls(output: list) -> list:
+    """Extract function tool calls from Response API output items."""
+    result = []
+    for item in output:
+        item_dict = serialize_value(item)
+        if isinstance(item_dict, dict) and item_dict.get("type") == "function_call":
+            result.append({
+                "id": item_dict.get("call_id", ""),
+                "type": "function",
+                "function": {
+                    "name": item_dict.get("name", ""),
+                    "arguments": item_dict.get("arguments", ""),
+                },
+            })
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Per-type emitters
 # ---------------------------------------------------------------------------
@@ -189,6 +230,15 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
         if hasattr(resp, "output") and resp.output:
             output = _format_output(resp.output)
             attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json(output)
+
+            tool_calls = _extract_tool_calls(resp.output)
+            if tool_calls:
+                attrs["tool_calls"] = tool_calls
+
+        if hasattr(resp, "tools") and resp.tools:
+            tools_list = _extract_tools(resp.tools)
+            if tools_list:
+                attrs["tools"] = tools_list
 
         usage = getattr(resp, "usage", None)
         if usage:

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
@@ -88,49 +88,47 @@ def _format_input_messages(raw_input: Any) -> List[Dict[str, Any]]:
     return [{"role": "user", "content": str(serialized)}]
 
 
-def _format_output(resp_output: Any) -> Dict[str, Any]:
-    """Extract a clean ``{"role": "assistant", "content": ...}`` from Response output."""
+def _format_output(resp_output: Any) -> List[Dict[str, Any]]:
+    """Extract response output as a normalized message list."""
     serialized = serialize_value(resp_output)
     if not serialized:
-        return {"role": "assistant", "content": "", "_is_placeholder": True}
+        return [{"role": "assistant", "content": "", "_is_placeholder": True}]
 
     if isinstance(serialized, str):
-        return {"role": "assistant", "content": serialized}
+        return [{"role": "assistant", "content": serialized}]
 
     if isinstance(serialized, dict):
         if "role" in serialized:
-            return serialized
-        return {"role": "assistant", "content": str(serialized)}
+            return [serialized]
+        return [{"role": "assistant", "content": json.dumps(serialized, default=str)}]
 
     if isinstance(serialized, list):
-        text_parts = []
-        tool_calls = []
+        messages = []
         for item in serialized:
             if not isinstance(item, dict):
+                messages.append({"role": "assistant", "content": str(item)})
                 continue
-            item_type = item.get("type", "")
-            if item_type == "message":
-                for block in item.get("content", []):
-                    if isinstance(block, dict) and block.get("type") == "output_text":
-                        text_parts.append(block.get("text", ""))
-            elif item_type == "function_call":
-                tool_calls.append({
-                    "id": item.get("call_id", ""),
-                    "type": "function",
-                    "function": {
-                        "name": item.get("name", ""),
-                        "arguments": item.get("arguments", ""),
-                    },
-                })
-            elif item_type == "output_text":
-                text_parts.append(item.get("text", ""))
+            if "type" in item:
+                msg = _responses_api_item_to_message(item)
+                if msg is not None:
+                    messages.append(msg)
+                    continue
+                if item.get("type") == "output_text":
+                    messages.append({
+                        "role": "assistant",
+                        "content": item.get("text", ""),
+                    })
+                    continue
+            if "role" in item:
+                messages.append(item)
+                continue
+            messages.append({
+                "role": "assistant",
+                "content": json.dumps(item, default=str),
+            })
+        return messages or [{"role": "assistant", "content": "", "_is_placeholder": True}]
 
-        msg: Dict[str, Any] = {"role": "assistant", "content": "\n".join(text_parts)}
-        if tool_calls:
-            msg["tool_calls"] = tool_calls
-        return msg
-
-    return {"role": "assistant", "content": str(serialized)}
+    return [{"role": "assistant", "content": str(serialized)}]
 
 
 def _parse_ts(ts: str) -> datetime:

--- a/python-sdks/respan-sdk/src/respan_sdk/constants/otlp_constants.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/otlp_constants.py
@@ -163,6 +163,8 @@ GEN_AI_PROMOTED_KEYS = frozenset({
     "prompt_tokens",
     "completion_tokens",
     "total_request_tokens",
+    "tools",
+    "tool_calls",
 })
 
 # Union of all promoted keys for quick lookup

--- a/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
@@ -43,6 +43,11 @@ class RespanSpanAttributes(str, Enum):
 
     # Metadata
     RESPAN_METADATA = "respan.metadata"
+    RESPAN_METADATA_AGENT_NAME = "respan.metadata.agent_name"
+    RESPAN_METADATA_FROM_AGENT = "respan.metadata.from_agent"
+    RESPAN_METADATA_TO_AGENT = "respan.metadata.to_agent"
+    RESPAN_METADATA_GUARDRAIL_NAME = "respan.metadata.guardrail_name"
+    RESPAN_METADATA_TRIGGERED = "respan.metadata.triggered"
 
     # Prompt & environment
     RESPAN_PROMPT = "respan.prompt"
@@ -50,6 +55,10 @@ class RespanSpanAttributes(str, Enum):
 
     # Span links
     RESPAN_LINK_TIMESTAMP = "respan.link.timestamp"
+
+    # Span metadata
+    RESPAN_SPAN_TOOLS = "respan.span.tools"
+    RESPAN_SPAN_HANDOFFS = "respan.span.handoffs"
 
     # Logging
     LOG_METHOD = "respan.entity.log_method"
@@ -83,6 +92,11 @@ RESPAN_TRACE_GROUP_ID = RespanSpanAttributes.RESPAN_TRACE_GROUP_ID.value
 
 # Metadata (pattern: "respan.metadata.<key>" where key is customizable)
 RESPAN_METADATA = RespanSpanAttributes.RESPAN_METADATA.value
+RESPAN_METADATA_AGENT_NAME = RespanSpanAttributes.RESPAN_METADATA_AGENT_NAME.value
+RESPAN_METADATA_FROM_AGENT = RespanSpanAttributes.RESPAN_METADATA_FROM_AGENT.value
+RESPAN_METADATA_TO_AGENT = RespanSpanAttributes.RESPAN_METADATA_TO_AGENT.value
+RESPAN_METADATA_GUARDRAIL_NAME = RespanSpanAttributes.RESPAN_METADATA_GUARDRAIL_NAME.value
+RESPAN_METADATA_TRIGGERED = RespanSpanAttributes.RESPAN_METADATA_TRIGGERED.value
 
 # Prompt & environment
 RESPAN_PROMPT = RespanSpanAttributes.RESPAN_PROMPT.value
@@ -90,6 +104,10 @@ RESPAN_ENVIRONMENT = RespanSpanAttributes.RESPAN_ENVIRONMENT.value
 
 # Span links
 RESPAN_LINK_TIMESTAMP = RespanSpanAttributes.RESPAN_LINK_TIMESTAMP.value
+
+# Span metadata
+RESPAN_SPAN_TOOLS = RespanSpanAttributes.RESPAN_SPAN_TOOLS.value
+RESPAN_SPAN_HANDOFFS = RespanSpanAttributes.RESPAN_SPAN_HANDOFFS.value
 
 # Logging
 RESPAN_LOG_METHOD = RespanSpanAttributes.LOG_METHOD.value

--- a/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
@@ -1,8 +1,71 @@
+from dataclasses import asdict, is_dataclass
 from datetime import date, datetime
+from typing import Any, Dict, List
+
 
 def json_serial(obj):
-    """JSON serializer for objects not serializable by default json code"""
+    """JSON serializer for objects not serializable by default json code."""
 
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
-    raise TypeError ("Type %s not serializable" % type(obj))
+    raise TypeError("Type %s not serializable" % type(obj))
+
+
+def serialize_value(value: Any) -> Any:
+    """Convert complex values into JSON-safe Python structures.
+
+    This preserves dict/list structure for downstream instrumentations that
+    need to shape messages before JSON-encoding them for span attributes.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, (str, int, float, bool)):
+        return value
+
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+
+    if isinstance(value, dict):
+        normalized_dict: Dict[str, Any] = {}
+        for key, nested_value in value.items():
+            normalized_dict[str(key)] = serialize_value(nested_value)
+        return normalized_dict
+
+    if isinstance(value, (list, tuple, set)):
+        normalized_list: List[Any] = []
+        for nested_value in value:
+            normalized_list.append(serialize_value(nested_value))
+        return normalized_list
+
+    if is_dataclass(value):
+        return serialize_value(asdict(value))
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return serialize_value(model_dump())
+        except TypeError:
+            pass
+
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        try:
+            return serialize_value(to_dict())
+        except TypeError:
+            pass
+
+    dict_method = getattr(value, "dict", None)
+    if callable(dict_method):
+        try:
+            return serialize_value(dict_method())
+        except TypeError:
+            pass
+
+    if hasattr(value, "__dict__"):
+        return serialize_value(value.__dict__)
+
+    return str(value)

--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.13.1"
+version = "2.12.0"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"
@@ -16,7 +16,6 @@ opentelemetry-api = "^1.29.0"
 opentelemetry-sdk = "^1.29.0"
 respan-sdk = ">=2.6.1"
 opentelemetry-instrumentation-threading = ">=0.55b1"
-openinference-semantic-conventions = ">=0.1.12"
 requests = ">=2.28.0"
 
 

--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.12.0"
+version = "2.13.2"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"


### PR DESCRIPTION
1. fix input serialize problem
2. fix output serialize problem
3. fix span tools and tool calls lost problem

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span attribute shapes/keys (notably output format and tool metadata promotion), which can affect downstream telemetry parsing and backend ingestion, though it doesn’t touch auth or user data flows.
> 
> **Overview**
> Fixes OpenAI Agents OTEL emission to **preserve structured payloads** by introducing `serialize_value()` and updating response output formatting to always emit a normalized message list.
> 
> Adds extraction and emission of `tools` and `tool_calls` from Responses API data (and promotes these keys for backend ingestion), plus new `respan.metadata.*` and `respan.span.*` attribute constants to carry agent/handoff/guardrail metadata.
> 
> Bumps `respan-tracing` version to `2.13.2` and removes the `openinference-semantic-conventions` dependency from its `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15d237b95594e9a833afc0d47c02c9d6b22476ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->