### PR TITLE
fix: stabilize cli publish smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,8 +165,19 @@ jobs:
           cd "${tmpdir}"
           npm init -y >/dev/null 2>&1
 
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+            if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/tmp/npm-view.log 2>&1; then
+              break
+            fi
+            if [ "${attempt}" -eq 16 ]; then
+              cat /tmp/npm-view.log
+              exit 1
+            fi
+            sleep 15
+          done
+
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
-            if npm install "${PACKAGE_NAME}@${PACKAGE_VERSION}" >/tmp/npm-install.log 2>&1; then
+            if npm install --prefer-online "${PACKAGE_NAME}@${PACKAGE_VERSION}" >/tmp/npm-install.log 2>&1; then
               break
             fi
             if [ "${attempt}" -eq 10 ]; then

--- a/.release-intents/20260409-cli-publish-smoke.json
+++ b/.release-intents/20260409-cli-publish-smoke.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Patch @respan/cli publish smoke checks to wait for npm registry visibility before install verification",
+  "packages": {
+    "@respan/cli": "patch"
+  }
+}


### PR DESCRIPTION
## Summary
- wait for npm registry visibility before install-based smoke verification
- scope the release intent to `@respan/cli` only
- keep this PR limited to workflow + intent changes

## Validation
- `python3 scripts/release_intents.py validate`
- `python3 scripts/release_intents.py plan --ecosystem javascript --changed-from origin/main --changed-to HEAD --format names` -> `@respan/cli`
- `python3 scripts/release_intents.py plan --ecosystem python --changed-from origin/main --changed-to HEAD --format names` -> empty
- `python3 scripts/release_inventory.py --ecosystem javascript --changed-from origin/main --changed-to HEAD --include-dependents --format names` -> `[]`
- `python3 scripts/release_inventory.py --ecosystem python --changed-from origin/main --changed-to HEAD --include-dependents --format names` -> `[]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adds retry/wait logic around npm registry propagation; main impact is slightly longer publish jobs if npm is slow to index new versions.
> 
> **Overview**
> Stabilizes the npm publish **registry smoke test** by first polling `npm view` for the newly published version to become visible (with retries) before attempting installation.
> 
> Updates the install verification to use `npm install --prefer-online` and adds a release intent scoped to `@respan/cli` (patch) to ship the workflow fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4584dd4ef2b075d3bbf3d90eabee360a74a2d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->