### PR TITLE
fix: coerce JSON strings to dicts for metadata/properties fields

### DIFF
--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
@@ -258,6 +258,25 @@ class RespanLogParams(PreprocessLogDataMixin, RespanBaseModel):
             return json.dumps(v, default=str)
         return v
 
+    @field_validator("metadata", "properties", mode="before")
+    @classmethod
+    def coerce_dict_fields(cls, v):
+        """Coerce JSON strings to dicts for Map/JSON CH columns.
+
+        Span attributes and overridable keys in SpanType.to_request_log()
+        can produce JSON strings for dict-typed fields. Without this
+        coercion, Pydantic validation rejects the value and the log is
+        silently dropped.
+        """
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+                if isinstance(parsed, dict):
+                    return parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return v
+
     @field_validator("span_name", mode="after")
     def stringify_span_name(cls, v):
         if v:


### PR DESCRIPTION
## Summary

`SpanType.to_request_log()` overridable keys can produce JSON strings for dict-typed fields (`metadata`, `properties`). Without coercion, `RespanFullLogParams` Pydantic validation rejects the value and the log is **silently dropped** from CH ingestion.

This was the root cause of experiment trace root spans disappearing from ClickHouse (DEV-7693).

## Fix

Add `field_validator` on `metadata` and `properties` that parses JSON strings back to dicts before validation. Follows the existing pattern (`stringify_input`, `stringify_embedding`).

## Impact

Once this SDK version is released, the backend workaround in `trace_types.py` (parsing `CUSTOM_PROPERTIES_KEY` from JSON string to dict in the overridable keys loop) can be removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized validation change in the SDK; main risk is minor behavior change in how JSON-string dicts are interpreted during logging.
> 
> **Overview**
> Prevents logs from being dropped when `metadata` or `properties` are passed as JSON strings (e.g., from span attributes/overridable keys) by adding a Pydantic `field_validator` that attempts to `json.loads` these fields and returns the parsed dict when applicable.
> 
> This keeps existing behavior for non-string inputs and for strings that don’t parse into dicts, while making dict-typed log fields more robust during ingestion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f5c84c5872f59f55c553d03621b41e2bf2e8bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->