### PR TITLE
feat: inject caller's trace_id as OTel trace context in SpanBuffer

### DIFF
--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.15.2"
+version = "2.16.0"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -378,11 +378,27 @@ class SpanBuffer:
         """
         logger.debug(f"[SpanBuffer] Entering buffering context for trace {self.trace_id}")
 
-        # Inject parent context for trace continuation (workflow resume)
+        # Inject trace context so all spans in this buffer share the
+        # caller's trace ID. Without this, the OTel SDK generates a
+        # random trace ID that diverges from the caller's trace_id.
         if self._parent_trace_id and self._parent_span_id:
+            # Resume path: continue an existing trace under a specific parent.
+            inject_trace_id = int(self._parent_trace_id, 16)
+            inject_span_id = int(self._parent_span_id, 16)
+        elif self.trace_id:
+            # Initial path: use the caller's trace_id as the OTel trace.
+            # A synthetic root span ID seeds the trace context — the real
+            # root span becomes a child and inherits this trace_id.
+            inject_trace_id = int(self.trace_id, 16) if len(self.trace_id) == 32 else None
+            inject_span_id = None
+        else:
+            inject_trace_id = None
+            inject_span_id = None
+
+        if inject_trace_id is not None:
             parent_ctx = SpanContext(
-                trace_id=int(self._parent_trace_id, 16),
-                span_id=int(self._parent_span_id, 16),
+                trace_id=inject_trace_id,
+                span_id=inject_span_id or int("0000000000000001", 16),
                 is_remote=True,
                 trace_flags=TraceFlags(TraceFlags.SAMPLED),
             )
@@ -390,8 +406,8 @@ class SpanBuffer:
             ctx = trace.set_span_in_context(parent_span)
             self._parent_context_token = context_api.attach(ctx)
             logger.debug(
-                f"[SpanBuffer] Injected parent context: "
-                f"trace_id={self._parent_trace_id}, span_id={self._parent_span_id}"
+                f"[SpanBuffer] Injected trace context: "
+                f"trace_id={format(inject_trace_id, '032x')}"
             )
 
         # Mark as buffering


### PR DESCRIPTION
## Summary
When `trace_id` is provided to `get_span_buffer()` without a parent context, the SDK now injects it as the OTel trace context. All spans in the buffer inherit this trace_id instead of generating a random one.

## Problem
The caller (workflow executor) generates a UUID for `trace_id` and passes it to `get_span_buffer()`. But the OTel SDK generates a completely different trace ID for spans. This causes a three-way ID mismatch between the caller's trace_id, OTel trace_id, and CH trace_unique_id — breaking every downstream join.

## Fix
In `SpanBuffer.__enter__`, when no `parent_trace_id` is set but `trace_id` is provided, create a synthetic `NonRecordingSpan` with the caller's trace_id and attach it to the OTel context. All subsequent spans inherit this trace_id.

## Bump
2.15.1 → 2.16.0