### PR TITLE
chore: bump openinference package to 1.1.3 for another publish smoke test

### DIFF
--- a/javascript-sdks/respan-instrumentation-openinference/package.json
+++ b/javascript-sdks/respan-instrumentation-openinference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/instrumentation-openinference",
   "type": "module",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Respan instrumentation plugin for OpenInference (Arize Phoenix) instrumentors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/javascript-sdks/respan-instrumentation-openinference/src/_translator.ts
+++ b/javascript-sdks/respan-instrumentation-openinference/src/_translator.ts
@@ -8,6 +8,7 @@
  * The mapping is the exact reverse of Arize's `openinference-instrumentation-openllmetry`
  * package which converts OpenLLMetry → OpenInference.
  * Translation stays additive on the live span; cleanup is reserved for export clones.
+ * This keeps source attributes available to downstream processors until export time.
  *
  * Arize direction (OpenLLMetry → OI)          | Our reverse (OI → OpenLLMetry)
  * ---------------------------------------------|------------------------------------------


### PR DESCRIPTION
## Summary
- bump @respan/instrumentation-openinference from 1.1.2 to 1.1.3
- add one harmless package-local translator comment

## Purpose
- run one more end-to-end selective publish smoke test after the previous release

## Verification
- yarn workspace @respan/instrumentation-openinference test

## Notes
- this PR is intentionally minimal and package-local
- it is meant to be merged to validate the publish pipeline again

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a package version bump plus a documentation-only comment change with no runtime behavior impact.
> 
> **Overview**
> Bumps `@respan/instrumentation-openinference` from `1.1.2` to `1.1.3` for a new publish.
> 
> Adds a small comment in `src/_translator.ts` clarifying that translation remains additive on live spans and cleanup happens only on export clones.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c17ec3050fb821df37221b0f19dd9ab4a8c6fab3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->