### PR TITLE
fix: replace workspace publish deps

### DIFF
--- a/.release-intents/20260409-js-workspace-publish-deps.json
+++ b/.release-intents/20260409-js-workspace-publish-deps.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Replace unreleasable workspace dependency ranges in active JS instrumentation packages and republish the broken OpenAI Agents package",
+  "packages": {
+    "@respan/instrumentation-anthropic": "none",
+    "@respan/instrumentation-openai-agents": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-anthropic/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-anthropic/package.json
@@ -30,7 +30,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/sdk-trace-base": "^1.26.0",
-    "@respan/respan-sdk": "workspace:*",
+    "@respan/respan-sdk": "^1.1.7",
     "@traceloop/ai-semantic-conventions": "^0.13.0"
   },
   "peerDependencies": {

--- a/javascript-sdks/instrumentations/respan-instrumentation-openai-agents/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-openai-agents/package.json
@@ -30,7 +30,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/sdk-trace-base": "^1.26.0",
-    "@respan/respan-sdk": "workspace:*",
+    "@respan/respan-sdk": "^1.1.7",
     "@traceloop/ai-semantic-conventions": "^0.13.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- replace unreleasable `workspace:*` runtime dependencies in active JS instrumentation packages
- republish `@respan/instrumentation-openai-agents` with a real `@respan/respan-sdk` semver range
- keep `@respan/instrumentation-anthropic` source fixed in-repo but mark it as `none` to avoid triggering the still-broken npm permission path

## Validation
- `python3 scripts/release_intents.py validate`
- `python3 scripts/release_intents.py plan --ecosystem javascript --changed-from origin/main --changed-to HEAD --format names` -> `@respan/instrumentation-openai-agents`
- `python3 scripts/release_intents.py plan --ecosystem python --changed-from origin/main --changed-to HEAD --format names` -> empty
- `python3 scripts/release_inventory.py --ecosystem javascript --changed-from origin/main --changed-to HEAD --include-dependents --format names` -> anthropic + openai-agents
- `npm view @respan/instrumentation-openai-agents@1.0.5 dependencies --json` confirms the currently published package is broken because it contains `"@respan/respan-sdk": "workspace:*"`
- local repro: `npm install @respan/instrumentation-openai-agents@1.0.5` fails with `EUNSUPPORTEDPROTOCOL`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-metadata change: swaps unreleasable `workspace:*` ranges to a published semver range to unblock npm installs and a republish.
> 
> **Overview**
> Fixes broken npm publish/install behavior for JS instrumentation packages by replacing the `@respan/respan-sdk` dependency from `workspace:*` to `^1.1.7` in `@respan/instrumentation-anthropic` and `@respan/instrumentation-openai-agents`.
> 
> Adds a `.release-intents` entry to **republish** `@respan/instrumentation-openai-agents` as a patch release while marking the Anthropic package as `none` (no release triggered).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f3346c3294925dba9f7835cad73a25584734020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->