### PR TITLE
feat(sdk): add is_cache_by_model to CacheOptions [DEV-5019]

### DIFF
--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "respan-sdk"
-version = "2.6.14"
+version = "2.6.15"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 
 [tool.poetry]
 name = "respan-sdk"
-version = "2.6.14"
+version = "2.6.15"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
@@ -167,6 +167,7 @@ class Customer(RespanBaseModel):
 
 class CacheOptions(RespanBaseModel):
     cache_by_customer: Optional[bool] = None  # Create cache for each customer_user
+    is_cache_by_model: Optional[bool] = None  # Partition cache by model name
     omit_log: Optional[bool] = None  # When cache is hit, don't log the request
 
     def model_dump(self, *args, **kwargs) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Add `is_cache_by_model: Optional[bool] = None` to `CacheOptions` in `param_types.py`
- Bump version to 2.6.15
- Required by backend PR respanai/respan-backend#1563 — without this field, Pydantic strips the option during `validate_and_separate_params`

## Test plan
- [x] Verified locally: `validate_and_separate_params` now preserves `is_cache_by_model` in `cache_options`
- [x] Backend unit tests pass with local editable install