### PR TITLE
fix: remove OI attributes for respan-instrumentation-openinference

### DIFF
--- a/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_translator.py
@@ -279,7 +279,8 @@ class OpenInferenceTranslator(SpanProcessor):
     enriches them with the Traceloop attributes the Respan backend expects.
 
     All mappings are the exact reverse of Arize's openinference-instrumentation-openllmetry.
-    OI attributes are preserved (additive enrichment via setdefault, not destructive).
+    After translation, redundant raw OpenInference attributes are removed so they
+    do not leak into passthrough metadata / custom properties.
     """
 
     def on_start(self, span: Any, parent_context: Any = None) -> None:
@@ -357,6 +358,8 @@ class OpenInferenceTranslator(SpanProcessor):
         if oi_kind_upper in _LLM_KINDS:
             self._translate_llm(attrs)
 
+        self._remove_redundant_oi_attrs(attrs)
+
     def _translate_llm(self, attrs: Dict[str, Any]) -> None:
         """Extra translation for LLM/EMBEDDING spans."""
         # Mark as chat request type
@@ -383,6 +386,39 @@ class OpenInferenceTranslator(SpanProcessor):
         tools_raw = attrs.get(OI_LLM_TOOLS)
         if tools_raw:
             attrs.setdefault(_TL_REQUEST_FUNCTIONS, tools_raw)
+
+    @staticmethod
+    def _remove_redundant_oi_attrs(attrs: Dict[str, Any]) -> None:
+        """Remove noisy raw OpenInference attrs while keeping useful passthrough."""
+        keys_to_remove = {
+            OPENINFERENCE_SPAN_KIND,
+            OI_INPUT_VALUE,
+            "input.mime_type",
+            OI_OUTPUT_VALUE,
+            "output.mime_type",
+            OI_LLM_MODEL_NAME,
+            OI_LLM_PROVIDER,
+            OI_LLM_SYSTEM,
+            OI_LLM_INVOCATION_PARAMETERS,
+            OI_LLM_TOKEN_COUNT_PROMPT,
+            OI_LLM_TOKEN_COUNT_COMPLETION,
+            OI_LLM_TOKEN_COUNT_TOTAL,
+            OI_LLM_TOKEN_COUNT_CACHE_READ,
+            OI_LLM_TOOLS,
+            OI_AGENT_NAME,
+        }
+        prefixes_to_remove = (
+            "llm.input_messages.",
+            "llm.output_messages.",
+            "llm.token_count.",
+        )
+
+        for key in keys_to_remove:
+            attrs.pop(key, None)
+
+        for key in list(attrs.keys()):
+            if any(key.startswith(prefix) for prefix in prefixes_to_remove):
+                attrs.pop(key, None)
 
     def shutdown(self) -> None:
         pass

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_translator.py
@@ -206,3 +206,57 @@ def test_invocation_params_extracted(translator):
     assert span._attributes["gen_ai.request.temperature"] == 0.7
     assert span._attributes["gen_ai.request.top_p"] == 0.9
     assert span._attributes["gen_ai.request.max_tokens"] == 1024
+
+
+# ------------------------------------------------------------------
+# 13. noisy raw OI attrs are removed after translation
+# ------------------------------------------------------------------
+
+def test_redundant_oi_attrs_removed_after_translation(translator):
+    span = _make_span({
+        "openinference.span.kind": "LLM",
+        "input.value": "hello world",
+        "input.mime_type": "text/plain",
+        "output.value": "goodbye world",
+        "output.mime_type": "text/plain",
+        "llm.model_name": "gpt-4o",
+        "llm.system": "OpenAI",
+        "llm.provider": "OpenAI",
+        "llm.invocation_parameters": json.dumps({"temperature": 0.3}),
+        "llm.input_messages.0.message.role": "user",
+        "llm.input_messages.0.message.content": "Hello!",
+        "llm.output_messages.0.message.role": "assistant",
+        "llm.output_messages.0.message.content": "Goodbye!",
+        "llm.token_count.prompt": 10,
+        "llm.token_count.completion": 4,
+        "llm.token_count.total": 14,
+    })
+
+    translator.on_end(span)
+
+    assert span._attributes["traceloop.entity.input"] == "hello world"
+    assert span._attributes["traceloop.entity.output"] == "goodbye world"
+    assert span._attributes["gen_ai.request.model"] == "gpt-4o"
+    assert span._attributes["gen_ai.system"] == "openai"
+    assert span._attributes["gen_ai.provider.name"] == "openai"
+    assert span._attributes["gen_ai.prompt.0.content"] == "Hello!"
+    assert span._attributes["gen_ai.completion.0.content"] == "Goodbye!"
+    assert span._attributes["gen_ai.usage.prompt_tokens"] == 10
+    assert span._attributes["gen_ai.usage.completion_tokens"] == 4
+
+    assert "input.value" not in span._attributes
+    assert "input.mime_type" not in span._attributes
+    assert "output.value" not in span._attributes
+    assert "output.mime_type" not in span._attributes
+    assert "openinference.span.kind" not in span._attributes
+    assert "llm.model_name" not in span._attributes
+    assert "llm.system" not in span._attributes
+    assert "llm.provider" not in span._attributes
+    assert "llm.invocation_parameters" not in span._attributes
+    assert "llm.input_messages.0.message.role" not in span._attributes
+    assert "llm.input_messages.0.message.content" not in span._attributes
+    assert "llm.output_messages.0.message.role" not in span._attributes
+    assert "llm.output_messages.0.message.content" not in span._attributes
+    assert "llm.token_count.prompt" not in span._attributes
+    assert "llm.token_count.completion" not in span._attributes
+    assert "llm.token_count.total" not in span._attributes


### PR DESCRIPTION
remove Openinference attributes for respan-instrumentation-openinference

common fix works for both anthropic, claude agents, crewAI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span attribute output by deleting raw OpenInference keys after translation, which could impact consumers relying on those passthrough attributes. Scope is limited to the OpenInference→Traceloop translation path and is covered by a new unit test.
> 
> **Overview**
> Updates `OpenInferenceTranslator` to **delete raw OpenInference attributes after enrichment** (including `openinference.span.kind`, `input/output.*`, `llm.*` model/provider/system, invocation params, token counts, tools, and message/token_count prefixes) so only the translated Traceloop/OpenLLMetry fields remain.
> 
> Adds a unit test asserting translated fields are present while the original OpenInference fields are removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e89bdc23eed980306795993f1a040147748f73ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->