### PR TITLE
fix: unify cli base url resolution

### DIFF
--- a/.release-intents/20260414-cli-auth-baseurl.json
+++ b/.release-intents/20260414-cli-auth-baseurl.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Patch @respan/cli to use auth login as the persistent API base URL source and reserve --base-url for temporary command overrides",
+  "packages": {
+    "@respan/cli": "patch"
+  }
+}

--- a/.release-intents/20260414-cli-auth-baseurl.json
+++ b/.release-intents/20260414-cli-auth-baseurl.json
@@ -1,6 +1,7 @@
 {
-  "summary": "Patch @respan/cli to use auth login as the persistent API base URL source and reserve --base-url for temporary command overrides",
+  "summary": "Patch @respan/cli base URL resolution and backfill the missing respan-sdk patch intent for reasoning token persistence",
   "packages": {
-    "@respan/cli": "patch"
+    "@respan/cli": "patch",
+    "respan-sdk": "patch"
   }
 }

--- a/javascript-sdks/respan-cli/src/commands/auth/status.ts
+++ b/javascript-sdks/respan-cli/src/commands/auth/status.ts
@@ -14,10 +14,11 @@ export default class AuthStatus extends BaseCommand {
       this.log('Not authenticated. Run `respan auth login`.');
       return;
     }
+    const auth = this.getAuth();
     this.log(`Profile: ${profile}`);
     this.log(`Type: ${cred.type}`);
     if (cred.type === 'api_key') this.log(`API Key: ${cred.apiKey.slice(0, 8)}...`);
     if (cred.type === 'jwt') this.log(`Email: ${cred.email}`);
-    this.log(`Base URL: ${cred.baseUrl}`);
+    this.log(`Base URL: ${auth.baseUrl}`);
   }
 }

--- a/javascript-sdks/respan-cli/src/commands/config/get.ts
+++ b/javascript-sdks/respan-cli/src/commands/config/get.ts
@@ -10,6 +10,13 @@ export default class ConfigGet extends BaseCommand {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(ConfigGet);
     this.globalFlags = flags;
+    const normalizedKey = args.key.toLowerCase();
+    if (['base_url', 'baseurl', 'api_base_url'].includes(normalizedKey)) {
+      this.log(
+        'CLI API base URLs are managed by `respan auth login --base-url ...` and can be temporarily overridden with `--base-url` on any command.',
+      );
+      return;
+    }
     const value = getConfigValue(args.key);
     this.log(value !== undefined ? String(value) : `Key "${args.key}" not set.`);
   }

--- a/javascript-sdks/respan-cli/src/commands/config/list.ts
+++ b/javascript-sdks/respan-cli/src/commands/config/list.ts
@@ -13,6 +13,16 @@ export default class ConfigList extends BaseCommand {
     const active = getActiveProfile();
     this.log(`Active profile: ${active}`);
     this.log(`Profiles: ${Object.keys(creds).join(', ') || '(none)'}`);
-    if (config.defaults) this.log(`Defaults: ${JSON.stringify(config.defaults)}`);
+    if (config.defaults) {
+      const { base_url, baseUrl, api_base_url, ...remainingDefaults } = config.defaults as Record<string, string>;
+      if (Object.keys(remainingDefaults).length > 0) {
+        this.log(`Defaults: ${JSON.stringify(remainingDefaults)}`);
+      }
+      if (base_url || baseUrl || api_base_url) {
+        this.log(
+          'Note: stored `base_url` config is ignored for CLI API commands. Use `respan auth login --base-url ...` to save an endpoint, or `--base-url` for a temporary override.',
+        );
+      }
+    }
   }
 }

--- a/javascript-sdks/respan-cli/src/commands/config/set.ts
+++ b/javascript-sdks/respan-cli/src/commands/config/set.ts
@@ -13,6 +13,13 @@ export default class ConfigSet extends BaseCommand {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(ConfigSet);
     this.globalFlags = flags;
+    const normalizedKey = args.key.toLowerCase();
+    if (['base_url', 'baseurl', 'api_base_url'].includes(normalizedKey)) {
+      this.error(
+        'CLI API base URLs are no longer managed with `respan config set`. Use `respan auth login --base-url ...` to save an endpoint, or `--base-url` on a command for a temporary override.',
+        { exit: 1 },
+      );
+    }
     setConfigValue(args.key, args.value);
     this.log(`Set ${args.key} = ${args.value}`);
   }

--- a/javascript-sdks/respan-cli/src/commands/whoami.ts
+++ b/javascript-sdks/respan-cli/src/commands/whoami.ts
@@ -8,7 +8,7 @@ export default class Whoami extends BaseCommand {
   async run(): Promise<void> {
     const { flags } = await this.parse(Whoami);
     this.globalFlags = flags;
-    const profile = getActiveProfile();
+    const profile = flags.profile || getActiveProfile();
     const cred = getCredential(profile);
     if (!cred) {
       this.log('Not authenticated.');

--- a/javascript-sdks/respan-cli/src/commands/whoami.ts
+++ b/javascript-sdks/respan-cli/src/commands/whoami.ts
@@ -14,8 +14,9 @@ export default class Whoami extends BaseCommand {
       this.log('Not authenticated.');
       return;
     }
+    const auth = this.getAuth();
     this.log(`Profile: ${profile}`);
     if (cred.type === 'jwt') this.log(`Email: ${cred.email}`);
-    this.log(`Base URL: ${cred.baseUrl}`);
+    this.log(`Base URL: ${auth.baseUrl}`);
   }
 }

--- a/javascript-sdks/respan-cli/src/lib/auth.ts
+++ b/javascript-sdks/respan-cli/src/lib/auth.ts
@@ -10,31 +10,41 @@ export interface AuthConfig {
   baseUrl: string;
 }
 
-export function resolveAuth(flags: { 'api-key'?: string; profile?: string }): AuthConfig {
+function normalizeBaseUrl(baseUrl?: string): string {
+  return (baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
+}
+
+function resolveConfiguredBaseUrl(credential?: Credential, flagBaseUrl?: string): string {
+  return normalizeBaseUrl(flagBaseUrl || credential?.baseUrl || DEFAULT_BASE_URL);
+}
+
+export function resolveAuth(flags: { 'api-key'?: string; 'base-url'?: string; profile?: string }): AuthConfig {
+  const credential = getCredential(flags.profile);
+  const baseUrl = resolveConfiguredBaseUrl(credential, flags['base-url']);
+
   if (flags['api-key']) {
-    return { apiKey: flags['api-key'], baseUrl: DEFAULT_BASE_URL };
+    return { apiKey: flags['api-key'], baseUrl };
   }
   if (process.env.RESPAN_API_KEY) {
     return {
       apiKey: process.env.RESPAN_API_KEY,
-      baseUrl: process.env.RESPAN_API_BASE_URL || DEFAULT_BASE_URL,
+      baseUrl,
     };
   }
-  const credential = getCredential(flags.profile);
   if (credential) {
-    return credentialToAuth(credential);
+    return credentialToAuth(credential, baseUrl);
   }
   throw new Error('Not authenticated. Run `respan auth login` or set RESPAN_API_KEY.');
 }
 
-function credentialToAuth(cred: Credential): AuthConfig {
+function credentialToAuth(cred: Credential, baseUrl: string): AuthConfig {
   if (cred.type === 'api_key') {
-    return { apiKey: cred.apiKey, baseUrl: cred.baseUrl };
+    return { apiKey: cred.apiKey, baseUrl };
   }
   return {
     accessToken: cred.accessToken,
     refreshToken: cred.refreshToken,
-    baseUrl: cred.baseUrl,
+    baseUrl,
   };
 }
 

--- a/javascript-sdks/respan-cli/src/lib/auth.ts
+++ b/javascript-sdks/respan-cli/src/lib/auth.ts
@@ -15,7 +15,11 @@ function normalizeBaseUrl(baseUrl?: string): string {
 }
 
 function resolveConfiguredBaseUrl(credential?: Credential, flagBaseUrl?: string): string {
-  return normalizeBaseUrl(flagBaseUrl || credential?.baseUrl || DEFAULT_BASE_URL);
+  // Keep the legacy env override for scripted/CI flows while auth login remains
+  // the main persistent configuration path for CLI users.
+  return normalizeBaseUrl(
+    flagBaseUrl || process.env.RESPAN_API_BASE_URL || credential?.baseUrl || DEFAULT_BASE_URL,
+  );
 }
 
 export function resolveAuth(flags: { 'api-key'?: string; 'base-url'?: string; profile?: string }): AuthConfig {

--- a/javascript-sdks/respan-cli/src/lib/base-command.ts
+++ b/javascript-sdks/respan-cli/src/lib/base-command.ts
@@ -12,6 +12,9 @@ export abstract class BaseCommand extends Command {
       description: 'API key (env: RESPAN_API_KEY)',
       env: 'RESPAN_API_KEY',
     }),
+    'base-url': Flags.string({
+      description: 'Temporary API base URL override for this command',
+    }),
     profile: Flags.string({
       description: 'Named profile to use',
     }),
@@ -35,6 +38,7 @@ export abstract class BaseCommand extends Command {
   protected getAuth(): AuthConfig {
     return resolveAuth({
       'api-key': this.globalFlags['api-key'],
+      'base-url': this.globalFlags['base-url'],
       profile: this.globalFlags.profile,
     });
   }


### PR DESCRIPTION
Summary
- make respan auth login the persistent source of the CLI API base URL
- keep --base-url as a per-command temporary override and stop using respan config set base_url for API commands
- add a release intent for @respan/cli

Testing
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CLI chooses the API endpoint (new `--base-url` override plus normalization and updated precedence), which could inadvertently point commands at the wrong environment if misconfigured. Scope is limited to CLI auth/config plumbing and output messaging.
> 
> **Overview**
> **CLI base URL handling is standardized around auth.** `resolveAuth` now derives `baseUrl` via a single precedence chain (`--base-url` flag → `RESPAN_API_BASE_URL` → stored credential → default) and normalizes trailing slashes.
> 
> **User-facing commands are aligned with the new source of truth.** `whoami`/`auth status` report the resolved `auth.baseUrl` (and `whoami` now honors `--profile`), while `config get/set/list` blocks or warns on legacy `base_url` keys and directs users to `respan auth login --base-url ...` or per-command `--base-url`.
> 
> Adds a release intent to ship patch bumps for `@respan/cli` and `respan-sdk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d099e7b38ad65376149e6ebd3812d6c71bab890c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->