### PR TITLE
chore: republish new python instrumentation packages

### DIFF
--- a/.release-intents/20260409-python-new-package-publish.json
+++ b/.release-intents/20260409-python-new-package-publish.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Publish newly registered Python instrumentation packages after adding trusted publishers",
+  "packages": {
+    "respan-instrumentation-anthropic": "new",
+    "respan-instrumentation-pydantic-ai": "new"
+  }
+}


### PR DESCRIPTION
## Summary
- trigger publish for the newly registered PyPI instrumentation projects
- scope the release intent to `respan-instrumentation-anthropic` and `respan-instrumentation-pydantic-ai`
- avoid any JavaScript release work in this PR

## Validation
- `python3 scripts/release_intents.py validate`
- `python3 scripts/release_intents.py plan --ecosystem python --changed-from origin/main --changed-to HEAD --format names` -> `respan-instrumentation-anthropic`, `respan-instrumentation-pydantic-ai`
- `python3 scripts/release_intents.py plan --ecosystem javascript --changed-from origin/main --changed-to HEAD --format names` -> empty
- `python3 scripts/release_inventory.py --ecosystem python --changed-from origin/main --changed-to HEAD --include-dependents --format names` -> `[]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a single `.release-intents` JSON file to trigger publishing two newly registered Python packages; no runtime code or build logic changes.
> 
> **Overview**
> Adds a new `.release-intents/20260409-python-new-package-publish.json` intent marking `respan-instrumentation-anthropic` and `respan-instrumentation-pydantic-ai` as `new`, so the release tooling plans/publishes only these Python packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7409cc8d4b320d631d7f950a2829f1c99ee61ef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->