### PR TITLE
feat(oi): forward kwargs to OpenInference instrumentors

### DIFF
--- a/python-sdks/examples/crewai/hello_world.py
+++ b/python-sdks/examples/crewai/hello_world.py
@@ -10,7 +10,13 @@ from respan_instrumentation_openinference import OpenInferenceInstrumentor
 from openinference.instrumentation.crewai import CrewAIInstrumentor
 
 respan = Respan(
-    instrumentations=[OpenInferenceInstrumentor(CrewAIInstrumentor)],
+    instrumentations=[
+        OpenInferenceInstrumentor(
+            CrewAIInstrumentor,
+            use_event_listener=True,
+            create_llm_spans=True,
+        ),
+    ],
 )
 
 # Import CrewAI AFTER Respan init so it uses our TracerProvider

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-instrumentation-openinference"
-version = "1.1.0"
+version = "1.2.0"
 description = "Respan instrumentation wrapper for OpenInference"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_instrumentation.py
@@ -29,8 +29,9 @@ class OpenInferenceInstrumentor:
     # Class-level flag: only register the translator once across all instances
     _translator_registered = False
 
-    def __init__(self, instrumentor_class: type) -> None:
+    def __init__(self, instrumentor_class: type, **kwargs) -> None:
         self._instrumentor_class = instrumentor_class
+        self._instrumentor_kwargs = kwargs
         self._instrumentor = None
         self._is_instrumented = False
         self._is_span_processor = False
@@ -59,7 +60,7 @@ class OpenInferenceInstrumentor:
 
         # Standard OI instrumentors expose .instrument()
         if hasattr(self._instrumentor, "instrument"):
-            self._instrumentor.instrument(tracer_provider=tp)
+            self._instrumentor.instrument(tracer_provider=tp, **self._instrumentor_kwargs)
         # SpanProcessor-based OI packages (pydantic-ai, strands-agents)
         elif hasattr(tp, "add_span_processor"):
             tp.add_span_processor(self._instrumentor)

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_instrumentation.py
@@ -31,6 +31,8 @@ class OpenInferenceInstrumentor:
 
     def __init__(self, instrumentor_class: type, **kwargs) -> None:
         self._instrumentor_class = instrumentor_class
+        # tracer_provider is always set by activate(); drop to avoid collision
+        kwargs.pop("tracer_provider", None)
         self._instrumentor_kwargs = kwargs
         self._instrumentor = None
         self._is_instrumented = False


### PR DESCRIPTION
## Summary
- Forward `**kwargs` from `OpenInferenceInstrumentor` to the wrapped OI instrumentor's `.instrument()` call, enabling configuration like `use_event_listener=True` and `create_llm_spans=True`
- Update CrewAI example to use event listener mode for proper LLM span capture (model, tokens, messages)
- Bump `respan-instrumentation-openinference` version to 1.2.0

## Test plan
- [x] Ran CrewAI hello_world example with event listener mode
- [x] Verified trace in Respan: 3 spans (crew.kickoff, agent.execute, llm_call), tokens captured (99/16/115), model detected (gpt-4.1-mini), cost calculated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OpenInference instrumentation wrapper to pass through arbitrary `.instrument()` options, which can alter tracing behavior across all OpenInference integrations. Risk is limited to telemetry but could break specific instrumentors if unexpected kwargs are forwarded.
> 
> **Overview**
> **Enables configuration of wrapped OpenInference instrumentors via `OpenInferenceInstrumentor(..., **kwargs)`.** The wrapper now stores and forwards kwargs into the underlying instrumentor’s `.instrument()` call (while dropping any `tracer_provider` kwarg to avoid collisions).
> 
> Updates the CrewAI hello-world example to run `CrewAIInstrumentor` in event-listener mode with LLM span creation enabled, and bumps `respan-instrumentation-openinference` to `1.2.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27f46005b48d9caf52dab5c9be645d772083a361. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->