### PR TITLE
add: respan-instrumentation-claude-agent-sdk ts

### DIFF
--- a/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/README.md
+++ b/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/README.md
@@ -1,0 +1,62 @@
+# @respan/instrumentation-claude-agent-sdk
+
+Respan instrumentation plugin for the
+[Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview).
+
+This package patches `query()` on a mutable Claude Agent SDK module, merges in
+Claude hook callbacks for tool lifecycle tracking, and emits OTEL spans that
+match the Respan tracing pipeline.
+
+## Install
+
+```bash
+yarn add @anthropic-ai/claude-agent-sdk @respan/instrumentation-claude-agent-sdk
+```
+
+## Quickstart
+
+```ts
+import "dotenv/config";
+import * as _ClaudeAgentSDK from "@anthropic-ai/claude-agent-sdk";
+import { Respan } from "@respan/respan";
+import { ClaudeAgentSDKInstrumentor } from "@respan/instrumentation-claude-agent-sdk";
+
+// ESM namespace objects are read-only. Patch a mutable copy instead.
+const ClaudeAgentSDK = { ..._ClaudeAgentSDK };
+
+const respan = new Respan({
+  apiKey: process.env.RESPAN_API_KEY,
+  baseURL: process.env.RESPAN_BASE_URL,
+  instrumentations: [
+    new ClaudeAgentSDKInstrumentor({
+      sdkModule: ClaudeAgentSDK,
+      agentName: "claude-agent-sdk",
+    }),
+  ],
+});
+
+await respan.initialize();
+
+const result = await ClaudeAgentSDK.query({
+  prompt: "Write a haiku about tracing.",
+  options: {
+    maxTurns: 1,
+  },
+});
+
+for await (const event of result) {
+  if (event.type === "result") {
+    console.log(event.result);
+  }
+}
+
+await respan.flush();
+```
+
+## Notes
+
+- `sdkModule` should be the same mutable module object your app calls.
+- Existing Claude hook callbacks are preserved and merged with the
+  instrumentation hooks.
+- Tool executions are emitted as OTEL tool spans and linked to the enclosing
+  agent span.

--- a/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@respan/instrumentation-claude-agent-sdk",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Respan instrumentation plugin for the Claude Agent SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "author": "Respan <team@respan.ai>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "yarn build && node --test tests/*.test.mjs",
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^1.26.0",
+    "@opentelemetry/sdk-trace-base": "^1.26.0",
+    "@respan/respan-sdk": "^1.1.7",
+    "@traceloop/ai-semantic-conventions": "^0.13.0"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/claude-agent-sdk": ">=0.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/claude-agent-sdk": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.29",
+    "typescript": "^5.7.3"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/_otel_emitter.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/_otel_emitter.ts
@@ -1,0 +1,824 @@
+import { context, trace, SpanKind, SpanStatusCode, TraceFlags } from "@opentelemetry/api";
+import { hrTime, hrTimeDuration } from "@opentelemetry/core";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { randomBytes } from "node:crypto";
+import { RespanLogType, RespanSpanAttributes } from "@respan/respan-sdk";
+import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
+
+const PACKAGE_VERSION = "1.0.0";
+const RESPAN_LOG_METHOD_TS_TRACING = "ts_tracing";
+
+export interface PendingToolState {
+  spanId: string;
+  startTime: [number, number];
+  toolName: string;
+  toolInput: unknown;
+}
+
+export interface QueryState {
+  agentName: string;
+  agentSpanId: string;
+  completionTokens?: number;
+  errorMessage?: string;
+  finalOutput?: unknown;
+  inputMessages: Record<string, unknown>[];
+  model?: string;
+  outputMessages: Record<string, unknown>[];
+  parentSpanId?: string;
+  pendingTools: Map<string, PendingToolState>;
+  prompt: unknown;
+  promptCacheCreationTokens?: number;
+  promptCacheHitTokens?: number;
+  promptTokens?: number;
+  sessionId?: string;
+  startTime: [number, number];
+  statusCode: number;
+  toolCalls: Record<string, unknown>[];
+  toolDefinitions?: Record<string, unknown>[];
+  totalCostUsd?: number;
+  totalRequestTokens?: number;
+  traceFlags: number;
+  traceId: string;
+}
+
+interface BuildSpanOptions {
+  name: string;
+  traceId: string;
+  spanId: string;
+  traceFlags?: number;
+  parentId?: string;
+  startTime: [number, number];
+  endTime: [number, number];
+  attributes: Record<string, unknown>;
+  statusCode?: number;
+  errorMessage?: string;
+}
+
+function randomHex(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+export function createQueryState({
+  prompt,
+  options,
+  agentName,
+}: {
+  prompt: unknown;
+  options?: Record<string, unknown>;
+  agentName?: string;
+}): QueryState {
+  const activeSpan = trace.getSpan(context.active());
+  const activeSpanContext = activeSpan?.spanContext();
+
+  return {
+    agentName: agentName?.trim() || inferAgentName(options) || "claude-agent-sdk",
+    agentSpanId: randomHex(8),
+    inputMessages: normalizeInputMessages(prompt, options),
+    outputMessages: [],
+    parentSpanId: activeSpanContext?.spanId,
+    pendingTools: new Map(),
+    prompt,
+    startTime: hrTime(),
+    statusCode: 200,
+    toolCalls: [],
+    toolDefinitions: normalizeToolDefinitions(options?.tools),
+    traceFlags: activeSpanContext?.traceFlags ?? TraceFlags.SAMPLED,
+    traceId: activeSpanContext?.traceId ?? randomHex(16),
+  };
+}
+
+function inferAgentName(options?: Record<string, unknown>): string | undefined {
+  const candidate =
+    options?.agentName ??
+    options?.name ??
+    options?.agent_name;
+  return typeof candidate === "string" && candidate.trim() ? candidate.trim() : undefined;
+}
+
+function normalizeInputMessages(
+  prompt: unknown,
+  options?: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const messages: Record<string, unknown>[] = [];
+  const systemInstructions =
+    options?.system ??
+    options?.systemPrompt ??
+    options?.instructions;
+
+  if (typeof systemInstructions === "string" && systemInstructions.trim()) {
+    messages.push({
+      role: "system",
+      content: systemInstructions,
+    });
+  }
+
+  if (typeof prompt === "string") {
+    messages.push({
+      role: "user",
+      content: prompt,
+    });
+    return messages;
+  }
+
+  const serializedPrompt = toSerializableValue(prompt);
+  if (Array.isArray(serializedPrompt)) {
+    messages.push({
+      role: "user",
+      content: serializedPrompt,
+    });
+    return messages;
+  }
+
+  if (serializedPrompt !== undefined) {
+    messages.push({
+      role: "user",
+      content: serializedPrompt,
+    });
+  }
+
+  return messages;
+}
+
+function normalizeToolDefinitions(
+  tools: unknown,
+): Record<string, unknown>[] | undefined {
+  if (!Array.isArray(tools)) {
+    return undefined;
+  }
+
+  const normalizedTools = tools
+    .map((tool) => normalizeToolDefinition(tool))
+    .filter((tool): tool is Record<string, unknown> => tool !== null);
+
+  return normalizedTools.length > 0 ? normalizedTools : undefined;
+}
+
+function normalizeToolDefinition(
+  tool: unknown,
+): Record<string, unknown> | null {
+  if (typeof tool === "string" && tool) {
+    return {
+      type: "function",
+      function: { name: tool },
+    };
+  }
+
+  if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
+    return null;
+  }
+
+  const record = tool as Record<string, unknown>;
+  const functionPayload =
+    record.function && typeof record.function === "object" && !Array.isArray(record.function)
+      ? (record.function as Record<string, unknown>)
+      : null;
+
+  if (functionPayload) {
+    const functionName = functionPayload.name;
+    if (typeof functionName !== "string" || !functionName) {
+      return null;
+    }
+
+    const normalizedFunction: Record<string, unknown> = { name: functionName };
+    for (const key of ["description", "parameters", "strict"]) {
+      if (functionPayload[key] !== undefined) {
+        normalizedFunction[key] = toSerializableValue(functionPayload[key]);
+      }
+    }
+
+    return {
+      type: record.type ?? "function",
+      function: normalizedFunction,
+    };
+  }
+
+  const toolName = record.name;
+  if (typeof toolName !== "string" || !toolName) {
+    return null;
+  }
+
+  const normalizedFunction: Record<string, unknown> = { name: toolName };
+  if (record.description !== undefined) {
+    normalizedFunction.description = toSerializableValue(record.description);
+  }
+  const parameters = record.input_schema ?? record.parameters;
+  if (parameters !== undefined) {
+    normalizedFunction.parameters = toSerializableValue(parameters);
+  }
+
+  return {
+    type: record.type ?? "function",
+    function: normalizedFunction,
+  };
+}
+
+export function trackClaudeMessage(state: QueryState, message: unknown): void {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return;
+  }
+
+  const record = message as Record<string, unknown>;
+  updateSessionId(state, record.session_id ?? record.sessionId);
+
+  switch (record.type) {
+    case "system":
+      handleSystemMessage(state, record);
+      break;
+    case "assistant":
+      handleAssistantMessage(state, record);
+      break;
+    case "result":
+      handleResultMessage(state, record);
+      break;
+    case "stream_event":
+      updateSessionId(state, record.session_id ?? record.sessionId);
+      break;
+    default:
+      break;
+  }
+}
+
+function handleSystemMessage(state: QueryState, message: Record<string, unknown>): void {
+  const data =
+    message.data && typeof message.data === "object" && !Array.isArray(message.data)
+      ? (message.data as Record<string, unknown>)
+      : undefined;
+  updateSessionId(state, data?.session_id ?? data?.sessionId ?? data?.id);
+}
+
+function handleAssistantMessage(state: QueryState, message: Record<string, unknown>): void {
+  const payload = resolveAssistantPayload(message);
+  const model = payload.model ?? message.model;
+  if (typeof model === "string" && model) {
+    state.model = model;
+  }
+
+  updateUsageFromMessage(
+    state,
+    payload.usage && typeof payload.usage === "object" && !Array.isArray(payload.usage)
+      ? (payload.usage as Record<string, unknown>)
+      : message.usage && typeof message.usage === "object" && !Array.isArray(message.usage)
+        ? (message.usage as Record<string, unknown>)
+      : undefined,
+  );
+
+  const rawContent = payload.content ?? message.content;
+  const content = Array.isArray(rawContent)
+    ? toSerializableValue(rawContent)
+    : toSerializableValue(rawContent);
+  if (hasMeaningfulContent(content)) {
+    state.outputMessages.push({
+      role: "assistant",
+      content,
+    });
+  }
+
+  if (Array.isArray(rawContent)) {
+    for (const block of rawContent) {
+      const toolCall = normalizeToolCall(block);
+      if (toolCall) {
+        addToolCall(state, toolCall);
+      }
+    }
+  }
+}
+
+function handleResultMessage(state: QueryState, message: Record<string, unknown>): void {
+  updateUsageFromMessage(
+    state,
+    message.usage && typeof message.usage === "object" && !Array.isArray(message.usage)
+      ? (message.usage as Record<string, unknown>)
+      : undefined,
+  );
+
+  if (typeof message.total_cost_usd === "number") {
+    state.totalCostUsd = message.total_cost_usd;
+  }
+
+  if (message.is_error) {
+    state.statusCode = 500;
+    state.errorMessage = `agent_result_error:${String(message.subtype ?? "error")}`;
+  }
+
+  const outputValue =
+    message.result ??
+    message.structured_output;
+  if (
+    outputValue !== undefined &&
+    !hasRenderableAssistantOutput(state.outputMessages)
+  ) {
+    state.finalOutput = toSerializableValue(outputValue);
+    state.outputMessages.push({
+      role: "assistant",
+      content: toSerializableValue(outputValue),
+    });
+  } else if (outputValue !== undefined) {
+    state.finalOutput = toSerializableValue(outputValue);
+  }
+}
+
+function resolveAssistantPayload(
+  message: Record<string, unknown>,
+): Record<string, unknown> {
+  const nestedMessage = message.message;
+  if (
+    nestedMessage &&
+    typeof nestedMessage === "object" &&
+    !Array.isArray(nestedMessage)
+  ) {
+    return nestedMessage as Record<string, unknown>;
+  }
+  return message;
+}
+
+function hasMeaningfulContent(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  }
+  return true;
+}
+
+function hasRenderableAssistantOutput(
+  messages: Record<string, unknown>[],
+): boolean {
+  return messages.some((message) => hasRenderableContent(message.content));
+}
+
+function hasRenderableContent(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        return hasRenderableContent(item);
+      }
+
+      const record = item as Record<string, unknown>;
+      if (record.type === "thinking" || record.type === "tool_use") {
+        return false;
+      }
+      if (record.type === "text") {
+        return typeof record.text === "string" && record.text.trim().length > 0;
+      }
+      if ("content" in record) {
+        return hasRenderableContent(record.content);
+      }
+      return Object.keys(record).length > 0;
+    });
+  }
+  if (typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  }
+  return true;
+}
+
+function updateUsageFromMessage(
+  state: QueryState,
+  usage?: Record<string, unknown>,
+): void {
+  if (!usage) {
+    return;
+  }
+
+  const rawPromptTokens = coerceInteger(usage.input_tokens ?? usage.prompt_tokens);
+  const completionTokens = coerceInteger(
+    usage.output_tokens ?? usage.completion_tokens,
+  );
+  const cacheHitTokens = coerceInteger(usage.cache_read_input_tokens);
+  const cacheCreationTokens = coerceInteger(usage.cache_creation_input_tokens);
+  const totalTokens = coerceInteger(
+    usage.total_tokens ??
+      usage.totalTokens,
+  );
+  let promptTokens = rawPromptTokens;
+
+  if (
+    promptTokens !== null &&
+    (cacheHitTokens !== null || cacheCreationTokens !== null)
+  ) {
+    const uncachedPromptTokens =
+      promptTokens -
+      ((cacheHitTokens ?? 0) + (cacheCreationTokens ?? 0));
+    if (uncachedPromptTokens >= 0) {
+      promptTokens = uncachedPromptTokens;
+    }
+  }
+
+  if (promptTokens !== null) {
+    state.promptTokens = promptTokens;
+  }
+  if (completionTokens !== null) {
+    state.completionTokens = completionTokens;
+  }
+  if (cacheHitTokens !== null) {
+    state.promptCacheHitTokens = cacheHitTokens;
+  }
+  if (cacheCreationTokens !== null) {
+    state.promptCacheCreationTokens = cacheCreationTokens;
+  }
+
+  if (promptTokens !== null || completionTokens !== null) {
+    state.totalRequestTokens =
+      (promptTokens ?? 0) +
+      (completionTokens ?? 0);
+    return;
+  }
+
+  if (totalTokens !== null) {
+    state.totalRequestTokens = totalTokens;
+  }
+}
+
+export function registerPromptSubmit(
+  state: QueryState,
+  input: Record<string, unknown>,
+): void {
+  updateSessionId(state, input.session_id ?? input.sessionId);
+}
+
+export function registerPendingTool(
+  state: QueryState,
+  input: Record<string, unknown>,
+  toolUseId?: string,
+): void {
+  updateSessionId(state, input.session_id ?? input.sessionId);
+  const resolvedToolUseId = String(input.tool_use_id ?? toolUseId ?? randomHex(8));
+  const toolName = String(input.tool_name ?? "tool");
+  const toolInput = input.tool_input;
+
+  state.pendingTools.set(resolvedToolUseId, {
+    spanId: randomHex(8),
+    startTime: hrTime(),
+    toolInput,
+    toolName,
+  });
+
+  addToolCall(state, {
+    id: resolvedToolUseId,
+    type: "function",
+    function: {
+      name: toolName,
+      arguments: safeJson(toolInput ?? {}),
+    },
+  });
+}
+
+export function emitCompletedTool(
+  state: QueryState,
+  input: Record<string, unknown>,
+  toolUseId?: string,
+): void {
+  updateSessionId(state, input.session_id ?? input.sessionId);
+  const resolvedToolUseId = String(input.tool_use_id ?? toolUseId ?? randomHex(8));
+  const pendingTool =
+    state.pendingTools.get(resolvedToolUseId) ?? {
+      spanId: randomHex(8),
+      startTime: hrTime(),
+      toolInput: input.tool_input,
+      toolName: String(input.tool_name ?? "tool"),
+    };
+  state.pendingTools.delete(resolvedToolUseId);
+
+  const toolName = String(input.tool_name ?? pendingTool.toolName ?? "tool");
+  const attrs = baseAttrs(toolName, toolName, RespanLogType.TOOL);
+  attrs[RespanSpanAttributes.RESPAN_LOG_METHOD] = RESPAN_LOG_METHOD_TS_TRACING;
+  attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(
+    pendingTool.toolInput ?? input.tool_input ?? {},
+  );
+  attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson(
+    input.tool_response ?? input.tool_result ?? input.output ?? "",
+  );
+  attrs[RespanSpanAttributes.RESPAN_SPAN_TOOLS] = safeJson([
+    {
+      type: "function",
+      function: { name: toolName },
+    },
+  ]);
+
+  if (state.model) {
+    attrs[RespanSpanAttributes.GEN_AI_REQUEST_MODEL] = state.model;
+    attrs.model = state.model;
+  }
+  if (state.sessionId) {
+    attrs[RespanSpanAttributes.RESPAN_SESSION_ID] = state.sessionId;
+  }
+
+  injectSpan(
+    buildReadableSpan({
+      name: `${toolName}.tool`,
+      traceId: state.traceId,
+      spanId: pendingTool.spanId,
+      traceFlags: state.traceFlags,
+      parentId: state.agentSpanId,
+      startTime: pendingTool.startTime,
+      endTime: hrTime(),
+      attributes: attrs,
+    }),
+  );
+}
+
+export function emitAgentSpan(state: QueryState): void {
+  const attrs = baseAttrs(state.agentName, state.agentName, RespanLogType.AGENT);
+  attrs[RespanSpanAttributes.RESPAN_LOG_METHOD] = RESPAN_LOG_METHOD_TS_TRACING;
+  attrs[RespanSpanAttributes.GEN_AI_SYSTEM] = "anthropic";
+  attrs[RespanSpanAttributes.LLM_SYSTEM] = "anthropic";
+  attrs[RespanSpanAttributes.LLM_REQUEST_TYPE] = RespanLogType.CHAT;
+  attrs[RespanSpanAttributes.RESPAN_METADATA_AGENT_NAME] = state.agentName;
+  attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = state.agentName;
+
+  if (state.inputMessages.length > 0) {
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(state.inputMessages);
+  }
+  const formattedOutput = formatAgentOutput(state);
+  if (formattedOutput) {
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = formattedOutput;
+  }
+  if (state.toolDefinitions && state.toolDefinitions.length > 0) {
+    attrs[RespanSpanAttributes.RESPAN_SPAN_TOOLS] = safeJson(state.toolDefinitions);
+  }
+  if (state.toolCalls.length > 0) {
+    attrs[RespanSpanAttributes.RESPAN_SPAN_TOOL_CALLS] = safeJson(
+      dedupeToolCalls(state.toolCalls),
+    );
+  }
+  if (state.model) {
+    attrs[RespanSpanAttributes.GEN_AI_REQUEST_MODEL] = state.model;
+    attrs.model = state.model;
+  }
+  if (state.promptTokens !== undefined) {
+    attrs[RespanSpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS] = state.promptTokens;
+    attrs.prompt_tokens = state.promptTokens;
+  }
+  if (state.completionTokens !== undefined) {
+    attrs[RespanSpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS] = state.completionTokens;
+    attrs.completion_tokens = state.completionTokens;
+  }
+  if (state.totalRequestTokens !== undefined) {
+    attrs.total_request_tokens = state.totalRequestTokens;
+  }
+  if (state.promptCacheHitTokens !== undefined) {
+    attrs.prompt_cache_hit_tokens = state.promptCacheHitTokens;
+  }
+  if (state.promptCacheCreationTokens !== undefined) {
+    attrs.prompt_cache_creation_tokens = state.promptCacheCreationTokens;
+  }
+  if (state.totalCostUsd !== undefined) {
+    attrs.cost = state.totalCostUsd;
+  }
+  if (state.sessionId) {
+    attrs[RespanSpanAttributes.RESPAN_SESSION_ID] = state.sessionId;
+  }
+
+  injectSpan(
+    buildReadableSpan({
+      name: `${state.agentName}.agent`,
+      traceId: state.traceId,
+      spanId: state.agentSpanId,
+      traceFlags: state.traceFlags,
+      parentId: state.parentSpanId,
+      startTime: state.startTime,
+      endTime: hrTime(),
+      attributes: attrs,
+      statusCode: state.statusCode,
+      errorMessage: state.errorMessage,
+    }),
+  );
+}
+
+function formatAgentOutput(state: QueryState): string {
+  if (state.finalOutput !== undefined) {
+    return stringifyOutputValue(state.finalOutput);
+  }
+
+  for (let index = state.outputMessages.length - 1; index >= 0; index -= 1) {
+    const formatted = stringifyOutputValue(state.outputMessages[index]?.content);
+    if (formatted) {
+      return formatted;
+    }
+  }
+
+  return "";
+}
+
+function stringifyOutputValue(value: unknown): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) => stringifyOutputValue(item))
+      .filter((part) => part.trim().length > 0);
+    return parts.join("\n");
+  }
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (record.type === "thinking" || record.type === "tool_use") {
+      return "";
+    }
+    if (record.type === "text" && typeof record.text === "string") {
+      return record.text;
+    }
+    if ("content" in record) {
+      return stringifyOutputValue(record.content);
+    }
+    return safeJson(record);
+  }
+
+  return String(value);
+}
+
+function normalizeToolCall(block: unknown): Record<string, unknown> | null {
+  if (!block || typeof block !== "object" || Array.isArray(block)) {
+    return null;
+  }
+
+  const record = block as Record<string, unknown>;
+  if (record.type !== "tool_use") {
+    return null;
+  }
+
+  const toolName = record.name;
+  if (typeof toolName !== "string" || !toolName) {
+    return null;
+  }
+
+  return {
+    id: String(record.id ?? record.tool_use_id ?? ""),
+    type: "function",
+    function: {
+      name: toolName,
+      arguments: safeJson(record.input ?? {}),
+    },
+  };
+}
+
+function addToolCall(state: QueryState, toolCall: Record<string, unknown>): void {
+  state.toolCalls.push(toolCall);
+}
+
+function dedupeToolCalls(
+  toolCalls: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  const seen = new Set<string>();
+  const deduped: Record<string, unknown>[] = [];
+
+  for (const toolCall of toolCalls) {
+    const functionPayload =
+      toolCall.function &&
+      typeof toolCall.function === "object" &&
+      !Array.isArray(toolCall.function)
+        ? (toolCall.function as Record<string, unknown>)
+        : {};
+    const signature = safeJson([
+      toolCall.id ?? "",
+      functionPayload.name ?? "",
+      functionPayload.arguments ?? "",
+    ]);
+    if (seen.has(signature)) {
+      continue;
+    }
+    seen.add(signature);
+    deduped.push(toolCall);
+  }
+
+  return deduped;
+}
+
+function updateSessionId(state: QueryState, rawSessionId: unknown): void {
+  if (rawSessionId === undefined || rawSessionId === null) {
+    return;
+  }
+  const sessionId = String(rawSessionId);
+  if (sessionId) {
+    state.sessionId = sessionId;
+  }
+}
+
+function baseAttrs(
+  entityName: string,
+  entityPath: string,
+  logType: string,
+): Record<string, unknown> {
+  return {
+    [SpanAttributes.TRACELOOP_ENTITY_NAME]: entityName,
+    [SpanAttributes.TRACELOOP_ENTITY_PATH]: entityPath,
+    [RespanSpanAttributes.RESPAN_LOG_TYPE]: logType,
+  };
+}
+
+function buildReadableSpan(opts: BuildSpanOptions): ReadableSpan {
+  const status =
+    opts.statusCode && opts.statusCode >= 400
+      ? { code: SpanStatusCode.ERROR, message: opts.errorMessage ?? "" }
+      : { code: SpanStatusCode.OK, message: "" };
+
+  return {
+    name: opts.name,
+    kind: SpanKind.INTERNAL,
+    spanContext: () => ({
+      traceId: opts.traceId,
+      spanId: opts.spanId,
+      traceFlags: opts.traceFlags ?? TraceFlags.SAMPLED,
+      isRemote: false,
+    }),
+    parentSpanId: opts.parentId,
+    startTime: opts.startTime,
+    endTime: opts.endTime,
+    duration: hrTimeDuration(opts.startTime, opts.endTime),
+    status,
+    attributes: opts.attributes,
+    links: [],
+    events: [],
+    resource: { attributes: {} } as any,
+    instrumentationLibrary: {
+      name: "@respan/instrumentation-claude-agent-sdk",
+      version: PACKAGE_VERSION,
+    },
+    ended: true,
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  } as unknown as ReadableSpan;
+}
+
+function injectSpan(span: ReadableSpan): void {
+  const tracerProvider = trace.getTracerProvider() as any;
+  const processor =
+    tracerProvider?.activeSpanProcessor ??
+    tracerProvider?._delegate?.activeSpanProcessor ??
+    tracerProvider?._delegate?._tracerProvider?.activeSpanProcessor;
+
+  if (processor && typeof processor.onEnd === "function") {
+    processor.onEnd(span);
+  }
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(toSerializableValue(value), (_key, innerValue) =>
+      typeof innerValue === "bigint" ? innerValue.toString() : innerValue,
+    );
+  } catch {
+    return String(value);
+  }
+}
+
+function toSerializableValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => toSerializableValue(item));
+  }
+  if (typeof value === "object") {
+    const normalizedObject: Record<string, unknown> = {};
+    Object.entries(value as Record<string, unknown>).forEach(([key, itemValue]) => {
+      normalizedObject[key] = toSerializableValue(itemValue);
+    });
+    return normalizedObject;
+  }
+  return String(value);
+}
+
+function coerceInteger(value: unknown): number | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return null;
+  }
+  return Math.trunc(numericValue);
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/index.ts
@@ -1,0 +1,216 @@
+/**
+ * Respan instrumentation plugin for the Claude Agent SDK.
+ *
+ * This plugin patches `query()` on a mutable Claude Agent SDK module, merges in
+ * tool lifecycle hooks, and emits OTEL ReadableSpan objects into the active
+ * Respan tracing pipeline.
+ *
+ * ```typescript
+ * import * as _ClaudeAgentSDK from "@anthropic-ai/claude-agent-sdk";
+ * import { Respan } from "@respan/respan";
+ * import { ClaudeAgentSDKInstrumentor } from "@respan/instrumentation-claude-agent-sdk";
+ *
+ * const ClaudeAgentSDK = { ..._ClaudeAgentSDK };
+ *
+ * const respan = new Respan({
+ *   instrumentations: [
+ *     new ClaudeAgentSDKInstrumentor({ sdkModule: ClaudeAgentSDK }),
+ *   ],
+ * });
+ * await respan.initialize();
+ * ```
+ */
+
+import {
+  createQueryState,
+  emitAgentSpan,
+  emitCompletedTool,
+  registerPendingTool,
+  registerPromptSubmit,
+  trackClaudeMessage,
+  type QueryState,
+} from "./_otel_emitter.js";
+
+export interface ClaudeAgentSDKInstrumentorOptions {
+  agentName?: string;
+  sdkModule: Record<string, unknown>;
+}
+
+type HookCallback = (
+  input: Record<string, unknown>,
+  toolUseId?: string,
+) => Promise<Record<string, unknown>>;
+
+type HookGroup = {
+  matcher?: string;
+  hooks?: HookCallback[];
+};
+
+export class ClaudeAgentSDKInstrumentor {
+  public readonly name = "claude-agent-sdk";
+
+  private readonly _agentName?: string;
+  private readonly _sdkModule: Record<string, unknown>;
+  private _isInstrumented = false;
+  private _originalQuery: ((...args: unknown[]) => unknown) | null = null;
+
+  constructor({ sdkModule, agentName }: ClaudeAgentSDKInstrumentorOptions) {
+    this._sdkModule = sdkModule;
+    this._agentName = agentName;
+  }
+
+  async activate(): Promise<void> {
+    if (this._isInstrumented) {
+      return;
+    }
+
+    const query = this._sdkModule.query;
+    if (typeof query !== "function") {
+      throw new Error(
+        "ClaudeAgentSDKInstrumentor requires sdkModule.query to be a function.",
+      );
+    }
+
+    this._originalQuery = query as (...args: unknown[]) => unknown;
+    const instrumentor = this;
+
+    this._sdkModule.query = async function instrumentedQuery(
+      args: unknown,
+    ): Promise<unknown> {
+      const normalizedArgs =
+        args && typeof args === "object" && !Array.isArray(args)
+          ? ({ ...(args as Record<string, unknown>) } as Record<string, unknown>)
+          : {};
+
+      const options =
+        normalizedArgs.options &&
+        typeof normalizedArgs.options === "object" &&
+        !Array.isArray(normalizedArgs.options)
+          ? ({ ...(normalizedArgs.options as Record<string, unknown>) } as Record<string, unknown>)
+          : {};
+
+      const state = createQueryState({
+        prompt: normalizedArgs.prompt,
+        options,
+        agentName: instrumentor._agentName,
+      });
+
+      normalizedArgs.options = instrumentor._buildHooks(options, state);
+
+      let originalResult: unknown;
+      try {
+        originalResult = await instrumentor._originalQuery?.call(
+          instrumentor._sdkModule,
+          normalizedArgs,
+        );
+      } catch (error) {
+        state.statusCode = 500;
+        state.errorMessage = error instanceof Error ? error.message : String(error);
+        emitAgentSpan(state);
+        throw error;
+      }
+
+      if (
+        !originalResult ||
+        typeof originalResult !== "object" ||
+        !(Symbol.asyncIterator in (originalResult as Record<string, unknown>))
+      ) {
+        emitAgentSpan(state);
+        return originalResult;
+      }
+
+      return instrumentor._wrapAsyncIterable(
+        originalResult as AsyncIterable<unknown>,
+        state,
+      );
+    };
+
+    this._isInstrumented = true;
+  }
+
+  deactivate(): void {
+    if (!this._isInstrumented || !this._originalQuery) {
+      return;
+    }
+
+    this._sdkModule.query = this._originalQuery;
+    this._originalQuery = null;
+    this._isInstrumented = false;
+  }
+
+  private _buildHooks(
+    options: Record<string, unknown>,
+    state: QueryState,
+  ): Record<string, unknown> {
+    const hooks =
+      options.hooks && typeof options.hooks === "object" && !Array.isArray(options.hooks)
+        ? ({ ...(options.hooks as Record<string, unknown>) } as Record<string, unknown>)
+        : {};
+
+    const appendHook = (eventName: string, callback: HookCallback): void => {
+      const existingHooks = Array.isArray(hooks[eventName])
+        ? ([...(hooks[eventName] as HookGroup[])] as HookGroup[])
+        : [];
+      existingHooks.push({ hooks: [callback] });
+      hooks[eventName] = existingHooks;
+    };
+
+    appendHook("UserPromptSubmit", async (input) => {
+      try {
+        registerPromptSubmit(state, input);
+      } catch (error) {
+        console.warn("[respan] ClaudeAgentSDKInstrumentor UserPromptSubmit hook failed:", error);
+      }
+      return {};
+    });
+
+    appendHook("PreToolUse", async (input, toolUseId) => {
+      try {
+        registerPendingTool(state, input, toolUseId);
+      } catch (error) {
+        console.warn("[respan] ClaudeAgentSDKInstrumentor PreToolUse hook failed:", error);
+      }
+      return {};
+    });
+
+    appendHook("PostToolUse", async (input, toolUseId) => {
+      try {
+        emitCompletedTool(state, input, toolUseId);
+      } catch (error) {
+        console.warn("[respan] ClaudeAgentSDKInstrumentor PostToolUse hook failed:", error);
+      }
+      return {};
+    });
+
+    return {
+      ...options,
+      hooks,
+    };
+  }
+
+  private _wrapAsyncIterable(
+    originalResult: AsyncIterable<unknown>,
+    state: QueryState,
+  ): AsyncIterable<unknown> {
+    return {
+      [Symbol.asyncIterator]: async function*() {
+        try {
+          for await (const message of originalResult) {
+            try {
+              trackClaudeMessage(state, message);
+            } catch (error) {
+              console.warn("[respan] ClaudeAgentSDKInstrumentor message tracking failed:", error);
+            }
+            yield message;
+          }
+        } catch (error) {
+          state.statusCode = 500;
+          state.errorMessage = error instanceof Error ? error.message : String(error);
+          throw error;
+        } finally {
+          emitAgentSpan(state);
+        }
+      },
+    };
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/claude_agent_sdk_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/claude_agent_sdk_instrumentor.test.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { trace } from "@opentelemetry/api";
+
+import { ClaudeAgentSDKInstrumentor } from "../dist/index.js";
+
+const captureState = { spans: [] };
+const originalGetTracerProvider = trace.getTracerProvider.bind(trace);
+
+test.before(() => {
+  Object.defineProperty(trace, "getTracerProvider", {
+    configurable: true,
+    writable: true,
+    value() {
+      return {
+        activeSpanProcessor: {
+          onEnd(span) {
+            captureState.spans.push(span);
+          },
+        },
+      };
+    },
+  });
+});
+
+test.after(() => {
+  Object.defineProperty(trace, "getTracerProvider", {
+    configurable: true,
+    writable: true,
+    value: originalGetTracerProvider,
+  });
+});
+
+function createFakeSdk() {
+  const calls = [];
+
+  return {
+    calls,
+    async query(args) {
+      calls.push(args);
+      const hooks = args.options?.hooks ?? {};
+
+      function firstHook(name) {
+        const groups = Array.isArray(hooks[name]) ? hooks[name] : [];
+        for (const group of groups) {
+          if (Array.isArray(group?.hooks) && typeof group.hooks[0] === "function") {
+            return group.hooks[0];
+          }
+        }
+        return undefined;
+      }
+
+      return (async function*() {
+        await firstHook("UserPromptSubmit")?.({
+          session_id: "sess-123",
+          prompt: args.prompt,
+        });
+
+        await firstHook("PreToolUse")?.({
+          session_id: "sess-123",
+          tool_use_id: "toolu_123",
+          tool_name: "get_weather",
+          tool_input: { city: "Tokyo" },
+        });
+
+        yield {
+          type: "system",
+          data: {
+            session_id: "sess-123",
+          },
+        };
+
+        yield {
+          type: "assistant",
+          message: {
+            model: "claude-sonnet-4-5",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_123",
+                name: "get_weather",
+                input: { city: "Tokyo" },
+              },
+              {
+                type: "text",
+                text: "Tokyo is sunny.",
+              },
+            ],
+          },
+        };
+
+        await firstHook("PostToolUse")?.({
+          session_id: "sess-123",
+          tool_use_id: "toolu_123",
+          tool_name: "get_weather",
+          tool_response: { forecast: "sunny" },
+        });
+
+        yield {
+          type: "result",
+          subtype: "success",
+          session_id: "sess-123",
+          result: "Tokyo is sunny.",
+          total_cost_usd: 0.04241955,
+          usage: {
+            input_tokens: 19,
+            output_tokens: 7,
+            cache_read_input_tokens: 2,
+            cache_creation_input_tokens: 1,
+          },
+        };
+      })();
+    },
+  };
+}
+
+test("instrumentor patches query, merges hooks, and emits tool + agent spans", async () => {
+  captureState.spans = [];
+  const sdk = createFakeSdk();
+  const existingHook = async () => ({ ok: true });
+  const originalQuery = sdk.query;
+
+  const instrumentor = new ClaudeAgentSDKInstrumentor({
+    sdkModule: sdk,
+    agentName: "weather_agent",
+  });
+
+  await instrumentor.activate();
+
+  assert.notEqual(sdk.query, originalQuery);
+
+  const iterator = await sdk.query({
+    prompt: "What is the weather in Tokyo?",
+    options: {
+      hooks: {
+        Stop: [{ hooks: [existingHook] }],
+      },
+      tools: [{ name: "get_weather", input_schema: { type: "object" } }],
+    },
+  });
+
+  const yielded = [];
+  for await (const item of iterator) {
+    yielded.push(item.type);
+  }
+
+  assert.deepEqual(yielded, ["system", "assistant", "result"]);
+  assert.equal(sdk.calls.length, 1);
+  assert.equal(sdk.calls[0].options.hooks.Stop[0].hooks[0], existingHook);
+  assert.ok(Array.isArray(sdk.calls[0].options.hooks.UserPromptSubmit));
+  assert.ok(Array.isArray(sdk.calls[0].options.hooks.PreToolUse));
+  assert.ok(Array.isArray(sdk.calls[0].options.hooks.PostToolUse));
+
+  assert.equal(captureState.spans.length, 2);
+
+  const toolSpan = captureState.spans.find(
+    (span) => span.attributes["respan.entity.log_type"] === "tool",
+  );
+  const agentSpan = captureState.spans.find(
+    (span) => span.attributes["respan.entity.log_type"] === "agent",
+  );
+
+  assert.ok(toolSpan);
+  assert.ok(agentSpan);
+  assert.equal(toolSpan.attributes["traceloop.entity.name"], "get_weather");
+  assert.deepEqual(JSON.parse(toolSpan.attributes["traceloop.entity.input"]), {
+    city: "Tokyo",
+  });
+  assert.deepEqual(JSON.parse(toolSpan.attributes["traceloop.entity.output"]), {
+    forecast: "sunny",
+  });
+
+  assert.equal(agentSpan.attributes["traceloop.entity.name"], "weather_agent");
+  assert.equal(agentSpan.attributes["gen_ai.request.model"], "claude-sonnet-4-5");
+  assert.equal(agentSpan.attributes.model, "claude-sonnet-4-5");
+  assert.equal(agentSpan.attributes.prompt_tokens, 16);
+  assert.equal(agentSpan.attributes.completion_tokens, 7);
+  assert.equal(agentSpan.attributes.total_request_tokens, 23);
+  assert.equal(agentSpan.attributes.prompt_cache_hit_tokens, 2);
+  assert.equal(agentSpan.attributes.prompt_cache_creation_tokens, 1);
+  assert.equal(agentSpan.attributes.cost, 0.04241955);
+  assert.equal(
+    agentSpan.attributes["respan.sessions.session_identifier"],
+    "sess-123",
+  );
+  assert.deepEqual(
+    JSON.parse(agentSpan.attributes["respan.span.tools"]),
+    [{ type: "function", function: { name: "get_weather", parameters: { type: "object" } } }],
+  );
+  assert.deepEqual(
+    JSON.parse(agentSpan.attributes["respan.span.tool_calls"]),
+    [
+      {
+        id: "toolu_123",
+        type: "function",
+        function: {
+          name: "get_weather",
+          arguments: "{\"city\":\"Tokyo\"}",
+        },
+      },
+    ],
+  );
+  assert.deepEqual(
+    JSON.parse(agentSpan.attributes["traceloop.entity.input"]),
+    [{ role: "user", content: "What is the weather in Tokyo?" }],
+  );
+  assert.deepEqual(
+    agentSpan.attributes["traceloop.entity.output"],
+    "Tokyo is sunny.",
+  );
+  assert.equal(toolSpan.parentSpanId, agentSpan.spanContext().spanId);
+  assert.equal(toolSpan.spanContext().traceId, agentSpan.spanContext().traceId);
+
+  instrumentor.deactivate();
+
+  assert.equal(sdk.query, originalQuery);
+});

--- a/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tsconfig.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es2022",
+    "outDir": "./dist",
+    "declaration": true,
+    "lib": ["DOM", "DOM.Iterable", "es2022"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "sourceMap": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

-add: respan-instrumentation-claude-agent-sdk ts

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new instrumentation package that monkey-patches `claude-agent-sdk`'s `query()` and injects synthetic OTEL `ReadableSpan`s via the active span processor, which could affect apps that adopt it or rely on Claude hook behavior.
> 
> **Overview**
> Adds a new `@respan/instrumentation-claude-agent-sdk` TypeScript package that instruments the Claude Agent SDK by patching `query()`, merging in tool lifecycle hooks, and emitting Respan-compatible OTEL spans for the overall agent run and each tool execution.
> 
> The implementation tracks streaming messages to capture model, input/output, tool definitions/calls, token usage (including cache hit/creation adjustments), cost, and session IDs, then injects `ReadableSpan`s into the active tracer provider on completion/error. Includes package scaffolding (`package.json`, `tsconfig`), README quickstart, and a node test validating hook merging plus tool/agent span attributes and parent/trace linkage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b72bab5e321f5cac9b65ab3458d83ad85cdb65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->