### PR TITLE
fix: fix build error, revert parent span dedup to preserve doStream

### DIFF
--- a/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
+++ b/javascript-sdks/respan-instrumentation-vercel/src/_translator.ts
@@ -39,7 +39,8 @@ const CUSTOMER_ID = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_ID;
 const CUSTOMER_EMAIL = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_EMAIL;
 const CUSTOMER_NAME = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_NAME;
 const THREAD_ID = RespanSpanAttributes.RESPAN_THREADS_ID;
-const SESSION_ID = RespanSpanAttributes.RESPAN_SESSION_ID;
+// RESPAN_SESSION_ID not yet published in @respan/respan-sdk — use wire value directly
+const SESSION_ID = "respan.sessions.session_identifier";
 const TRACE_GROUP_ID = RespanSpanAttributes.RESPAN_TRACE_GROUP_ID;
 const RESPAN_SPAN_TOOLS = RespanSpanAttributes.RESPAN_SPAN_TOOLS;
 const RESPAN_METADATA_AGENT_NAME = RespanSpanAttributes.RESPAN_METADATA_AGENT_NAME;
@@ -680,8 +681,7 @@ export class VercelAITranslator implements SpanProcessor {
     if (config) {
       s.setAttribute(RESPAN_LOG_TYPE, config.logType);
     } else if (VERCEL_PARENT_SPANS[name] !== undefined) {
-      // Parent wrappers are structural — mark as TASK to avoid duplicate LLM entries
-      s.setAttribute(RESPAN_LOG_TYPE, RespanLogType.TASK);
+      s.setAttribute(RESPAN_LOG_TYPE, VERCEL_PARENT_SPANS[name]);
     } else {
       // Unknown ai.* span — use full fallback detection
       // At onStart, attributes may be sparse, so set a generic type.
@@ -707,10 +707,8 @@ export class VercelAITranslator implements SpanProcessor {
     enrichMetadata(attrs, name);
 
     // ── Parent wrapper spans: minimal enrichment only ─────────────────────
-    // Use TASK type so these structural wrappers don't create duplicate LLM
-    // entries alongside their .doGenerate/.doStream children.
     if (parentLogType !== undefined && !config) {
-      attrs[RESPAN_LOG_TYPE] = RespanLogType.TASK;
+      setDefault(attrs, RESPAN_LOG_TYPE, logType);
       stripRedundantAttrs(attrs);
       return;
     }


### PR DESCRIPTION
- Use string literal for SESSION_ID (RESPAN_SESSION_ID not yet in published @respan/respan-sdk)
- Revert parent wrapper spans back to their original log type instead of TASK — the 2 wrapper spans are acceptable and changing them may affect child span export timing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `ai.*` wrapper spans are classified and which spans pass early filtering, which can affect downstream span export/aggregation and streaming timing. Also hardcodes a wire-format attribute key to avoid SDK version mismatches, with low functional risk beyond attribute naming.
> 
> **Overview**
> Fixes a build break by replacing `RespanSpanAttributes.RESPAN_SESSION_ID` usage with the literal wire key `"respan.sessions.session_identifier"` until the SDK publishes the constant.
> 
> Adjusts Vercel AI parent/wrapper span handling so `VERCEL_PARENT_SPANS` sets the early `RESPAN_LOG_TYPE` in `onStart`, and wrapper spans no longer get forced to `TASK` in `onEnd` (they keep the resolved/original log type while still receiving only minimal enrichment/stripping).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ad150793bba5ff656aa8c48f4b3d9c365c6a3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->