### PR TITLE
fix: SDK compat fixes, OI→OpenLLMetry translator, JS exporter v2

### DIFF
--- a/javascript-sdks/examples/anthropic-openinference/hello_world.ts
+++ b/javascript-sdks/examples/anthropic-openinference/hello_world.ts
@@ -1,0 +1,33 @@
+/** Anthropic SDK — Chat completion with Respan tracing via OpenInference. */
+
+import "dotenv/config";
+import Anthropic from "@anthropic-ai/sdk";
+import { AnthropicInstrumentation } from "@arizeai/openinference-instrumentation-anthropic";
+import { Respan } from "@respan/respan";
+import { OpenInferenceInstrumentor } from "@respan/instrumentation-openinference";
+
+const respan = new Respan({
+  apiKey: process.env.RESPAN_API_KEY,
+  baseURL: process.env.RESPAN_BASE_URL,
+  instrumentations: [
+    new OpenInferenceInstrumentor(AnthropicInstrumentation, Anthropic),
+  ],
+});
+await respan.initialize();
+
+const client = new Anthropic();
+
+const message = await client.messages.create({
+  model: "claude-sonnet-4-20250514",
+  max_tokens: 100,
+  messages: [
+    { role: "user", content: "Write a haiku about recursion in programming." },
+  ],
+});
+
+const text = message.content[0];
+if (text.type === "text") {
+  console.log(text.text);
+}
+
+await respan.flush();

--- a/javascript-sdks/examples/anthropic-openinference/package.json
+++ b/javascript-sdks/examples/anthropic-openinference/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "respan-anthropic-openinference-examples",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "hello": "tsx hello_world.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
+    "@arizeai/openinference-instrumentation-anthropic": "^0.1.7",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.30.1",
+    "@respan/instrumentation-openinference": "file:../../respan-instrumentation-openinference",
+    "@respan/respan": "file:../../respan",
+    "@respan/respan-sdk": "file:../../respan-sdk",
+    "@respan/tracing": "file:../../respan-tracing",
+    "dotenv": "^16.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/javascript-sdks/examples/anthropic-openinference/tsconfig.json
+++ b/javascript-sdks/examples/anthropic-openinference/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/javascript-sdks/examples/claude-agent-sdk/hello_world.ts
+++ b/javascript-sdks/examples/claude-agent-sdk/hello_world.ts
@@ -1,0 +1,34 @@
+/** Claude Agent SDK — Simple query with Respan tracing via OpenInference. */
+
+import "dotenv/config";
+import * as _ClaudeAgentSDK from "@anthropic-ai/claude-agent-sdk";
+import { ClaudeAgentSDKInstrumentation } from "@arizeai/openinference-instrumentation-claude-agent-sdk";
+import { Respan } from "@respan/respan";
+import { OpenInferenceInstrumentor } from "@respan/instrumentation-openinference";
+
+// Create a mutable copy of the ESM module so the OI instrumentor can monkey-patch it
+const ClaudeAgentSDK = { ..._ClaudeAgentSDK };
+
+const respan = new Respan({
+  apiKey: process.env.RESPAN_API_KEY,
+  baseURL: process.env.RESPAN_BASE_URL,
+  instrumentations: [
+    new OpenInferenceInstrumentor(ClaudeAgentSDKInstrumentation, ClaudeAgentSDK),
+  ],
+});
+await respan.initialize();
+
+const result = await ClaudeAgentSDK.query({
+  prompt: "Write a haiku about recursion in programming.",
+  options: {
+    maxTurns: 1,
+  },
+});
+
+for await (const event of result) {
+  if (event.type === "result") {
+    console.log(event.result);
+  }
+}
+
+await respan.flush();

--- a/javascript-sdks/examples/claude-agent-sdk/package.json
+++ b/javascript-sdks/examples/claude-agent-sdk/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "respan-claude-agent-sdk-examples",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "hello": "tsx hello_world.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.83",
+    "@anthropic-ai/sdk": "^0.80.0",
+    "@arizeai/openinference-instrumentation-claude-agent-sdk": "^0.2.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.30.1",
+    "@respan/instrumentation-openinference": "file:../../respan-instrumentation-openinference",
+    "@respan/respan": "file:../../respan",
+    "@respan/respan-sdk": "file:../../respan-sdk",
+    "@respan/tracing": "file:../../respan-tracing",
+    "dotenv": "^16.0.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/javascript-sdks/examples/claude-agent-sdk/tsconfig.json
+++ b/javascript-sdks/examples/claude-agent-sdk/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/javascript-sdks/examples/claude-agent-sdk/with_tools.ts
+++ b/javascript-sdks/examples/claude-agent-sdk/with_tools.ts
@@ -1,0 +1,34 @@
+/** Claude Agent SDK — Query that triggers tool usage for multiple spans. */
+
+import "dotenv/config";
+import * as _ClaudeAgentSDK from "@anthropic-ai/claude-agent-sdk";
+import { ClaudeAgentSDKInstrumentation } from "@arizeai/openinference-instrumentation-claude-agent-sdk";
+import { Respan } from "@respan/respan";
+import { OpenInferenceInstrumentor } from "@respan/instrumentation-openinference";
+
+const ClaudeAgentSDK = { ..._ClaudeAgentSDK };
+
+const respan = new Respan({
+  apiKey: process.env.RESPAN_API_KEY,
+  baseURL: process.env.RESPAN_BASE_URL,
+  instrumentations: [
+    new OpenInferenceInstrumentor(ClaudeAgentSDKInstrumentation, ClaudeAgentSDK),
+  ],
+});
+await respan.initialize();
+
+// Ask something that will trigger Claude Code to use tools (read files, run commands)
+const result = await ClaudeAgentSDK.query({
+  prompt: "List the files in the current directory using the bash tool, then tell me how many there are.",
+  options: {
+    maxTurns: 5,
+  },
+});
+
+for await (const event of result) {
+  if (event.type === "result") {
+    console.log("Result:", event.result);
+  }
+}
+
+await respan.flush();

--- a/javascript-sdks/examples/openai-agents-sdk/hello_world.ts
+++ b/javascript-sdks/examples/openai-agents-sdk/hello_world.ts
@@ -1,0 +1,23 @@
+/** Hello World — Minimal agent with Respan tracing (mirrors Python example). */
+
+import "dotenv/config";
+import { Agent, run } from "@openai/agents";
+import { Respan } from "@respan/respan";
+import { OpenAIAgentsInstrumentor } from "@respan/instrumentation-openai-agents";
+
+const respan = new Respan({
+  apiKey: process.env.RESPAN_API_KEY,
+  baseURL: process.env.RESPAN_BASE_URL,
+  instrumentations: [new OpenAIAgentsInstrumentor()],
+});
+await respan.initialize();
+
+const agent = new Agent({
+  name: "Assistant",
+  instructions: "You only respond in haikus.",
+});
+
+const result = await run(agent, "Tell me about recursion in programming.");
+console.log(result.finalOutput);
+
+await respan.flush();

--- a/javascript-sdks/examples/openai-agents-sdk/package.json
+++ b/javascript-sdks/examples/openai-agents-sdk/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "respan-openai-agents-sdk-examples",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "hello": "tsx hello_world.ts"
+  },
+  "dependencies": {
+    "@openai/agents": "^0.8.1",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.30.1",
+    "@respan/instrumentation-openai-agents": "file:../../respan-instrumentation-openai-agents",
+    "@respan/respan": "file:../../respan",
+    "@respan/respan-sdk": "file:../../respan-sdk",
+    "@respan/tracing": "file:../../respan-tracing",
+    "dotenv": "^16.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/javascript-sdks/examples/openai-agents-sdk/tsconfig.json
+++ b/javascript-sdks/examples/openai-agents-sdk/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/javascript-sdks/examples/openai-sdk/hello_world.ts
+++ b/javascript-sdks/examples/openai-sdk/hello_world.ts
@@ -13,8 +13,8 @@ const respan = new Respan({
 await respan.initialize();
 
 const client = new OpenAI({
-  apiKey: process.env.RESPAN_API_KEY,
-  baseURL: process.env.RESPAN_BASE_URL,
+  apiKey: process.env.OPENAI_API_KEY,
+  baseURL: process.env.OPENAI_BASE_URL,
 });
 
 const response = await client.chat.completions.create({

--- a/javascript-sdks/respan-instrumentation-openai-agents/package.json
+++ b/javascript-sdks/respan-instrumentation-openai-agents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/instrumentation-openai-agents",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Respan instrumentation plugin for OpenAI Agents SDK (OTEL pipeline)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
     "@traceloop/ai-semantic-conventions": "^0.13.0"
   },
   "peerDependencies": {
-    "@openai/agents": ">=0.0.8"
+    "@openai/agents": ">=0.8.0"
   },
   "peerDependenciesMeta": {
     "@openai/agents": {
@@ -37,7 +37,7 @@
     }
   },
   "devDependencies": {
-    "@openai/agents": "^0.0.8",
+    "@openai/agents": "^0.8.1",
     "@types/node": "^22.15.29",
     "typescript": "^5.7.3"
   }

--- a/javascript-sdks/respan-instrumentation-openai-agents/src/_otel_emitter.ts
+++ b/javascript-sdks/respan-instrumentation-openai-agents/src/_otel_emitter.ts
@@ -143,8 +143,12 @@ function buildReadableSpan(opts: BuildSpanOptions): ReadableSpan {
 
 function injectSpan(span: ReadableSpan): void {
   const tp = trace.getTracerProvider() as any;
+  // Walk the provider chain to find activeSpanProcessor:
+  // ProxyTracerProvider._delegate (NodeTracerProvider) has activeSpanProcessor
   const processor =
-    tp?.activeSpanProcessor ?? tp?._delegate?.activeSpanProcessor;
+    tp?.activeSpanProcessor ??
+    tp?._delegate?.activeSpanProcessor ??
+    tp?._delegate?._tracerProvider?.activeSpanProcessor;
   if (processor && typeof processor.onEnd === "function") {
     processor.onEnd(span);
   }
@@ -235,9 +239,9 @@ function emitAgent(item: Span<any>): void {
 
   const attrs = baseAttrs(RespanLogType.AGENT, name, name, RespanLogType.AGENT);
   attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = name;
-  attrs["respan.metadata.agent_name"] = name;
-  if (data.tools) attrs["respan.span.tools"] = safeJson(data.tools);
-  if (data.handoffs) attrs["respan.span.handoffs"] = safeJson(data.handoffs);
+  attrs[RespanSpanAttributes.RESPAN_METADATA_AGENT_NAME] = name;
+  if (data.tools) attrs[RespanSpanAttributes.RESPAN_SPAN_TOOLS] = safeJson(data.tools);
+  if (data.handoffs) attrs[RespanSpanAttributes.RESPAN_SPAN_HANDOFFS] = safeJson(data.handoffs);
 
   const span = buildReadableSpan({
     name: `${name}.agent`,
@@ -383,8 +387,8 @@ function emitHandoff(item: Span<any>): void {
   const attrs = baseAttrs(RespanLogType.TASK, "handoff", "handoff", RespanLogType.HANDOFF);
   attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(fromAgent);
   attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson(toAgent);
-  attrs["respan.metadata.from_agent"] = fromAgent;
-  attrs["respan.metadata.to_agent"] = toAgent;
+  attrs[RespanSpanAttributes.RESPAN_METADATA_FROM_AGENT] = fromAgent;
+  attrs[RespanSpanAttributes.RESPAN_METADATA_TO_AGENT] = toAgent;
 
   const span = buildReadableSpan({
     name: "handoff.task",
@@ -408,8 +412,8 @@ function emitGuardrail(item: Span<any>): void {
   const endHr = parseISOToHrTime(json.ended_at);
 
   const attrs = baseAttrs(RespanLogType.TASK, name, name, RespanLogType.GUARDRAIL);
-  attrs["respan.metadata.guardrail_name"] = data.name;
-  attrs["respan.metadata.triggered"] = String(data.triggered);
+  attrs[RespanSpanAttributes.RESPAN_METADATA_GUARDRAIL_NAME] = data.name;
+  attrs[RespanSpanAttributes.RESPAN_METADATA_TRIGGERED] = String(data.triggered);
 
   const span = buildReadableSpan({
     name: `${name}.task`,

--- a/javascript-sdks/respan-instrumentation-openinference/package.json
+++ b/javascript-sdks/respan-instrumentation-openinference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/instrumentation-openinference",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Respan instrumentation plugin for OpenInference (Arize Phoenix) instrumentors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,9 @@
   },
   "packageManager": "yarn@4.6.0",
   "dependencies": {
-    "@opentelemetry/api": "^1.9.0"
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.29.0",
+    "@respan/respan-sdk": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.29",

--- a/javascript-sdks/respan-instrumentation-openinference/src/_translator.ts
+++ b/javascript-sdks/respan-instrumentation-openinference/src/_translator.ts
@@ -1,0 +1,344 @@
+/**
+ * Translate OpenInference spans → OpenLLMetry/Traceloop format.
+ *
+ * This SpanProcessor converts spans produced by OpenInference instrumentors
+ * (Haystack, CrewAI, LangChain, Google ADK, etc.) into the Traceloop/OpenLLMetry
+ * semantic conventions that the Respan backend expects.
+ *
+ * The mapping is the exact reverse of Arize's `openinference-instrumentation-openllmetry`
+ * package which converts OpenLLMetry → OpenInference.
+ *
+ * Arize direction (OpenLLMetry → OI)          | Our reverse (OI → OpenLLMetry)
+ * ---------------------------------------------|------------------------------------------
+ * traceloop.span.kind → openinference.span.kind | openinference.span.kind → traceloop.span.kind
+ * traceloop.entity.input → input.value          | input.value → traceloop.entity.input
+ * traceloop.entity.output → output.value        | output.value → traceloop.entity.output
+ * gen_ai.prompt.N.* → llm.input_messages.N.*    | llm.input_messages.N.* → gen_ai.prompt.N.*
+ * gen_ai.completion.N.* → llm.output_messages.N.*| llm.output_messages.N.* → gen_ai.completion.N.*
+ * gen_ai.usage.input_tokens → llm.token_count.prompt     | llm.token_count.prompt → gen_ai.usage.input_tokens
+ * gen_ai.usage.output_tokens → llm.token_count.completion | llm.token_count.completion → gen_ai.usage.output_tokens
+ * llm.usage.total_tokens → llm.token_count.total         | llm.token_count.total → llm.usage.total_tokens
+ * llm.usage.cache_read_input_tokens → llm.token_count.prompt_details.cache_read | (reverse)
+ * gen_ai.request.model → llm.invocation_parameters.model | llm.invocation_parameters → gen_ai.request.*
+ * gen_ai.request.temperature → llm.invocation_parameters.temperature | (reverse)
+ * llm.request.functions → llm.tools             | llm.tools → llm.request.functions
+ * gen_ai.system → llm.system                    | llm.system → gen_ai.system
+ * gen_ai.provider.name → llm.provider           | llm.provider → gen_ai.provider.name
+ */
+
+import type { Context } from "@opentelemetry/api";
+import type { SpanProcessor, ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
+import { RespanSpanAttributes, RespanLogType } from "@respan/respan-sdk";
+
+// ---------------------------------------------------------------------------
+// Attribute keys imported from SDK (single source of truth)
+// ---------------------------------------------------------------------------
+const OI_SPAN_KIND = RespanSpanAttributes.OPENINFERENCE_SPAN_KIND;
+const OI_LLM_MODEL_NAME = RespanSpanAttributes.OPENINFERENCE_LLM_MODEL_NAME;
+const OI_LLM_TOKEN_COUNT_PROMPT = RespanSpanAttributes.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT;
+const OI_LLM_TOKEN_COUNT_COMPLETION = RespanSpanAttributes.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION;
+const RESPAN_LOG_TYPE = RespanSpanAttributes.RESPAN_LOG_TYPE;
+const GEN_AI_SYSTEM = RespanSpanAttributes.GEN_AI_SYSTEM;
+const GEN_AI_REQUEST_MODEL = RespanSpanAttributes.GEN_AI_REQUEST_MODEL;
+const GEN_AI_USAGE_PROMPT_TOKENS = RespanSpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS;
+const GEN_AI_USAGE_COMPLETION_TOKENS = RespanSpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS;
+const LLM_REQUEST_TYPE = RespanSpanAttributes.LLM_REQUEST_TYPE;
+
+// ---------------------------------------------------------------------------
+// OpenInference attribute keys (not in SDK — OI-specific, used only here)
+// ---------------------------------------------------------------------------
+const OI_INPUT_VALUE = "input.value";
+const OI_OUTPUT_VALUE = "output.value";
+const OI_LLM_PROVIDER = "llm.provider";
+const OI_LLM_SYSTEM = "llm.system";
+const OI_LLM_INVOCATION_PARAMETERS = "llm.invocation_parameters";
+const OI_LLM_TOKEN_COUNT_TOTAL = "llm.token_count.total";
+const OI_LLM_TOKEN_COUNT_CACHE_READ = "llm.token_count.prompt_details.cache_read";
+const OI_LLM_TOOLS = "llm.tools";
+const OI_AGENT_NAME = "agent.name";
+
+// ---------------------------------------------------------------------------
+// OpenLLMetry wire-format attribute keys (not in SDK — mapping targets only)
+// ---------------------------------------------------------------------------
+const TL_SPAN_KIND = "traceloop.span.kind";
+const TL_ENTITY_NAME = "traceloop.entity.name";
+const TL_ENTITY_INPUT = "traceloop.entity.input";
+const TL_ENTITY_OUTPUT = "traceloop.entity.output";
+const TL_ENTITY_PATH = "traceloop.entity.path";
+const TL_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens";
+const TL_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens";
+const TL_USAGE_TOTAL_TOKENS = "llm.usage.total_tokens";
+const TL_USAGE_CACHE_READ = "llm.usage.cache_read_input_tokens";
+const TL_REQUEST_TEMPERATURE = "gen_ai.request.temperature";
+const TL_REQUEST_TOP_P = "gen_ai.request.top_p";
+const TL_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens";
+const TL_TOP_K = "llm.top_k";
+const TL_STOP_SEQUENCES = "llm.chat.stop_sequences";
+const TL_REPETITION_PENALTY = "llm.request.repetition_penalty";
+const TL_FREQUENCY_PENALTY = "llm.frequency_penalty";
+const TL_PRESENCE_PENALTY = "llm.presence_penalty";
+const TL_PROVIDER_NAME = "gen_ai.provider.name";
+const TL_REQUEST_FUNCTIONS = "llm.request.functions";
+
+// ---------------------------------------------------------------------------
+// Span kind mapping: OpenInference → Traceloop (reverse of Arize)
+// ---------------------------------------------------------------------------
+const OI_KIND_TO_TRACELOOP: Record<string, string> = {
+  LLM: RespanLogType.TASK,
+  CHAIN: RespanLogType.WORKFLOW,
+  TOOL: RespanLogType.TOOL,
+  AGENT: RespanLogType.AGENT,
+  EMBEDDING: RespanLogType.TASK,
+  RETRIEVER: RespanLogType.TASK,
+  RERANKER: RespanLogType.TASK,
+  GUARDRAIL: RespanLogType.TASK,
+  EVALUATOR: RespanLogType.TASK,
+  PROMPT: RespanLogType.TASK,
+  UNKNOWN: RespanLogType.TASK,
+};
+
+const OI_KIND_TO_LOG_TYPE: Record<string, string> = {
+  LLM: RespanLogType.CHAT,
+  CHAIN: RespanLogType.WORKFLOW,
+  TOOL: RespanLogType.TOOL,
+  AGENT: RespanLogType.AGENT,
+  EMBEDDING: RespanLogType.EMBEDDING,
+  RETRIEVER: RespanLogType.TASK,
+  RERANKER: RespanLogType.TASK,
+  GUARDRAIL: RespanLogType.GUARDRAIL,
+  EVALUATOR: RespanLogType.TASK,
+  PROMPT: RespanLogType.TASK,
+  UNKNOWN: RespanLogType.TASK,
+};
+
+const OI_LLM_REQUEST_KINDS: Record<string, string> = {
+  LLM: RespanLogType.CHAT,
+  EMBEDDING: RespanLogType.EMBEDDING,
+};
+
+const LLM_KINDS = new Set(["LLM", "EMBEDDING"]);
+
+// Invocation parameter key → OpenLLMetry target attribute
+const INVOCATION_PARAM_MAP: Record<string, string> = {
+  model: GEN_AI_REQUEST_MODEL,
+  temperature: TL_REQUEST_TEMPERATURE,
+  top_p: TL_REQUEST_TOP_P,
+  max_tokens: TL_REQUEST_MAX_TOKENS,
+  max_output_tokens: TL_REQUEST_MAX_TOKENS,
+  top_k: TL_TOP_K,
+  stop_sequences: TL_STOP_SEQUENCES,
+  stop: TL_STOP_SEQUENCES,
+  repetition_penalty: TL_REPETITION_PENALTY,
+  frequency_penalty: TL_FREQUENCY_PENALTY,
+  presence_penalty: TL_PRESENCE_PENALTY,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function safeJsonStr(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Convert OI indexed messages to OpenLLMetry gen_ai.prompt.N / gen_ai.completion.N.
+ *
+ * OI format:
+ *   llm.input_messages.0.message.role = "user"
+ *   llm.input_messages.0.message.content = "hello"
+ *   llm.input_messages.0.message.tool_calls.0.tool_call.function.name = "get_weather"
+ *
+ * OpenLLMetry format:
+ *   gen_ai.prompt.0.role = "user"
+ *   gen_ai.prompt.0.content = "hello"
+ *   gen_ai.prompt.0.tool_calls.0.function.name = "get_weather"
+ */
+function oiMessagesToOpenLLMetry(
+  attrs: Record<string, any>,
+  oiPrefix: string,
+  genAiPrefix: string,
+): void {
+  const buckets = new Map<number, Map<string, any>>();
+
+  for (const [key, val] of Object.entries(attrs)) {
+    if (!key.startsWith(oiPrefix)) continue;
+    const rest = key.slice(oiPrefix.length);
+    const dotIdx = rest.indexOf(".");
+    const idxStr = dotIdx === -1 ? rest : rest.slice(0, dotIdx);
+    if (!/^\d+$/.test(idxStr)) continue;
+    const idx = parseInt(idxStr, 10);
+    const field = dotIdx === -1 ? "" : rest.slice(dotIdx + 1);
+    if (!buckets.has(idx)) buckets.set(idx, new Map());
+    buckets.get(idx)!.set(field, val);
+  }
+
+  const sortedIndices = [...buckets.keys()].sort((a, b) => a - b);
+
+  for (const idx of sortedIndices) {
+    const raw = buckets.get(idx)!;
+    const target = `${genAiPrefix}.${idx}`;
+
+    const role = raw.get("message.role");
+    if (role) attrs[`${target}.role`] = role;
+
+    const content = raw.get("message.content");
+    if (content !== undefined) attrs[`${target}.content`] = content;
+
+    // Tool calls
+    for (const [fieldKey, fieldVal] of raw) {
+      if (fieldKey.startsWith("message.tool_calls.")) {
+        const tcRest = fieldKey.slice("message.tool_calls.".length);
+        const tcDotIdx = tcRest.indexOf(".");
+        if (tcDotIdx === -1) continue;
+        const tcIdx = tcRest.slice(0, tcDotIdx);
+        if (!/^\d+$/.test(tcIdx)) continue;
+        let tcField = tcRest.slice(tcDotIdx + 1);
+        if (tcField.startsWith("tool_call.")) tcField = tcField.slice("tool_call.".length);
+        attrs[`${target}.tool_calls.${tcIdx}.${tcField}`] = fieldVal;
+      }
+    }
+
+    // Function call fields
+    const funcName = raw.get("message.function_call_name");
+    if (funcName) attrs[`${target}.function_call.name`] = funcName;
+    const funcArgs = raw.get("message.function_call_arguments_json");
+    if (funcArgs) attrs[`${target}.function_call.arguments`] = funcArgs;
+
+    // Finish reason
+    const finishReason = raw.get("message.finish_reason");
+    if (finishReason) attrs[`${target}.finish_reason`] = finishReason;
+  }
+}
+
+function setDefault(attrs: Record<string, any>, key: string, value: any): void {
+  if (attrs[key] === undefined) attrs[key] = value;
+}
+
+// ---------------------------------------------------------------------------
+// Main processor
+// ---------------------------------------------------------------------------
+
+/**
+ * SpanProcessor that translates OpenInference attributes to OpenLLMetry/Traceloop.
+ *
+ * Detects OI spans by `openinference.span.kind` and enriches them with the
+ * Traceloop attributes the Respan backend expects. All mappings are the exact
+ * reverse of Arize's openinference-instrumentation-openllmetry.
+ *
+ * OI attributes are preserved (additive enrichment via setDefault, not destructive).
+ */
+export class OpenInferenceTranslator implements SpanProcessor {
+  onStart(_span: Span, _parentContext: Context): void {
+    // no-op
+  }
+
+  onEnd(span: ReadableSpan): void {
+    const attrs = (span as any).attributes as Record<string, any> | undefined;
+    if (!attrs) return;
+
+    const oiKind = attrs[OI_SPAN_KIND];
+    if (oiKind === undefined) return;
+
+    const oiKindUpper = String(oiKind).toUpperCase();
+
+    // --- Span kind ---
+    setDefault(attrs, TL_SPAN_KIND, OI_KIND_TO_TRACELOOP[oiKindUpper] ?? "task");
+    setDefault(attrs, RESPAN_LOG_TYPE, OI_KIND_TO_LOG_TYPE[oiKindUpper] ?? "task");
+
+    if (OI_LLM_REQUEST_KINDS[oiKindUpper]) {
+      setDefault(attrs, LLM_REQUEST_TYPE, OI_LLM_REQUEST_KINDS[oiKindUpper]);
+    }
+
+    // --- Entity name ---
+    const entityName = attrs[OI_AGENT_NAME] ?? span.name;
+    setDefault(attrs, TL_ENTITY_NAME, entityName);
+
+    // --- Entity path ---
+    setDefault(attrs, TL_ENTITY_PATH, OI_KIND_TO_TRACELOOP[oiKindUpper] !== "workflow" ? span.name : "");
+
+    // --- Input / output ---
+    if (attrs[OI_INPUT_VALUE] !== undefined) {
+      setDefault(attrs, TL_ENTITY_INPUT, safeJsonStr(attrs[OI_INPUT_VALUE]));
+    }
+    if (attrs[OI_OUTPUT_VALUE] !== undefined) {
+      setDefault(attrs, TL_ENTITY_OUTPUT, safeJsonStr(attrs[OI_OUTPUT_VALUE]));
+    }
+
+    // --- Model name ---
+    if (attrs[OI_LLM_MODEL_NAME] !== undefined) {
+      setDefault(attrs, GEN_AI_REQUEST_MODEL, attrs[OI_LLM_MODEL_NAME]);
+    }
+
+    // --- System / provider ---
+    if (attrs[OI_LLM_SYSTEM] !== undefined) {
+      setDefault(attrs, GEN_AI_SYSTEM, String(attrs[OI_LLM_SYSTEM]).toLowerCase());
+    }
+    if (attrs[OI_LLM_PROVIDER] !== undefined) {
+      setDefault(attrs, TL_PROVIDER_NAME, String(attrs[OI_LLM_PROVIDER]).toLowerCase());
+      setDefault(attrs, GEN_AI_SYSTEM, String(attrs[OI_LLM_PROVIDER]).toLowerCase());
+    }
+
+    // --- Token counts ---
+    if (attrs[OI_LLM_TOKEN_COUNT_PROMPT] !== undefined) {
+      setDefault(attrs, GEN_AI_USAGE_PROMPT_TOKENS, attrs[OI_LLM_TOKEN_COUNT_PROMPT]);
+      setDefault(attrs, TL_USAGE_INPUT_TOKENS, attrs[OI_LLM_TOKEN_COUNT_PROMPT]);
+    }
+    if (attrs[OI_LLM_TOKEN_COUNT_COMPLETION] !== undefined) {
+      setDefault(attrs, GEN_AI_USAGE_COMPLETION_TOKENS, attrs[OI_LLM_TOKEN_COUNT_COMPLETION]);
+      setDefault(attrs, TL_USAGE_OUTPUT_TOKENS, attrs[OI_LLM_TOKEN_COUNT_COMPLETION]);
+    }
+    if (attrs[OI_LLM_TOKEN_COUNT_TOTAL] !== undefined) {
+      setDefault(attrs, TL_USAGE_TOTAL_TOKENS, attrs[OI_LLM_TOKEN_COUNT_TOTAL]);
+    }
+    if (attrs[OI_LLM_TOKEN_COUNT_CACHE_READ] !== undefined) {
+      setDefault(attrs, TL_USAGE_CACHE_READ, attrs[OI_LLM_TOKEN_COUNT_CACHE_READ]);
+    }
+
+    // --- LLM-specific: messages, invocation params, tools ---
+    if (LLM_KINDS.has(oiKindUpper)) {
+      this._translateLlm(attrs);
+    }
+  }
+
+  private _translateLlm(attrs: Record<string, any>): void {
+    // Messages
+    oiMessagesToOpenLLMetry(attrs, "llm.input_messages.", "gen_ai.prompt");
+    oiMessagesToOpenLLMetry(attrs, "llm.output_messages.", "gen_ai.completion");
+
+    // Invocation parameters
+    const invParamsRaw = attrs[OI_LLM_INVOCATION_PARAMETERS];
+    if (invParamsRaw) {
+      const params = parseJson(invParamsRaw);
+      if (params && typeof params === "object" && !Array.isArray(params)) {
+        for (const [key, val] of Object.entries(params as Record<string, any>)) {
+          const targetAttr = INVOCATION_PARAM_MAP[key];
+          if (targetAttr) setDefault(attrs, targetAttr, val);
+        }
+      }
+    }
+
+    // Tools
+    if (attrs[OI_LLM_TOOLS] !== undefined) {
+      setDefault(attrs, TL_REQUEST_FUNCTIONS, attrs[OI_LLM_TOOLS]);
+    }
+  }
+
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}

--- a/javascript-sdks/respan-instrumentation-openinference/src/index.ts
+++ b/javascript-sdks/respan-instrumentation-openinference/src/index.ts
@@ -1,4 +1,7 @@
 import { trace } from "@opentelemetry/api";
+import { OpenInferenceTranslator } from "./_translator.js";
+
+export { OpenInferenceTranslator } from "./_translator.js";
 
 /**
  * Generic Respan instrumentation wrapper for any OpenInference instrumentor.
@@ -9,6 +12,9 @@ import { trace } from "@opentelemetry/api";
  * - SpanProcessor interface (added via `tracerProvider.addSpanProcessor()`)
  *
  * This wrapper detects the interface and handles both patterns.
+ *
+ * Automatically registers an {@link OpenInferenceTranslator} SpanProcessor that
+ * converts OI span attributes to OpenLLMetry/Traceloop format before export.
  *
  * ```typescript
  * import { Respan } from "@respan/respan";
@@ -28,8 +34,20 @@ export class OpenInferenceInstrumentor {
   private _isInstrumented = false;
   private _isSpanProcessor = false;
 
-  constructor(instrumentorClass: any) {
+  /** Class-level flag: only register the translator once across all instances */
+  private static _translatorRegistered = false;
+
+  private _sdkModule: any;
+
+  /**
+   * @param instrumentorClass - The OI instrumentor class (e.g. GoogleADKInstrumentor)
+   * @param sdkModule - Optional SDK module for ESM manual instrumentation.
+   *   Required for instrumentors that use `manuallyInstrument(module)` instead of
+   *   auto-patching (e.g. Claude Agent SDK in ESM environments).
+   */
+  constructor(instrumentorClass: any, sdkModule?: any) {
     this._instrumentorClass = instrumentorClass;
+    this._sdkModule = sdkModule;
     this.name = `openinference-${instrumentorClass.name || "unknown"}`;
   }
 
@@ -37,9 +55,27 @@ export class OpenInferenceInstrumentor {
     this._instrumentor = new this._instrumentorClass();
     const tp = trace.getTracerProvider();
 
-    if (typeof this._instrumentor.instrument === "function") {
+    // Register the OI → OpenLLMetry translator once
+    if (!OpenInferenceInstrumentor._translatorRegistered && tp && typeof (tp as any).addSpanProcessor === "function") {
+      (tp as any).addSpanProcessor(new OpenInferenceTranslator());
+      OpenInferenceInstrumentor._translatorRegistered = true;
+    }
+
+    // Set tracer provider if the instrumentor supports it
+    if (typeof this._instrumentor.setTracerProvider === "function") {
+      this._instrumentor.setTracerProvider(tp);
+    }
+
+    // ESM manual instrumentation (e.g. Claude Agent SDK)
+    if (this._sdkModule && typeof this._instrumentor.manuallyInstrument === "function") {
+      this._instrumentor.manuallyInstrument(this._sdkModule);
+    }
+    // Standard OTEL auto-patching
+    else if (typeof this._instrumentor.instrument === "function") {
       this._instrumentor.instrument({ tracerProvider: tp });
-    } else if (tp && typeof (tp as any).addSpanProcessor === "function") {
+    }
+    // SpanProcessor-based (e.g. pydantic-ai, strands-agents)
+    else if (tp && typeof (tp as any).addSpanProcessor === "function") {
       (tp as any).addSpanProcessor(this._instrumentor);
       this._isSpanProcessor = true;
     }

--- a/javascript-sdks/respan-sdk/package.json
+++ b/javascript-sdks/respan-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/respan-sdk",
   "type": "module",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Respan typing SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/javascript-sdks/respan-sdk/src/types/spanTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/spanTypes.ts
@@ -38,13 +38,26 @@ export enum RespanSpanAttributes {
     RESPAN_LOG_ROOT_ID = "respan.entity.log_root_id",
     RESPAN_LOG_SOURCE = "respan.entity.log_source",
 
-    // OpenInference attributes (used for OI → Traceloop/GenAI enrichment)
+    // Respan metadata attributes (agent-specific)
+    RESPAN_METADATA_AGENT_NAME = "respan.metadata.agent_name",
+    RESPAN_METADATA_FROM_AGENT = "respan.metadata.from_agent",
+    RESPAN_METADATA_TO_AGENT = "respan.metadata.to_agent",
+    RESPAN_METADATA_GUARDRAIL_NAME = "respan.metadata.guardrail_name",
+    RESPAN_METADATA_TRIGGERED = "respan.metadata.triggered",
+    RESPAN_SPAN_TOOLS = "respan.span.tools",
+    RESPAN_SPAN_HANDOFFS = "respan.span.handoffs",
+
+    // OpenInference attributes (used by composite processor for span detection)
     OPENINFERENCE_SPAN_KIND = "openinference.span.kind",
     OPENINFERENCE_LLM_MODEL_NAME = "llm.model_name",
     OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT = "llm.token_count.prompt",
     OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION = "llm.token_count.completion",
 
-    // GenAI / LLM semantic conventions (for packages that don't depend on @traceloop/ai-semantic-conventions)
+    // GenAI / LLM semantic conventions
+    // Used by composite processor and instrumentation emitters.
+    // Traceloop attrs (TRACELOOP_*) come from @traceloop/ai-semantic-conventions.
+    // OI attrs come from @arizeai/openinference-* packages.
+    // Only Respan-specific or attrs removed from upstream are defined here.
     GEN_AI_SYSTEM = "gen_ai.system",
     GEN_AI_REQUEST_MODEL = "gen_ai.request.model",
     GEN_AI_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens",

--- a/javascript-sdks/respan-tracing/package.json
+++ b/javascript-sdks/respan-tracing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/tracing",
   "type": "module",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "TypeScript support for Respan SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
     "@respan/respan-sdk": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.26.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.56.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.56.0",
     "@opentelemetry/resources": "^1.26.0",
     "@opentelemetry/sdk-node": "^0.56.0",
     "@opentelemetry/sdk-trace-base": "^1.26.0",

--- a/javascript-sdks/respan-tracing/src/main.ts
+++ b/javascript-sdks/respan-tracing/src/main.ts
@@ -2,7 +2,7 @@ import { withTask, withWorkflow, withAgent, withTool } from "./decorators/index.
 import { WithFunctionType } from "./types/decoratorTypes.js";
 import { RespanOptions, ProcessorConfig } from "./types/clientTypes.js";
 import { withRespanSpanAttributes } from "./contexts/span.js";
-import { startTracing, forceFlush, addProcessorToSDK } from "./utils/tracing.js";
+import { startTracing, forceFlush, addProcessorToSDK, injectSpan } from "./utils/tracing.js";
 import { enableInstrumentation } from "./instrumentation/index.js";
 import { getClient as getClientAPI } from "./utils/client.js";
 import { getSpanBufferManager } from "./utils/spanBuffer.js";

--- a/javascript-sdks/respan-tracing/src/processor/composite.ts
+++ b/javascript-sdks/respan-tracing/src/processor/composite.ts
@@ -7,7 +7,6 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import {
   RESPAN_SPAN_ATTRIBUTES_MAP,
   RespanSpanAttributes,
-  RespanLogType,
 } from "@respan/respan-sdk";
 import { MultiProcessorManager } from "./manager.js";
 import { getEntityPath, getPropagatedAttributes } from "../utils/context.js";
@@ -21,80 +20,6 @@ const LLM_SPAN_NAME_PATTERNS = [
   "openai.chat",
   "chat.completions",
 ] as const;
-
-// ── OpenInference span enrichment ──────────────────────────────────────────
-
-/** Map OI span kinds → Traceloop span kinds */
-const OI_KIND_TO_TRACELOOP: Record<string, string> = {
-  LLM: RespanLogType.TASK,
-  CHAIN: RespanLogType.WORKFLOW,
-  TOOL: RespanLogType.TOOL,
-  AGENT: RespanLogType.AGENT,
-  EMBEDDING: RespanLogType.TASK,
-  RETRIEVER: RespanLogType.TASK,
-  RERANKER: RespanLogType.TASK,
-  GUARDRAIL: RespanLogType.TASK,
-  EVALUATOR: RespanLogType.TASK,
-};
-
-/** OI span kinds that imply an LLM request type */
-const OI_LLM_REQUEST_KINDS: Record<string, string> = {
-  LLM: RespanLogType.CHAT,
-  EMBEDDING: RespanLogType.EMBEDDING,
-};
-
-/** Map OI span kinds → respan.entity.log_type values */
-const OI_LOG_TYPE: Record<string, string> = {
-  LLM: RespanLogType.CHAT,
-  CHAIN: RespanLogType.WORKFLOW,
-  TOOL: RespanLogType.TOOL,
-  AGENT: RespanLogType.AGENT,
-  EMBEDDING: RespanLogType.EMBEDDING,
-  RETRIEVER: RespanLogType.TASK,
-  RERANKER: RespanLogType.TASK,
-  GUARDRAIL: RespanLogType.GUARDRAIL,
-  EVALUATOR: RespanLogType.TASK,
-};
-
-/**
- * Build Traceloop/GenAI enrichment attributes for an OpenInference span.
- * Returns only the attributes that need to be *added*; callers merge them
- * on top of the original span attributes.
- */
-function getOIEnrichmentAttrs(span: ReadableSpan): Record<string, any> {
-  const attrs: Record<string, any> = {};
-  const oiKind = String(span.attributes[RespanSpanAttributes.OPENINFERENCE_SPAN_KIND] ?? "");
-
-  if (OI_KIND_TO_TRACELOOP[oiKind]) {
-    attrs[SpanAttributes.TRACELOOP_SPAN_KIND] = OI_KIND_TO_TRACELOOP[oiKind];
-  }
-  if (OI_LLM_REQUEST_KINDS[oiKind]) {
-    attrs[RespanSpanAttributes.LLM_REQUEST_TYPE] = OI_LLM_REQUEST_KINDS[oiKind];
-  }
-  if (OI_LOG_TYPE[oiKind]) {
-    attrs[RespanSpanAttributes.RESPAN_LOG_TYPE] = OI_LOG_TYPE[oiKind];
-  }
-
-  // Bridge OI semantic attrs → Traceloop/GenAI equivalents
-  if (span.attributes["input.value"] !== undefined)
-    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = span.attributes["input.value"];
-  if (span.attributes["output.value"] !== undefined)
-    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = span.attributes["output.value"];
-  if (span.attributes[RespanSpanAttributes.OPENINFERENCE_LLM_MODEL_NAME] !== undefined)
-    attrs[RespanSpanAttributes.GEN_AI_REQUEST_MODEL] = span.attributes[RespanSpanAttributes.OPENINFERENCE_LLM_MODEL_NAME];
-  if (span.attributes[RespanSpanAttributes.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT] !== undefined)
-    attrs[RespanSpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS] = span.attributes[RespanSpanAttributes.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT];
-  if (span.attributes[RespanSpanAttributes.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION] !== undefined)
-    attrs[RespanSpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS] = span.attributes[RespanSpanAttributes.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION];
-
-  // Entity name / path
-  attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] = span.name;
-  if (OI_KIND_TO_TRACELOOP[oiKind] !== "workflow") {
-    attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] = span.name;
-  }
-
-  return attrs;
-}
 
 // ── Composite processor ────────────────────────────────────────────────────
 
@@ -222,22 +147,11 @@ export class RespanCompositeProcessor implements SpanProcessor {
       // Route to processors
       this._processorManager.onEnd(span);
     } else if (span.attributes[RespanSpanAttributes.OPENINFERENCE_SPAN_KIND] !== undefined) {
-      // OpenInference span — enrich with Traceloop/GenAI attrs, then route
+      // OpenInference span — already enriched by OpenInferenceTranslator processor
       console.debug(
         `[Respan Debug] Processing OpenInference span: ${span.name} (kind: ${span.attributes[RespanSpanAttributes.OPENINFERENCE_SPAN_KIND]})`
       );
-
-      const enrichmentAttrs = getOIEnrichmentAttrs(span);
-      const enrichedSpan = Object.create(Object.getPrototypeOf(span));
-      Object.assign(enrichedSpan, span);
-      Object.defineProperty(enrichedSpan, "attributes", {
-        value: { ...span.attributes, ...enrichmentAttrs },
-        writable: false,
-        configurable: true,
-        enumerable: true,
-      });
-
-      this._processorManager.onEnd(enrichedSpan);
+      this._processorManager.onEnd(span);
     } else if (span.attributes[RespanSpanAttributes.RESPAN_LOG_TYPE] !== undefined) {
       // Enriched Respan span (from an instrumentation plugin)
       console.debug(

--- a/javascript-sdks/respan-tracing/src/utils/tracing.ts
+++ b/javascript-sdks/respan-tracing/src/utils/tracing.ts
@@ -1,6 +1,7 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { diag, DiagLogLevel } from "@opentelemetry/api";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { Resource } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { RespanOptions, ProcessorConfig } from "../types/clientTypes.js";
@@ -197,10 +198,10 @@ export const startTracing = async (options: RespanOptions) => {
   );
 
   // Prepare exporter URL and configuration
-  const exporterUrl = `${_resolveBaseURL(baseURL)}/api/v1/traces`;
+  // Use /v2/traces with OTLP JSON — same format as the Python RespanSpanExporter.
+  const exporterUrl = `${_resolveBaseURL(baseURL)}/api/v2/traces`;
   const exporterHeaders = {
     Authorization: `Bearer ${apiKey}`,
-    "Content-Type": "application/x-protobuf",
     ...headers,
   };
 
@@ -326,6 +327,26 @@ export const getClient = (): NodeSDK | undefined => {
  * 
  * @param config - Processor configuration
  */
+/**
+ * Inject a ReadableSpan into the OTEL pipeline.
+ *
+ * This is how plugin-constructed spans enter the pipeline without
+ * needing a live tracer context. The span passes through the
+ * RespanCompositeProcessor (filtering + routing) → exporter → /v2/traces.
+ *
+ * Equivalent to Python's ``inject_span()`` in ``span_factory.py``.
+ *
+ * @returns true if injected, false if SDK not initialized
+ */
+export const injectSpan = (span: ReadableSpan): boolean => {
+  if (!_compositeProcessor) {
+    console.warn("[Respan] Cannot inject span — SDK not initialized");
+    return false;
+  }
+  _compositeProcessor.onEnd(span);
+  return true;
+};
+
 export const addProcessorToSDK = (config: ProcessorConfig): void => {
   if (!_compositeProcessor) {
     console.error("[Respan] Cannot add processor - SDK not initialized");

--- a/python-sdks/examples/crewai/hello_world.py
+++ b/python-sdks/examples/crewai/hello_world.py
@@ -1,0 +1,36 @@
+"""CrewAI Hello World — Simple agent with Respan tracing via OpenInference."""
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+# Initialize Respan FIRST (sets up TracerProvider)
+from respan import Respan
+from respan_instrumentation_openinference import OpenInferenceInstrumentor
+from openinference.instrumentation.crewai import CrewAIInstrumentor
+
+respan = Respan(
+    instrumentations=[OpenInferenceInstrumentor(CrewAIInstrumentor)],
+)
+
+# Import CrewAI AFTER Respan init so it uses our TracerProvider
+from crewai import Agent, Task, Crew
+
+agent = Agent(
+    role="Poet",
+    goal="Write a short haiku about recursion in programming",
+    backstory="You are a programmer who writes haikus.",
+    verbose=False,
+)
+
+task = Task(
+    description="Write a haiku about recursion in programming.",
+    expected_output="A single haiku (3 lines: 5-7-5 syllables).",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task], verbose=False)
+result = crew.kickoff()
+print(result.raw)
+
+respan.flush()

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-instrumentation-openai-agents"
-version = "1.0.0"
+version = "1.0.2"
 description = "Respan instrumentation plugin for the OpenAI Agents SDK"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
@@ -42,6 +42,11 @@ from respan_sdk.constants.llm_logging import (
     LOG_TYPE_WORKFLOW,
 )
 from respan_sdk.constants.span_attributes import (
+    GEN_AI_SYSTEM,
+    LLM_REQUEST_MODEL,
+    LLM_REQUEST_TYPE,
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
     RESPAN_LOG_TYPE,
     RESPAN_METADATA_AGENT_NAME,
     RESPAN_METADATA_FROM_AGENT,
@@ -171,8 +176,8 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
         entity_path="response",
         log_type=LOG_TYPE_RESPONSE,
     )
-    attrs[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
-    attrs[SpanAttributes.LLM_SYSTEM] = "openai"
+    attrs[LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+    attrs[GEN_AI_SYSTEM] = "openai"
 
     # Input
     input_msgs = _format_input_messages(span_data.input)
@@ -184,7 +189,7 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
     if resp:
         model = getattr(resp, "model", None) or ""
         if model:
-            attrs[SpanAttributes.LLM_REQUEST_MODEL] = model
+            attrs[LLM_REQUEST_MODEL] = model
 
         if hasattr(resp, "output") and resp.output:
             output = _format_output(resp.output)
@@ -192,8 +197,8 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
 
         usage = getattr(resp, "usage", None)
         if usage:
-            attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = getattr(usage, "input_tokens", 0) or 0
-            attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = getattr(usage, "output_tokens", 0) or 0
+            attrs[LLM_USAGE_PROMPT_TOKENS] = getattr(usage, "input_tokens", 0) or 0
+            attrs[LLM_USAGE_COMPLETION_TOKENS] = getattr(usage, "output_tokens", 0) or 0
 
     span = build_readable_span(
         name="openai.chat",
@@ -253,10 +258,10 @@ def emit_generation(item: SpanImpl, span_data: GenerationSpanData) -> None:
         entity_path="generation",
         log_type=LOG_TYPE_GENERATION,
     )
-    attrs[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+    attrs[LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
 
     if span_data.model:
-        attrs[SpanAttributes.LLM_REQUEST_MODEL] = span_data.model
+        attrs[LLM_REQUEST_MODEL] = span_data.model
 
     input_msgs = _format_input_messages(span_data.input)
     if input_msgs:
@@ -267,8 +272,8 @@ def emit_generation(item: SpanImpl, span_data: GenerationSpanData) -> None:
 
     if span_data.usage:
         u = span_data.usage
-        attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = u.get("prompt_tokens") or u.get("input_tokens") or 0
-        attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = u.get("completion_tokens") or u.get("output_tokens") or 0
+        attrs[LLM_USAGE_PROMPT_TOKENS] = u.get("prompt_tokens") or u.get("input_tokens") or 0
+        attrs[LLM_USAGE_COMPLETION_TOKENS] = u.get("completion_tokens") or u.get("output_tokens") or 0
 
     span = build_readable_span(
         name="openai.chat",
@@ -354,11 +359,11 @@ def emit_custom(item: SpanImpl, span_data: CustomSpanData) -> None:
     data = span_data.data or {}
     for k, v in data.items():
         if k in ("model",):
-            attrs[SpanAttributes.LLM_REQUEST_MODEL] = v
+            attrs[LLM_REQUEST_MODEL] = v
         elif k == "prompt_tokens":
-            attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = v
+            attrs[LLM_USAGE_PROMPT_TOKENS] = v
         elif k == "completion_tokens":
-            attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = v
+            attrs[LLM_USAGE_COMPLETION_TOKENS] = v
         elif k == "input":
             attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(v)
         elif k == "output":

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-instrumentation-openinference"
-version = "1.0.0"
+version = "1.1.0"
 description = "Respan instrumentation wrapper for OpenInference"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"
@@ -12,6 +12,8 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
 respan-tracing = "^2.3.0"
+openinference-semantic-conventions = ">=0.1.12"
+opentelemetry-semantic-conventions-ai = ">=0.4.1"
 # Users install individual OpenInference packages as needed, e.g.:
 #   pip install openinference-instrumentation-google-adk
 

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/__init__.py
@@ -3,5 +3,8 @@
 from respan_instrumentation_openinference._instrumentation import (
     OpenInferenceInstrumentor,
 )
+from respan_instrumentation_openinference._translator import (
+    OpenInferenceTranslator,
+)
 
-__all__ = ["OpenInferenceInstrumentor"]
+__all__ = ["OpenInferenceInstrumentor", "OpenInferenceTranslator"]

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_instrumentation.py
@@ -2,6 +2,8 @@ import logging
 
 from opentelemetry import trace
 
+from respan_instrumentation_openinference._translator import OpenInferenceTranslator
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,7 +21,13 @@ class OpenInferenceInstrumentor:
 
     Handles both standard OI instrumentors (``.instrument()``) and
     SpanProcessor-based ones (e.g. pydantic-ai, strands-agents) automatically.
+
+    Automatically registers an ``OpenInferenceTranslator`` SpanProcessor that
+    converts OI span attributes to OpenLLMetry/Traceloop format before export.
     """
+
+    # Class-level flag: only register the translator once across all instances
+    _translator_registered = False
 
     def __init__(self, instrumentor_class: type) -> None:
         self._instrumentor_class = instrumentor_class
@@ -31,6 +39,23 @@ class OpenInferenceInstrumentor:
     def activate(self) -> None:
         self._instrumentor = self._instrumentor_class()
         tp = trace.get_tracer_provider()
+
+        # Register the OI → OpenLLMetry translator once so it runs
+        # BEFORE the export processors on every OI span.  The translator
+        # enriches spans with traceloop.* attributes that is_processable_span()
+        # needs to see.  Insert at position 0 of the processor list so it
+        # runs before BufferingSpanProcessor → FilteringSpanProcessor → exporter.
+        if not OpenInferenceInstrumentor._translator_registered:
+            translator = OpenInferenceTranslator()
+            asp = getattr(tp, "_active_span_processor", None)
+            processors = getattr(asp, "_span_processors", None)
+            if processors is not None:
+                # _span_processors may be a tuple; rebuild with translator first
+                asp._span_processors = (translator, *processors)
+            elif hasattr(tp, "add_span_processor"):
+                tp.add_span_processor(translator)
+            OpenInferenceInstrumentor._translator_registered = True
+            logger.info("Registered OpenInference → OpenLLMetry translator")
 
         # Standard OI instrumentors expose .instrument()
         if hasattr(self._instrumentor, "instrument"):

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_translator.py
@@ -1,0 +1,391 @@
+"""Translate OpenInference spans → OpenLLMetry/Traceloop format.
+
+This SpanProcessor converts spans produced by OpenInference instrumentors
+(Haystack, CrewAI, LangChain, Google ADK, etc.) into the Traceloop/OpenLLMetry
+semantic conventions that the Respan backend expects.
+
+The mapping is the exact reverse of Arize's ``openinference-instrumentation-openllmetry``
+package (``_span_processor.py``) which converts OpenLLMetry → OpenInference.
+
+Arize mapping (OpenLLMetry → OI):
+    traceloop.span.kind          → openinference.span.kind
+    traceloop.entity.input       → input.value + input.mime_type
+    traceloop.entity.output      → output.value + output.mime_type
+    gen_ai.prompt.N.*            → llm.input_messages.N.message.*
+    gen_ai.completion.N.*        → llm.output_messages.N.message.*
+    gen_ai.usage.input_tokens    → llm.token_count.prompt
+    gen_ai.usage.output_tokens   → llm.token_count.completion
+    llm.usage.total_tokens       → llm.token_count.total
+    llm.usage.cache_read_input_tokens → llm.token_count.prompt_details.cache_read
+    gen_ai.request.model         → llm.invocation_parameters.model
+    gen_ai.request.temperature   → llm.invocation_parameters.temperature
+    gen_ai.request.top_p         → llm.invocation_parameters.top_p
+    llm.top_k                    → llm.invocation_parameters.top_k
+    llm.chat.stop_sequences      → llm.invocation_parameters.stop_sequences
+    llm.request.repetition_penalty → llm.invocation_parameters.repetition_penalty
+    llm.frequency_penalty        → llm.invocation_parameters.frequency_penalty
+    llm.presence_penalty         → llm.invocation_parameters.presence_penalty
+    llm.request.functions        → llm.tools
+    gen_ai.system                → llm.system
+    gen_ai.provider.name         → llm.provider
+
+This module reverses every mapping above.
+
+References:
+- Arize source: openinference-instrumentation-openllmetry/_span_processor.py
+- OpenInference semconv: openinference.semconv.trace.SpanAttributes
+- OpenLLMetry semconv: opentelemetry.semconv_ai.SpanAttributes
+"""
+
+import json
+import logging
+from collections import defaultdict
+from typing import Any, Dict
+
+from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
+from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from openinference.semconv.trace import SpanAttributes as OISpanAttributes
+
+from respan_sdk.constants.span_attributes import (
+    GEN_AI_SYSTEM,
+    LLM_REQUEST_MODEL,
+    LLM_REQUEST_TYPE,
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
+    OPENINFERENCE_SPAN_KIND,
+    RESPAN_LOG_TYPE,
+)
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_AGENT,
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_GUARDRAIL,
+    LOG_TYPE_TASK,
+    LOG_TYPE_TOOL,
+    LOG_TYPE_WORKFLOW,
+)
+
+# Traceloop attributes (from upstream opentelemetry-semantic-conventions-ai)
+TRACELOOP_SPAN_KIND = TLSpanAttributes.TRACELOOP_SPAN_KIND
+TRACELOOP_ENTITY_NAME = TLSpanAttributes.TRACELOOP_ENTITY_NAME
+TRACELOOP_ENTITY_INPUT = TLSpanAttributes.TRACELOOP_ENTITY_INPUT
+TRACELOOP_ENTITY_OUTPUT = TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT
+TRACELOOP_ENTITY_PATH = TLSpanAttributes.TRACELOOP_ENTITY_PATH
+
+# OpenInference attributes (from upstream openinference-semantic-conventions)
+OI_INPUT_VALUE = OISpanAttributes.INPUT_VALUE
+OI_OUTPUT_VALUE = OISpanAttributes.OUTPUT_VALUE
+OI_LLM_MODEL_NAME = OISpanAttributes.LLM_MODEL_NAME
+OI_LLM_PROVIDER = OISpanAttributes.LLM_PROVIDER
+OI_LLM_SYSTEM = OISpanAttributes.LLM_SYSTEM
+OI_LLM_INVOCATION_PARAMETERS = OISpanAttributes.LLM_INVOCATION_PARAMETERS
+OI_LLM_TOKEN_COUNT_PROMPT = OISpanAttributes.LLM_TOKEN_COUNT_PROMPT
+OI_LLM_TOKEN_COUNT_COMPLETION = OISpanAttributes.LLM_TOKEN_COUNT_COMPLETION
+OI_LLM_TOKEN_COUNT_TOTAL = OISpanAttributes.LLM_TOKEN_COUNT_TOTAL
+OI_LLM_TOKEN_COUNT_CACHE_READ = OISpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ
+OI_LLM_TOOLS = OISpanAttributes.LLM_TOOLS
+OI_AGENT_NAME = OISpanAttributes.AGENT_NAME
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# OpenLLMetry / Traceloop attribute keys not yet in respan_sdk.constants
+# (wire-format keys used only for the reverse-Arize mapping)
+# ---------------------------------------------------------------------------
+# Token attributes (OpenLLMetry side)
+_TL_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+_TL_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+_TL_USAGE_TOTAL_TOKENS = "llm.usage.total_tokens"
+_TL_USAGE_CACHE_READ = "llm.usage.cache_read_input_tokens"
+
+# Invocation parameter attributes (OpenLLMetry side)
+_TL_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
+_TL_REQUEST_TOP_P = "gen_ai.request.top_p"
+_TL_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"
+_TL_TOP_K = "llm.top_k"
+_TL_STOP_SEQUENCES = "llm.chat.stop_sequences"
+_TL_REPETITION_PENALTY = "llm.request.repetition_penalty"
+_TL_FREQUENCY_PENALTY = "llm.frequency_penalty"
+_TL_PRESENCE_PENALTY = "llm.presence_penalty"
+
+# Provider (OpenLLMetry side)
+_TL_PROVIDER_NAME = "gen_ai.provider.name"
+
+# Tools (OpenLLMetry side)
+_TL_REQUEST_FUNCTIONS = "llm.request.functions"
+
+# ---------------------------------------------------------------------------
+# Span kind mapping: OpenInference → Traceloop
+# Exact reverse of Arize's _SPAN_KIND_MAPPING
+# ---------------------------------------------------------------------------
+_OI_KIND_TO_TRACELOOP: Dict[str, str] = {
+    "CHAIN": "workflow",
+    "LLM": "task",
+    "TOOL": "tool",
+    "AGENT": "agent",
+    "RETRIEVER": "task",
+    "EMBEDDING": "task",
+    "RERANKER": "task",
+    "GUARDRAIL": "task",
+    "EVALUATOR": "task",
+    "PROMPT": "task",
+    "UNKNOWN": "task",
+}
+
+_OI_KIND_TO_LOG_TYPE: Dict[str, str] = {
+    "CHAIN": LOG_TYPE_WORKFLOW,
+    "LLM": LOG_TYPE_CHAT,
+    "TOOL": LOG_TYPE_TOOL,
+    "AGENT": LOG_TYPE_AGENT,
+    "RETRIEVER": LOG_TYPE_TASK,
+    "EMBEDDING": LOG_TYPE_EMBEDDING,
+    "RERANKER": LOG_TYPE_TASK,
+    "GUARDRAIL": LOG_TYPE_GUARDRAIL,
+    "EVALUATOR": LOG_TYPE_TASK,
+    "PROMPT": LOG_TYPE_TASK,
+    "UNKNOWN": LOG_TYPE_TASK,
+}
+
+# OI span kinds that represent LLM calls
+_LLM_KINDS = {"LLM", "EMBEDDING"}
+
+# Invocation parameter key → OpenLLMetry target attribute
+_INVOCATION_PARAM_MAP: Dict[str, str] = {
+    "model": LLM_REQUEST_MODEL,
+    "temperature": _TL_REQUEST_TEMPERATURE,
+    "top_p": _TL_REQUEST_TOP_P,
+    "max_tokens": _TL_REQUEST_MAX_TOKENS,
+    "max_output_tokens": _TL_REQUEST_MAX_TOKENS,
+    "top_k": _TL_TOP_K,
+    "stop_sequences": _TL_STOP_SEQUENCES,
+    "stop": _TL_STOP_SEQUENCES,
+    "repetition_penalty": _TL_REPETITION_PENALTY,
+    "frequency_penalty": _TL_FREQUENCY_PENALTY,
+    "presence_penalty": _TL_PRESENCE_PENALTY,
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _safe_json_str(value: Any) -> str:
+    """Ensure value is a JSON string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, default=str)
+
+
+def _parse_json(value: Any) -> Any:
+    """Parse a JSON string, or return value as-is if not a string."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+
+
+def _oi_messages_to_openllmetry(
+    attrs: Dict[str, Any],
+    oi_prefix: str,
+    gen_ai_prefix: str,
+) -> None:
+    """Convert OI indexed messages to OpenLLMetry gen_ai.prompt.N / gen_ai.completion.N format.
+
+    Reverse of Arize's ``_collect_oi_messages()`` which reads gen_ai.prompt.N.*
+    and builds OI Message objects stored as llm.input_messages.N.message.*.
+
+    OI format (source):
+        llm.input_messages.0.message.role = "user"
+        llm.input_messages.0.message.content = "hello"
+        llm.input_messages.0.message.tool_calls.0.tool_call.function.name = "get_weather"
+        llm.input_messages.0.message.tool_calls.0.tool_call.function.arguments = '{"city":"NYC"}'
+        llm.input_messages.0.message.function_call_name = "get_weather"
+        llm.input_messages.0.message.function_call_arguments_json = '{"city":"NYC"}'
+
+    OpenLLMetry format (target):
+        gen_ai.prompt.0.role = "user"
+        gen_ai.prompt.0.content = "hello"
+        gen_ai.prompt.0.tool_calls.0.function.name = "get_weather"
+        gen_ai.prompt.0.tool_calls.0.function.arguments = '{"city":"NYC"}'
+    """
+    buckets: Dict[int, Dict[str, Any]] = defaultdict(dict)
+
+    for key, val in attrs.items():
+        if not key.startswith(oi_prefix):
+            continue
+        rest = key[len(oi_prefix):]
+        parts = rest.split(".", 1)
+        if not parts[0].isdigit():
+            continue
+        idx = int(parts[0])
+        field = parts[1] if len(parts) > 1 else ""
+        buckets[idx][field] = val
+
+    for idx in sorted(buckets):
+        raw = buckets[idx]
+        target = f"{gen_ai_prefix}.{idx}"
+
+        # message.role → gen_ai.prompt.N.role
+        role = raw.get("message.role")
+        if role:
+            attrs[f"{target}.role"] = role
+
+        # message.content → gen_ai.prompt.N.content
+        content = raw.get("message.content")
+        if content is not None:
+            attrs[f"{target}.content"] = content
+
+        # message.tool_calls.M.tool_call.function.name → gen_ai.prompt.N.tool_calls.M.function.name
+        for field_key, field_val in raw.items():
+            if field_key.startswith("message.tool_calls."):
+                rest = field_key[len("message.tool_calls."):]
+                parts = rest.split(".", 1)
+                if parts[0].isdigit() and len(parts) > 1:
+                    tc_idx = parts[0]
+                    tc_field = parts[1]
+                    # Strip "tool_call." prefix (OI nests under tool_call.*)
+                    if tc_field.startswith("tool_call."):
+                        tc_field = tc_field[len("tool_call."):]
+                    attrs[f"{target}.tool_calls.{tc_idx}.{tc_field}"] = field_val
+
+        # message.function_call_name → gen_ai.prompt.N.function_call.name
+        func_name = raw.get("message.function_call_name")
+        if func_name:
+            attrs[f"{target}.function_call.name"] = func_name
+
+        # message.function_call_arguments_json → gen_ai.prompt.N.function_call.arguments
+        func_args = raw.get("message.function_call_arguments_json")
+        if func_args:
+            attrs[f"{target}.function_call.arguments"] = func_args
+
+        # message.finish_reason → gen_ai.completion.N.finish_reason (completions only)
+        finish_reason = raw.get("message.finish_reason")
+        if finish_reason:
+            attrs[f"{target}.finish_reason"] = finish_reason
+
+
+# ---------------------------------------------------------------------------
+# Main processor
+# ---------------------------------------------------------------------------
+
+class OpenInferenceTranslator(SpanProcessor):
+    """SpanProcessor that translates OpenInference attributes to OpenLLMetry/Traceloop.
+
+    Detects OI spans by the presence of ``openinference.span.kind`` and
+    enriches them with the Traceloop attributes the Respan backend expects.
+
+    All mappings are the exact reverse of Arize's openinference-instrumentation-openllmetry.
+    OI attributes are preserved (additive enrichment via setdefault, not destructive).
+    """
+
+    def on_start(self, span: Any, parent_context: Any = None) -> None:
+        pass
+
+    def on_end(self, span: ReadableSpan) -> None:
+        attrs = getattr(span, "_attributes", None)
+        if attrs is None:
+            return
+
+        oi_kind = attrs.get(OPENINFERENCE_SPAN_KIND)
+        if not oi_kind:
+            return
+
+        oi_kind_upper = str(oi_kind).upper()
+        logger.debug("[OI→TL] Translating %s span: %s", oi_kind_upper, span.name)
+
+        # --- Span kind (reverse of Arize _SPAN_KIND_MAPPING) ---
+        traceloop_kind = _OI_KIND_TO_TRACELOOP.get(oi_kind_upper, "task")
+        attrs.setdefault(TRACELOOP_SPAN_KIND, traceloop_kind)
+        attrs.setdefault(RESPAN_LOG_TYPE, _OI_KIND_TO_LOG_TYPE.get(oi_kind_upper, "task"))
+
+        # --- Entity name ---
+        entity_name = attrs.get(OI_AGENT_NAME) or span.name
+        attrs.setdefault(TRACELOOP_ENTITY_NAME, entity_name)
+
+        # --- Entity path (empty = root candidate) ---
+        attrs.setdefault(TRACELOOP_ENTITY_PATH, "")
+
+        # --- Input / output (reverse of Arize _map_generic_span) ---
+        input_val = attrs.get(OI_INPUT_VALUE)
+        if input_val is not None:
+            attrs.setdefault(TRACELOOP_ENTITY_INPUT, _safe_json_str(input_val))
+
+        output_val = attrs.get(OI_OUTPUT_VALUE)
+        if output_val is not None:
+            attrs.setdefault(TRACELOOP_ENTITY_OUTPUT, _safe_json_str(output_val))
+
+        # --- Model name (reverse: llm.model_name → gen_ai.request.model) ---
+        model = attrs.get(OI_LLM_MODEL_NAME)
+        if model:
+            attrs.setdefault(LLM_REQUEST_MODEL, model)
+
+        # --- System / provider (reverse of Arize _extract_llm_provider_and_system) ---
+        system = attrs.get(OI_LLM_SYSTEM)
+        if system:
+            attrs.setdefault(GEN_AI_SYSTEM, str(system).lower())
+
+        provider = attrs.get(OI_LLM_PROVIDER)
+        if provider:
+            attrs.setdefault(_TL_PROVIDER_NAME, str(provider).lower())
+            # Also set gen_ai.system if not already set (provider is a good fallback)
+            attrs.setdefault(GEN_AI_SYSTEM, str(provider).lower())
+
+        # --- Token counts (reverse of Arize token_count extraction) ---
+        prompt_tokens = attrs.get(OI_LLM_TOKEN_COUNT_PROMPT)
+        if prompt_tokens is not None:
+            attrs.setdefault(LLM_USAGE_PROMPT_TOKENS, prompt_tokens)
+            attrs.setdefault(_TL_USAGE_INPUT_TOKENS, prompt_tokens)
+
+        completion_tokens = attrs.get(OI_LLM_TOKEN_COUNT_COMPLETION)
+        if completion_tokens is not None:
+            attrs.setdefault(LLM_USAGE_COMPLETION_TOKENS, completion_tokens)
+            attrs.setdefault(_TL_USAGE_OUTPUT_TOKENS, completion_tokens)
+
+        total_tokens = attrs.get(OI_LLM_TOKEN_COUNT_TOTAL)
+        if total_tokens is not None:
+            attrs.setdefault(_TL_USAGE_TOTAL_TOKENS, total_tokens)
+
+        cache_read = attrs.get(OI_LLM_TOKEN_COUNT_CACHE_READ)
+        if cache_read is not None:
+            attrs.setdefault(_TL_USAGE_CACHE_READ, cache_read)
+
+        # --- LLM-specific: messages, invocation params, tools ---
+        if oi_kind_upper in _LLM_KINDS:
+            self._translate_llm(attrs)
+
+    def _translate_llm(self, attrs: Dict[str, Any]) -> None:
+        """Extra translation for LLM/EMBEDDING spans."""
+        # Mark as chat request type
+        attrs.setdefault(LLM_REQUEST_TYPE, "chat")
+
+        # --- Messages (reverse of Arize _collect_oi_messages) ---
+        _oi_messages_to_openllmetry(attrs, "llm.input_messages.", "gen_ai.prompt")
+        _oi_messages_to_openllmetry(attrs, "llm.output_messages.", "gen_ai.completion")
+
+        # --- Invocation parameters (reverse of Arize invocation_params extraction) ---
+        # OI stores all params as a single JSON string; OpenLLMetry uses individual attributes
+        inv_params_raw = attrs.get(OI_LLM_INVOCATION_PARAMETERS)
+        if inv_params_raw:
+            params = _parse_json(inv_params_raw)
+            if isinstance(params, dict):
+                for key, val in params.items():
+                    target_attr = _INVOCATION_PARAM_MAP.get(key)
+                    if target_attr:
+                        attrs.setdefault(target_attr, val)
+
+        # --- Tools (reverse of Arize _handle_tool_list) ---
+        # OI: llm.tools = JSON string of tool definitions
+        # OpenLLMetry: llm.request.functions = JSON string of tool definitions
+        tools_raw = attrs.get(OI_LLM_TOOLS)
+        if tools_raw:
+            attrs.setdefault(_TL_REQUEST_FUNCTIONS, tools_raw)
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_translator.py
@@ -1,0 +1,208 @@
+"""Unit tests for OpenInferenceTranslator.
+
+Uses a lightweight mock span (just needs ``_attributes`` and ``name``)
+so we don't depend on any OpenInference packages at test time.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from respan_instrumentation_openinference._translator import OpenInferenceTranslator
+
+
+def _make_span(attrs: dict, name: str = "test-span"):
+    """Return a minimal mock ReadableSpan with a mutable _attributes dict."""
+    span = SimpleNamespace()
+    span._attributes = dict(attrs)
+    span.name = name
+    return span
+
+
+@pytest.fixture
+def translator():
+    return OpenInferenceTranslator()
+
+
+# ------------------------------------------------------------------
+# 1. Non-OI span is ignored
+# ------------------------------------------------------------------
+
+def test_non_oi_span_ignored(translator):
+    """Span without openinference.span.kind is not modified."""
+    span = _make_span({"some.attr": "value"})
+    original = dict(span._attributes)
+    translator.on_end(span)
+    assert span._attributes == original
+
+
+# ------------------------------------------------------------------
+# 2. CHAIN → workflow
+# ------------------------------------------------------------------
+
+def test_chain_span_maps_to_workflow(translator):
+    span = _make_span({"openinference.span.kind": "CHAIN"})
+    translator.on_end(span)
+    assert span._attributes["traceloop.span.kind"] == "workflow"
+    assert span._attributes["respan.entity.log_type"] == "workflow"
+
+
+# ------------------------------------------------------------------
+# 3. LLM → task + llm.request.type=chat
+# ------------------------------------------------------------------
+
+def test_llm_span_maps_to_task_with_chat(translator):
+    span = _make_span({"openinference.span.kind": "LLM"})
+    translator.on_end(span)
+    assert span._attributes["traceloop.span.kind"] == "task"
+    assert span._attributes["llm.request.type"] == "chat"
+    assert span._attributes["respan.entity.log_type"] == "chat"
+
+
+# ------------------------------------------------------------------
+# 4. TOOL → tool
+# ------------------------------------------------------------------
+
+def test_tool_span_maps_to_tool(translator):
+    span = _make_span({"openinference.span.kind": "TOOL"})
+    translator.on_end(span)
+    assert span._attributes["traceloop.span.kind"] == "tool"
+    assert span._attributes["respan.entity.log_type"] == "tool"
+
+
+# ------------------------------------------------------------------
+# 5. AGENT → agent
+# ------------------------------------------------------------------
+
+def test_agent_span_maps_to_agent(translator):
+    span = _make_span({"openinference.span.kind": "AGENT"})
+    translator.on_end(span)
+    assert span._attributes["traceloop.span.kind"] == "agent"
+    assert span._attributes["respan.entity.log_type"] == "agent"
+
+
+# ------------------------------------------------------------------
+# 6. input/output mapped
+# ------------------------------------------------------------------
+
+def test_input_output_mapped(translator):
+    span = _make_span({
+        "openinference.span.kind": "CHAIN",
+        "input.value": "hello world",
+        "output.value": "goodbye world",
+    })
+    translator.on_end(span)
+    assert span._attributes["traceloop.entity.input"] == "hello world"
+    assert span._attributes["traceloop.entity.output"] == "goodbye world"
+
+
+# ------------------------------------------------------------------
+# 7. model name mapped
+# ------------------------------------------------------------------
+
+def test_model_name_mapped(translator):
+    span = _make_span({
+        "openinference.span.kind": "LLM",
+        "llm.model_name": "gpt-4o",
+    })
+    translator.on_end(span)
+    assert span._attributes["gen_ai.request.model"] == "gpt-4o"
+
+
+# ------------------------------------------------------------------
+# 8. token counts mapped
+# ------------------------------------------------------------------
+
+def test_token_counts_mapped(translator):
+    span = _make_span({
+        "openinference.span.kind": "LLM",
+        "llm.token_count.prompt": 100,
+        "llm.token_count.completion": 50,
+        "llm.token_count.total": 150,
+        "llm.token_count.prompt_details.cache_read": 20,
+    })
+    translator.on_end(span)
+    assert span._attributes["gen_ai.usage.prompt_tokens"] == 100
+    assert span._attributes["gen_ai.usage.input_tokens"] == 100
+    assert span._attributes["gen_ai.usage.completion_tokens"] == 50
+    assert span._attributes["gen_ai.usage.output_tokens"] == 50
+    assert span._attributes["llm.usage.total_tokens"] == 150
+    assert span._attributes["llm.usage.cache_read_input_tokens"] == 20
+
+
+# ------------------------------------------------------------------
+# 9. system / provider mapped
+# ------------------------------------------------------------------
+
+def test_system_provider_mapped(translator):
+    span = _make_span({
+        "openinference.span.kind": "LLM",
+        "llm.system": "OpenAI",
+        "llm.provider": "Azure",
+    })
+    translator.on_end(span)
+    assert span._attributes["gen_ai.system"] == "openai"
+    assert span._attributes["gen_ai.provider.name"] == "azure"
+
+
+# ------------------------------------------------------------------
+# 10. setdefault does not overwrite existing attributes
+# ------------------------------------------------------------------
+
+def test_setdefault_does_not_overwrite(translator):
+    span = _make_span({
+        "openinference.span.kind": "CHAIN",
+        "traceloop.span.kind": "agent",  # pre-existing
+        "traceloop.entity.input": "keep me",  # pre-existing
+        "input.value": "should not overwrite",
+    })
+    translator.on_end(span)
+    # Pre-existing values must be preserved
+    assert span._attributes["traceloop.span.kind"] == "agent"
+    assert span._attributes["traceloop.entity.input"] == "keep me"
+
+
+# ------------------------------------------------------------------
+# 11. messages translated
+# ------------------------------------------------------------------
+
+def test_messages_translated(translator):
+    span = _make_span({
+        "openinference.span.kind": "LLM",
+        "llm.input_messages.0.message.role": "user",
+        "llm.input_messages.0.message.content": "Hello!",
+        "llm.input_messages.1.message.role": "assistant",
+        "llm.input_messages.1.message.content": "Hi there!",
+        "llm.output_messages.0.message.role": "assistant",
+        "llm.output_messages.0.message.content": "Goodbye!",
+    })
+    translator.on_end(span)
+    assert span._attributes["gen_ai.prompt.0.role"] == "user"
+    assert span._attributes["gen_ai.prompt.0.content"] == "Hello!"
+    assert span._attributes["gen_ai.prompt.1.role"] == "assistant"
+    assert span._attributes["gen_ai.prompt.1.content"] == "Hi there!"
+    assert span._attributes["gen_ai.completion.0.role"] == "assistant"
+    assert span._attributes["gen_ai.completion.0.content"] == "Goodbye!"
+
+
+# ------------------------------------------------------------------
+# 12. invocation parameters extracted
+# ------------------------------------------------------------------
+
+def test_invocation_params_extracted(translator):
+    params = {
+        "model": "claude-3-opus",
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "max_tokens": 1024,
+    }
+    span = _make_span({
+        "openinference.span.kind": "LLM",
+        "llm.invocation_parameters": json.dumps(params),
+    })
+    translator.on_end(span)
+    assert span._attributes["gen_ai.request.model"] == "claude-3-opus"
+    assert span._attributes["gen_ai.request.temperature"] == 0.7
+    assert span._attributes["gen_ai.request.top_p"] == 0.9
+    assert span._attributes["gen_ai.request.max_tokens"] == 1024

--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "respan-sdk"
-version = "2.6.14"
+version = "2.6.15"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 
 [tool.poetry]
 name = "respan-sdk"
-version = "2.6.14"
+version = "2.6.15"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
@@ -121,10 +121,32 @@ RESPAN_SPAN_ATTRIBUTES_MAP = {
 }
 
 # ---------------------------------------------------------------------------
+# Respan metadata attributes (agent-specific)
+# ---------------------------------------------------------------------------
+RESPAN_METADATA_AGENT_NAME = "respan.metadata.agent_name"
+RESPAN_METADATA_FROM_AGENT = "respan.metadata.from_agent"
+RESPAN_METADATA_TO_AGENT = "respan.metadata.to_agent"
+RESPAN_METADATA_GUARDRAIL_NAME = "respan.metadata.guardrail_name"
+RESPAN_METADATA_TRIGGERED = "respan.metadata.triggered"
+RESPAN_SPAN_TOOLS = "respan.span.tools"
+RESPAN_SPAN_HANDOFFS = "respan.span.handoffs"
+
+# ---------------------------------------------------------------------------
+# LLM attributes (removed from opentelemetry-semantic-conventions-ai 0.5.0)
+# Defined locally for backward compatibility with the Respan pipeline.
+# ---------------------------------------------------------------------------
+LLM_REQUEST_TYPE = "llm.request.type"
+LLM_REQUEST_MODEL = "gen_ai.request.model"
+LLM_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"
+LLM_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"
+LLM_REQUEST_REASONING_EFFORT = "llm.request.reasoning_effort"
+
+# ---------------------------------------------------------------------------
 # OTEL incubating GenAI attributes
 # Not yet available in opentelemetry.semconv_ai.SpanAttributes — defined
 # locally until the upstream package includes them.
 # ---------------------------------------------------------------------------
+GEN_AI_SYSTEM = "gen_ai.system"
 GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
 GEN_AI_AGENT_NAME = "gen_ai.agent.name"
 GEN_AI_TOOL_NAME = "gen_ai.tool.name"
@@ -140,5 +162,8 @@ PYDANTIC_AI_TOOL_RESPONSE = "tool_response"
 
 # ---------------------------------------------------------------------------
 # OpenInference vendor attributes
+# Only OPENINFERENCE_SPAN_KIND is here because respan-tracing uses it
+# for span filtering without depending on the openinference package.
+# All other OI attributes should be imported from openinference.semconv.trace.
 # ---------------------------------------------------------------------------
 OPENINFERENCE_SPAN_KIND = "openinference.span.kind"

--- a/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
@@ -1,4 +1,6 @@
 from datetime import date, datetime
+from typing import Any, Dict, List
+
 
 def json_serial(obj):
     """JSON serializer for objects not serializable by default json code"""
@@ -6,3 +8,32 @@ def json_serial(obj):
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
     raise TypeError ("Type %s not serializable" % type(obj))
+
+
+def serialize_value(value: Any) -> Any:
+    """Convert complex payload values into JSON-serializable structures."""
+    if value is None:
+        return None
+
+    if isinstance(value, (str, int, float, bool)):
+        return value
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+
+    if isinstance(value, dict):
+        normalized: Dict[str, Any] = {}
+        for key, nested_value in value.items():
+            normalized[str(key)] = serialize_value(value=nested_value)
+        return normalized
+
+    if isinstance(value, (list, tuple, set)):
+        result: List[Any] = []
+        for nested_value in value:
+            result.append(serialize_value(value=nested_value))
+        return result
+
+    if hasattr(value, "__dict__"):
+        return serialize_value(value=value.__dict__)
+
+    return str(value)

--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.13.1"
+version = "2.13.2"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"
@@ -17,6 +17,7 @@ opentelemetry-sdk = "^1.29.0"
 respan-sdk = ">=2.6.1"
 opentelemetry-instrumentation-threading = ">=0.55b1"
 openinference-semantic-conventions = ">=0.1.12"
+opentelemetry-semantic-conventions-ai = ">=0.4.1"
 requests = ">=2.28.0"
 
 

--- a/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
@@ -55,9 +55,11 @@ from respan_sdk.constants.otlp_constants import (
 )
 
 from opentelemetry.semconv_ai import SpanAttributes, LLMRequestTypeValues
-from openinference.semconv.trace import SpanAttributes as OpenInferenceSpanAttributes
 
-from respan_sdk.constants.span_attributes import OPENINFERENCE_SPAN_KIND
+from respan_sdk.constants.span_attributes import (
+    GEN_AI_SYSTEM,
+    LLM_REQUEST_TYPE,
+)
 from respan_tracing.utils.logging import get_respan_logger, build_spans_export_preview
 from respan_tracing.utils.preprocessing.span_processing import is_root_span_candidate
 from respan_tracing.constants.generic_constants import LOGGER_NAME_EXPORTER
@@ -337,89 +339,22 @@ def _build_otlp_payload(spans: Sequence[ReadableSpan]) -> Dict[str, Any]:
     return {OTLP_RESOURCE_SPANS_KEY: resource_spans}
 
 
-# ---------------------------------------------------------------------------
-# OpenInference → Traceloop/GenAI attribute mapping
-# ---------------------------------------------------------------------------
-_OI_KIND_TO_TRACELOOP_KIND = {
-    "LLM": "task",
-    "CHAIN": "workflow",
-    "TOOL": "tool",
-    "AGENT": "agent",
-    "EMBEDDING": "task",
-    "RETRIEVER": "task",
-    "RERANKER": "task",
-    "GUARDRAIL": "task",
-    "EVALUATOR": "task",
-}
-
-_OI_LLM_REQUEST_TYPE_KINDS = {
-    "LLM": LLMRequestTypeValues.CHAT.value,
-    "EMBEDDING": LLMRequestTypeValues.EMBEDDING.value,
-}
-
-
 def _get_enrichment_attrs(span: ReadableSpan) -> Dict[str, Any]:
     """Return extra attributes to inject into a span before export.
 
-    Handles two cases:
+    Handles GenAI spans (e.g. ``openai.response``) that carry ``gen_ai.system``
+    but lack ``llm.request.type``.  The Respan backend uses ``llm.request.type``
+    to trigger prompt/completion/model/token parsing, so we inject ``"chat"``
+    to ensure the backend processes these spans.
 
-    1. **GenAI spans** (e.g. ``openai.response``) that carry ``gen_ai.system``
-       but lack ``llm.request.type``.  The Respan backend uses
-       ``llm.request.type`` to trigger prompt/completion/model/token parsing,
-       so we inject ``"chat"`` to ensure the backend processes these spans.
-
-    2. **OpenInference spans** — OI instrumentors use their own attribute
-       namespace (``openinference.span.kind``, ``input.value``, ``llm.model_name``,
-       etc.).  We map these to the Traceloop/GenAI equivalents the backend expects.
+    Note: OpenInference → Traceloop translation is handled earlier in the
+    pipeline by ``OpenInferenceTranslator`` (a SpanProcessor).
     """
     attrs = span.attributes or {}
     extra: Dict[str, Any] = {}
 
-    # Case 1: GenAI spans missing llm.request.type
-    if attrs.get(SpanAttributes.LLM_SYSTEM) and not attrs.get(SpanAttributes.LLM_REQUEST_TYPE):
-        extra[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
-
-    # Case 2: OpenInference spans
-    oi_kind = attrs.get(OPENINFERENCE_SPAN_KIND)
-    if oi_kind:
-        # Map OI kind → traceloop.span.kind
-        traceloop_kind = _OI_KIND_TO_TRACELOOP_KIND.get(oi_kind, "task")
-        if not attrs.get(SpanAttributes.TRACELOOP_SPAN_KIND):
-            extra[SpanAttributes.TRACELOOP_SPAN_KIND] = traceloop_kind
-
-        # Inject llm.request.type for LLM/EMBEDDING kinds
-        llm_req_type = _OI_LLM_REQUEST_TYPE_KINDS.get(oi_kind)
-        if llm_req_type and not attrs.get(SpanAttributes.LLM_REQUEST_TYPE):
-            extra[SpanAttributes.LLM_REQUEST_TYPE] = llm_req_type
-
-        # Map input.value → traceloop.entity.input
-        input_val = attrs.get(OpenInferenceSpanAttributes.INPUT_VALUE)
-        if input_val and not attrs.get(SpanAttributes.TRACELOOP_ENTITY_INPUT):
-            extra[SpanAttributes.TRACELOOP_ENTITY_INPUT] = input_val
-
-        # Map output.value → traceloop.entity.output
-        output_val = attrs.get(OpenInferenceSpanAttributes.OUTPUT_VALUE)
-        if output_val and not attrs.get(SpanAttributes.TRACELOOP_ENTITY_OUTPUT):
-            extra[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = output_val
-
-        # Map llm.model_name → gen_ai.request.model
-        model_name = attrs.get(OpenInferenceSpanAttributes.LLM_MODEL_NAME)
-        if model_name and not attrs.get(SpanAttributes.LLM_REQUEST_MODEL):
-            extra[SpanAttributes.LLM_REQUEST_MODEL] = model_name
-
-        # Map llm.token_count.prompt → gen_ai.usage.prompt_tokens
-        prompt_tokens = attrs.get(OpenInferenceSpanAttributes.LLM_TOKEN_COUNT_PROMPT)
-        if prompt_tokens is not None and not attrs.get(SpanAttributes.LLM_USAGE_PROMPT_TOKENS):
-            extra[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = prompt_tokens
-
-        # Map llm.token_count.completion → gen_ai.usage.completion_tokens
-        completion_tokens = attrs.get(OpenInferenceSpanAttributes.LLM_TOKEN_COUNT_COMPLETION)
-        if completion_tokens is not None and not attrs.get(SpanAttributes.LLM_USAGE_COMPLETION_TOKENS):
-            extra[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = completion_tokens
-
-        # Map span name → traceloop.entity.name
-        if span.name and not attrs.get(SpanAttributes.TRACELOOP_ENTITY_NAME):
-            extra[SpanAttributes.TRACELOOP_ENTITY_NAME] = span.name
+    if attrs.get(GEN_AI_SYSTEM) and not attrs.get(LLM_REQUEST_TYPE):
+        extra[LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
 
     return extra
 

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/__init__.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/__init__.py
@@ -9,7 +9,7 @@ from respan_tracing.processors.base import RespanSpanProcessor, BufferingSpanPro
 
 __all__ = [
     "RespanSpanProcessor",
-    "BufferingSpanProcessor", 
+    "BufferingSpanProcessor",
     "SpanBuffer",
     "FilteringSpanProcessor",
 ]

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/instrumentation.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/instrumentation.py
@@ -189,7 +189,7 @@ def _patch_chat_prompt_capture():
         from opentelemetry.semconv._incubating.attributes import (
             gen_ai_attributes as GenAIAttributes,
         )
-        from opentelemetry.semconv_ai import SpanAttributes
+        from respan_sdk.constants.span_attributes import LLM_REQUEST_REASONING_EFFORT
 
         def _set_prompts_sync(span, messages):
             if not span.is_recording() or messages is None:
@@ -281,7 +281,7 @@ def _patch_chat_prompt_capture():
                 reasoning_effort = kwargs.get("reasoning_effort")
                 _set_span_attribute(
                     span,
-                    SpanAttributes.LLM_REQUEST_REASONING_EFFORT,
+                    LLM_REQUEST_REASONING_EFFORT,
                     reasoning_effort or (),
                 )
             except Exception:

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/preprocessing/span_processing.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/preprocessing/span_processing.py
@@ -3,11 +3,13 @@ from opentelemetry.semconv_ai import SpanAttributes
 import logging
 
 from respan_sdk.constants.span_attributes import (
+    GEN_AI_SYSTEM,
     GEN_AI_OPERATION_NAME,
     GEN_AI_AGENT_NAME,
     GEN_AI_TOOL_NAME,
     GEN_AI_TOOL_CALL_ARGUMENTS,
     GEN_AI_TOOL_CALL_RESULT,
+    LLM_REQUEST_TYPE,
     OPENINFERENCE_SPAN_KIND,
     PYDANTIC_AI_AGENT_NAME,
     PYDANTIC_AI_TOOL_ARGUMENTS,
@@ -20,7 +22,7 @@ logger = logging.getLogger(__name__)
 # Attribute names that indicate a GenAI span (OTEL incubating + Pydantic AI vendor attrs)
 _GENAI_INDICATOR_ATTRS = (
     GEN_AI_OPERATION_NAME,
-    SpanAttributes.LLM_SYSTEM,
+    GEN_AI_SYSTEM,
     GEN_AI_AGENT_NAME,
     PYDANTIC_AI_AGENT_NAME,
     GEN_AI_TOOL_NAME,
@@ -81,20 +83,20 @@ def is_processable_span(span: ReadableSpan) -> bool:
 
     # Standalone auto-instrumented LLM span (has llm.request.type, e.g. "chat")
     # This covers OpenAI/Anthropic/etc. calls made outside @workflow/@task decorators
-    if span.attributes.get(SpanAttributes.LLM_REQUEST_TYPE):
+    if span.attributes.get(LLM_REQUEST_TYPE):
         logger.debug(
             f"[Respan Debug] Processing standalone LLM span: {span.name} "
-            f"(llm.request.type: {span.attributes.get(SpanAttributes.LLM_REQUEST_TYPE)})"
+            f"(llm.request.type: {span.attributes.get(LLM_REQUEST_TYPE)})"
         )
         return True
 
     # Standalone GenAI span (has gen_ai.system, e.g. "openai")
     # This covers spans from OTEL instrumentors that don't set llm.request.type,
     # such as the OpenAI Responses API instrumentor.
-    if span.attributes.get(SpanAttributes.LLM_SYSTEM):
+    if span.attributes.get(GEN_AI_SYSTEM):
         logger.debug(
             f"[Respan Debug] Processing standalone GenAI span: {span.name} "
-            f"(gen_ai.system: {span.attributes.get(SpanAttributes.LLM_SYSTEM)})"
+            f"(gen_ai.system: {span.attributes.get(GEN_AI_SYSTEM)})"
         )
         return True
 
@@ -147,7 +149,7 @@ def is_root_span_candidate(span: ReadableSpan) -> bool:
     """
     span_kind = span.attributes.get(SpanAttributes.TRACELOOP_SPAN_KIND)
     entity_path = span.attributes.get(SpanAttributes.TRACELOOP_ENTITY_PATH, "")
-    llm_request_type = span.attributes.get(SpanAttributes.LLM_REQUEST_TYPE)
+    llm_request_type = span.attributes.get(LLM_REQUEST_TYPE)
 
     has_no_entity_path = not entity_path or entity_path == ""
 
@@ -162,7 +164,7 @@ def is_root_span_candidate(span: ReadableSpan) -> bool:
         return True
 
     # Standalone GenAI span (gen_ai.system) without entity path should become root
-    gen_ai_system = span.attributes.get(SpanAttributes.LLM_SYSTEM)
+    gen_ai_system = span.attributes.get(GEN_AI_SYSTEM)
     if gen_ai_system and span_kind is None and not llm_request_type and has_no_entity_path:
         logger.debug(f"[Respan Debug] Span is root candidate (standalone GenAI): {span.name}")
         return True


### PR DESCRIPTION
## Summary

- **Fix published package crashes**: `respan-tracing` and `respan-instrumentation-openai-agents` broke because `opentelemetry-semantic-conventions-ai` 0.5.0 removed `LLM_*` attributes, and `respan-sdk` was missing constants + `serialize_value()`. All LLM/GenAI constants now live in `respan-sdk` as the single source of truth.

- **OpenInference → OpenLLMetry translator** (Python + JS): Comprehensive `SpanProcessor` that converts all 33+ OpenInference instrumentor outputs to Traceloop/OpenLLMetry format. Exact reverse of [Arize's openinference-instrumentation-openllmetry](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openllmetry). Lives in `respan-instrumentation-openinference` (not `respan-tracing`).

- **Fix JS trace export**: Switched from `otlp-proto` (`/v1/traces`) to `otlp-http` JSON (`/v2/traces`) — same wire format as Python's `RespanSpanExporter`.

- **New examples**: JS OpenAI Agents SDK, JS Claude Agent SDK (OI), JS Anthropic SDK (OI), Python CrewAI (OI)

## Verified on dashboard (via MCP)

| Integration | Lang | Spans | Status |
|---|---|---|---|
| OpenAI Agents SDK (customer_service) | Python | 10 (workflow→agents→chat→handoff→tool) | ✅ |
| OpenAI Agents SDK | JS | 3 (workflow→agent→chat) | ✅ |
| CrewAI via OpenInference | Python | 2 (workflow→agent) | ✅ |
| Claude Agent SDK via OpenInference | JS | 2 (agent→Bash tool) | ✅ |
| Anthropic SDK via OpenInference | JS | 1 (LLM call) | ✅ |

## Test plan

- [x] Python `hello_world.py` — trace verified on dashboard
- [x] Python `basic_handoff.py` — 6 spans with handoff verified
- [x] Python `customer_service.py` — 10 spans, multi-agent with tools
- [x] Python CrewAI example — OI translator working
- [x] JS `hello_world.ts` (OpenAI Agents) — trace verified on dashboard
- [x] JS Claude Agent SDK with tools — AGENT + TOOL spans verified
- [x] JS Anthropic SDK via OI — LLM span verified
- [x] `respan-tracing` builds clean (Python + JS)
- [x] `respan-instrumentation-openinference` builds clean (Python + JS)
- [x] No `.env` files or API keys in commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect trace exporting and span enrichment/processing across both JS and Python, including a new translation processor and a new OTLP endpoint/format; mistakes could drop or mislabel spans in production.
> 
> **Overview**
> **Improves SDK compatibility and OpenInference support across JS + Python.** Adds an `OpenInferenceTranslator` `SpanProcessor` (and auto-registers it via `OpenInferenceInstrumentor`) to convert OpenInference attributes into OpenLLMetry/Traceloop attributes *before* export, and removes the older OpenInference-enrichment logic from the JS composite processor.
> 
> **Updates trace export + span injection paths.** JS `@respan/tracing` switches from OTLP protobuf (`/api/v1/traces`) to OTLP HTTP JSON (`/api/v2/traces`) and exposes `injectSpan()` for plugin-constructed spans; the OpenAI Agents emitter is hardened to locate the active span processor through common tracer-provider delegate chains.
> 
> **Normalizes attribute constants and bumps versions.** Moves/extends Respan attribute keys (agent metadata + GenAI/LLM keys) into `respan-sdk` as a shared source of truth and updates instrumentation packages to use them (including Python OpenAI Agents), with version bumps.
> 
> **Adds new runnable examples.** Introduces JS examples for OpenAI Agents, Anthropic via OpenInference, and Claude Agent SDK via OpenInference, plus a Python CrewAI OpenInference example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40d8fb7b2482964ee84f94a02db85b237cf40acf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->