### PR TITLE
feat: add session_identifier as first-class span attribute [DEV-5553]

### DIFF
--- a/javascript-sdks/respan-cli/src/hooks/claude-code.ts
+++ b/javascript-sdks/respan-cli/src/hooks/claude-code.ts
@@ -281,6 +281,7 @@ function createSpans(
   const rootSpanId = `claudecode_${traceUniqueId}_root`;
   spans.push({
     trace_unique_id: traceUniqueId,
+    session_identifier: threadId,
     thread_identifier: threadId,
     customer_identifier: customerId,
     span_unique_id: rootSpanId,

--- a/javascript-sdks/respan-cli/src/hooks/codex-cli.ts
+++ b/javascript-sdks/respan-cli/src/hooks/codex-cli.ts
@@ -261,6 +261,7 @@ function createSpans(
   const rootSpanId = `codexcli_${traceUniqueId}_root`;
   spans.push({
     trace_unique_id: traceUniqueId,
+    session_identifier: threadId,
     thread_identifier: threadId,
     customer_identifier: customerId,
     span_unique_id: rootSpanId,

--- a/javascript-sdks/respan-cli/src/hooks/gemini-cli.ts
+++ b/javascript-sdks/respan-cli/src/hooks/gemini-cli.ts
@@ -275,6 +275,7 @@ function buildSpans(
   // Root span
   spans.push({
     trace_unique_id: traceUniqueId,
+    session_identifier: threadId,
     thread_identifier: threadId,
     customer_identifier: customerId,
     span_unique_id: rootSpanId,

--- a/javascript-sdks/respan-cli/src/hooks/shared.ts
+++ b/javascript-sdks/respan-cli/src/hooks/shared.ts
@@ -39,6 +39,7 @@ export interface SpanData {
   span_name: string;
   span_workflow_name: string;
   span_path?: string;
+  session_identifier?: string;
   thread_identifier?: string;
   customer_identifier?: string;
   model?: string;
@@ -378,6 +379,7 @@ export function toOtlpPayload(spans: SpanData[]): Record<string, unknown> {
     const attrs: Record<string, unknown> = {};
 
     // Respan-specific attributes
+    if (span.session_identifier) attrs['respan.sessions.session_identifier'] = span.session_identifier;
     if (span.thread_identifier) attrs['respan.threads.thread_identifier'] = span.thread_identifier;
     if (span.customer_identifier) attrs['respan.customer_params.customer_identifier'] = span.customer_identifier;
     if (span.span_workflow_name) attrs['traceloop.workflow.name'] = span.span_workflow_name;

--- a/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
+++ b/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
@@ -39,6 +39,7 @@ const CUSTOMER_ID = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_ID;
 const CUSTOMER_EMAIL = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_EMAIL;
 const CUSTOMER_NAME = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_NAME;
 const THREAD_ID = RespanSpanAttributes.RESPAN_THREADS_ID;
+const SESSION_ID = RespanSpanAttributes.RESPAN_SESSION_ID;
 const TRACE_GROUP_ID = RespanSpanAttributes.RESPAN_TRACE_GROUP_ID;
 const RESPAN_SPAN_TOOLS = RespanSpanAttributes.RESPAN_SPAN_TOOLS;
 const RESPAN_METADATA_AGENT_NAME = RespanSpanAttributes.RESPAN_METADATA_AGENT_NAME;
@@ -408,6 +409,9 @@ function enrichMetadata(attrs: Record<string, any>, spanName: string): void {
         break;
       case "customer_name":
         setDefault(attrs, CUSTOMER_NAME, String(value));
+        break;
+      case "session_identifier":
+        setDefault(attrs, SESSION_ID, String(value));
         break;
       case "thread_identifier":
         setDefault(attrs, THREAD_ID, String(value));

--- a/javascript-sdks/respan-sdk/src/types/baseTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/baseTypes.ts
@@ -4,6 +4,7 @@ export type RespanParams = {
     customer_email?: string;
     customer_name?: string;
     evaluation_identifier?: string | number;
+    session_identifier?: string | number;
     thread_identifier?: string | number;
     trace_group_identifier?: string | number;
     group_identifier?: string | number;

--- a/javascript-sdks/respan-sdk/src/types/logTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/logTypes.ts
@@ -565,6 +565,10 @@ const RespanParamsSchema = z.object({
   span_tools: z.array(z.string()).optional(),
   span_workflow_name: z.string().optional(),
 
+  //#region session
+  session_identifier: StringOrNumberSchema.optional(),
+  //#endregion session
+
   //#region thread
   thread_identifier: StringOrNumberSchema.optional(),
   //#endregion thread

--- a/javascript-sdks/respan-sdk/src/types/spanTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/spanTypes.ts
@@ -13,6 +13,9 @@ export enum RespanSpanAttributes {
     // Threads
     RESPAN_THREADS_ID = "respan.threads.thread_identifier",
 
+    // Sessions
+    RESPAN_SESSION_ID = "respan.sessions.session_identifier",
+
     // Trace
     RESPAN_TRACE_GROUP_ID = "respan.trace.trace_group_identifier",
 
@@ -72,6 +75,7 @@ export const RESPAN_SPAN_ATTRIBUTES_MAP: { [key: string]: string } = {
     customer_name: RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_NAME,
     evaluation_identifier: RespanSpanAttributes.RESPAN_EVALUATION_PARAMS_ID,
     thread_identifier: RespanSpanAttributes.RESPAN_THREADS_ID,
+    session_identifier: RespanSpanAttributes.RESPAN_SESSION_ID,
     custom_identifier: RespanSpanAttributes.RESPAN_SPAN_CUSTOM_ID,
     trace_group_identifier: RespanSpanAttributes.RESPAN_TRACE_GROUP_ID,
     group_identifier: RespanSpanAttributes.RESPAN_TRACE_GROUP_ID,

--- a/python-sdks/respan-exporter-litellm/src/respan_exporter_litellm/exporter.py
+++ b/python-sdks/respan-exporter-litellm/src/respan_exporter_litellm/exporter.py
@@ -318,10 +318,14 @@ class RespanLiteLLMCallback(LiteLLMCustomLogger):
                     f"customer_{k}": v for k, v in cp.items() if k != "customer_identifier"
                 })
         
+        # Session identifier
+        if "session_identifier" in kw_params:
+            payload["session_identifier"] = kw_params["session_identifier"]
+
         # Thread identifier
         if "thread_identifier" in kw_params:
             payload["thread_identifier"] = kw_params["thread_identifier"]
-        
+
         # Custom metadata
         if m := kw_params.get("metadata"):
             if isinstance(m, dict):
@@ -329,7 +333,7 @@ class RespanLiteLLMCallback(LiteLLMCustomLogger):
         
         # Add remaining params as metadata
         excluded = {
-            "customer_identifier", "customer_params", "thread_identifier", "metadata",
+            "customer_identifier", "customer_params", "session_identifier", "thread_identifier", "metadata",
             "workflow_name", "trace_id", "trace_name", "span_id", "parent_span_id", "span_name",
         }
         extra_meta.update({k: v for k, v in kw_params.items() if k not in excluded})

--- a/python-sdks/respan-sdk/src/respan_sdk/constants/otlp_constants.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/otlp_constants.py
@@ -111,6 +111,7 @@ RESPAN_PROMOTED_KEYS = frozenset({
     "respan.customer_params.name",
     "respan.evaluation_params.evaluation_identifier",
     "respan.threads.thread_identifier",
+    "respan.sessions.session_identifier",
     "respan.trace.trace_group_identifier",
     "respan.metadata",
     "respan.entity.log_method",

--- a/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
@@ -38,6 +38,9 @@ class RespanSpanAttributes(str, Enum):
     # Threads
     RESPAN_THREADS_ID = "respan.threads.thread_identifier"
 
+    # Sessions
+    RESPAN_SESSION_ID = "respan.sessions.session_identifier"
+
     # Trace
     RESPAN_TRACE_GROUP_ID = "respan.trace.trace_group_identifier"
 
@@ -79,6 +82,9 @@ RESPAN_EVALUATION_PARAMS_ID = RespanSpanAttributes.RESPAN_EVALUATION_PARAMS_ID.v
 # Threads
 RESPAN_THREADS_ID = RespanSpanAttributes.RESPAN_THREADS_ID.value
 
+# Sessions
+RESPAN_SESSION_ID = RespanSpanAttributes.RESPAN_SESSION_ID.value
+
 # Trace
 RESPAN_TRACE_GROUP_ID = RespanSpanAttributes.RESPAN_TRACE_GROUP_ID.value
 
@@ -111,6 +117,7 @@ RESPAN_SPAN_ATTRIBUTES_MAP = {
     "customer_name": RESPAN_CUSTOMER_PARAMS_NAME,
     "evaluation_identifier": RESPAN_EVALUATION_PARAMS_ID,
     "thread_identifier": RESPAN_THREADS_ID,
+    "session_identifier": RESPAN_SESSION_ID,
     "custom_identifier": RESPAN_SPAN_CUSTOM_ID,
     "trace_group_identifier": RESPAN_TRACE_GROUP_ID,
     "group_identifier": RESPAN_TRACE_GROUP_ID,

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
@@ -406,6 +406,7 @@ class RespanFullLogParams(RespanLogParams):
     # endregion: usage (additional)
 
     # region: tracing (additional)
+    session_identifier: Optional[Union[str, int]] = None
     thread_identifier: Optional[Union[str, int]] = None
     thread_unique_id: Optional[str] = None
     # endregion: tracing

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
@@ -472,6 +472,9 @@ class RespanParams(RespanBaseModel, PreprocessLogDataMixin):
     trace_group_identifier: Optional[Union[str, int]] = (
         None  # The customizable id for grouping traces together
     )
+    # region: session
+    session_identifier: Optional[Union[str, int]] = None
+    # endregion: session
     # region: thread, deprecated
     thread_identifier: Optional[Union[str, int]] = (
         None  # 2025-06-04: Deprecated, merged into tracing as a special case

--- a/python-sdks/respan/src/respan/_core.py
+++ b/python-sdks/respan/src/respan/_core.py
@@ -68,6 +68,7 @@ class Respan:
         instrumentations: Optional[Sequence[object]] = None,
         is_auto_instrument: Optional[bool] = None,
         customer_identifier: Optional[str] = None,
+        session_identifier: Optional[str] = None,
         thread_identifier: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         environment: Optional[str] = None,
@@ -82,6 +83,8 @@ class Respan:
         default_attributes: Dict[str, Any] = {}
         if customer_identifier:
             default_attributes["customer_identifier"] = customer_identifier
+        if session_identifier:
+            default_attributes["session_identifier"] = session_identifier
         if thread_identifier:
             default_attributes["thread_identifier"] = thread_identifier
         if metadata:


### PR DESCRIPTION
## Summary
- Phase 3 of session_identifier migration (BE Phases 1-2: PRs #1674, #1678)
- Adds `session_identifier` as a first-class span attribute across Python and JS SDKs
- CLI hooks dual-write `threadId` to both `session_identifier` and `thread_identifier` for backward compat

### Python SDK
- `span_attributes.py`: enum + flat alias + attributes map entry
- `otlp_constants.py`: promoted key
- `param_types.py` + `log_types.py`: field definitions
- `_core.py`: Respan init param
- LiteLLM exporter: payload + excluded set

### JS SDK
- `spanTypes.ts`: enum + attributes map entry
- `baseTypes.ts` + `logTypes.ts`: type definitions
- Vercel translator: constant + switch case
- CLI hooks (claude-code, codex-cli, gemini-cli): dual-write + SpanData type

## Test plan
- [ ] Python: `propagate_attributes(session_identifier="s1")` sets OTel attr `respan.sessions.session_identifier`
- [ ] JS: `propagateAttributes({ session_identifier: "s1" })` sets OTel attr
- [ ] CLI hooks: spans include both `session_identifier` and `thread_identifier`
- [ ] LiteLLM: `session_identifier` in `respan_params` flows to payload