### PR TITLE
fix(tracing): propagate processors in SpanBuffer continuation mode

### DIFF
--- a/python-sdks/respan-tracing/src/respan_tracing/core/client.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/core/client.py
@@ -372,6 +372,9 @@ class RespanClient:
         # use setup_span() directly and are not skipped.
         active_buffer = _active_span_buffer.get(None)
         if active_buffer and active_buffer._parent_span_id:
+            # Stash processors so child spans inherit via on_start fallback.
+            if processors:
+                active_buffer.continuation_processors = processors if isinstance(processors, str) else ",".join(processors)
             yield None
             return
 

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -94,6 +94,16 @@ class RespanSpanProcessor:
                 if parent_processors:
                     span.set_attribute(PROCESSORS_ATTR, parent_processors)
 
+            # Fallback: in continuation mode, the parent is a NonRecordingSpan
+            # with no attributes. Check the active SpanBuffer for stashed
+            # processors from the skipped client.start_span() call.
+            if not span.attributes.get(PROCESSORS_ATTR):
+                active_buffer = _active_span_buffer.get(None)
+                if active_buffer:
+                    buffer_processors = getattr(active_buffer, "continuation_processors", None)
+                    if buffer_processors:
+                        span.set_attribute(PROCESSORS_ATTR, buffer_processors)
+
         # Add custom parameters if present
         respan_params = context_api.get_value(PARAMS_KEY)
         if respan_params and isinstance(respan_params, dict):


### PR DESCRIPTION
## Summary

When `client.start_span()` is skipped in continuation mode (SpanBuffer with parent_span_id), child spans lose the `processors` attribute because:
- The parent in continuation mode is a `NonRecordingSpan` (no attributes)
- `RespanSpanProcessor.on_start` inherits `processors` from parent span attributes
- No parent attributes → no inheritance → FilteringProcessors reject child spans

**Fix:**
1. `client.start_span()` stashes `processors` on the active SpanBuffer before returning
2. `RespanSpanProcessor.on_start` checks active SpanBuffer's `continuation_processors` as fallback

This completes the continuation mode story:
- PR #135: skip wrapper span creation
- This PR: propagate processors so child spans route correctly

## Test plan
- [ ] Resumed workflow: child @task spans reach CHDatasetLog (not filtered)
- [ ] Non-continuation mode unchanged
- [ ] Explicit processors on child spans still respected (no override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)