### PR TITLE
fix: relax peer-dependent js smoke imports

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,6 +160,7 @@ jobs:
           PACKAGE_NAME: ${{ matrix.name }}
           PACKAGE_VERSION: ${{ env.RELEASE_VERSION }}
           BIN_NAME: ${{ matrix.bin_name }}
+          PACKAGE_PATH: ${{ matrix.path }}
         run: |
           tmpdir="$(mktemp -d)"
           cd "${tmpdir}"
@@ -187,8 +188,20 @@ jobs:
             sleep 15
           done
 
+          HAS_PEER_DEPENDENCIES="$(python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = json.loads(Path(os.environ["GITHUB_WORKSPACE"], os.environ["PACKAGE_PATH"], "package.json").read_text())
+          print("true" if manifest.get("peerDependencies") else "false")
+          PY
+          )"
+
           if [ -n "${BIN_NAME}" ] && [ "${BIN_NAME}" != "null" ]; then
             "./node_modules/.bin/${BIN_NAME}" --help >/dev/null
+          elif [ "${HAS_PEER_DEPENDENCIES}" = "true" ]; then
+            echo "Skipping empty-project import smoke for ${PACKAGE_NAME} because it declares peer dependencies."
           else
             node --input-type=module -e "await import(process.env.PACKAGE_NAME)"
           fi

--- a/.release-intents/20260409-openai-agents-publish-smoke.json
+++ b/.release-intents/20260409-openai-agents-publish-smoke.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Patch @respan/instrumentation-openai-agents publish smoke checks to treat peer-dependent installs as install-only verification",
+  "packages": {
+    "@respan/instrumentation-openai-agents": "patch"
+  }
+}


### PR DESCRIPTION
## Summary
- treat JS packages with peer dependencies as install-only in the registry smoke check
- avoid empty-project import assertions for peer-dependent packages like `@respan/instrumentation-openai-agents`
- scope the release intent to `@respan/instrumentation-openai-agents` only

## Validation
- `python3 scripts/release_intents.py validate`
- `python3 scripts/release_intents.py plan --ecosystem javascript --changed-from origin/main --changed-to HEAD --format names` -> `@respan/instrumentation-openai-agents`
- `python3 scripts/release_intents.py plan --ecosystem python --changed-from origin/main --changed-to HEAD --format names` -> empty
- `python3 scripts/release_inventory.py --ecosystem javascript --changed-from origin/main --changed-to HEAD --include-dependents --format names` -> `[]`
- `python3 scripts/release_inventory.py --ecosystem python --changed-from origin/main --changed-to HEAD --include-dependents --format names` -> `[]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that relaxes a post-publish smoke check; main impact is reduced verification for packages with `peerDependencies`.
> 
> **Overview**
> Updates the npm publish workflow’s registry smoke test to detect whether the published package declares `peerDependencies` (by reading its `package.json`) and, if so, **skip the empty-project `import` assertion** while still verifying `npm install` succeeds.
> 
> Adds a release intent to patch-bump only `@respan/instrumentation-openai-agents` to apply this adjusted smoke-check behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6105ce526b9205324569d56270805cd928be0f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->