### PR TITLE
fix: repair anthropic package README for PyPI

### DIFF
--- a/.release-intents/20260409-python-anthropic-readme-fix.json
+++ b/.release-intents/20260409-python-anthropic-readme-fix.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Republish respan-instrumentation-anthropic after fixing its package README for PyPI rendering",
+  "packages": {
+    "respan-instrumentation-anthropic": "new"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/README.md
@@ -1,0 +1,45 @@
+# respan-instrumentation-anthropic
+
+Respan instrumentation plugin for the
+[Anthropic Python SDK](https://github.com/anthropics/anthropic-sdk-python).
+
+This package patches Anthropic client calls and emits spans using the
+Respan/Traceloop GenAI attribute shape used across this repository.
+
+## Install
+
+```bash
+pip install respan-instrumentation-anthropic
+```
+
+## Quickstart
+
+```python
+import os
+
+from anthropic import Anthropic
+from respan import Respan
+from respan_instrumentation_anthropic import AnthropicInstrumentor
+
+respan = Respan(
+    api_key=os.environ["RESPAN_API_KEY"],
+    instrumentations=[AnthropicInstrumentor()],
+)
+
+client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+
+message = client.messages.create(
+    model="claude-3-5-haiku-latest",
+    max_tokens=128,
+    messages=[{"role": "user", "content": "Write one line about tracing."}],
+)
+
+print(message.content)
+respan.flush()
+```
+
+## Notes
+
+- The instrumentor patches both `Anthropic` and `AsyncAnthropic`.
+- `messages.create()` and streaming responses are traced.
+- Managed agent session streaming is also captured when available through the Anthropic SDK.


### PR DESCRIPTION
## Summary
- add a real package README for respan-instrumentation-anthropic
- add a release intent to republish the package
- fix the PyPI markdown render failure blocking publish

## Validation
- python3 scripts/release_intents.py validate
- python3 -m build --no-isolation
- python3 -m twine check dist/*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change plus a release-intent entry to trigger republishing; no runtime code paths are modified.
> 
> **Overview**
> Adds a real `README.md` for `respan-instrumentation-anthropic` (install instructions, quickstart snippet, and tracing notes) to fix PyPI Markdown rendering.
> 
> Introduces a `.release-intents/...json` entry marking `respan-instrumentation-anthropic` for republish with the corrected README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ce1afb87cb6625ad0dafe80934d2219b9b3deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->