### PR TITLE
fix: avoid npm publish lifecycle recursion in JS packages

### DIFF
--- a/javascript-sdks/respan-exporter-anthropic-agents/package.json
+++ b/javascript-sdks/respan-exporter-anthropic-agents/package.json
@@ -24,8 +24,8 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "tsx --test tests/**/*.test.ts",
-    "publish": "yarn npm publish",
-    "release": "yarn build && yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": ">=0.2.0",

--- a/javascript-sdks/respan-exporter-openai-agents/package.json
+++ b/javascript-sdks/respan-exporter-openai-agents/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
-    "publish": "yarn npm publish",
-    "release": "yarn build && yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "dependencies": {
     "@openai/agents": "^0.0.8",

--- a/javascript-sdks/respan-exporter-vercel/package.json
+++ b/javascript-sdks/respan-exporter-vercel/package.json
@@ -22,8 +22,8 @@
     "test": "yarn build && node --test",
     "test:live": "yarn build && RESPAN_RUN_LIVE_TESTS=1 node --test",
     "quickstart": "yarn build && node examples/quickstart.js",
-    "publish": "yarn npm publish",
-    "release": "yarn build && yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "publishConfig": {
     "access": "public"

--- a/javascript-sdks/respan-instrumentation-anthropic/package.json
+++ b/javascript-sdks/respan-instrumentation-anthropic/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "publish": "yarn npm publish",
-    "release": "yarn build && yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "packageManager": "yarn@4.6.0",
   "dependencies": {

--- a/javascript-sdks/respan-instrumentation-openai-agents/package.json
+++ b/javascript-sdks/respan-instrumentation-openai-agents/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "publish": "yarn npm publish",
-    "release": "yarn build && yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/javascript-sdks/respan-instrumentation-openai/package.json
+++ b/javascript-sdks/respan-instrumentation-openai/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "publish": "yarn npm publish",
-    "release": "yarn build && yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "dependencies": {},
   "peerDependencies": {

--- a/javascript-sdks/respan-instrumentation-openinference/package.json
+++ b/javascript-sdks/respan-instrumentation-openinference/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && node --test tests/*.test.js",
-    "publish": "yarn npm publish",
-    "release": "yarn build && yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "dependencies": {
     "@arizeai/openinference-semantic-conventions": "^2.1.7",

--- a/javascript-sdks/respan-instrumentation-vercel/package.json
+++ b/javascript-sdks/respan-instrumentation-vercel/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "publish": "yarn npm publish",
-    "release": "yarn build && yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/javascript-sdks/respan-sdk/package.json
+++ b/javascript-sdks/respan-sdk/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "publish": "yarn npm publish",
-    "release": "yarn build &&yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/javascript-sdks/respan/package.json
+++ b/javascript-sdks/respan/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "publish": "yarn npm publish",
-    "release": "yarn build && yarn version patch && yarn publish"
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary
- rename package helper scripts from publish to publish:package across affected JavaScript packages
- update release scripts to call publish:package instead of publish

## Why
- npm publish runs the publish lifecycle script automatically
- these packages defined "publish": "yarn npm publish", which causes a second recursive publish attempt
- under the new GitHub Actions trusted-publishing flow, the first npm publish succeeds and the recursive Yarn publish fails auth

## Scope
- all affected JavaScript packages under javascript-sdks/* that currently define publish = yarn npm publish

## Result
- GitHub Actions can use npm publish directly without triggering a recursive second publish
- local manual publish helper remains available as yarn publish:package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only `package.json` script name changes across JS SDK packages, with no runtime code impact. Main risk is CI/docs or release tooling still referencing the old `yarn publish` script name.
> 
> **Overview**
> Avoids `npm publish` triggering a recursive re-publish in the JavaScript SDK packages by renaming the helper script from `publish` to `publish:package`.
> 
> Updates each package’s `release` script to call `publish:package` instead of `publish`, ensuring GitHub Actions trusted publishing can run `npm publish` without hitting the lifecycle-script loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd6156ebec6ab2197da2ef089c34b8a36daea4f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->