### PR TITLE
chore: bump openinference package to 1.1.2 for publish smoke test

### DIFF
--- a/javascript-sdks/respan-instrumentation-openinference/package.json
+++ b/javascript-sdks/respan-instrumentation-openinference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/instrumentation-openinference",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Respan instrumentation plugin for OpenInference (Arize Phoenix) instrumentors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/javascript-sdks/respan-instrumentation-openinference/src/_translator.ts
+++ b/javascript-sdks/respan-instrumentation-openinference/src/_translator.ts
@@ -7,6 +7,7 @@
  *
  * The mapping is the exact reverse of Arize's `openinference-instrumentation-openllmetry`
  * package which converts OpenLLMetry → OpenInference.
+ * Translation stays additive on the live span; cleanup is reserved for export clones.
  *
  * Arize direction (OpenLLMetry → OI)          | Our reverse (OI → OpenLLMetry)
  * ---------------------------------------------|------------------------------------------


### PR DESCRIPTION
## Summary
- bump @respan/instrumentation-openinference from 1.1.1 to 1.1.2
- add one harmless package-local documentation comment in the translator source

## Purpose
- exercise the selective JavaScript publish workflow with a minimal package change
- validate trusted publishing after the workflow fix PR

## Verification
- yarn workspace @respan/instrumentation-openinference test

## Notes
- this PR is intended as a publish smoke test
- if you use this PR for release validation, it supersedes the earlier 1.1.1 release bump PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only a patch version bump and a documentation-only comment change; no runtime logic is modified.
> 
> **Overview**
> Bumps `@respan/instrumentation-openinference` version from `1.1.1` to `1.1.2`.
> 
> Adds a small documentation note in `src/_translator.ts` clarifying that translation is additive on live spans and cleanup happens only on export clones.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e84f586b78b3d8cfaf7744e2e74dab4a87521bdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->