### PR TITLE
feat: stamp tracing sdk version on exported spans

### DIFF
--- a/.release-intents/20260418-tracing-sdk-version-attribute.json
+++ b/.release-intents/20260418-tracing-sdk-version-attribute.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Add tracing SDK version metadata to exported spans",
+  "packages": {
+    "respan-sdk": "patch",
+    "respan-tracing": "patch"
+  }
+}

--- a/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
@@ -47,6 +47,9 @@ class RespanSpanAttributes(str, Enum):
     # Metadata
     RESPAN_METADATA = "respan.metadata"
     RESPAN_PROPERTIES = "respan.properties"
+    RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION = (
+        "respan.metadata._tracing_sdk_version"
+    )
 
     # Prompt & environment
     RESPAN_PROMPT = "respan.prompt"
@@ -91,6 +94,9 @@ RESPAN_TRACE_GROUP_ID = RespanSpanAttributes.RESPAN_TRACE_GROUP_ID.value
 # Metadata (pattern: "respan.metadata.<key>" where key is customizable)
 RESPAN_METADATA = RespanSpanAttributes.RESPAN_METADATA.value
 RESPAN_PROPERTIES = RespanSpanAttributes.RESPAN_PROPERTIES.value
+RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION = (
+    RespanSpanAttributes.RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION.value
+)
 
 # Prompt & environment
 RESPAN_PROMPT = RespanSpanAttributes.RESPAN_PROMPT.value

--- a/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import importlib.metadata
 import json
 from collections.abc import Mapping
 from types import SimpleNamespace
@@ -52,7 +53,6 @@ from respan_sdk.constants.otlp_constants import (
     OTEL_STATUS_CODE_KEY,
     OTEL_STATUS_MESSAGE_KEY,
     OTEL_SPAN_PARENT_FIELD,
-    OTEL_SPAN_PARENT_PRIVATE_FIELD,
     OTEL_SPAN_ATTRIBUTES_FIELD,
 )
 
@@ -64,6 +64,7 @@ from respan_sdk.constants.span_attributes import (
     LLM_REQUEST_MODEL,
     LLM_REQUEST_TYPE,
     RESPAN_LOG_TYPE,
+    RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION,
     RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
 )
@@ -71,6 +72,11 @@ from respan_tracing.utils.logging import get_respan_logger, build_spans_export_p
 from respan_tracing.constants.generic_constants import LOGGER_NAME_EXPORTER
 
 logger = get_respan_logger(LOGGER_NAME_EXPORTER)
+
+try:
+    _RESPAN_TRACING_SDK_VERSION = importlib.metadata.version("respan-tracing")
+except importlib.metadata.PackageNotFoundError:
+    _RESPAN_TRACING_SDK_VERSION = ""
 
 
 def _resolve_traces_endpoint(endpoint: str) -> str:
@@ -702,6 +708,13 @@ def _get_enrichment_attrs(span: ReadableSpan) -> Dict[str, Any]:
     """
     attrs = span.attributes or {}
     extra: Dict[str, Any] = {}
+
+    if _RESPAN_TRACING_SDK_VERSION and not attrs.get(
+        RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION
+    ):
+        extra[RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION] = (
+            _RESPAN_TRACING_SDK_VERSION
+        )
 
     if attrs.get(GEN_AI_SYSTEM) and not attrs.get(LLM_REQUEST_TYPE):
         extra[LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value

--- a/python-sdks/respan-tracing/tests/test_respan_exporter.py
+++ b/python-sdks/respan-tracing/tests/test_respan_exporter.py
@@ -17,6 +17,7 @@ from respan_sdk.constants.otlp_constants import (
     OTLP_STRING_VALUE,
 )
 from respan_sdk.constants.span_attributes import (
+    RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION,
     RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
 )
@@ -131,6 +132,40 @@ def test_prepare_spans_preserves_parent_relationships():
 
     assert [s.name for s in prepared] == ["chat gpt-4o", "http.request"]
     assert prepared[1].parent.span_id == wrapper_context.span_id
+
+
+def test_get_enrichment_attrs_adds_internal_tracing_sdk_version(monkeypatch):
+    span = _make_span(name="chat gpt-4o", span_id=2004)
+    monkeypatch.setattr(
+        "respan_tracing.exporters.respan._RESPAN_TRACING_SDK_VERSION",
+        "2.16.4-test",
+    )
+
+    extra = _get_enrichment_attrs(span)
+
+    assert (
+        extra[RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION] == "2.16.4-test"
+    )
+
+
+def test_get_enrichment_attrs_preserves_existing_internal_tracing_sdk_version(
+    monkeypatch,
+):
+    span = _make_span(
+        name="chat gpt-4o",
+        span_id=2005,
+        attributes={
+            RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION: "existing-version"
+        },
+    )
+    monkeypatch.setattr(
+        "respan_tracing.exporters.respan._RESPAN_TRACING_SDK_VERSION",
+        "2.16.4-test",
+    )
+
+    extra = _get_enrichment_attrs(span)
+
+    assert RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION not in extra
 
 
 def test_prepare_spans_keeps_all_provider_spans():


### PR DESCRIPTION
## Summary
- add an internal span attribute for the sender tracing SDK version: `respan.metadata._tracing_sdk_version`
- stamp that attribute onto exported spans in `respan-tracing` when it is not already set
- cover the enrichment behavior with exporter tests and include the required release intent

## Why
Backend analysis can currently see `log_method=python_tracing`, but that no longer tells us whether a trace came from the older SDK path or the newer `/v2/traces` exporter path.

The Python tracing SDK switched its exporter normalization to `/v2/traces` in commit `94ebf08` (`SDK v2: OTLP JSON exporter with anti-recursion`). Stamping the tracing SDK version on exported spans gives the backend a reliable way to tell which side of that change a trace came from.

## Validation
- `python3 scripts/release_intents.py validate`
- `python3 -m ruff check python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py python-sdks/respan-tracing/tests/test_respan_exporter.py python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src:../respan-sdk/src python3 -m pytest tests/test_respan_exporter.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional span attribute and exporter-side enrichment, guarded to not override user-provided values; minimal behavior change beyond extra metadata on exported spans.
> 
> **Overview**
> Adds a new internal span attribute key, `respan.metadata._tracing_sdk_version`, to `respan-sdk` constants.
> 
> Updates the `respan-tracing` exporter to read its installed package version and inject it into spans during `_get_enrichment_attrs()` when missing, with new tests covering both injection and non-overwrite behavior. Includes a release intent bump for `respan-sdk` and `respan-tracing` patch releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffcfecff9525ea73aa2ffc0a6c72128343899b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->