### PR TITLE
fix: publish js anthropic and opt workflows into node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,9 @@ on:
         description: Optional git ref or SHA to compare to
         required: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 

--- a/.release-intents/20260409-js-anthropic-publish-node24.json
+++ b/.release-intents/20260409-js-anthropic-publish-node24.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Republish @respan/instrumentation-anthropic and opt GitHub Actions workflows into Node 24 execution",
+  "packages": {
+    "@respan/instrumentation-anthropic": "patch"
+  }
+}


### PR DESCRIPTION
## Summary
- add a release intent to publish @respan/instrumentation-anthropic
- opt CI and Publish workflows into Node 24 action execution
- keep the change surface limited to release metadata and workflow env

## Validation
- python3 scripts/release_intents.py validate
- python3 scripts/release_intents.py plan --ecosystem javascript --changed-from origin/main --changed-to HEAD --format json
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); yaml.safe_load(open('.github/workflows/publish.yml'))"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only GitHub Actions workflow environment configuration and release-intent metadata are changed, with no product/runtime code modifications. Main impact is CI/publish behavior if Node 24 action execution exposes compatibility issues in the workflow environment.
> 
> **Overview**
> Updates the `CI` and `Publish` GitHub Actions workflows to opt JavaScript actions into Node 24 execution via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.
> 
> Adds a new release intent to republish `@respan/instrumentation-anthropic` as a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd5ee3dccda1e3e280c7aeab7483b368ac79bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->