### PR TITLE
fix: span lost in trace of pydantic-ai exporter

### DIFF
--- a/python-sdks/respan-exporter-pydantic-ai/src/respan_exporter_pydantic_ai/instrument.py
+++ b/python-sdks/respan-exporter-pydantic-ai/src/respan_exporter_pydantic_ai/instrument.py
@@ -426,14 +426,16 @@ def _extract_log_type(span: ReadableSpan, attributes: dict[str, Any]) -> Optiona
     if isinstance(attributes.get(PYDANTIC_AI_TOOL_NAME_ATTR), str):
         return LOG_TYPE_TOOL
 
+    operation_name = attributes.get(PYDANTIC_AI_OPERATION_NAME_ATTR)
+    if isinstance(operation_name, str):
+        operation_log_type = _PYDANTIC_AI_OPERATION_TO_LOG_TYPE.get(operation_name)
+        if operation_log_type is not None:
+            return operation_log_type
+
     if isinstance(attributes.get(PYDANTIC_AI_AGENT_NAME_ATTR), str) or isinstance(
         attributes.get(PYDANTIC_AI_LEGACY_AGENT_NAME_ATTR), str
     ):
         return LOG_TYPE_AGENT
-
-    operation_name = attributes.get(PYDANTIC_AI_OPERATION_NAME_ATTR)
-    if isinstance(operation_name, str):
-        return _PYDANTIC_AI_OPERATION_TO_LOG_TYPE.get(operation_name)
 
     running_tool_names = _extract_tool_name_sequence(attributes=attributes)
     if span.name == PYDANTIC_AI_RUNNING_TOOLS_SPAN_NAME and running_tool_names:

--- a/python-sdks/respan-exporter-pydantic-ai/tests/test_extraction_functions.py
+++ b/python-sdks/respan-exporter-pydantic-ai/tests/test_extraction_functions.py
@@ -5,19 +5,24 @@ telemetry providers, or span processors involved.
 """
 
 import json
+from types import SimpleNamespace
 
 import pytest
 from respan_exporter_pydantic_ai.constants import (
+    PYDANTIC_AI_AGENT_NAME_ATTR,
+    PYDANTIC_AI_OPERATION_NAME_ATTR,
     RESPAN_RESPONSE_FORMAT_ATTR,
     RESPAN_TOOLS_ATTR,
     PYDANTIC_AI_REQUEST_PARAMETERS_ATTR,
     PYDANTIC_AI_TOOL_DEFINITIONS_ATTR,
 )
 from respan_exporter_pydantic_ai.instrument import (
+    _extract_log_type,
     _extract_response_format,
     _extract_tools,
     _normalize_tool_definition,
 )
+from respan_sdk.constants.llm_logging import LOG_TYPE_AGENT, LOG_TYPE_CHAT
 
 
 # ── _normalize_tool_definition ──────────────────────────────────────────────
@@ -273,3 +278,25 @@ class TestExtractResponseFormat:
         """Returns None when response_format is a non-JSON string and no params."""
         attrs = {RESPAN_RESPONSE_FORMAT_ATTR: "not-valid-json{"}
         assert _extract_response_format(attrs) is None
+
+
+class TestExtractLogType:
+    def test_chat_operation_takes_precedence_over_agent_baggage(self):
+        """Model spans inherit agent baggage, but chat spans must still map to CHAT."""
+        attrs = {
+            PYDANTIC_AI_AGENT_NAME_ATTR: "agent",
+            PYDANTIC_AI_OPERATION_NAME_ATTR: "chat",
+        }
+        span = SimpleNamespace(name="chat gpt-4o")
+
+        assert _extract_log_type(span, attrs) == LOG_TYPE_CHAT
+
+    def test_agent_span_without_known_operation_maps_to_agent(self):
+        """Agent run spans use invoke_agent and should remain AGENT spans."""
+        attrs = {
+            PYDANTIC_AI_AGENT_NAME_ATTR: "agent",
+            PYDANTIC_AI_OPERATION_NAME_ATTR: "invoke_agent",
+        }
+        span = SimpleNamespace(name="invoke_agent agent")
+
+        assert _extract_log_type(span, attrs) == LOG_TYPE_AGENT


### PR DESCRIPTION
## Summary

- fix: span lost in trace of pydantic-ai exporter

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [ ] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [ ] I ran the relevant local checks for the packages I touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span `log_type` classification precedence, which can affect how telemetry is ingested and displayed (e.g., chat spans vs agent spans). Scope is small and covered by new unit tests, but impacts observability semantics.
> 
> **Overview**
> Updates `_extract_log_type` in `instrument.py` to **prefer operation-derived log types** (e.g. mapping `operation_name="chat"` to `LOG_TYPE_CHAT`) before falling back to agent baggage, preventing chat/model spans from being mislabeled as agent spans.
> 
> Adds focused unit tests in `tests/test_extraction_functions.py` to verify the new precedence and ensure `invoke_agent` continues to classify as `LOG_TYPE_AGENT` when no known operation mapping applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 401268ec148c1bb48d3b9d4ef5ba3562b472ca0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->