### PR TITLE
fix: add repository metadata to JavaScript packages

### DIFF
--- a/javascript-sdks/respan-cli/package.json
+++ b/javascript-sdks/respan-cli/package.json
@@ -8,6 +8,11 @@
   "bin": {
     "respan": "./bin/run.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-cli"
+  },
   "scripts": {
     "build": "tsc && npm run build:hooks",
     "build:hooks": "node -e \"const{build}=require('esbuild');const hooks=['claude-code','codex-cli','gemini-cli'];Promise.all(hooks.map(h=>build({entryPoints:['src/hooks/'+h+'.ts'],bundle:true,platform:'node',target:'node18',format:'cjs',outfile:'dist/hooks/'+h+'.cjs',external:[]}))).then(()=>console.log('Hooks bundled.'))\"",

--- a/javascript-sdks/respan-exporter-anthropic-agents/package.json
+++ b/javascript-sdks/respan-exporter-anthropic-agents/package.json
@@ -7,6 +7,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-exporter-anthropic-agents"
+  },
   "files": [
     "dist",
     "README.md",

--- a/javascript-sdks/respan-exporter-n8n/package.json
+++ b/javascript-sdks/respan-exporter-n8n/package.json
@@ -16,7 +16,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/respan-ai/respan-sdks",
+		"url": "https://github.com/respanai/respan",
 		"directory": "javascript-sdks/respan-exporter-n8n"
 	},
 	"scripts": {

--- a/javascript-sdks/respan-exporter-openai-agents/package.json
+++ b/javascript-sdks/respan-exporter-openai-agents/package.json
@@ -7,6 +7,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-exporter-openai-agents"
+  },
   "files": [
     "dist",
     "README.md",

--- a/javascript-sdks/respan-exporter-vercel/package.json
+++ b/javascript-sdks/respan-exporter-vercel/package.json
@@ -10,7 +10,11 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "https://github.com/respan-ai/respan-sdks.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-exporter-vercel"
+  },
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
   "scripts": {

--- a/javascript-sdks/respan-instrumentation-anthropic/package.json
+++ b/javascript-sdks/respan-instrumentation-anthropic/package.json
@@ -7,6 +7,11 @@
   "types": "dist/index.d.ts",
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-instrumentation-anthropic"
+  },
   "files": [
     "dist",
     "README.md",

--- a/javascript-sdks/respan-instrumentation-openai-agents/package.json
+++ b/javascript-sdks/respan-instrumentation-openai-agents/package.json
@@ -7,6 +7,11 @@
   "types": "dist/index.d.ts",
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-instrumentation-openai-agents"
+  },
   "files": [
     "dist",
     "README.md",

--- a/javascript-sdks/respan-instrumentation-openai/package.json
+++ b/javascript-sdks/respan-instrumentation-openai/package.json
@@ -7,6 +7,11 @@
   "types": "dist/index.d.ts",
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-instrumentation-openai"
+  },
   "files": [
     "dist",
     "README.md",

--- a/javascript-sdks/respan-instrumentation-openinference/package.json
+++ b/javascript-sdks/respan-instrumentation-openinference/package.json
@@ -7,6 +7,11 @@
   "types": "dist/index.d.ts",
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-instrumentation-openinference"
+  },
   "files": [
     "dist",
     "README.md",

--- a/javascript-sdks/respan-instrumentation-vercel/package.json
+++ b/javascript-sdks/respan-instrumentation-vercel/package.json
@@ -7,6 +7,11 @@
   "types": "dist/index.d.ts",
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-instrumentation-vercel"
+  },
   "files": [
     "dist",
     "README.md",

--- a/javascript-sdks/respan-sdk/package.json
+++ b/javascript-sdks/respan-sdk/package.json
@@ -7,6 +7,11 @@
   "types": "dist/index.d.ts",
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-sdk"
+  },
   "files": [
     "dist",
     "README.md",

--- a/javascript-sdks/respan-tracing/package.json
+++ b/javascript-sdks/respan-tracing/package.json
@@ -22,7 +22,11 @@
     "examples:advanced": "yarn build && cd examples && yarn dev",
     "test:build": "npm run build && npm pack && npm install ./respan-tracing-*.tgz --no-save && tsx tests/test_build.ts"
   },
-  "repository": "https://github.com/respan-ai/respan-sdks.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan-tracing"
+  },
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
   "dependencies": {

--- a/javascript-sdks/respan/package.json
+++ b/javascript-sdks/respan/package.json
@@ -7,6 +7,11 @@
   "types": "dist/index.d.ts",
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/respan"
+  },
   "files": [
     "dist",
     "README.md",


### PR DESCRIPTION
## Summary
- add repository metadata to all JavaScript package manifests under javascript-sdks/*
- normalize repository.url to https://github.com/respanai/respan
- set repository.directory for each package path in the monorepo
- replace stale respan-ai/respan-sdks repository references

## Why
- npm provenance verification compares published package metadata against GitHub Actions provenance
- packages without correct repository metadata can fail publish with repository information validation errors

## Validation
- verified every javascript-sdks/*/package.json now has:
  - repository.type = git
  - repository.url = https://github.com/respanai/respan
  - repository.directory = its package directory

## Notes
- this PR is metadata-only and separate from the release/test version bump PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only updates to `package.json` files; low risk aside from potentially affecting npm publish/provenance validation if misconfigured.
> 
> **Overview**
> Adds/standardizes `repository` metadata across all `javascript-sdks/*` packages, using a consistent `{ type: "git", url: "https://github.com/respanai/respan", directory: "..." }` format.
> 
> Replaces stale `respan-ai/respan-sdks` repository references and converts string `repository` fields to structured objects so npm provenance/repository validation aligns with the monorepo layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77bc80e1aee22659568477130d70ec922b935f8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->