### PR TITLE
docs(tracing): document client.flush() for thread pool workers

### DIFF
--- a/python-sdks/respan-tracing/README.md
+++ b/python-sdks/respan-tracing/README.md
@@ -1228,6 +1228,40 @@ result = process_data("user-123", {"key": "value"})
 
 See [`examples/simple_span_updating_example.py`](examples/simple_span_updating_example.py) for a complete example.
 
+### Flushing Spans
+
+When batching is enabled (`is_batching_enabled=True`, the default), spans are exported in the background on a periodic schedule. In most cases this is transparent — the SDK registers an `atexit` handler that flushes remaining spans when the process exits.
+
+However, there are cases where you need to flush manually:
+
+- **Thread pool workers** — If your code runs in a `ThreadPoolExecutor` (e.g., Temporal activities, custom worker pools), the background flush thread may not export spans before the thread returns to the pool. The spans are created but never reach your backend.
+- **Short-lived processes** — Scripts or serverless functions that exit quickly may terminate before the batch interval fires.
+- **Test assertions** — When verifying spans in tests, you need to flush before checking the exporter.
+
+```python
+from respan_tracing import get_client
+
+@workflow(name="my_worker_task", processors="dogfood")
+def process_item(item):
+    client = get_client()
+    if client:
+        client.update_current_span(attributes={"item.id": item.id})
+
+    result = do_work(item)
+    return result
+
+# In a thread pool worker, flush after the decorated function returns:
+def worker_wrapper(item):
+    try:
+        return process_item(item)
+    finally:
+        client = get_client()
+        if client:
+            client.flush()
+```
+
+`flush()` is safe to call multiple times and is a no-op when there are no pending spans.
+
 ### Manual Span Creation
 
 For fine-grained control, you can manually create custom spans using the tracer directly. This is useful when:


### PR DESCRIPTION
## Summary

- Adds a "Flushing Spans" section to the respan-tracing README
- Documents when `client.flush()` is needed:
  - **Thread pool workers** (Temporal activities, custom thread pools) — BatchSpanProcessor may not flush before the thread returns
  - **Short-lived processes** — scripts/serverless that exit before batch interval
  - **Test assertions** — need to flush before checking exporter
- Includes code example showing the pattern for thread pool workers

## Context

Discovered while instrumenting Temporal export pipeline activities in the backend. Spans were created but never reached staging because `BatchSpanProcessor`'s background thread didn't flush in the `ThreadPoolExecutor` context. `client.flush()` existed but wasn't documented — had to read SDK source to find it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or APIs are modified.
> 
> **Overview**
> Adds a new **"Flushing Spans"** section to the `respan-tracing` README explaining when `client.flush()` is needed with batched export (notably thread pool workers, short-lived processes, and tests).
> 
> Includes a small code example showing a `try/finally` wrapper pattern that calls `flush()` after a decorated function returns, and notes that `flush()` is idempotent/no-op when nothing is pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a812509b01eaf6e00bc50c39b677f18cbf68f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->