### PR TITLE
fix(instrumentation-vercel): fix tool call output, strip redundant attrs, deduplicate parent spans

### DIFF
--- a/javascript-sdks/respan-instrumentation-vercel/package.json
+++ b/javascript-sdks/respan-instrumentation-vercel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@respan/instrumentation-vercel",
   "type": "module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Respan instrumentation plugin for Vercel AI SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
+++ b/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
@@ -244,12 +244,13 @@ function formatCompletionOutput(attrs: Record<string, any>): string | undefined 
     content = String(attrs["ai.response.text"] ?? "");
   }
 
-  if (!content) return undefined;
-
   // Build assistant message with optional tool calls
-  const message: Record<string, any> = { role: "assistant", content };
-
   const toolCalls = parseToolCalls(attrs);
+
+  // Bail only when there's no text AND no tool calls
+  if (!content && (!toolCalls || toolCalls.length === 0)) return undefined;
+
+  const message: Record<string, any> = { role: "assistant", content };
   if (toolCalls && toolCalls.length > 0) {
     message.tool_calls = toolCalls;
   }
@@ -350,15 +351,24 @@ function parseTools(attrs: Record<string, any>): string | undefined {
       .map((tool: any) => {
         // Accept both nested and flat shapes; normalize to nested
         if (tool && tool.type === "function") {
-          if (tool.function && typeof tool.function === "object") return tool;
-          const { name, description, parameters, ...rest } = tool;
+          if (tool.function && typeof tool.function === "object") {
+            // Already nested — move top-level inputSchema into function.parameters
+            // (Vercel AI SDK puts inputSchema at the top level, backend expects function.parameters)
+            if (tool.inputSchema && !tool.function.parameters) {
+              const { inputSchema, ...rest } = tool;
+              return { ...rest, function: { ...tool.function, parameters: inputSchema } };
+            }
+            return tool;
+          }
+          const { name, description, parameters, inputSchema, ...rest } = tool;
+          const params = parameters ?? inputSchema;
           return {
             ...rest,
             type: "function",
             function: {
               name,
               ...(description ? { description } : {}),
-              ...(parameters ? { parameters } : {}),
+              ...(params ? { parameters: params } : {}),
             },
           };
         }
@@ -540,9 +550,14 @@ const VERCEL_ATTRS_TO_STRIP = [
   "ai.response.text",
   "ai.response.object",
 
-  // Tokens (translated to gen_ai.usage.prompt_tokens/completion_tokens)
+  // Tokens — old names (v5) + new names (v6)
   "ai.usage.promptTokens",
   "ai.usage.completionTokens",
+  "ai.usage.inputTokens",
+  "ai.usage.outputTokens",
+  "ai.usage.totalTokens",
+  "ai.usage.reasoningTokens",
+  "ai.usage.cachedInputTokens",
 
   // Response metadata (redundant with standard OTEL/GenAI attrs)
   "ai.response.finishReason",
@@ -550,6 +565,15 @@ const VERCEL_ATTRS_TO_STRIP = [
   "ai.response.timestamp",
   "ai.response.providerMetadata",
   "ai.response.msToFinish",
+  "ai.response.msToFirstChunk",
+  "ai.response.avgOutputTokensPerSecond",
+  "ai.response.avgCompletionTokensPerSecond",
+
+  // Request metadata
+  "ai.request.headers.user-agent",
+
+  // Tool choice (translated to respan.metadata.tool_choice)
+  "ai.prompt.toolChoice",
 
   // SDK internals (no user value)
   "ai.operationId",
@@ -614,10 +638,16 @@ function stripRedundantAttrs(attrs: Record<string, any>): void {
   for (const key of VERCEL_ATTRS_TO_STRIP) {
     delete attrs[key];
   }
-  // Strip ai.telemetry.metadata.* (already mapped to respan.metadata.* / respan.customer_params.*)
   for (const key of Object.keys(attrs)) {
+    // Strip ai.telemetry.metadata.* (already mapped to respan.metadata.* / respan.customer_params.*)
     if (key.startsWith("ai.telemetry.metadata.")) {
       delete attrs[key];
+      continue;
+    }
+    // Strip ai.usage.*Details.* (e.g. inputTokenDetails.noCacheTokens, outputTokenDetails.textTokens)
+    if (key.startsWith("ai.usage.") && key.includes("Details.")) {
+      delete attrs[key];
+      continue;
     }
   }
   // Strip ai.prompt.tools (translated to respan.span.tools)
@@ -647,7 +677,8 @@ export class VercelAITranslator implements SpanProcessor {
     if (config) {
       s.setAttribute(RESPAN_LOG_TYPE, config.logType);
     } else if (VERCEL_PARENT_SPANS[name] !== undefined) {
-      s.setAttribute(RESPAN_LOG_TYPE, VERCEL_PARENT_SPANS[name]);
+      // Parent wrappers are structural — mark as TASK to avoid duplicate LLM entries
+      s.setAttribute(RESPAN_LOG_TYPE, RespanLogType.TASK);
     } else {
       // Unknown ai.* span — use full fallback detection
       // At onStart, attributes may be sparse, so set a generic type.
@@ -673,8 +704,10 @@ export class VercelAITranslator implements SpanProcessor {
     enrichMetadata(attrs, name);
 
     // ── Parent wrapper spans: minimal enrichment only ─────────────────────
+    // Use TASK type so these structural wrappers don't create duplicate LLM
+    // entries alongside their .doGenerate/.doStream children.
     if (parentLogType !== undefined && !config) {
-      setDefault(attrs, RESPAN_LOG_TYPE, logType);
+      attrs[RESPAN_LOG_TYPE] = RespanLogType.TASK;
       stripRedundantAttrs(attrs);
       return;
     }

--- a/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
+++ b/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
@@ -16,7 +16,7 @@
  * - Prompt message parsing (ai.prompt.messages + ai.prompt fallback)
  * - Completion message building (ai.response.text, ai.response.object, tool calls)
  * - Token count normalization (input/output → prompt/completion)
- * - Tool definitions (ai.prompt.tools) and tool choice (gen_ai.usage.tool_choice)
+ * - Tool definitions (ai.prompt.tools) and tool choice (ai.prompt.toolChoice)
  * - Customer params (ai.telemetry.metadata.customer_* + customer_params JSON)
  * - General metadata (ai.telemetry.metadata.* → respan.metadata.*)
  * - Stream detection, environment, cost, TTFT, generation time, unit prices
@@ -382,11 +382,11 @@ function parseTools(attrs: Record<string, any>): string | undefined {
 }
 
 /**
- * Parse tool choice from Vercel (ai.prompt.toolChoice) or GenAI (gen_ai.usage.tool_choice).
+ * Parse tool choice from Vercel's ai.prompt.toolChoice attribute.
  */
 function parseToolChoice(attrs: Record<string, any>): string | undefined {
   try {
-    const toolChoice = attrs["ai.prompt.toolChoice"] ?? attrs["gen_ai.usage.tool_choice"];
+    const toolChoice = attrs["ai.prompt.toolChoice"];
     if (!toolChoice) return undefined;
     const parsed = typeof toolChoice === "string" ? JSON.parse(toolChoice) : toolChoice;
     if (parsed.function?.name) {

--- a/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
+++ b/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
@@ -382,17 +382,20 @@ function parseTools(attrs: Record<string, any>): string | undefined {
 }
 
 /**
- * Parse gen_ai.usage.tool_choice into a normalized structure.
+ * Parse tool choice from Vercel (ai.prompt.toolChoice) or GenAI (gen_ai.usage.tool_choice).
  */
 function parseToolChoice(attrs: Record<string, any>): string | undefined {
   try {
-    const toolChoice = attrs["gen_ai.usage.tool_choice"];
+    const toolChoice = attrs["ai.prompt.toolChoice"] ?? attrs["gen_ai.usage.tool_choice"];
     if (!toolChoice) return undefined;
     const parsed = typeof toolChoice === "string" ? JSON.parse(toolChoice) : toolChoice;
-    return safeJsonStr({
-      type: String(parsed.type),
-      function: { name: String(parsed.function.name) },
-    });
+    if (parsed.function?.name) {
+      return safeJsonStr({
+        type: String(parsed.type),
+        function: { name: String(parsed.function.name) },
+      });
+    }
+    return safeJsonStr({ type: String(parsed.type) });
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- **Tool calls dropped**: `formatCompletionOutput()` returned `undefined` when LLM responded with only tool calls (no text), causing empty output and `has_tool_calls: false`. Now preserves tool calls even when text content is empty.
- **Redundant attrs in metadata**: Vercel AI SDK v6 usage attrs (`ai.usage.inputTokens`, `outputTokens`, `totalTokens`, etc.) and other attrs (`ai.request.headers.user-agent`, `ai.prompt.toolChoice`, `ai.response.msToFirstChunk`) were leaking into custom properties. Added to strip list + prefix-based stripping for `ai.usage.*Details.*`.
- **Tool definitions format**: `parseTools()` now maps Vercel's top-level `inputSchema` to `function.parameters` (backend expected format), fixing "Tools: 0" in UI.
- **Duplicate LLM entries**: Parent wrapper spans (`ai.generateText`, `ai.streamText`) now marked as `TASK` instead of `TEXT` to avoid duplicate entries alongside `.doGenerate`/`.doStream` children.
- Bumps version to 1.0.2

## Test plan
- [ ] Deploy docs-chat and trigger a query that uses tool calls — verify output contains tool_calls in completion_message
- [ ] Check span metadata no longer contains `ai.usage.*`, `ai.request.headers.*`, `ai.prompt.toolChoice`
- [ ] Verify Tools section in UI shows tool definitions (not 0)
- [ ] Confirm parent spans (`ai.generateText`, `ai.streamText`) show as task type, not duplicate LLM entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches span translation logic for LLM/tool outputs and log-type classification, which can change what data is sent/stored and how traces appear. Changes are localized to the Vercel AI SDK translator but impact production telemetry semantics.
> 
> **Overview**
> Improves Vercel AI SDK span translation so LLM completions that contain *only tool calls* still produce an output payload (rather than being dropped when `content` is empty).
> 
> Normalizes tool metadata to match backend expectations by mapping Vercel tool definitions’ top-level `inputSchema` into `function.parameters`, and parsing tool choice from `ai.prompt.toolChoice` (handling non-function choices).
> 
> Reduces noisy/custom metadata by stripping additional Vercel AI SDK v6 attributes (new `ai.usage.*` token fields, request/response perf fields, `ai.prompt.toolChoice`, and `ai.usage.*Details.*`), and marks parent wrapper spans (e.g. `ai.generateText`) as `TASK` to avoid duplicate LLM entries. Also bumps package version to `1.0.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e32a865079cde1187ad7230abea74c06ce120778. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->