### PR TITLE
feat(cli): add --enable/--disable flags to integrate commands

### DIFF
--- a/javascript-sdks/respan-cli/src/commands/integrate/claude-code.ts
+++ b/javascript-sdks/respan-cli/src/commands/integrate/claude-code.ts
@@ -28,6 +28,7 @@ Scope:
 
   static examples = [
     'respan integrate claude-code',
+    'respan integrate claude-code --disable',
     'respan integrate claude-code --global',
     'respan integrate claude-code --local --project-id my-project',
     'respan integrate claude-code --attrs \'{"env":"prod"}\'',
@@ -44,6 +45,32 @@ Scope:
     this.globalFlags = flags;
 
     try {
+      const dryRun = flags['dry-run'];
+      const scope = resolveScope(flags, 'both');
+      const doLocal = scope === 'local' || scope === 'both';
+
+      // ── Disable mode ─────────────────────────────────────────────
+      if (flags.disable) {
+        if (doLocal) {
+          const projectRoot = findProjectRoot();
+          const localSettingsPath = `${projectRoot}/.claude/settings.local.json`;
+          const localSettings = readJsonFile(localSettingsPath);
+          const envBlock = (localSettings.env || {}) as Record<string, string>;
+          envBlock.TRACE_TO_RESPAN = 'false';
+          const merged = deepMerge(localSettings, { env: envBlock });
+          if (dryRun) {
+            this.log(`[dry-run] Would update: ${localSettingsPath}`);
+            this.log(JSON.stringify(merged, null, 2));
+          } else {
+            writeJsonFile(localSettingsPath, merged);
+            this.log(`Disabled tracing: ${localSettingsPath}`);
+          }
+        }
+        this.log('Claude Code tracing disabled. Run with --enable to re-enable.');
+        return;
+      }
+
+      // ── Enable mode (default) ────────────────────────────────────
       // Verify the user is authenticated (key is read by hook from ~/.respan/)
       this.resolveApiKey();
       const baseUrl = flags['base-url']!;
@@ -52,12 +79,9 @@ Scope:
       const spanName = flags['span-name'];
       const workflowName = flags['workflow-name'];
       const attrs = parseAttrs(flags.attrs!);
-      const dryRun = flags['dry-run'];
       // Claude Code default: both global + local
-      const scope = resolveScope(flags, 'both');
 
       const doGlobal = scope === 'global' || scope === 'both';
-      const doLocal = scope === 'local' || scope === 'both';
 
       // ── Global: hook script + registration ────────────────────────
       if (doGlobal) {

--- a/javascript-sdks/respan-cli/src/commands/integrate/claude-code.ts
+++ b/javascript-sdks/respan-cli/src/commands/integrate/claude-code.ts
@@ -51,22 +51,30 @@ Scope:
 
       // ── Disable mode ─────────────────────────────────────────────
       if (flags.disable) {
-        if (doLocal) {
-          const projectRoot = findProjectRoot();
-          const localSettingsPath = `${projectRoot}/.claude/settings.local.json`;
-          const localSettings = readJsonFile(localSettingsPath);
-          const envBlock = (localSettings.env || {}) as Record<string, string>;
-          envBlock.TRACE_TO_RESPAN = 'false';
-          const merged = deepMerge(localSettings, { env: envBlock });
-          if (dryRun) {
-            this.log(`[dry-run] Would update: ${localSettingsPath}`);
-            this.log(JSON.stringify(merged, null, 2));
-          } else {
-            writeJsonFile(localSettingsPath, merged);
-            this.log(`Disabled tracing: ${localSettingsPath}`);
-          }
+        // Remove the Stop hook entry from global settings
+        const globalSettingsPath = expandHome('~/.claude/settings.json');
+        const globalSettings = readJsonFile(globalSettingsPath);
+        const hooksSection = (globalSettings.hooks || {}) as Record<string, unknown>;
+        if (Array.isArray(hooksSection.Stop)) {
+          hooksSection.Stop = (hooksSection.Stop as Array<Record<string, unknown>>).filter((entry) => {
+            const inner = Array.isArray(entry.hooks)
+              ? (entry.hooks as Array<Record<string, unknown>>)
+              : [];
+            return !inner.some(
+              (h) => typeof h.command === 'string' &&
+                ((h.command as string).includes('respan') || (h.command as string).includes('hook.py') || (h.command as string).includes('claude-code')),
+            );
+          });
         }
-        this.log('Claude Code tracing disabled. Run with --enable to re-enable.');
+        const merged = deepMerge(globalSettings, { hooks: hooksSection });
+        if (dryRun) {
+          this.log(`[dry-run] Would update: ${globalSettingsPath}`);
+          this.log(JSON.stringify(merged, null, 2));
+        } else {
+          writeJsonFile(globalSettingsPath, merged);
+          this.log(`Removed hook entry: ${globalSettingsPath}`);
+        }
+        this.log('Claude Code tracing disabled. Run "respan integrate claude-code" to re-enable.');
         return;
       }
 

--- a/javascript-sdks/respan-cli/src/commands/integrate/codex-cli.ts
+++ b/javascript-sdks/respan-cli/src/commands/integrate/codex-cli.ts
@@ -47,10 +47,13 @@ Scope:
 
       // ── Disable mode ─────────────────────────────────────────────
       if (flags.disable) {
+        // Remove the notify line from ~/.codex/config.toml
         const configPath = expandHome('~/.codex/config.toml');
         const existing = readTextFile(configPath);
         const lines = existing.split('\n');
-        const filtered = lines.filter((line) => !/^\s*notify\s*=/.test(line) && !line.includes('respan integrate codex-cli'));
+        const filtered = lines.filter((line) =>
+          !/^\s*notify\s*=/.test(line) && !line.includes('respan integrate codex-cli'),
+        );
         if (dryRun) {
           this.log(`[dry-run] Would update: ${configPath}`);
           this.log(filtered.join('\n'));
@@ -58,7 +61,7 @@ Scope:
           writeTextFile(configPath, filtered.join('\n'));
           this.log(`Removed notify hook: ${configPath}`);
         }
-        this.log('Codex CLI tracing disabled. Run with --enable to re-enable.');
+        this.log('Codex CLI tracing disabled. Run "respan integrate codex-cli" to re-enable.');
         return;
       }
 

--- a/javascript-sdks/respan-cli/src/commands/integrate/codex-cli.ts
+++ b/javascript-sdks/respan-cli/src/commands/integrate/codex-cli.ts
@@ -26,6 +26,7 @@ Scope:
 
   static examples = [
     'respan integrate codex-cli',
+    'respan integrate codex-cli --disable',
     'respan integrate codex-cli --global',
     'respan integrate codex-cli --local --customer-id frank',
     'respan integrate codex-cli --attrs \'{"env":"prod"}\'',
@@ -42,6 +43,26 @@ Scope:
     this.globalFlags = flags;
 
     try {
+      const dryRun = flags['dry-run'];
+
+      // ── Disable mode ─────────────────────────────────────────────
+      if (flags.disable) {
+        const configPath = expandHome('~/.codex/config.toml');
+        const existing = readTextFile(configPath);
+        const lines = existing.split('\n');
+        const filtered = lines.filter((line) => !/^\s*notify\s*=/.test(line) && !line.includes('respan integrate codex-cli'));
+        if (dryRun) {
+          this.log(`[dry-run] Would update: ${configPath}`);
+          this.log(filtered.join('\n'));
+        } else {
+          writeTextFile(configPath, filtered.join('\n'));
+          this.log(`Removed notify hook: ${configPath}`);
+        }
+        this.log('Codex CLI tracing disabled. Run with --enable to re-enable.');
+        return;
+      }
+
+      // ── Enable mode (default) ────────────────────────────────────
       // Verify the user is authenticated (key is read by hook from ~/.respan/)
       this.resolveApiKey();
       const projectId = flags['project-id'];
@@ -49,7 +70,6 @@ Scope:
       const spanName = flags['span-name'];
       const workflowName = flags['workflow-name'];
       const attrs = parseAttrs(flags.attrs!);
-      const dryRun = flags['dry-run'];
       // Codex CLI default: both global + local
       const scope = resolveScope(flags, 'both');
 

--- a/javascript-sdks/respan-cli/src/commands/integrate/gemini-cli.ts
+++ b/javascript-sdks/respan-cli/src/commands/integrate/gemini-cli.ts
@@ -31,6 +31,7 @@ Note: Gemini CLI ignores workspace-level telemetry settings, so
 
   static examples = [
     'respan integrate gemini-cli',
+    'respan integrate gemini-cli --disable',
     'respan integrate gemini-cli --local',
     'respan integrate gemini-cli --project-id my-project --attrs \'{"env":"prod"}\'',
     'respan integrate gemini-cli --dry-run',
@@ -46,6 +47,42 @@ Note: Gemini CLI ignores workspace-level telemetry settings, so
     this.globalFlags = flags;
 
     try {
+      const dryRun = flags['dry-run'];
+      const scope = resolveScope(flags, 'global');
+
+      // ── Disable mode ─────────────────────────────────────────────
+      if (flags.disable) {
+        const settingsPath = scope === 'global'
+          ? expandHome('~/.gemini/settings.json')
+          : path.join(findProjectRoot(), '.gemini', 'settings.json');
+        const existing = readJsonFile(settingsPath);
+        const hooksSection = (existing.hooks || {}) as Record<string, unknown>;
+
+        // Remove respan hook entries from each event type
+        for (const eventName of ['AfterModel', 'BeforeTool', 'AfterTool']) {
+          if (!Array.isArray(hooksSection[eventName])) continue;
+          hooksSection[eventName] = (hooksSection[eventName] as Array<Record<string, unknown>>).filter((entry) => {
+            const inner = Array.isArray(entry.hooks) ? (entry.hooks as Array<Record<string, unknown>>) : [];
+            return !inner.some(
+              (h) => typeof h.command === 'string' &&
+                ((h.command as string).includes('respan') || (h.command as string).includes('gemini-cli.js')),
+            );
+          });
+        }
+
+        const merged = { ...existing, hooks: hooksSection };
+        if (dryRun) {
+          this.log(`[dry-run] Would update: ${settingsPath}`);
+          this.log(JSON.stringify(merged, null, 2));
+        } else {
+          writeJsonFile(settingsPath, merged);
+          this.log(`Removed hooks: ${settingsPath}`);
+        }
+        this.log('Gemini CLI tracing disabled. Run with --enable to re-enable.');
+        return;
+      }
+
+      // ── Enable mode (default) ────────────────────────────────────
       // Verify the user is authenticated (key is read by hook from ~/.respan/)
       this.resolveApiKey();
       const projectId = flags['project-id'];
@@ -53,8 +90,6 @@ Note: Gemini CLI ignores workspace-level telemetry settings, so
       const spanName = flags['span-name'];
       const workflowName = flags['workflow-name'];
       const attrs = parseAttrs(flags.attrs!);
-      const dryRun = flags['dry-run'];
-      const scope = resolveScope(flags, 'global');
 
       // ── 1. Install hook script ──────────────────────────────────
       const hookDir = expandHome('~/.respan/hooks');

--- a/javascript-sdks/respan-cli/src/commands/integrate/gemini-cli.ts
+++ b/javascript-sdks/respan-cli/src/commands/integrate/gemini-cli.ts
@@ -52,33 +52,33 @@ Note: Gemini CLI ignores workspace-level telemetry settings, so
 
       // ── Disable mode ─────────────────────────────────────────────
       if (flags.disable) {
+        // Remove respan hook entries from settings.json
         const settingsPath = scope === 'global'
           ? expandHome('~/.gemini/settings.json')
           : path.join(findProjectRoot(), '.gemini', 'settings.json');
         const existing = readJsonFile(settingsPath);
         const hooksSection = (existing.hooks || {}) as Record<string, unknown>;
-
-        // Remove respan hook entries from each event type
         for (const eventName of ['AfterModel', 'BeforeTool', 'AfterTool']) {
           if (!Array.isArray(hooksSection[eventName])) continue;
           hooksSection[eventName] = (hooksSection[eventName] as Array<Record<string, unknown>>).filter((entry) => {
-            const inner = Array.isArray(entry.hooks) ? (entry.hooks as Array<Record<string, unknown>>) : [];
+            const inner = Array.isArray(entry.hooks)
+              ? (entry.hooks as Array<Record<string, unknown>>)
+              : [];
             return !inner.some(
               (h) => typeof h.command === 'string' &&
-                ((h.command as string).includes('respan') || (h.command as string).includes('gemini-cli.js')),
+                ((h.command as string).includes('respan') || (h.command as string).includes('gemini-cli')),
             );
           });
         }
-
         const merged = { ...existing, hooks: hooksSection };
         if (dryRun) {
           this.log(`[dry-run] Would update: ${settingsPath}`);
           this.log(JSON.stringify(merged, null, 2));
         } else {
           writeJsonFile(settingsPath, merged);
-          this.log(`Removed hooks: ${settingsPath}`);
+          this.log(`Removed hook entries: ${settingsPath}`);
         }
-        this.log('Gemini CLI tracing disabled. Run with --enable to re-enable.');
+        this.log('Gemini CLI tracing disabled. Run "respan integrate gemini-cli" to re-enable.');
         return;
       }
 

--- a/javascript-sdks/respan-cli/src/commands/integrate/opencode.ts
+++ b/javascript-sdks/respan-cli/src/commands/integrate/opencode.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { BaseCommand } from '../../lib/base-command.js';
@@ -23,6 +24,7 @@ Scope:
 
   static examples = [
     'respan integrate opencode',
+    'respan integrate opencode --disable',
     'respan integrate opencode --global',
     'respan integrate opencode --project-id my-project --attrs \'{"env":"prod"}\'',
     'respan integrate opencode --dry-run',
@@ -38,12 +40,33 @@ Scope:
     this.globalFlags = flags;
 
     try {
+      const dryRun = flags['dry-run'];
+      const scope = resolveScope(flags, 'local');
+
+      // ── Disable mode ─────────────────────────────────────────────
+      if (flags.disable) {
+        const pluginPath = scope === 'global'
+          ? expandHome('~/.config/opencode/plugins/otel.json')
+          : path.join(findProjectRoot(), '.opencode', 'plugins', 'otel.json');
+        if (dryRun) {
+          this.log(`[dry-run] Would remove: ${pluginPath}`);
+        } else {
+          try {
+            fs.unlinkSync(pluginPath);
+            this.log(`Removed plugin config: ${pluginPath}`);
+          } catch {
+            this.log(`No plugin config found at: ${pluginPath}`);
+          }
+        }
+        this.log('OpenCode tracing disabled. Run with --enable to re-enable.');
+        return;
+      }
+
+      // ── Enable mode (default) ────────────────────────────────────
       const apiKey = this.resolveApiKey();
       const baseUrl = (flags['base-url']!).replace(/\/+$/, '');
       const projectId = flags['project-id'];
       const attrs = parseAttrs(flags.attrs!);
-      const dryRun = flags['dry-run'];
-      const scope = resolveScope(flags, 'local');
 
       // ── 1. Install opencode-otel (always global) ─────────────────
       if (dryRun) {

--- a/javascript-sdks/respan-cli/src/lib/integrate.ts
+++ b/javascript-sdks/respan-cli/src/lib/integrate.ts
@@ -23,6 +23,16 @@ export const integrateFlags = {
     default: false,
     exclusive: ['local'],
   }),
+  enable: Flags.boolean({
+    description: 'Enable tracing (default)',
+    default: false,
+    exclusive: ['disable'],
+  }),
+  disable: Flags.boolean({
+    description: 'Disable tracing',
+    default: false,
+    exclusive: ['enable'],
+  }),
   'project-id': Flags.string({
     description: 'Respan project ID (added to metadata / resource attributes)',
     env: 'RESPAN_PROJECT_ID',


### PR DESCRIPTION
## Summary
- Adds `--enable` and `--disable` flags to all four `respan integrate` commands
- `--disable` reverses the integration per tool:
  - **claude-code**: sets `TRACE_TO_RESPAN=false` in `.claude/settings.local.json`
  - **codex-cli**: removes `notify` hook from `~/.codex/config.toml`
  - **gemini-cli**: removes respan hook entries from `settings.json`
  - **opencode**: removes the `otel.json` plugin config file
- `--enable` is the default (backward compatible, same as running without flag)

## Usage
```bash
respan integrate claude-code --disable
respan integrate claude-code --enable   # or just: respan integrate claude-code
```

## Test plan
- [ ] `respan integrate claude-code` still works as before (enable by default)
- [ ] `respan integrate claude-code --disable` sets `TRACE_TO_RESPAN=false`
- [ ] `respan integrate codex-cli --disable` removes notify from config.toml
- [ ] `respan integrate gemini-cli --disable` removes hook entries from settings.json
- [ ] `respan integrate opencode --disable` removes plugin config
- [ ] `--enable` and `--disable` are mutually exclusive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new disable path that mutates or deletes user/project config files for multiple tools (JSON/TOML and plugin config), so mistakes in pattern matching or scope selection could unintentionally remove unrelated settings. Enable behavior is intended to be unchanged, but the new branching increases surface area for edge cases and dry-run parity.
> 
> **Overview**
> Adds `--enable`/`--disable` (mutually exclusive) to shared `integrateFlags` and wires `--disable` into all `respan integrate` commands.
> 
> When `--disable` is used, each command now reverses its integration by editing/removing the relevant hook/config: Claude Code removes the `Stop` hook from `~/.claude/settings.json`, Codex CLI removes the `notify` line from `~/.codex/config.toml`, Gemini CLI removes Respan hook entries from `settings.json` (global or local per scope), and OpenCode deletes the `otel.json` plugin config (global or local). All commands support `--dry-run` previews for these disable operations and include updated usage examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3799e4af74848a8b8cafcce3e76e249de5d45ce0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->