### PR TITLE
fix: respan-instrumentation-openai-agents fix based on new published sdks

### DIFF
--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
@@ -233,12 +233,12 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
 
             tool_calls = _extract_tool_calls(resp.output)
             if tool_calls:
-                attrs["tool_calls"] = tool_calls
+                attrs["tool_calls"] = _safe_json(tool_calls)
 
         if hasattr(resp, "tools") and resp.tools:
             tools_list = _extract_tools(resp.tools)
             if tools_list:
-                attrs["tools"] = tools_list
+                attrs["tools"] = _safe_json(tools_list)
 
         usage = getattr(resp, "usage", None)
         if usage:

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
@@ -42,11 +42,6 @@ from respan_sdk.constants.llm_logging import (
     LOG_TYPE_WORKFLOW,
 )
 from respan_sdk.constants.span_attributes import (
-    GEN_AI_SYSTEM,
-    LLM_REQUEST_MODEL,
-    LLM_REQUEST_TYPE,
-    LLM_USAGE_COMPLETION_TOKENS,
-    LLM_USAGE_PROMPT_TOKENS,
     RESPAN_LOG_TYPE,
     RESPAN_METADATA_AGENT_NAME,
     RESPAN_METADATA_FROM_AGENT,
@@ -110,6 +105,47 @@ def _safe_json(obj: Any) -> str:
         return json.dumps(obj, default=str)
     except Exception:
         return str(obj)
+
+
+def _extract_tools(tools: list) -> list:
+    """Convert Response API tool definitions to Chat Completions format."""
+    result = []
+    for tool in tools:
+        tool_dict = serialize_value(tool)
+        if not isinstance(tool_dict, dict):
+            continue
+        tool_type = tool_dict.get("type", "")
+        if tool_type == "function":
+            func = {
+                "name": tool_dict.get("name", ""),
+            }
+            desc = tool_dict.get("description")
+            if desc:
+                func["description"] = desc
+            params = tool_dict.get("parameters")
+            if params:
+                func["parameters"] = params
+            result.append({"type": "function", "function": func})
+        else:
+            result.append(tool_dict)
+    return result
+
+
+def _extract_tool_calls(output: list) -> list:
+    """Extract function tool calls from Response API output items."""
+    result = []
+    for item in output:
+        item_dict = serialize_value(item)
+        if isinstance(item_dict, dict) and item_dict.get("type") == "function_call":
+            result.append({
+                "id": item_dict.get("call_id", ""),
+                "type": "function",
+                "function": {
+                    "name": item_dict.get("name", ""),
+                    "arguments": item_dict.get("arguments", ""),
+                },
+            })
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -176,8 +212,8 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
         entity_path="response",
         log_type=LOG_TYPE_RESPONSE,
     )
-    attrs[LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
-    attrs[GEN_AI_SYSTEM] = "openai"
+    attrs[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+    attrs[SpanAttributes.LLM_SYSTEM] = "openai"
 
     # Input
     input_msgs = _format_input_messages(span_data.input)
@@ -189,16 +225,25 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
     if resp:
         model = getattr(resp, "model", None) or ""
         if model:
-            attrs[LLM_REQUEST_MODEL] = model
+            attrs[SpanAttributes.LLM_REQUEST_MODEL] = model
 
         if hasattr(resp, "output") and resp.output:
             output = _format_output(resp.output)
-            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json(output)
+            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = output
+
+            tool_calls = _extract_tool_calls(resp.output)
+            if tool_calls:
+                attrs["tool_calls"] = tool_calls
+
+        if hasattr(resp, "tools") and resp.tools:
+            tools_list = _extract_tools(resp.tools)
+            if tools_list:
+                attrs["tools"] = tools_list
 
         usage = getattr(resp, "usage", None)
         if usage:
-            attrs[LLM_USAGE_PROMPT_TOKENS] = getattr(usage, "input_tokens", 0) or 0
-            attrs[LLM_USAGE_COMPLETION_TOKENS] = getattr(usage, "output_tokens", 0) or 0
+            attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = getattr(usage, "input_tokens", 0) or 0
+            attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = getattr(usage, "output_tokens", 0) or 0
 
     span = build_readable_span(
         name="openai.chat",
@@ -258,22 +303,22 @@ def emit_generation(item: SpanImpl, span_data: GenerationSpanData) -> None:
         entity_path="generation",
         log_type=LOG_TYPE_GENERATION,
     )
-    attrs[LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+    attrs[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
 
     if span_data.model:
-        attrs[LLM_REQUEST_MODEL] = span_data.model
+        attrs[SpanAttributes.LLM_REQUEST_MODEL] = span_data.model
 
     input_msgs = _format_input_messages(span_data.input)
     if input_msgs:
         attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(input_msgs)
 
     output = _format_output(span_data.output)
-    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json(output)
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = output
 
     if span_data.usage:
         u = span_data.usage
-        attrs[LLM_USAGE_PROMPT_TOKENS] = u.get("prompt_tokens") or u.get("input_tokens") or 0
-        attrs[LLM_USAGE_COMPLETION_TOKENS] = u.get("completion_tokens") or u.get("output_tokens") or 0
+        attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = u.get("prompt_tokens") or u.get("input_tokens") or 0
+        attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = u.get("completion_tokens") or u.get("output_tokens") or 0
 
     span = build_readable_span(
         name="openai.chat",
@@ -359,11 +404,11 @@ def emit_custom(item: SpanImpl, span_data: CustomSpanData) -> None:
     data = span_data.data or {}
     for k, v in data.items():
         if k in ("model",):
-            attrs[LLM_REQUEST_MODEL] = v
+            attrs[SpanAttributes.LLM_REQUEST_MODEL] = v
         elif k == "prompt_tokens":
-            attrs[LLM_USAGE_PROMPT_TOKENS] = v
+            attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = v
         elif k == "completion_tokens":
-            attrs[LLM_USAGE_COMPLETION_TOKENS] = v
+            attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = v
         elif k == "input":
             attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(v)
         elif k == "output":

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
@@ -54,6 +54,7 @@ from respan_sdk.constants.span_attributes import (
     RESPAN_METADATA_TO_AGENT,
     RESPAN_METADATA_TRIGGERED,
     RESPAN_SPAN_HANDOFFS,
+    RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
 )
 from respan_sdk.utils.serialization import serialize_value
@@ -110,6 +111,12 @@ def _safe_json(obj: Any) -> str:
         return json.dumps(obj, default=str)
     except Exception:
         return str(obj)
+
+
+def _set_json_structured_attr(attrs: Dict[str, Any], key: str, value: Any) -> None:
+    """Store structured values as JSON strings for OTEL attribute safety."""
+    if value:
+        attrs[key] = _safe_json(value)
 
 
 def _extract_tools(tools: list) -> list:
@@ -237,13 +244,11 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
             attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = output
 
             tool_calls = _extract_tool_calls(resp.output)
-            if tool_calls:
-                attrs["tool_calls"] = tool_calls
+            _set_json_structured_attr(attrs, RESPAN_SPAN_TOOL_CALLS, tool_calls)
 
         if hasattr(resp, "tools") and resp.tools:
             tools_list = _extract_tools(resp.tools)
-            if tools_list:
-                attrs["tools"] = tools_list
+            _set_json_structured_attr(attrs, RESPAN_SPAN_TOOLS, tools_list)
 
         usage = getattr(resp, "usage", None)
         if usage:
@@ -319,6 +324,11 @@ def emit_generation(item: SpanImpl, span_data: GenerationSpanData) -> None:
 
     output = _format_output(span_data.output)
     attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = output
+    _set_json_structured_attr(
+        attrs,
+        RESPAN_SPAN_TOOL_CALLS,
+        _extract_tool_calls(span_data.output or []),
+    )
 
     if span_data.usage:
         u = span_data.usage

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
@@ -42,6 +42,11 @@ from respan_sdk.constants.llm_logging import (
     LOG_TYPE_WORKFLOW,
 )
 from respan_sdk.constants.span_attributes import (
+    GEN_AI_SYSTEM,
+    LLM_REQUEST_MODEL,
+    LLM_REQUEST_TYPE,
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
     RESPAN_LOG_TYPE,
     RESPAN_METADATA_AGENT_NAME,
     RESPAN_METADATA_FROM_AGENT,
@@ -212,8 +217,8 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
         entity_path="response",
         log_type=LOG_TYPE_RESPONSE,
     )
-    attrs[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
-    attrs[SpanAttributes.LLM_SYSTEM] = "openai"
+    attrs[LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+    attrs[GEN_AI_SYSTEM] = "openai"
 
     # Input
     input_msgs = _format_input_messages(span_data.input)
@@ -225,7 +230,7 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
     if resp:
         model = getattr(resp, "model", None) or ""
         if model:
-            attrs[SpanAttributes.LLM_REQUEST_MODEL] = model
+            attrs[LLM_REQUEST_MODEL] = model
 
         if hasattr(resp, "output") and resp.output:
             output = _format_output(resp.output)
@@ -233,17 +238,17 @@ def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
 
             tool_calls = _extract_tool_calls(resp.output)
             if tool_calls:
-                attrs["tool_calls"] = _safe_json(tool_calls)
+                attrs["tool_calls"] = tool_calls
 
         if hasattr(resp, "tools") and resp.tools:
             tools_list = _extract_tools(resp.tools)
             if tools_list:
-                attrs["tools"] = _safe_json(tools_list)
+                attrs["tools"] = tools_list
 
         usage = getattr(resp, "usage", None)
         if usage:
-            attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = getattr(usage, "input_tokens", 0) or 0
-            attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = getattr(usage, "output_tokens", 0) or 0
+            attrs[LLM_USAGE_PROMPT_TOKENS] = getattr(usage, "input_tokens", 0) or 0
+            attrs[LLM_USAGE_COMPLETION_TOKENS] = getattr(usage, "output_tokens", 0) or 0
 
     span = build_readable_span(
         name="openai.chat",
@@ -303,10 +308,10 @@ def emit_generation(item: SpanImpl, span_data: GenerationSpanData) -> None:
         entity_path="generation",
         log_type=LOG_TYPE_GENERATION,
     )
-    attrs[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+    attrs[LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
 
     if span_data.model:
-        attrs[SpanAttributes.LLM_REQUEST_MODEL] = span_data.model
+        attrs[LLM_REQUEST_MODEL] = span_data.model
 
     input_msgs = _format_input_messages(span_data.input)
     if input_msgs:
@@ -317,8 +322,8 @@ def emit_generation(item: SpanImpl, span_data: GenerationSpanData) -> None:
 
     if span_data.usage:
         u = span_data.usage
-        attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = u.get("prompt_tokens") or u.get("input_tokens") or 0
-        attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = u.get("completion_tokens") or u.get("output_tokens") or 0
+        attrs[LLM_USAGE_PROMPT_TOKENS] = u.get("prompt_tokens") or u.get("input_tokens") or 0
+        attrs[LLM_USAGE_COMPLETION_TOKENS] = u.get("completion_tokens") or u.get("output_tokens") or 0
 
     span = build_readable_span(
         name="openai.chat",
@@ -404,11 +409,11 @@ def emit_custom(item: SpanImpl, span_data: CustomSpanData) -> None:
     data = span_data.data or {}
     for k, v in data.items():
         if k in ("model",):
-            attrs[SpanAttributes.LLM_REQUEST_MODEL] = v
+            attrs[LLM_REQUEST_MODEL] = v
         elif k == "prompt_tokens":
-            attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = v
+            attrs[LLM_USAGE_PROMPT_TOKENS] = v
         elif k == "completion_tokens":
-            attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = v
+            attrs[LLM_USAGE_COMPLETION_TOKENS] = v
         elif k == "input":
             attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(v)
         elif k == "output":

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
@@ -136,8 +136,10 @@ def _format_output(resp_output: Any) -> str:
                         elif isinstance(block, str):
                             text_parts.append(block)
                 continue
-            if item.get("content"):
-                text_parts.append(str(item["content"]))
+            if "content" in item:
+                content = item["content"]
+                if content is not None:
+                    text_parts.append(str(content))
                 continue
             text_parts.append(str(item))
         return "\n".join(text_parts) if text_parts else ""

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
@@ -88,49 +88,52 @@ def _format_input_messages(raw_input: Any) -> List[Dict[str, Any]]:
     return [{"role": "user", "content": str(serialized)}]
 
 
-def _format_output(resp_output: Any) -> Dict[str, Any]:
-    """Extract a clean ``{"role": "assistant", "content": ...}`` from Response output."""
+def _format_output(resp_output: Any) -> str:
+    """Extract the text content from response output items.
+
+    Returns the plain text string from message output items.
+    Function-call / tool items are intentionally skipped here because
+    they are extracted separately via ``_extract_tool_calls`` and stored
+    as their own span attribute.
+    """
     serialized = serialize_value(resp_output)
     if not serialized:
-        return {"role": "assistant", "content": "", "_is_placeholder": True}
+        return ""
 
     if isinstance(serialized, str):
-        return {"role": "assistant", "content": serialized}
+        return serialized
 
     if isinstance(serialized, dict):
-        if "role" in serialized:
-            return serialized
-        return {"role": "assistant", "content": str(serialized)}
+        return serialized.get("content", json.dumps(serialized, default=str))
 
     if isinstance(serialized, list):
-        text_parts = []
-        tool_calls = []
+        text_parts: List[str] = []
         for item in serialized:
             if not isinstance(item, dict):
+                text_parts.append(str(item))
                 continue
             item_type = item.get("type", "")
+            if item_type in ("function_call", "function_call_output"):
+                continue
             if item_type == "message":
-                for block in item.get("content", []):
-                    if isinstance(block, dict) and block.get("type") == "output_text":
-                        text_parts.append(block.get("text", ""))
-            elif item_type == "function_call":
-                tool_calls.append({
-                    "id": item.get("call_id", ""),
-                    "type": "function",
-                    "function": {
-                        "name": item.get("name", ""),
-                        "arguments": item.get("arguments", ""),
-                    },
-                })
-            elif item_type == "output_text":
-                text_parts.append(item.get("text", ""))
+                content_blocks = item.get("content", [])
+                if isinstance(content_blocks, str):
+                    text_parts.append(content_blocks)
+                elif isinstance(content_blocks, list):
+                    for block in content_blocks:
+                        if isinstance(block, dict):
+                            bt = block.get("type", "")
+                            if bt in ("output_text", "text", "input_text"):
+                                text_parts.append(block.get("text", ""))
+                        elif isinstance(block, str):
+                            text_parts.append(block)
+                continue
+            if item.get("content"):
+                text_parts.append(str(item["content"]))
+                continue
+        return "\n".join(text_parts) if text_parts else ""
 
-        msg: Dict[str, Any] = {"role": "assistant", "content": "\n".join(text_parts)}
-        if tool_calls:
-            msg["tool_calls"] = tool_calls
-        return msg
-
-    return {"role": "assistant", "content": str(serialized)}
+    return str(serialized)
 
 
 def _parse_ts(ts: str) -> datetime:

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
@@ -104,7 +104,12 @@ def _format_output(resp_output: Any) -> str:
         return serialized
 
     if isinstance(serialized, dict):
-        return serialized.get("content", json.dumps(serialized, default=str))
+        content = serialized.get("content")
+        if content is None:
+            return json.dumps(serialized, default=str)
+        if isinstance(content, str):
+            return content
+        return json.dumps(content, default=str)
 
     if isinstance(serialized, list):
         text_parts: List[str] = []
@@ -114,6 +119,9 @@ def _format_output(resp_output: Any) -> str:
                 continue
             item_type = item.get("type", "")
             if item_type in ("function_call", "function_call_output"):
+                continue
+            if item_type in ("output_text", "text", "input_text"):
+                text_parts.append(item.get("text", ""))
                 continue
             if item_type == "message":
                 content_blocks = item.get("content", [])

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
@@ -131,6 +131,7 @@ def _format_output(resp_output: Any) -> str:
             if item.get("content"):
                 text_parts.append(str(item["content"]))
                 continue
+            text_parts.append(str(item))
         return "\n".join(text_parts) if text_parts else ""
 
     return str(serialized)

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/tests/test_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/tests/test_otel_emitter.py
@@ -1,0 +1,126 @@
+"""Unit tests for OpenAI Agents OTEL emitter tool attributes."""
+
+import json
+from types import SimpleNamespace
+
+from respan_sdk.constants.span_attributes import (
+    RESPAN_SPAN_TOOL_CALLS,
+    RESPAN_SPAN_TOOLS,
+)
+
+from respan_instrumentation_openai_agents import _otel_emitter
+
+
+def _make_span_item() -> SimpleNamespace:
+    return SimpleNamespace(
+        trace_id="trace_123",
+        span_id="span_456",
+        parent_id=None,
+        started_at=None,
+        ended_at=None,
+        error=None,
+    )
+
+
+def _capture_attrs(monkeypatch):
+    captured = {}
+
+    def _fake_build_readable_span(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(_otel_emitter, "build_readable_span", _fake_build_readable_span)
+    monkeypatch.setattr(_otel_emitter, "inject_span", lambda span: None)
+    return captured
+
+
+def test_emit_response_serializes_namespaced_tool_attrs(monkeypatch):
+    captured = _capture_attrs(monkeypatch)
+    response = SimpleNamespace(
+        model="gpt-4o",
+        output=[
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "lookup_weather",
+                "arguments": '{"city":"NYC"}',
+            }
+        ],
+        tools=[
+            {
+                "type": "function",
+                "name": "lookup_weather",
+                "description": "Look up the weather.",
+                "parameters": {"type": "object"},
+            }
+        ],
+        usage=SimpleNamespace(input_tokens=12, output_tokens=4),
+    )
+    span_data = SimpleNamespace(response=response, input="What is the weather in NYC?")
+
+    _otel_emitter.emit_response(_make_span_item(), span_data)
+
+    attrs = captured["attributes"]
+    assert attrs[RESPAN_SPAN_TOOL_CALLS] == json.dumps(
+        [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "lookup_weather",
+                    "arguments": '{"city":"NYC"}',
+                },
+            }
+        ],
+        default=str,
+    )
+    assert attrs[RESPAN_SPAN_TOOLS] == json.dumps(
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup_weather",
+                    "description": "Look up the weather.",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        default=str,
+    )
+    assert "tool_calls" not in attrs
+    assert "tools" not in attrs
+
+
+def test_emit_generation_extracts_tool_calls(monkeypatch):
+    captured = _capture_attrs(monkeypatch)
+    span_data = SimpleNamespace(
+        input=[{"role": "user", "content": "Use the tool"}],
+        output=[
+            {
+                "type": "function_call",
+                "call_id": "call_2",
+                "name": "search_docs",
+                "arguments": '{"query":"otel"}',
+            }
+        ],
+        model="gpt-4o",
+        usage={"prompt_tokens": 8, "completion_tokens": 2},
+    )
+
+    _otel_emitter.emit_generation(_make_span_item(), span_data)
+
+    attrs = captured["attributes"]
+    assert attrs[RESPAN_SPAN_TOOL_CALLS] == json.dumps(
+        [
+            {
+                "id": "call_2",
+                "type": "function",
+                "function": {
+                    "name": "search_docs",
+                    "arguments": '{"query":"otel"}',
+                },
+            }
+        ],
+        default=str,
+    )
+    assert "tool_calls" not in attrs

--- a/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
@@ -129,6 +129,7 @@ RESPAN_METADATA_TO_AGENT = "respan.metadata.to_agent"
 RESPAN_METADATA_GUARDRAIL_NAME = "respan.metadata.guardrail_name"
 RESPAN_METADATA_TRIGGERED = "respan.metadata.triggered"
 RESPAN_SPAN_TOOLS = "respan.span.tools"
+RESPAN_SPAN_TOOL_CALLS = "respan.span.tool_calls"
 RESPAN_SPAN_HANDOFFS = "respan.span.handoffs"
 
 # ---------------------------------------------------------------------------

--- a/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
@@ -33,17 +33,7 @@ def serialize_value(value: Any) -> Any:
             result.append(serialize_value(value=nested_value))
         return result
 
-    if hasattr(value, "model_dump"):
-        try:
-            return value.model_dump(mode="json")
-        except Exception:
-            pass
-
     if hasattr(value, "__dict__"):
-        return {
-            k: serialize_value(value=v)
-            for k, v in vars(value).items()
-            if not k.startswith("_")
-        }
+        return serialize_value(value=value.__dict__)
 
     return str(value)

--- a/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
@@ -33,7 +33,17 @@ def serialize_value(value: Any) -> Any:
             result.append(serialize_value(value=nested_value))
         return result
 
+    if hasattr(value, "model_dump"):
+        try:
+            return value.model_dump(mode="json")
+        except Exception:
+            pass
+
     if hasattr(value, "__dict__"):
-        return serialize_value(value=value.__dict__)
+        return {
+            k: serialize_value(value=v)
+            for k, v in vars(value).items()
+            if not k.startswith("_")
+        }
 
     return str(value)


### PR DESCRIPTION
1. fix span attribute output format
2. fix span attribute tools capture

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OTEL span attribute schema/encoding for OpenAI Agents responses (output, tools, and tool calls), which may impact downstream telemetry parsing and dashboards. Added tests reduce regression risk but attribute shape changes could still affect consumers.
> 
> **Overview**
> Updates OpenAI Agents OTEL emission to **separate assistant text output from tool/function activity**: `_format_output` now returns plain text (skipping tool items), while tool calls are extracted into a new namespaced `respan.span.tool_calls` attribute.
> 
> Tool definitions from the Responses API are normalized into a Chat Completions–style structure and stored in `respan.span.tools`, with structured values JSON-encoded via a helper for OTEL attribute safety. Adds unit tests to assert the new `respan.span.tool_calls`/`respan.span.tools` behavior and avoid leaking un-namespaced `tools`/`tool_calls` attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d270fdcaa5fa33164a013e291de9b29504eae4df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->