### PR TITLE
feat(tracing): SpanBuffer continuation mode — skip wrapper spans

### DIFF
--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.14.2"
+version = "2.15.0"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-tracing/src/respan_tracing/core/client.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/client.py
@@ -371,7 +371,7 @@ class RespanClient:
         # the parent context. Only client.start_span() is affected — decorators
         # use setup_span() directly and are not skipped.
         active_buffer = _active_span_buffer.get(None)
-        if active_buffer and active_buffer.is_continuation:
+        if active_buffer and active_buffer._parent_span_id:
             yield None
             return
 

--- a/python-sdks/respan-tracing/src/respan_tracing/core/client.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/client.py
@@ -364,6 +364,17 @@ class RespanClient:
             yield None
             return
 
+        # Continuation mode: when inside a SpanBuffer with a parent span,
+        # skip creating wrapper spans — the parent already exists. Child spans
+        # (from @task/@workflow decorators via setup_span) attach directly to
+        # the parent context. Only client.start_span() is affected — decorators
+        # use setup_span() directly and are not skipped.
+        from respan_tracing.processors.base import _active_span_buffer
+        active_buffer = _active_span_buffer.get(None)
+        if active_buffer and active_buffer.is_continuation:
+            yield None
+            return
+
         span, ctx_token, entity_name_token, entity_path_token = setup_span(
             entity_name=name,
             span_kind=kind,

--- a/python-sdks/respan-tracing/src/respan_tracing/core/client.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/client.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 
 from respan_tracing.core.tracer import RespanTracer
 from respan_tracing.processors import SpanBuffer
+from respan_tracing.processors.base import _active_span_buffer
 from respan_tracing.utils.logging import get_respan_logger
 from respan_tracing.utils.span_setup import setup_span, cleanup_span, LinksParam
 
@@ -369,7 +370,6 @@ class RespanClient:
         # (from @task/@workflow decorators via setup_span) attach directly to
         # the parent context. Only client.start_span() is affected — decorators
         # use setup_span() directly and are not skipped.
-        from respan_tracing.processors.base import _active_span_buffer
         active_buffer = _active_span_buffer.get(None)
         if active_buffer and active_buffer.is_continuation:
             yield None

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -349,6 +349,7 @@ class SpanBuffer:
         self._tracer_provider = tracer_provider
         self._parent_trace_id = parent_trace_id
         self._parent_span_id = parent_span_id
+        self.is_continuation = bool(parent_trace_id and parent_span_id)
     
     def __enter__(self):
         """

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -349,7 +349,6 @@ class SpanBuffer:
         self._tracer_provider = tracer_provider
         self._parent_trace_id = parent_trace_id
         self._parent_span_id = parent_span_id
-        self.is_continuation = bool(parent_trace_id and parent_span_id)
     
     def __enter__(self):
         """


### PR DESCRIPTION
## Summary

When `SpanBuffer` has a `parent_span_id` (trace continuation, e.g., workflow resume), `client.start_span()` now yields `None` instead of creating a wrapper span. This prevents duplicate parent spans.

**How it works:**
- `SpanBuffer.__init__` sets `is_continuation=True` when `parent_trace_id` and `parent_span_id` are provided
- `client.start_span()` checks `_active_span_buffer.is_continuation` — if True, skips span creation
- `@task`/`@workflow` decorators use `setup_span()` directly and are NOT affected — they still create spans as children of the parent context

**Before:** Resumed executor creates a duplicate `evaluator_workflow.workflow` wrapper with same span name as original
**After:** Resumed tasks (`transform.task`, etc.) attach directly under the original `evaluator_workflow.workflow`

## Test plan
- [ ] Resumed workflow spans appear directly under original parent (no wrapper)
- [ ] @task decorators still create spans normally inside continuation
- [ ] Non-continuation SpanBuffer (no parent_span_id) unchanged
- [ ] wait.paused span still emitted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)