### PR TITLE
chore: bump @respan/instrumentation-vercel to 1.0.1

### DIFF
--- a/javascript-sdks/respan-instrumentation-vercel/package.json
+++ b/javascript-sdks/respan-instrumentation-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/instrumentation-vercel",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Respan instrumentation plugin for Vercel AI SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Syncs package.json version with what was published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the `package.json` version number and does not change runtime code or dependencies.
> 
> **Overview**
> Bumps `@respan/instrumentation-vercel` package version in `package.json` from `1.0.0` to `1.0.1` to align with the published npm release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34b7be7785aa19568cb6b16d1ffddaa113f307b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->