### PR TITLE
chore(sdk): bump to 2.6.17 for is_cached_by_model rename

### DIFF
--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "respan-sdk"
-version = "2.6.16"
+version = "2.6.17"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 
 [tool.poetry]
 name = "respan-sdk"
-version = "2.6.16"
+version = "2.6.17"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"


### PR DESCRIPTION
2.6.16 wheel on PyPI has the old name. Re-publish as 2.6.17.