### PR TITLE
fix: add claude-agent-sdk to release registry and fix change detection

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -20,6 +20,12 @@
     },
     {
       "ecosystem": "javascript",
+      "name": "@respan/instrumentation-claude-agent-sdk",
+      "path": "javascript-sdks/instrumentations/respan-instrumentation-claude-agent-sdk",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
       "name": "@respan/instrumentation-openai",
       "path": "javascript-sdks/instrumentations/respan-instrumentation-openai",
       "registry": "npm"
@@ -76,6 +82,12 @@
       "ecosystem": "python",
       "name": "respan-instrumentation-anthropic",
       "path": "python-sdks/instrumentations/respan-instrumentation-anthropic",
+      "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-claude-agent-sdk",
+      "path": "python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk",
       "registry": "pypi"
     },
     {

--- a/.release-intents/20260418-claude-agent-sdk-and-sdk.json
+++ b/.release-intents/20260418-claude-agent-sdk-and-sdk.json
@@ -2,6 +2,6 @@
   "summary": "Publish new Claude Agent SDK instrumentation packages for Python and JavaScript",
   "packages": {
     "respan-instrumentation-claude-agent-sdk": "new",
-    "@respan/instrumentation-claude-agent-sdk": "new"
+    "@respan/instrumentation-claude-agent-sdk": "patch"
   }
 }

--- a/.release-intents/20260418-claude-agent-sdk-and-sdk.json
+++ b/.release-intents/20260418-claude-agent-sdk-and-sdk.json
@@ -1,6 +1,7 @@
 {
-  "summary": "Patch the Python SDK and publish the new Claude Agent SDK instrumentation package",
+  "summary": "Publish new Claude Agent SDK instrumentation packages for Python and JavaScript",
   "packages": {
-    "respan-instrumentation-claude-agent-sdk": "new"
+    "respan-instrumentation-claude-agent-sdk": "new",
+    "@respan/instrumentation-claude-agent-sdk": "new"
   }
 }

--- a/scripts/release_inventory.py
+++ b/scripts/release_inventory.py
@@ -158,7 +158,7 @@ def changed_files(base: str, head: str) -> set[str]:
             for path in REPO_ROOT.rglob("*")
             if path.is_file() and ".git" not in path.parts
         }
-    output = git_stdout_or_none("diff", "--name-only", base, head)
+    output = git_stdout_or_none("diff", "--name-only", f"{base}...{head}")
     if output is None:
         return set()
     return {line.strip() for line in output.splitlines() if line.strip()}


### PR DESCRIPTION
## Summary

- Add `respan-instrumentation-claude-agent-sdk` (Python) and `@respan/instrumentation-claude-agent-sdk` (JS) to `.github/release-packages.json` — unblocks release intent validation for PRs #166 and #170
- Fix `changed_files()` in `release_inventory.py` to use three-dot diff (`base...head`) instead of two-dot (`base head`), matching GitHub's "Files changed" behavior so PRs don't get flagged for unrelated changes on main

## Test plan

- [x] `python3 scripts/release_intents.py validate` passes
- [x] `python3 scripts/release_inventory.py --validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `scripts/release_inventory.py` computes changed files, which can affect CI/release gating decisions, though the change is small and well-scoped.
> 
> **Overview**
> Adds the Claude Agent SDK instrumentation packages to the release inventory and release intent metadata so both Python and JavaScript packages are eligible for validation/publishing.
> 
> Updates `scripts/release_inventory.py` change detection to use a three-dot diff (`base...head`) when listing changed files, matching GitHub PR semantics and reducing false positives from unrelated commits on the base branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b03c37666e025db17a76bf915fa6df01dfaa63c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->