### PR TITLE
fix: use npm trusted publishing in release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Publish package
         working-directory: ${{ matrix.path }}
-        run: yarn npm publish --access public --provenance --tolerate-republish
+        run: npm publish --access public
 
   build-python:
     needs: discover


### PR DESCRIPTION
## Summary
- switch the release workflow from yarn npm publish to npm publish
- align the GitHub Actions publish step with npm trusted publishing and OIDC

## Why
- npm trusted publishing is designed around npm CLI authentication from GitHub Actions
- the previous yarn publish path failed with no authentication configured

## Change
- replace yarn npm publish --access public --provenance --tolerate-republish
- with npm publish --access public

## Notes
- npm provenance is automatic under trusted publishing for public packages from public repos
- this PR is intentionally separate from the package version-bump PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the production release workflow for npm packages and could affect publishing/authentication behavior. The change is small and isolated to the publish step.
> 
> **Overview**
> Switches the JavaScript package publish step in `.github/workflows/publish.yml` from `yarn npm publish --provenance --tolerate-republish` to `npm publish --access public` to align with npm trusted publishing/OIDC.
> 
> No other build or Python publishing steps are changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a639d2205227e722d6bbb0cdbec724aff080ab35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->