### PR TITLE
fix: unify openinference translation semantics and bump version

### DIFF
--- a/javascript-sdks/respan-instrumentation-openinference/package.json
+++ b/javascript-sdks/respan-instrumentation-openinference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/instrumentation-openinference",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Respan instrumentation plugin for OpenInference (Arize Phoenix) instrumentors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- unify openinference translation around upstream semantic-convention sources
- keep export cleanup on cloned spans so live spans retain source attrs for downstream processors
- fix workspace CI by removing the nested openinference lockfile and avoiding nested yarn invocation in tests
- bump @respan/instrumentation-openinference from 1.1.0 to 1.1.1 so selective publish picks it up

## Verification
- yarn workspace @respan/instrumentation-openinference test
- yarn run test from javascript-sdks/respan-instrumentation-openinference

## Notes
- this is a separate PR branch so the package version change is isolated for release selection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package version with no code or dependency changes.
> 
> **Overview**
> Updates `javascript-sdks/respan-instrumentation-openinference/package.json` to bump `@respan/instrumentation-openinference` from `1.1.0` to `1.1.1` for publishing/release selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d15f5b8f38d673eae9f69e97f3ea624318d4104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->