### PR TITLE
Add CI/CD workflows for core SDK packages

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -1,0 +1,88 @@
+{
+  "packages": [
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/respan",
+      "path": "javascript-sdks/respan",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/cli",
+      "path": "javascript-sdks/respan-cli",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/instrumentation-openai",
+      "path": "javascript-sdks/respan-instrumentation-openai",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/instrumentation-openai-agents",
+      "path": "javascript-sdks/respan-instrumentation-openai-agents",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/instrumentation-openinference",
+      "path": "javascript-sdks/respan-instrumentation-openinference",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/instrumentation-vercel",
+      "path": "javascript-sdks/respan-instrumentation-vercel",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/respan-sdk",
+      "path": "javascript-sdks/respan-sdk",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/tracing",
+      "path": "javascript-sdks/respan-tracing",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-sdk",
+      "path": "python-sdks/respan-sdk",
+      "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-tracing",
+      "path": "python-sdks/respan-tracing",
+      "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-ai",
+      "path": "python-sdks/respan",
+      "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-openinference",
+      "path": "python-sdks/instrumentations/respan-instrumentation-openinference",
+      "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-openai",
+      "path": "python-sdks/instrumentations/respan-instrumentation-openai",
+      "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-openai-agents",
+      "path": "python-sdks/instrumentations/respan-instrumentation-openai-agents",
+      "registry": "pypi"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
-          cache: yarn
-          cache-dependency-path: javascript-sdks/yarn.lock
 
       - name: Install JavaScript dependencies
         working-directory: javascript-sdks
         run: |
           corepack enable
-          yarn install
+          corepack install
+          yarn install --immutable
 
       - name: Build package
         if: ${{ matrix.has_build }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      javascript_matrix: ${{ steps.javascript_matrix.outputs.value }}
+      javascript_count: ${{ steps.javascript_count.outputs.value }}
+      python_matrix: ${{ steps.python_matrix.outputs.value }}
+      python_count: ${{ steps.python_count.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate release metadata
+        run: python3 scripts/release_inventory.py --validate
+
+      - id: javascript_matrix
+        name: Build JavaScript matrix
+        run: echo "value=$(python3 scripts/release_inventory.py --ecosystem javascript --format github-matrix)" >> "$GITHUB_OUTPUT"
+
+      - id: javascript_count
+        name: Count JavaScript packages
+        run: echo "value=$(python3 scripts/release_inventory.py --ecosystem javascript --count)" >> "$GITHUB_OUTPUT"
+
+      - id: python_matrix
+        name: Build Python matrix
+        run: echo "value=$(python3 scripts/release_inventory.py --ecosystem python --format github-matrix)" >> "$GITHUB_OUTPUT"
+
+      - id: python_count
+        name: Count Python packages
+        run: echo "value=$(python3 scripts/release_inventory.py --ecosystem python --count)" >> "$GITHUB_OUTPUT"
+
+  javascript:
+    needs: discover
+    if: ${{ needs.discover.outputs.javascript_count != '0' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.javascript_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: yarn
+          cache-dependency-path: javascript-sdks/yarn.lock
+
+      - name: Install JavaScript dependencies
+        working-directory: javascript-sdks
+        run: |
+          corepack enable
+          yarn install
+
+      - name: Build package
+        if: ${{ matrix.has_build }}
+        working-directory: javascript-sdks
+        run: yarn workspace "${{ matrix.name }}" build
+
+      - name: Test package
+        if: ${{ matrix.has_test }}
+        working-directory: javascript-sdks
+        run: yarn workspace "${{ matrix.name }}" test
+
+  python:
+    needs: discover
+    if: ${{ needs.discover.outputs.python_count != '0' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.python_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python build tooling
+        run: python3 -m pip install --upgrade build pip
+
+      - name: Build distribution
+        working-directory: ${{ matrix.path }}
+        run: python3 -m build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,13 @@ jobs:
           cd javascript-sdks
           yarn install
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format names | while IFS= read -r package_name; do
-              [ -n "${package_name}" ] || continue
-              yarn workspace "${package_name}" run build
+            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format paths | while IFS= read -r package_path; do
+              [ -n "${package_path}" ] || continue
+              if [ "${package_path}" = "javascript-sdks/respan-cli" ]; then
+                yarn workspace "@respan/cli" run build
+              else
+                ./node_modules/.bin/tsc -p "../${package_path}/tsconfig.json"
+              fi
             done
           fi
           if [ "${{ matrix.has_test }}" = "true" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,22 +62,18 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Install JavaScript dependencies
+      - name: Install and run package checks
         working-directory: javascript-sdks
         run: |
           corepack enable
           corepack install
           yarn install
-
-      - name: Build package
-        if: ${{ matrix.has_build }}
-        working-directory: javascript-sdks
-        run: yarn workspace "${{ matrix.name }}" build
-
-      - name: Test package
-        if: ${{ matrix.has_test }}
-        working-directory: javascript-sdks
-        run: yarn workspace "${{ matrix.name }}" test
+          if [ "${{ matrix.has_build }}" = "true" ]; then
+            yarn workspace "${{ matrix.name }}" build
+          fi
+          if [ "${{ matrix.has_test }}" = "true" ]; then
+            yarn workspace "${{ matrix.name }}" test
+          fi
 
   python:
     needs: discover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,17 @@ jobs:
           corepack enable
           cd javascript-sdks
           yarn install
-          cd ../${{ matrix.path }}
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            yarn build
+            if [ "${{ matrix.path }}" = "javascript-sdks/respan-cli" ]; then
+              cd ../${{ matrix.path }}
+              yarn build
+              cd -
+            else
+              ./node_modules/.bin/tsc -p ../${{ matrix.path }}/tsconfig.json
+            fi
           fi
           if [ "${{ matrix.has_test }}" = "true" ]; then
+            cd ../${{ matrix.path }}
             yarn test
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
       - name: Install and run package checks
         run: |
           corepack enable
-          corepack install
           cd javascript-sdks
           yarn install
           cd ../${{ matrix.path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           corepack enable
           corepack install
-          yarn install --immutable
+          yarn install
 
       - name: Build package
         if: ${{ matrix.has_build }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,16 @@ jobs:
           cd javascript-sdks
           yarn install
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            yarn workspaces foreach -Rt --from "${{ matrix.name }}" run build
+            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format paths | while IFS= read -r package_path; do
+              [ -n "${package_path}" ] || continue
+              cd "../${package_path}"
+              yarn build
+              cd ../javascript-sdks
+            done
           fi
           if [ "${{ matrix.has_test }}" = "true" ]; then
-            yarn workspace "${{ matrix.name }}" test
+            cd ../${{ matrix.path }}
+            yarn test
           fi
 
   python:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,16 +63,17 @@ jobs:
           node-version: "24"
 
       - name: Install and run package checks
-        working-directory: javascript-sdks
         run: |
           corepack enable
           corepack install
+          cd javascript-sdks
           yarn install
+          cd ../${{ matrix.path }}
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            yarn workspace "${{ matrix.name }}" build
+            yarn build
           fi
           if [ "${{ matrix.has_test }}" = "true" ]; then
-            yarn workspace "${{ matrix.name }}" test
+            yarn test
           fi
 
   python:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,16 +68,13 @@ jobs:
           cd javascript-sdks
           yarn install
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format paths | while IFS= read -r package_path; do
-              [ -n "${package_path}" ] || continue
-              cd "../${package_path}"
-              yarn build
-              cd ../javascript-sdks
+            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format names | while IFS= read -r package_name; do
+              [ -n "${package_name}" ] || continue
+              yarn workspace "${package_name}" run build
             done
           fi
           if [ "${{ matrix.has_test }}" = "true" ]; then
-            cd ../${{ matrix.path }}
-            yarn test
+            yarn workspace "${{ matrix.name }}" test
           fi
 
   python:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,17 +68,10 @@ jobs:
           cd javascript-sdks
           yarn install
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            if [ "${{ matrix.path }}" = "javascript-sdks/respan-cli" ]; then
-              cd ../${{ matrix.path }}
-              yarn build
-              cd -
-            else
-              ./node_modules/.bin/tsc -p ../${{ matrix.path }}/tsconfig.json
-            fi
+            yarn workspaces foreach -Rt --from "${{ matrix.name }}" run build
           fi
           if [ "${{ matrix.has_test }}" = "true" ]; then
-            cd ../${{ matrix.path }}
-            yarn test
+            yarn workspace "${{ matrix.name }}" test
           fi
 
   python:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,7 +120,12 @@ jobs:
           cd javascript-sdks
           yarn install
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            yarn workspaces foreach -Rt --from "${{ matrix.name }}" run build
+            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format paths | while IFS= read -r package_path; do
+              [ -n "${package_path}" ] || continue
+              cd "../${package_path}"
+              yarn build
+              cd ../javascript-sdks
+            done
           fi
 
       - name: Publish package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,7 +117,6 @@ jobs:
       - name: Install and build package
         run: |
           corepack enable
-          corepack install
           cd javascript-sdks
           yarn install
           cd ../${{ matrix.path }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,13 +120,7 @@ jobs:
           cd javascript-sdks
           yarn install
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            if [ "${{ matrix.path }}" = "javascript-sdks/respan-cli" ]; then
-              cd ../${{ matrix.path }}
-              yarn build
-              cd -
-            else
-              ./node_modules/.bin/tsc -p ../${{ matrix.path }}/tsconfig.json
-            fi
+            yarn workspaces foreach -Rt --from "${{ matrix.name }}" run build
           fi
 
       - name: Publish package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,15 +49,20 @@ jobs:
 
       - id: refs
         name: Resolve comparison refs
+        env:
+          DISPATCH_BASE_REF: ${{ inputs.base_ref }}
+          DISPATCH_HEAD_REF: ${{ inputs.head_ref }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEFAULT_HEAD_SHA: ${{ github.sha }}
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
-            HEAD_REF="${{ github.event.workflow_run.head_sha }}"
+            HEAD_REF="${WORKFLOW_RUN_HEAD_SHA}"
             BASE_REF="$(git rev-parse "${HEAD_REF}^")"
           else
-            BASE_REF="${{ inputs.base_ref }}"
-            HEAD_REF="${{ inputs.head_ref }}"
+            BASE_REF="${DISPATCH_BASE_REF}"
+            HEAD_REF="${DISPATCH_HEAD_REF}"
             if [ -z "${HEAD_REF}" ]; then
-              HEAD_REF="${{ github.sha }}"
+              HEAD_REF="${DEFAULT_HEAD_SHA}"
             fi
             if [ -z "${BASE_REF}" ]; then
               BASE_REF="$(git rev-parse "${HEAD_REF}^")"
@@ -73,23 +78,35 @@ jobs:
 
       - id: javascript_matrix
         name: Build JavaScript publish matrix
+        env:
+          BASE_REF: ${{ steps.refs.outputs.base_ref }}
+          HEAD_REF: ${{ steps.refs.outputs.head_ref }}
         run: |
-          echo "value=$(python3 scripts/release_inventory.py --ecosystem javascript --changed-from '${{ steps.refs.outputs.base_ref }}' --changed-to '${{ steps.refs.outputs.head_ref }}' --version-changed --format github-matrix)" >> "$GITHUB_OUTPUT"
+          echo "value=$(python3 scripts/release_inventory.py --ecosystem javascript --changed-from "${BASE_REF}" --changed-to "${HEAD_REF}" --version-changed --format github-matrix)" >> "$GITHUB_OUTPUT"
 
       - id: javascript_count
         name: Count JavaScript publish packages
+        env:
+          BASE_REF: ${{ steps.refs.outputs.base_ref }}
+          HEAD_REF: ${{ steps.refs.outputs.head_ref }}
         run: |
-          echo "value=$(python3 scripts/release_inventory.py --ecosystem javascript --changed-from '${{ steps.refs.outputs.base_ref }}' --changed-to '${{ steps.refs.outputs.head_ref }}' --version-changed --count)" >> "$GITHUB_OUTPUT"
+          echo "value=$(python3 scripts/release_inventory.py --ecosystem javascript --changed-from "${BASE_REF}" --changed-to "${HEAD_REF}" --version-changed --count)" >> "$GITHUB_OUTPUT"
 
       - id: python_matrix
         name: Build Python publish matrix
+        env:
+          BASE_REF: ${{ steps.refs.outputs.base_ref }}
+          HEAD_REF: ${{ steps.refs.outputs.head_ref }}
         run: |
-          echo "value=$(python3 scripts/release_inventory.py --ecosystem python --changed-from '${{ steps.refs.outputs.base_ref }}' --changed-to '${{ steps.refs.outputs.head_ref }}' --version-changed --format github-matrix)" >> "$GITHUB_OUTPUT"
+          echo "value=$(python3 scripts/release_inventory.py --ecosystem python --changed-from "${BASE_REF}" --changed-to "${HEAD_REF}" --version-changed --format github-matrix)" >> "$GITHUB_OUTPUT"
 
       - id: python_count
         name: Count Python publish packages
+        env:
+          BASE_REF: ${{ steps.refs.outputs.base_ref }}
+          HEAD_REF: ${{ steps.refs.outputs.head_ref }}
         run: |
-          echo "value=$(python3 scripts/release_inventory.py --ecosystem python --changed-from '${{ steps.refs.outputs.base_ref }}' --changed-to '${{ steps.refs.outputs.head_ref }}' --version-changed --count)" >> "$GITHUB_OUTPUT"
+          echo "value=$(python3 scripts/release_inventory.py --ecosystem python --changed-from "${BASE_REF}" --changed-to "${HEAD_REF}" --version-changed --count)" >> "$GITHUB_OUTPUT"
 
   publish-javascript:
     needs: discover

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,9 +119,14 @@ jobs:
           corepack enable
           cd javascript-sdks
           yarn install
-          cd ../${{ matrix.path }}
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            yarn build
+            if [ "${{ matrix.path }}" = "javascript-sdks/respan-cli" ]; then
+              cd ../${{ matrix.path }}
+              yarn build
+              cd -
+            else
+              ./node_modules/.bin/tsc -p ../${{ matrix.path }}/tsconfig.json
+            fi
           fi
 
       - name: Publish package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           corepack enable
           corepack install
-          yarn install --immutable
+          yarn install
 
       - name: Build package
         if: ${{ matrix.has_build }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,14 +113,13 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: yarn
-          cache-dependency-path: javascript-sdks/yarn.lock
 
       - name: Install JavaScript dependencies
         working-directory: javascript-sdks
         run: |
           corepack enable
-          yarn install
+          corepack install
+          yarn install --immutable
 
       - name: Build package
         if: ${{ matrix.has_build }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,188 @@
+name: Publish
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Optional git ref or SHA to compare from
+        required: false
+      head_ref:
+        description: Optional git ref or SHA to compare to
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      base_ref: ${{ steps.refs.outputs.base_ref }}
+      head_ref: ${{ steps.refs.outputs.head_ref }}
+      javascript_matrix: ${{ steps.javascript_matrix.outputs.value }}
+      javascript_count: ${{ steps.javascript_count.outputs.value }}
+      python_matrix: ${{ steps.python_matrix.outputs.value }}
+      python_count: ${{ steps.python_count.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate release metadata
+        run: python3 scripts/release_inventory.py --validate
+
+      - id: refs
+        name: Resolve comparison refs
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
+            HEAD_REF="${{ github.event.workflow_run.head_sha }}"
+            BASE_REF="$(git rev-parse "${HEAD_REF}^")"
+          else
+            BASE_REF="${{ inputs.base_ref }}"
+            HEAD_REF="${{ inputs.head_ref }}"
+            if [ -z "${HEAD_REF}" ]; then
+              HEAD_REF="${{ github.sha }}"
+            fi
+            if [ -z "${BASE_REF}" ]; then
+              BASE_REF="$(git rev-parse "${HEAD_REF}^")"
+            fi
+          fi
+
+          if [ -z "${BASE_REF}" ] || [ "${BASE_REF}" = "0000000000000000000000000000000000000000" ]; then
+            BASE_REF="$(git rev-parse "${HEAD_REF}^")"
+          fi
+
+          echo "base_ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+          echo "head_ref=${HEAD_REF}" >> "$GITHUB_OUTPUT"
+
+      - id: javascript_matrix
+        name: Build JavaScript publish matrix
+        run: |
+          echo "value=$(python3 scripts/release_inventory.py --ecosystem javascript --changed-from '${{ steps.refs.outputs.base_ref }}' --changed-to '${{ steps.refs.outputs.head_ref }}' --version-changed --format github-matrix)" >> "$GITHUB_OUTPUT"
+
+      - id: javascript_count
+        name: Count JavaScript publish packages
+        run: |
+          echo "value=$(python3 scripts/release_inventory.py --ecosystem javascript --changed-from '${{ steps.refs.outputs.base_ref }}' --changed-to '${{ steps.refs.outputs.head_ref }}' --version-changed --count)" >> "$GITHUB_OUTPUT"
+
+      - id: python_matrix
+        name: Build Python publish matrix
+        run: |
+          echo "value=$(python3 scripts/release_inventory.py --ecosystem python --changed-from '${{ steps.refs.outputs.base_ref }}' --changed-to '${{ steps.refs.outputs.head_ref }}' --version-changed --format github-matrix)" >> "$GITHUB_OUTPUT"
+
+      - id: python_count
+        name: Count Python publish packages
+        run: |
+          echo "value=$(python3 scripts/release_inventory.py --ecosystem python --changed-from '${{ steps.refs.outputs.base_ref }}' --changed-to '${{ steps.refs.outputs.head_ref }}' --version-changed --count)" >> "$GITHUB_OUTPUT"
+
+  publish-javascript:
+    needs: discover
+    if: ${{ needs.discover.outputs.javascript_count != '0' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: npm
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.javascript_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.discover.outputs.head_ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: yarn
+          cache-dependency-path: javascript-sdks/yarn.lock
+
+      - name: Install JavaScript dependencies
+        working-directory: javascript-sdks
+        run: |
+          corepack enable
+          yarn install
+
+      - name: Build package
+        if: ${{ matrix.has_build }}
+        working-directory: javascript-sdks
+        run: yarn workspace "${{ matrix.name }}" build
+
+      - name: Publish package
+        working-directory: javascript-sdks
+        run: yarn workspace "${{ matrix.name }}" npm publish --access public --provenance --tolerate-republish
+
+  build-python:
+    needs: discover
+    if: ${{ needs.discover.outputs.python_count != '0' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.python_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.discover.outputs.head_ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python build tooling
+        run: python3 -m pip install --upgrade build pip
+
+      - name: Build distribution
+        working-directory: ${{ matrix.path }}
+        run: python3 -m build
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-${{ matrix.slug }}
+          path: ${{ matrix.path }}/dist/*
+          if-no-files-found: error
+
+  publish-python:
+    needs:
+      - discover
+      - build-python
+    if: ${{ needs.discover.outputs.python_count != '0' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.python_matrix) }}
+    steps:
+      - name: Download distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: python-${{ matrix.slug }}
+          path: dist
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,11 +120,9 @@ jobs:
           cd javascript-sdks
           yarn install
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format paths | while IFS= read -r package_path; do
-              [ -n "${package_path}" ] || continue
-              cd "../${package_path}"
-              yarn build
-              cd ../javascript-sdks
+            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format names | while IFS= read -r package_name; do
+              [ -n "${package_name}" ] || continue
+              yarn workspace "${package_name}" run build
             done
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,18 +115,19 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install and build package
-        working-directory: javascript-sdks
         run: |
           corepack enable
           corepack install
+          cd javascript-sdks
           yarn install
+          cd ../${{ matrix.path }}
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            yarn workspace "${{ matrix.name }}" build
+            yarn build
           fi
 
       - name: Publish package
-        working-directory: javascript-sdks
-        run: yarn workspace "${{ matrix.name }}" npm publish --access public --provenance --tolerate-republish
+        working-directory: ${{ matrix.path }}
+        run: yarn npm publish --access public --provenance --tolerate-republish
 
   build-python:
     needs: discover

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,17 +114,15 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install JavaScript dependencies
+      - name: Install and build package
         working-directory: javascript-sdks
         run: |
           corepack enable
           corepack install
           yarn install
-
-      - name: Build package
-        if: ${{ matrix.has_build }}
-        working-directory: javascript-sdks
-        run: yarn workspace "${{ matrix.name }}" build
+          if [ "${{ matrix.has_build }}" = "true" ]; then
+            yarn workspace "${{ matrix.name }}" build
+          fi
 
       - name: Publish package
         working-directory: javascript-sdks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,9 +120,13 @@ jobs:
           cd javascript-sdks
           yarn install
           if [ "${{ matrix.has_build }}" = "true" ]; then
-            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format names | while IFS= read -r package_name; do
-              [ -n "${package_name}" ] || continue
-              yarn workspace "${package_name}" run build
+            python3 ../scripts/release_inventory.py --build-order-for "${{ matrix.name }}" --format paths | while IFS= read -r package_path; do
+              [ -n "${package_path}" ] || continue
+              if [ "${package_path}" = "javascript-sdks/respan-cli" ]; then
+                yarn workspace "@respan/cli" run build
+              else
+                ./node_modules/.bin/tsc -p "../${package_path}/tsconfig.json"
+              fi
             done
           fi
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,0 +1,74 @@
+# CI/CD
+
+This repository now treats package publishing as an explicit, checked-in inventory instead of ad hoc per-package logic.
+Only the selected core SDK packages are included in automation; other packages can remain in the repo without being part of CI publish decisions.
+
+## What The Pipeline Does
+
+- `ci.yml` runs on pull requests and pushes to `main`.
+- It validates the package inventory in `.github/release-packages.json`.
+- It builds every publishable Python package.
+- It installs the JavaScript workspace once per job and then builds or tests each publishable JavaScript package through Yarn workspaces.
+
+## What Publishes On `main`
+
+- `publish.yml` runs after the `CI` workflow completes successfully for `main`, or by manual dispatch.
+- A package is published only when its manifest version changed between the previous and current ref.
+- JavaScript packages publish to npm from the Yarn workspace.
+- Python packages build first, then publish from built artifacts with PyPI Trusted Publishing.
+
+This means merges to `main` can publish automatically, but only if the PR included an actual package version bump.
+
+## Included Packages
+
+Current release automation covers:
+
+- Python: `respan-ai`, `respan-sdk`, `respan-tracing`, `respan-instrumentation-openai`, `respan-instrumentation-openai-agents`, `respan-instrumentation-openinference`
+- JavaScript: `@respan/respan`, `@respan/cli`, `@respan/respan-sdk`, `@respan/tracing`, `@respan/instrumentation-openai`, `@respan/instrumentation-openai-agents`, `@respan/instrumentation-openinference`, `@respan/instrumentation-vercel`
+
+Exporters and other packages are intentionally excluded from release automation.
+
+## Release Metadata Contract
+
+Every publishable package must have:
+
+- one entry in `.github/release-packages.json`
+- a manifest name that matches that inventory entry
+- a single authoritative manifest version
+- public publish metadata for npm packages
+
+For JavaScript packages, the root workspace in `javascript-sdks/package.json` must include each release-managed package path. Extra workspaces are allowed.
+
+## Required Registry Setup
+
+Before the publish workflow can succeed, configure Trusted Publishing for each registry package:
+
+- npm: add this repository and the `publish.yml` workflow as a Trusted Publisher for each npm package
+- PyPI: add this repository and the `publish.yml` workflow as a Trusted Publisher for each PyPI project
+
+Recommended GitHub environments:
+
+- `npm`
+- `pypi`
+
+Use those environments for approval gates if you want a manual checkpoint before packages are released.
+
+## Local Validation
+
+Run:
+
+```bash
+python3 scripts/release_inventory.py --validate
+```
+
+List publishable packages:
+
+```bash
+python3 scripts/release_inventory.py --ecosystem all
+```
+
+List packages that would publish between two refs:
+
+```bash
+python3 scripts/release_inventory.py --ecosystem all --changed-from <base> --changed-to <head> --version-changed
+```

--- a/javascript-sdks/package.json
+++ b/javascript-sdks/package.json
@@ -5,11 +5,6 @@
   "workspaces": [
     "respan",
     "respan-cli",
-    "respan-exporter-anthropic-agents",
-    "respan-exporter-n8n",
-    "respan-exporter-openai-agents",
-    "respan-exporter-vercel",
-    "respan-instrumentation-anthropic",
     "respan-instrumentation-openai",
     "respan-instrumentation-openai-agents",
     "respan-instrumentation-openinference",

--- a/javascript-sdks/package.json
+++ b/javascript-sdks/package.json
@@ -9,6 +9,7 @@
     "respan-instrumentation-openai-agents",
     "respan-instrumentation-openinference",
     "respan-instrumentation-vercel",
+    "respan-exporter-anthropic-agents",
     "respan-sdk",
     "respan-tracing"
   ],

--- a/javascript-sdks/package.json
+++ b/javascript-sdks/package.json
@@ -3,8 +3,19 @@
   "private": true,
   "packageManager": "yarn@4.9.2+sha512.1fc009bc09d13cfd0e19efa44cbfc2b9cf6ca61482725eb35bbc5e257e093ebf4130db6dfe15d604ff4b79efd8e1e8e99b25fa7d0a6197c9f9826358d4d65c3c",
   "workspaces": [
+    "respan",
+    "respan-cli",
+    "respan-exporter-anthropic-agents",
+    "respan-exporter-n8n",
+    "respan-exporter-openai-agents",
+    "respan-exporter-vercel",
+    "respan-instrumentation-anthropic",
+    "respan-instrumentation-openai",
+    "respan-instrumentation-openai-agents",
+    "respan-instrumentation-openinference",
+    "respan-instrumentation-vercel",
     "respan-sdk",
-    "respan-exporter-anthropic-agents"
+    "respan-tracing"
   ],
   "scripts": {
     "test:exporter": "cd respan-exporter-anthropic-agents && node ../node_modules/tsx/dist/cli.mjs --test tests/exporter.test.ts"

--- a/javascript-sdks/respan-cli/package.json
+++ b/javascript-sdks/respan-cli/package.json
@@ -53,5 +53,8 @@
     "bin",
     "dist",
     "oclif.manifest.json"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/javascript-sdks/respan-instrumentation-openai-agents/package.json
+++ b/javascript-sdks/respan-instrumentation-openai-agents/package.json
@@ -20,7 +20,6 @@
     "publish": "yarn npm publish",
     "release": "yarn build && yarn version patch && yarn publish"
   },
-  "packageManager": "yarn@4.6.0",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.26.0",

--- a/javascript-sdks/respan-instrumentation-openai/package.json
+++ b/javascript-sdks/respan-instrumentation-openai/package.json
@@ -20,7 +20,6 @@
     "publish": "yarn npm publish",
     "release": "yarn build && yarn version patch && yarn publish"
   },
-  "packageManager": "yarn@4.6.0",
   "dependencies": {},
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/javascript-sdks/respan-instrumentation-openinference/package.json
+++ b/javascript-sdks/respan-instrumentation-openinference/package.json
@@ -20,7 +20,6 @@
     "publish": "yarn npm publish",
     "release": "yarn build && yarn version patch && yarn publish"
   },
-  "packageManager": "yarn@4.6.0",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^1.29.0",

--- a/javascript-sdks/respan-instrumentation-vercel/package.json
+++ b/javascript-sdks/respan-instrumentation-vercel/package.json
@@ -20,7 +20,6 @@
     "publish": "yarn npm publish",
     "release": "yarn build && yarn version patch && yarn publish"
   },
-  "packageManager": "yarn@4.6.0",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^1.29.0",

--- a/javascript-sdks/respan-sdk/package.json
+++ b/javascript-sdks/respan-sdk/package.json
@@ -20,7 +20,6 @@
     "publish": "yarn npm publish",
     "release": "yarn build &&yarn version patch && yarn publish"
   },
-  "packageManager": "yarn@4.6.0",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.1",

--- a/javascript-sdks/respan-sdk/package.json
+++ b/javascript-sdks/respan-sdk/package.json
@@ -17,7 +17,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "version": "1.0.0",
     "publish": "yarn npm publish",
     "release": "yarn build &&yarn version patch && yarn publish"
   },

--- a/javascript-sdks/respan-tracing/package.json
+++ b/javascript-sdks/respan-tracing/package.json
@@ -67,6 +67,5 @@
     "darwin",
     "linux",
     "win32"
-  ],
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  ]
 }

--- a/javascript-sdks/respan/package.json
+++ b/javascript-sdks/respan/package.json
@@ -20,7 +20,6 @@
     "publish": "yarn npm publish",
     "release": "yarn build && yarn version patch && yarn publish"
   },
-  "packageManager": "yarn@4.6.0",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@respan/respan-sdk": "^1.0.0",

--- a/javascript-sdks/respan/package.json
+++ b/javascript-sdks/respan/package.json
@@ -17,7 +17,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "version": "npm version",
     "publish": "yarn npm publish",
     "release": "yarn build && yarn version patch && yarn publish"
   },

--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -31,7 +31,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.extras]
 dev = ["pytest", "python-dotenv"]
 
-[project.urls]
+[tool.poetry.urls]
 Homepage = "https://respan.ai"
 Repository = "https://github.com/respan-ai/respan-sdks.git"
 Documentation = "https://docs.respan.ai"

--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,8 +1,3 @@
-[project]
-name = "respan-sdk"
-version = "2.6.20"
-description = "Respan SDK allows you to interact with the Respan API smoothly"
-
 [tool.poetry]
 name = "respan-sdk"
 version = "2.6.21"

--- a/scripts/release_inventory.py
+++ b/scripts/release_inventory.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INVENTORY_PATH = REPO_ROOT / ".github" / "release-packages.json"
+JS_WORKSPACE_ROOT = REPO_ROOT / "javascript-sdks"
+
+
+def load_inventory() -> list[dict]:
+    data = json.loads(INVENTORY_PATH.read_text())
+    return data["packages"]
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def read_toml(path: Path) -> dict:
+    text = path.read_text()
+    return parse_toml_text(text)
+
+
+def parse_toml_text(text: str) -> dict:
+    if tomllib is not None:
+        return tomllib.loads(text)
+    return parse_minimal_toml(text)
+
+
+def parse_minimal_toml(text: str) -> dict:
+    data: dict = {}
+    section: list[str] = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].split(".")
+            target = data
+            for part in section:
+                target = target.setdefault(part, {})
+            continue
+        if "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+
+        string_match = re.fullmatch(r'"(.*)"', value)
+        if not string_match:
+            continue
+
+        target = data
+        for part in section:
+            target = target.setdefault(part, {})
+        target[key] = string_match.group(1)
+
+    return data
+
+
+def manifest_path(entry: dict) -> Path:
+    filename = "package.json" if entry["ecosystem"] == "javascript" else "pyproject.toml"
+    return REPO_ROOT / entry["path"] / filename
+
+
+def load_manifest(entry: dict) -> dict:
+    path = manifest_path(entry)
+    if entry["ecosystem"] == "javascript":
+        return read_json(path)
+    return read_toml(path)
+
+
+def manifest_name(entry: dict, manifest: dict) -> str:
+    if entry["ecosystem"] == "javascript":
+        return manifest["name"]
+    return manifest["tool"]["poetry"]["name"]
+
+
+def manifest_version(entry: dict, manifest: dict) -> str:
+    if entry["ecosystem"] == "javascript":
+        return manifest["version"]
+    return manifest["tool"]["poetry"]["version"]
+
+
+def has_js_script(manifest: dict, script_name: str) -> bool:
+    return script_name in manifest.get("scripts", {})
+
+
+def slug_for(entry: dict) -> str:
+    return entry["path"].split("/")[-1].replace(".", "-")
+
+
+def git_stdout(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def git_stdout_or_none(*args: str) -> str | None:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout
+
+
+def changed_files(base: str, head: str) -> set[str]:
+    if not base or set(base) == {"0"}:
+        return {
+            str(path.relative_to(REPO_ROOT))
+            for path in REPO_ROOT.rglob("*")
+            if path.is_file() and ".git" not in path.parts
+        }
+    output = git_stdout_or_none("diff", "--name-only", base, head)
+    if output is None:
+        return set()
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
+def package_changed(entry: dict, files: set[str]) -> bool:
+    prefix = f"{entry['path']}/"
+    return any(path == entry["path"] or path.startswith(prefix) for path in files)
+
+
+def version_from_git_ref(entry: dict, ref: str) -> str | None:
+    if not ref:
+        return None
+    repo_path = f"{entry['path']}/{'package.json' if entry['ecosystem'] == 'javascript' else 'pyproject.toml'}"
+    content = git_stdout_or_none("show", f"{ref}:{repo_path}")
+    if content is None:
+        return None
+    if entry["ecosystem"] == "javascript":
+        manifest = json.loads(content)
+        return manifest["version"]
+    manifest = parse_toml_text(content)
+    return manifest["tool"]["poetry"]["version"]
+
+
+def workspace_paths(entries: list[dict]) -> list[str]:
+    paths = []
+    for entry in entries:
+        if entry["ecosystem"] != "javascript":
+            continue
+        paths.append(entry["path"].split("/", 1)[1])
+    return sorted(paths)
+
+
+def validate(entries: list[dict]) -> list[str]:
+    errors: list[str] = []
+    seen_names: set[tuple[str, str]] = set()
+
+    js_root_manifest = read_json(JS_WORKSPACE_ROOT / "package.json")
+    actual_workspaces = set(js_root_manifest.get("workspaces", []))
+    expected_workspaces = set(workspace_paths(entries))
+    missing_workspaces = sorted(expected_workspaces - actual_workspaces)
+    if missing_workspaces:
+        errors.append(
+            "javascript workspace list is missing release inventory packages: "
+            f"{missing_workspaces}"
+        )
+
+    for entry in entries:
+        key = (entry["ecosystem"], entry["name"])
+        if key in seen_names:
+            errors.append(f"duplicate inventory entry for {entry['ecosystem']} package {entry['name']}")
+            continue
+        seen_names.add(key)
+
+        path = manifest_path(entry)
+        if not path.exists():
+            errors.append(f"missing manifest for {entry['name']} at {path.relative_to(REPO_ROOT)}")
+            continue
+
+        manifest = load_manifest(entry)
+        if manifest_name(entry, manifest) != entry["name"]:
+            errors.append(
+                f"inventory name mismatch for {entry['path']}: "
+                f"expected {entry['name']}, got {manifest_name(entry, manifest)}"
+            )
+
+        if entry["ecosystem"] == "javascript":
+            if manifest.get("private"):
+                errors.append(f"{entry['name']} is marked private but included in release inventory")
+            publish_access = manifest.get("publishConfig", {}).get("access")
+            if entry["registry"] == "npm" and publish_access != "public":
+                errors.append(f"{entry['name']} is missing publishConfig.access=public")
+        else:
+            project_version = manifest.get("project", {}).get("version")
+            poetry_version = manifest["tool"]["poetry"]["version"]
+            if project_version and project_version != poetry_version:
+                errors.append(
+                    f"{entry['name']} has conflicting [project] and [tool.poetry] versions: "
+                    f"{project_version} != {poetry_version}"
+                )
+
+    return errors
+
+
+def build_record(entry: dict, manifest: dict) -> dict:
+    record = {
+        "ecosystem": entry["ecosystem"],
+        "name": entry["name"],
+        "path": entry["path"],
+        "registry": entry["registry"],
+        "slug": slug_for(entry),
+        "version": manifest_version(entry, manifest),
+    }
+    if entry["ecosystem"] == "javascript":
+        record["has_build"] = has_js_script(manifest, "build")
+        record["has_test"] = has_js_script(manifest, "test")
+    return record
+
+
+def filtered_entries(
+    entries: list[dict],
+    ecosystem: str,
+    base: str | None,
+    head: str | None,
+    require_version_change: bool,
+) -> list[dict]:
+    selected = [entry for entry in entries if ecosystem == "all" or entry["ecosystem"] == ecosystem]
+    manifests = {entry["name"]: load_manifest(entry) for entry in selected}
+
+    if base and head:
+        files = changed_files(base, head)
+        selected = [entry for entry in selected if package_changed(entry, files)]
+
+    if require_version_change:
+        filtered: list[dict] = []
+        for entry in selected:
+            current_version = manifest_version(entry, manifests[entry["name"]])
+            previous_version = version_from_git_ref(entry, base or "")
+            if previous_version != current_version:
+                filtered.append(entry)
+        selected = filtered
+
+    return [build_record(entry, manifests[entry["name"]]) for entry in selected]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ecosystem", choices=["all", "javascript", "python"], default="all")
+    parser.add_argument("--changed-from")
+    parser.add_argument("--changed-to")
+    parser.add_argument("--version-changed", action="store_true")
+    parser.add_argument("--validate", action="store_true")
+    parser.add_argument("--count", action="store_true")
+    parser.add_argument("--format", choices=["json", "github-matrix"], default="json")
+    args = parser.parse_args()
+
+    entries = load_inventory()
+
+    if args.validate:
+        errors = validate(entries)
+        if errors:
+            for error in errors:
+                print(error, file=sys.stderr)
+            return 1
+        print("release metadata validation passed")
+        return 0
+
+    selected = filtered_entries(
+        entries,
+        ecosystem=args.ecosystem,
+        base=args.changed_from,
+        head=args.changed_to,
+        require_version_change=args.version_changed,
+    )
+
+    if args.count:
+        print(len(selected))
+        return 0
+
+    if args.format == "github-matrix":
+        print(json.dumps(selected, separators=(",", ":")))
+        return 0
+
+    print(json.dumps(selected, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_inventory.py
+++ b/scripts/release_inventory.py
@@ -314,7 +314,7 @@ def main() -> int:
     parser.add_argument("--build-order-for")
     parser.add_argument("--validate", action="store_true")
     parser.add_argument("--count", action="store_true")
-    parser.add_argument("--format", choices=["json", "github-matrix", "paths"], default="json")
+    parser.add_argument("--format", choices=["json", "github-matrix", "paths", "names"], default="json")
     args = parser.parse_args()
 
     entries = load_inventory()
@@ -341,6 +341,10 @@ def main() -> int:
         if args.format == "paths":
             for entry in selected_entries:
                 print(entry["path"])
+            return 0
+        if args.format == "names":
+            for entry in selected_entries:
+                print(entry["name"])
             return 0
 
         selected = [build_record(entry, load_manifest(entry)) for entry in selected_entries]

--- a/scripts/release_inventory.py
+++ b/scripts/release_inventory.py
@@ -170,6 +170,49 @@ def workspace_paths(entries: list[dict]) -> list[str]:
     return sorted(paths)
 
 
+def js_internal_dependency_names(entries: list[dict]) -> dict[str, set[str]]:
+    js_entries = {entry["name"]: entry for entry in entries if entry["ecosystem"] == "javascript"}
+    manifests = {name: load_manifest(entry) for name, entry in js_entries.items()}
+    graph: dict[str, set[str]] = {}
+
+    for name, manifest in manifests.items():
+        internal: set[str] = set()
+        for section in ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies"):
+            for dependency_name in manifest.get(section, {}):
+                if dependency_name in js_entries:
+                    internal.add(dependency_name)
+        graph[name] = internal
+
+    return graph
+
+
+def javascript_build_order(entries: list[dict], package_name: str) -> list[dict]:
+    js_entries = {entry["name"]: entry for entry in entries if entry["ecosystem"] == "javascript"}
+    if package_name not in js_entries:
+        raise KeyError(package_name)
+
+    graph = js_internal_dependency_names(entries)
+    ordered_names: list[str] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in visited:
+            return
+        if name in visiting:
+            raise ValueError(f"cyclic javascript dependency detected at {name}")
+
+        visiting.add(name)
+        for dependency_name in sorted(graph.get(name, set())):
+            visit(dependency_name)
+        visiting.remove(name)
+        visited.add(name)
+        ordered_names.append(name)
+
+    visit(package_name)
+    return [js_entries[name] for name in ordered_names]
+
+
 def validate(entries: list[dict]) -> list[str]:
     errors: list[str] = []
     seen_names: set[tuple[str, str]] = set()
@@ -268,9 +311,10 @@ def main() -> int:
     parser.add_argument("--changed-from")
     parser.add_argument("--changed-to")
     parser.add_argument("--version-changed", action="store_true")
+    parser.add_argument("--build-order-for")
     parser.add_argument("--validate", action="store_true")
     parser.add_argument("--count", action="store_true")
-    parser.add_argument("--format", choices=["json", "github-matrix"], default="json")
+    parser.add_argument("--format", choices=["json", "github-matrix", "paths"], default="json")
     args = parser.parse_args()
 
     entries = load_inventory()
@@ -282,6 +326,31 @@ def main() -> int:
                 print(error, file=sys.stderr)
             return 1
         print("release metadata validation passed")
+        return 0
+
+    if args.build_order_for:
+        try:
+            selected_entries = javascript_build_order(entries, args.build_order_for)
+        except KeyError:
+            print(f"unknown javascript package: {args.build_order_for}", file=sys.stderr)
+            return 1
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 1
+
+        if args.format == "paths":
+            for entry in selected_entries:
+                print(entry["path"])
+            return 0
+
+        selected = [build_record(entry, load_manifest(entry)) for entry in selected_entries]
+        if args.count:
+            print(len(selected))
+            return 0
+        if args.format == "github-matrix":
+            print(json.dumps(selected, separators=(",", ":")))
+            return 0
+        print(json.dumps(selected, indent=2))
         return 0
 
     selected = filtered_entries(

--- a/scripts/release_inventory.py
+++ b/scripts/release_inventory.py
@@ -179,7 +179,7 @@ def js_internal_dependency_names(entries: list[dict]) -> dict[str, set[str]]:
         internal: set[str] = set()
         for section in ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies"):
             for dependency_name in manifest.get(section, {}):
-                if dependency_name in js_entries:
+                if dependency_name != name and dependency_name in js_entries:
                     internal.add(dependency_name)
         graph[name] = internal
 


### PR DESCRIPTION
## Summary
- add explicit release inventory for the managed Python and JavaScript SDK packages
- add CI and publish GitHub Actions workflows with publish gated on successful CI
- document the release contract and clean up package metadata needed for automation

## Included Packages
- Python: respan-ai, respan-sdk, respan-tracing, respan-instrumentation-openai, respan-instrumentation-openai-agents, respan-instrumentation-openinference
- JavaScript: @respan/respan, @respan/cli, @respan/respan-sdk, @respan/tracing, @respan/instrumentation-openai, @respan/instrumentation-openai-agents, @respan/instrumentation-openinference, @respan/instrumentation-vercel

## Validation
- python3 scripts/release_inventory.py --validate
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/publish.yml')"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new automated publish workflows for npm and PyPI, so misconfiguration in the inventory/manifests or matrix logic could cause failed or unintended releases. Changes are mostly confined to GitHub Actions and metadata validation, with minimal product-code impact.
> 
> **Overview**
> Adds an explicit release inventory (`.github/release-packages.json`) and a new `scripts/release_inventory.py` utility to validate package metadata, generate GitHub Actions matrices, compute JS build order, and gate publishing on manifest version changes.
> 
> Introduces new GitHub Actions workflows: `CI` validates the inventory then builds Python distributions and builds/tests JS packages via Yarn workspaces; `Publish` runs after successful `CI` on `main` (or manually), publishing only version-bumped packages to npm (OIDC provenance) and PyPI (trusted publishing via built artifacts).
> 
> Aligns package metadata to match the new release contract (JS workspace paths, `publishConfig.access=public`, removing per-package `packageManager`/script cruft) and updates `python-sdks/respan-sdk` `pyproject.toml` to Poetry-only metadata (incl. version bump to `2.6.21`), plus adds `docs/cicd.md` describing the pipeline and requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edf124fec1e202699520076db79649fcd5492cb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->