### PR TITLE
chore: sync respan-tracing manifest to 2.16.4

### DIFF
--- a/.release-intents/20260416-respan-tracing-manifest-sync.json
+++ b/.release-intents/20260416-respan-tracing-manifest-sync.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Sync respan-tracing manifest version to the already-published 2.16.4 release without triggering another publish",
+  "packages": {
+    "respan-tracing": "none"
+  }
+}

--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "2.16.3"
+version = "2.16.4"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- sync `python-sdks/respan-tracing/pyproject.toml` from `2.16.3` to `2.16.4`
- reconcile the repo manifest with the already-published manual Poetry release
- add a `none` release intent so this PR does not trigger another publish

## Release Intent

Added `.release-intents/20260416-respan-tracing-manifest-sync.json` with `respan-tracing: none`.

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched
- `python3 scripts/release_inventory.py --validate`
- `python3 scripts/release_intents.py validate`
- `python3 scripts/release_intents.py plan --ecosystem python --changed-from origin/main --changed-to HEAD --format github-matrix` returned `[]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk manifest-only change: bumps `respan-tracing` version metadata and adds a `none` release intent to avoid triggering an automated publish.
> 
> **Overview**
> Updates `python-sdks/respan-tracing/pyproject.toml` to set `respan-tracing`’s version from **2.16.3** to **2.16.4** to match an already-published release.
> 
> Adds a `.release-intents/*.json` entry marking `respan-tracing: none` so the version sync does **not** trigger another publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1be48dc1067388a8498f9dcfb2d4ab5ed7db25f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->