### PR TITLE
fix: add reasoning_tokens to RespanLogParams Pydantic model

### DIFF
--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
@@ -138,6 +138,7 @@ class RespanLogParams(PreprocessLogDataMixin, RespanBaseModel):
     prompt_tokens: Optional[int] = None
     prompt_cache_hit_tokens: Optional[int] = None
     prompt_cache_creation_tokens: Optional[int] = None
+    reasoning_tokens: Optional[int] = None
     # endregion: usage
 
     # region: user analytics

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
@@ -333,6 +333,7 @@ class RespanParams(RespanBaseModel, PreprocessLogDataMixin):
     prompt_tokens: Optional[int] = None
     prompt_cache_hit_tokens: Optional[int] = None
     prompt_cache_creation_tokens: Optional[int] = None
+    reasoning_tokens: Optional[int] = None
     usage: Optional[Union[Usage, dict]] = (
         None  # The usage object of the LLM response, which includes the token usage details; if cannot be parsed, can be a dict
     )


### PR DESCRIPTION
## Summary

- `reasoning_tokens` was being parsed from OpenAI `completion_tokens_details` and set in `keywordsai_params`, but stripped during `RespanFullLogParams.model_validate()` because the field wasn't on the Pydantic model
- This caused `reasoning_tokens` to be missing from S3 full log objects (the field existed in ClickHouse but not in S3)
- Added `reasoning_tokens: Optional[int] = None` to both `RespanLogParams` (log_types.py) and `RespanTextLogParams` (param_types.py), matching the existing `prompt_cache_hit_tokens` and `prompt_cache_creation_tokens` fields

## Test plan
- [ ] After SDK update + backend redeploy, verify new logs have `reasoning_tokens` in S3 full objects
- [ ] Run `test_prompt_cache_logging.py` — verify `reasoning_tokens` is `0` for non-reasoning models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a schema-only change adding an optional field, with minimal impact beyond allowing the extra attribute to pass through validation and appear in serialized logs.
> 
> **Overview**
> Ensures `reasoning_tokens` is not dropped during SDK model validation by adding `reasoning_tokens: Optional[int]` to the Pydantic models `RespanLogParams` (in `log_types.py`) and `RespanTextLogParams`/usage params (in `param_types.py`).
> 
> This allows reasoning token counts parsed from provider responses to be retained and included in downstream full log objects (e.g., S3 payloads) alongside existing cache/token usage fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87774dabb1fb4da255d7e859e4c595c0c8035c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->