### PR TITLE
chore: republish python anthropic instrumentation

### DIFF
--- a/.release-intents/20260409-python-anthropic-republish.json
+++ b/.release-intents/20260409-python-anthropic-republish.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Republish respan-instrumentation-anthropic after fixing its PyPI pending publisher configuration",
+  "packages": {
+    "respan-instrumentation-anthropic": "new"
+  }
+}


### PR DESCRIPTION
## Summary
- trigger a minimal republish for `respan-instrumentation-anthropic`
- assume the PyPI pending publisher entry has been corrected
- avoid any JavaScript or unrelated Python release work

## Validation
- `python3 scripts/release_intents.py validate`
- `python3 scripts/release_intents.py plan --ecosystem python --changed-from origin/main --changed-to HEAD --format names` -> `respan-instrumentation-anthropic`
- `python3 scripts/release_intents.py plan --ecosystem javascript --changed-from origin/main --changed-to HEAD --format names` -> empty
- `python3 scripts/release_inventory.py --ecosystem python --changed-from origin/main --changed-to HEAD --include-dependents --format names` -> `[]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that only affects the release automation by scheduling a republish of a single Python package.
> 
> **Overview**
> Adds a new `.release-intents/20260409-python-anthropic-republish.json` intent marking `respan-instrumentation-anthropic` as `new`, triggering the release tooling to republish the package after the PyPI publisher configuration fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b611e71bb216cf862cf5ee4c69dd293260c2af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->