### PR TITLE
fix: problems of respan-instrumentation-anthropic py

### DIFF
--- a/.release-intents/20260421-anthropic-managed-agent-tracing.json
+++ b/.release-intents/20260421-anthropic-managed-agent-tracing.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Patch respan-instrumentation-anthropic, fix serveral problems",
+  "packages": {
+    "respan-instrumentation-anthropic": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_constants.py
@@ -1,0 +1,108 @@
+"""Anthropic instrumentation constants."""
+
+from respan_sdk.constants.span_attributes import RESPAN_SESSION_ID
+
+ANTHROPIC_INSTRUMENTATION_NAME = "anthropic"
+ANTHROPIC_SYSTEM_NAME = "anthropic"
+ANTHROPIC_CHAT_SPAN_NAME = "anthropic.chat"
+ANTHROPIC_MANAGED_AGENT_SPAN_NAME = "anthropic.managed_agent"
+
+ANTHROPIC_RESOURCES_MODULE = "anthropic.resources"
+ANTHROPIC_BETA_SESSIONS_MODULE = "anthropic.resources.beta.sessions"
+ASYNC_EVENTS_CLASS_NAME = "AsyncEvents"
+ASYNC_MESSAGES_CLASS_NAME = "AsyncMessages"
+CREATE_METHOD_NAME = "create"
+EVENTS_CLASS_NAME = "Events"
+MESSAGES_CLASS_NAME = "Messages"
+STREAM_METHOD_NAME = "stream"
+CLOSE_METHOD_NAME = "close"
+
+ASSISTANT_ROLE = "assistant"
+FUNCTION_KEY = "function"
+FUNCTION_TOOL_TYPE = "function"
+MCP_SERVER_KEY = "mcp_server"
+MCP_SERVER_NAME_KEY = "mcp_server_name"
+ROLE_KEY = "role"
+SYSTEM_ROLE = "system"
+TOOL_ROLE = "tool"
+USER_ROLE = "user"
+
+ARGUMENTS_KEY = "arguments"
+CACHE_CONTROL_KEY = "cache_control"
+CITATIONS_KEY = "citations"
+CONTENT_KEY = "content"
+DESCRIPTION_KEY = "description"
+ID_KEY = "id"
+INPUT_KEY = "input"
+INPUT_SCHEMA_KEY = "input_schema"
+INPUT_TOKENS_KEY = "input_tokens"
+IS_ERROR_KEY = "is_error"
+MODEL_KEY = "model"
+MODEL_USAGE_KEY = "model_usage"
+MESSAGES_KEY = "messages"
+NAME_KEY = "name"
+OUTPUT_TOKENS_KEY = "output_tokens"
+PARAMETERS_KEY = "parameters"
+PROPERTIES_KEY = "properties"
+REQUIRED_KEY = "required"
+SOURCE_KEY = "source"
+STOP_REASON_KEY = "stop_reason"
+SYSTEM_KEY = "system"
+TEXT_KEY = "text"
+TOOLS_KEY = "tools"
+TOOL_CALL_ID_KEY = "tool_call_id"
+PENDING_TOOL_CALL_KEY = "tool_call"
+PENDING_TOOL_DEFINITION_KEY = "tool_definition"
+PENDING_EXPIRES_AT_NS_KEY = "expires_at_ns"
+PENDING_PARENT_ID_KEY = "parent_id"
+PENDING_START_NS_KEY = "start_ns"
+TOOL_USE_ID_KEY = "tool_use_id"
+TYPE_KEY = "type"
+UNIT_KEY = "unit"
+USAGE_KEY = "usage"
+CACHE_CREATION_INPUT_TOKENS_KEY = "cache_creation_input_tokens"
+CACHE_READ_INPUT_TOKENS_KEY = "cache_read_input_tokens"
+
+GEN_AI_COMPLETION_ROLE_ATTR = "gen_ai.completion.0.role"
+GEN_AI_COMPLETION_TOOL_CALLS_ATTR = "gen_ai.completion.0.tool_calls"
+GEN_AI_TOOL_CALL_ID_ATTR = "gen_ai.tool.call.id"
+GEN_AI_TOOL_DEFINITIONS_ATTR = "gen_ai.tool.definitions"
+MANAGED_AGENT_STOP_REASON_ATTR = "respan.managed_agent.stop_reason"
+MANAGED_AGENT_SESSION_ID_ATTR = RESPAN_SESSION_ID
+TOOL_CALLS_OVERRIDE = "tool_calls"
+TOOLS_OVERRIDE = "tools"
+
+GET_FINAL_MESSAGE_METHOD_NAME = "get_final_message"
+
+TEXT_BLOCK_TYPE = "text"
+TOOL_RESULT_BLOCK_TYPE = "tool_result"
+TOOL_USE_BLOCK_TYPE = "tool_use"
+
+AGENT_CUSTOM_TOOL_USE_EVENT = "agent.custom_tool_use"
+AGENT_MCP_TOOL_USE_EVENT = "agent.mcp_tool_use"
+AGENT_MESSAGE_EVENT = "agent.message"
+AGENT_TOOL_USE_EVENT = "agent.tool_use"
+MODEL_REQUEST_END_EVENT = "span.model_request_end"
+SESSION_ERROR_EVENT = "session.error"
+SESSION_STATUS_IDLE_EVENT = "session.status_idle"
+SESSION_STATUS_RUNNING_EVENT = "session.status_running"
+USER_MESSAGE_EVENT = "user.message"
+
+AGENT_TOOL_USE_EVENTS = (
+    AGENT_TOOL_USE_EVENT,
+    AGENT_MCP_TOOL_USE_EVENT,
+    AGENT_CUSTOM_TOOL_USE_EVENT,
+)
+
+SERIALIZED_CONTENT_FIELD_NAMES = (
+    TYPE_KEY,
+    ID_KEY,
+    NAME_KEY,
+    INPUT_KEY,
+    TOOL_USE_ID_KEY,
+    TEXT_KEY,
+    CONTENT_KEY,
+    SOURCE_KEY,
+    CITATIONS_KEY,
+    CACHE_CONTROL_KEY,
+)

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_instrumentation.py
@@ -1,735 +1,231 @@
-"""Anthropic SDK instrumentation plugin for Respan.
+"""Anthropic SDK instrumentation plugin for Respan."""
 
-Monkey-patches ``anthropic.Anthropic`` and ``anthropic.AsyncAnthropic`` to
-trace ``messages.create()`` and ``messages.stream()`` calls.  Also patches
-``beta.sessions.events.stream()`` to trace Managed Agents sessions — one
-span per agent turn with accumulated token usage, tool calls, and messages.
+from __future__ import annotations
 
-Spans carry GenAI semantic conventions and pass ``is_processable_span()``
-natively.
-"""
-
-import json
+import importlib
 import logging
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any
 
-from opentelemetry import trace
-from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+from respan_instrumentation_anthropic._constants import (
+    ANTHROPIC_BETA_SESSIONS_MODULE,
+    ANTHROPIC_CHAT_SPAN_NAME,
+    ANTHROPIC_INSTRUMENTATION_NAME,
+    ANTHROPIC_RESOURCES_MODULE,
+    ASYNC_EVENTS_CLASS_NAME,
+    ASYNC_MESSAGES_CLASS_NAME,
+    CREATE_METHOD_NAME,
+    EVENTS_CLASS_NAME,
+    GET_FINAL_MESSAGE_METHOD_NAME,
+    MESSAGES_CLASS_NAME,
+    SESSION_ERROR_EVENT,
+    STREAM_METHOD_NAME,
+)
+from respan_instrumentation_anthropic._managed_agents import (
+    _wrap_async_events_stream,
+    _wrap_sync_events_stream,
+)
+from respan_instrumentation_anthropic._messages import (
+    _build_error_attrs,
+    _emit_message_spans,
+    _emit_span,
+)
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Attribute helpers
-# ---------------------------------------------------------------------------
-
-
-def _safe_json(obj: Any) -> str:
-    try:
-        return json.dumps(obj, default=str)
-    except Exception:
-        return str(obj)
-
-
-def _serialize_content_value(value: Any) -> Any:
-    """Serialize Anthropic content while preserving structured blocks."""
-    if isinstance(value, list):
-        parts = [_serialize_content_block(block) for block in value]
-        parts = [part for part in parts if part not in ("", None, [], {})]
-
-        if not parts:
-            return ""
-        if all(isinstance(part, str) for part in parts):
-            return "\n".join(parts)
-        return parts
-
-    if isinstance(value, dict):
-        if "type" in value:
-            return _serialize_content_block(value)
-        return {key: _serialize_content_value(val) for key, val in value.items()}
-
-    return value
-
-
-def _serialize_content_block(block: Any) -> Any:
-    """Serialize a single Anthropic content block."""
-    if isinstance(block, str):
-        return block
-
-    if isinstance(block, dict):
-        block_type = block.get("type")
-        if block_type == "text":
-            return block.get("text", "")
-
-        result: Dict[str, Any] = {}
-        for key in (
-            "type",
-            "id",
-            "name",
-            "input",
-            "tool_use_id",
-            "text",
-            "content",
-            "source",
-            "citations",
-            "cache_control",
-        ):
-            if key in block:
-                result[key] = _serialize_content_value(block[key])
-        return result or str(block)
-
-    block_type = getattr(block, "type", None)
-    if block_type == "text":
-        return getattr(block, "text", "")
-
-    if block_type:
-        result: Dict[str, Any] = {"type": block_type}
-        for attr in (
-            "id",
-            "name",
-            "input",
-            "tool_use_id",
-            "text",
-            "content",
-            "source",
-            "citations",
-            "cache_control",
-        ):
-            if hasattr(block, attr):
-                result[attr] = _serialize_content_value(getattr(block, attr))
-        return result
-
-    if hasattr(block, "text"):
-        return block.text
-
-    return str(block)
-
-
-def _normalize_content_block(block: Any) -> str:
-    """Normalize a content block into human-readable text for turn tracking."""
-    value = _serialize_content_block(block)
-    if value in ("", None, [], {}):
-        return ""
-    if isinstance(value, str):
-        return value
-    return _safe_json(value)
-
-
-def _format_input_messages(
-    messages: List[Any],
-    system: Any = None,
-) -> str:
-    """Normalize Anthropic messages to [{role, content}] JSON."""
-    result: List[Dict[str, Any]] = []
-
-    # System prompt (string or list of content blocks)
-    if system is not None:
-        if isinstance(system, str):
-            result.append({"role": "system", "content": system})
-        else:
-            result.append({"role": "system", "content": _serialize_content_value(system)})
-
-    for msg in messages:
-        if isinstance(msg, dict):
-            role = msg.get("role", "user")
-            content = msg.get("content", "")
-        elif hasattr(msg, "role") and hasattr(msg, "content"):
-            role = msg.role
-            content = msg.content
-        else:
-            role = "user"
-            content = str(msg)
-
-        content = _serialize_content_value(content)
-
-        result.append({"role": role, "content": content})
-
-    return _safe_json(result)
-
-
-def _format_output(message: Any) -> str:
-    """Extract assistant response text from a Message object."""
-    content = getattr(message, "content", None)
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    return _safe_json(_serialize_content_value(content))
-
-
-def _extract_tool_calls(message: Any) -> Optional[str]:
-    """Extract tool_use blocks as normalized tool_calls JSON."""
-    content = getattr(message, "content", None)
-    if not isinstance(content, list):
-        return None
-
-    tool_calls: List[Dict[str, Any]] = []
-    for block in content:
-        block_type = getattr(block, "type", None)
-        if isinstance(block, dict):
-            block_type = block.get("type")
-
-        if block_type != "tool_use":
-            continue
-
-        if hasattr(block, "id"):
-            tc = {
-                "id": block.id,
-                "type": "function",
-                "function": {
-                    "name": block.name,
-                    "arguments": _safe_json(block.input),
-                },
-            }
-        elif isinstance(block, dict):
-            tc = {
-                "id": block.get("id", ""),
-                "type": "function",
-                "function": {
-                    "name": block.get("name", ""),
-                    "arguments": _safe_json(block.get("input", {})),
-                },
-            }
-        else:
-            continue
-        tool_calls.append(tc)
-
-    return _safe_json(tool_calls) if tool_calls else None
-
-
-def _format_tools(tools: Any) -> Optional[str]:
-    """Normalize tool definitions to JSON."""
-    if not tools:
-        return None
-
-    result: List[Dict[str, Any]] = []
-    for tool in tools:
-        if isinstance(tool, dict):
-            name = tool.get("name", "")
-            desc = tool.get("description", "")
-            params = tool.get("input_schema", {})
-        elif hasattr(tool, "name"):
-            name = tool.name
-            desc = getattr(tool, "description", "")
-            params = getattr(tool, "input_schema", {})
-        else:
-            continue
-
-        entry: Dict[str, Any] = {"type": "function", "function": {"name": name}}
-        if desc:
-            entry["function"]["description"] = desc
-        if params:
-            entry["function"]["parameters"] = params
-        result.append(entry)
-
-    return _safe_json(result) if result else None
-
-
-def _build_span_attrs(kwargs: Dict[str, Any], message: Any) -> Dict[str, Any]:
-    """Build the full span attribute dict from request kwargs and response Message."""
-    attrs: Dict[str, Any] = {
-        "gen_ai.system": "anthropic",
-        "llm.request.type": "chat",
-        "traceloop.entity.name": "anthropic.chat",
-        "traceloop.entity.path": "anthropic.chat",
-        "respan.entity.log_type": "chat",
-        SpanAttributes.TRACELOOP_SPAN_KIND: LLMRequestTypeValues.CHAT.value,
-    }
-
-    # Model
-    model = getattr(message, "model", None) or kwargs.get("model")
-    if model:
-        attrs["gen_ai.request.model"] = model
-
-    # Input messages
-    messages = kwargs.get("messages", [])
-    system = kwargs.get("system")
-    attrs["traceloop.entity.input"] = _format_input_messages(messages, system)
-
-    # Output
-    attrs["traceloop.entity.output"] = _format_output(message)
-
-    # Token usage
-    usage = getattr(message, "usage", None)
-    if usage is not None:
-        attrs["gen_ai.usage.prompt_tokens"] = getattr(usage, "input_tokens", 0)
-        attrs["gen_ai.usage.completion_tokens"] = getattr(usage, "output_tokens", 0)
-        cache_read = getattr(usage, "cache_read_input_tokens", 0)
-        cache_creation = getattr(usage, "cache_creation_input_tokens", 0)
-        if cache_read:
-            attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] = cache_read
-        if cache_creation:
-            attrs[SpanAttributes.LLM_USAGE_CACHE_CREATION_INPUT_TOKENS] = (
-                cache_creation
-            )
-
-    # Tool calls
-    tool_calls_json = _extract_tool_calls(message)
-    if tool_calls_json:
-        attrs["respan.span.tool_calls"] = tool_calls_json
-
-    # Tool definitions
-    tools_json = _format_tools(kwargs.get("tools"))
-    if tools_json:
-        attrs["respan.span.tools"] = tools_json
-
-    return attrs
-
-
-def _build_error_attrs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
-    """Build minimal span attributes for a failed request."""
-    attrs: Dict[str, Any] = {
-        "gen_ai.system": "anthropic",
-        "llm.request.type": "chat",
-        "traceloop.entity.name": "anthropic.chat",
-        "traceloop.entity.path": "anthropic.chat",
-        "respan.entity.log_type": "chat",
-        SpanAttributes.TRACELOOP_SPAN_KIND: LLMRequestTypeValues.CHAT.value,
-    }
-    model = kwargs.get("model")
-    if model:
-        attrs["gen_ai.request.model"] = model
-
-    messages = kwargs.get("messages", [])
-    system = kwargs.get("system")
-    attrs["traceloop.entity.input"] = _format_input_messages(messages, system)
-    return attrs
-
-
-# ---------------------------------------------------------------------------
-# Monkey-patch wrappers
-# ---------------------------------------------------------------------------
 
 _original_sync_create = None
 _original_async_create = None
 _original_sync_stream = None
 _original_async_stream = None
+_original_sync_events_stream = None
+_original_async_events_stream = None
 
 
-def _current_trace_parent_ids() -> tuple[Optional[str], Optional[str]]:
-    """Return the active OTEL trace/span IDs for parenting injected spans."""
-    try:
-        current_span = trace.get_current_span()
-        span_context = current_span.get_span_context()
-    except Exception:
-        return None, None
-
-    trace_id = getattr(span_context, "trace_id", 0) or 0
-    span_id = getattr(span_context, "span_id", 0) or 0
-    if trace_id == 0 or span_id == 0:
-        return None, None
-
-    return format(trace_id, "032x"), format(span_id, "016x")
+def _get_module_attr(module_path: str, attr_name: str) -> Any:
+    module = importlib.import_module(module_path)
+    attr_value = getattr(module, attr_name, None)
+    if attr_value is None:
+        raise AttributeError(f"{module_path}.{attr_name}")
+    return attr_value
 
 
-def _emit_span(
-    attrs: Dict[str, Any],
-    start_ns: int,
-    error_message: Optional[str] = None,
-    *,
-    name: str = "anthropic.chat",
+def _load_messages_classes() -> tuple[type[Any], type[Any]]:
+    return (
+        _get_module_attr(
+            module_path=ANTHROPIC_RESOURCES_MODULE,
+            attr_name=MESSAGES_CLASS_NAME,
+        ),
+        _get_module_attr(
+            module_path=ANTHROPIC_RESOURCES_MODULE,
+            attr_name=ASYNC_MESSAGES_CLASS_NAME,
+        ),
+    )
+
+
+def _load_events_classes() -> tuple[type[Any], type[Any]]:
+    return (
+        _get_module_attr(
+            module_path=ANTHROPIC_BETA_SESSIONS_MODULE,
+            attr_name=EVENTS_CLASS_NAME,
+        ),
+        _get_module_attr(
+            module_path=ANTHROPIC_BETA_SESSIONS_MODULE,
+            attr_name=ASYNC_EVENTS_CLASS_NAME,
+        ),
+    )
+
+
+def _emit_message_span_safely(
+    *, kwargs: dict[str, Any], message: Any, start_ns: int
 ) -> None:
-    """Build a ReadableSpan and inject into the OTEL pipeline."""
     try:
-        from respan_tracing.utils.span_factory import build_readable_span, inject_span
-
-        trace_id, parent_id = _current_trace_parent_ids()
-        span = build_readable_span(
-            name,
-            trace_id=trace_id,
-            parent_id=parent_id,
-            start_time_ns=start_ns,
-            end_time_ns=time.time_ns(),
-            attributes=attrs,
-            error_message=error_message,
-        )
-        inject_span(span)
+        _emit_message_spans(kwargs=kwargs, message=message, start_ns=start_ns)
     except Exception:
-        logger.debug("Failed to emit Anthropic span", exc_info=True)
+        logger.debug("Failed to build Anthropic span attrs", exc_info=True)
 
 
-def _wrap_sync_create(original):
-    """Wrap Messages.create() for sync Anthropic client."""
+def _emit_error_span(*, kwargs: dict[str, Any], start_ns: int, exc: Exception) -> None:
+    _emit_span(
+        attrs=_build_error_attrs(kwargs=kwargs),
+        start_ns=start_ns,
+        error_message=str(exc),
+    )
 
-    def wrapper(self, *args, **kwargs):
+
+def _wrap_sync_create(original: Any) -> Any:
+    """Wrap ``Messages.create()`` for the sync Anthropic client."""
+
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
         try:
             message = original(self, *args, **kwargs)
         except Exception as exc:
-            attrs = _build_error_attrs(kwargs)
-            _emit_span(attrs, start_ns, error_message=str(exc))
+            _emit_error_span(kwargs=kwargs, start_ns=start_ns, exc=exc)
             raise
 
-        try:
-            attrs = _build_span_attrs(kwargs, message)
-            _emit_span(attrs, start_ns)
-        except Exception:
-            logger.debug("Failed to build Anthropic span attrs", exc_info=True)
-
+        _emit_message_span_safely(kwargs=kwargs, message=message, start_ns=start_ns)
         return message
 
     return wrapper
 
 
-def _wrap_async_create(original):
-    """Wrap AsyncMessages.create() for async Anthropic client."""
+def _wrap_async_create(original: Any) -> Any:
+    """Wrap ``AsyncMessages.create()`` for the async Anthropic client."""
 
-    async def wrapper(self, *args, **kwargs):
+    async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
         try:
             message = await original(self, *args, **kwargs)
         except Exception as exc:
-            attrs = _build_error_attrs(kwargs)
-            _emit_span(attrs, start_ns, error_message=str(exc))
+            _emit_error_span(kwargs=kwargs, start_ns=start_ns, exc=exc)
             raise
 
-        try:
-            attrs = _build_span_attrs(kwargs, message)
-            _emit_span(attrs, start_ns)
-        except Exception:
-            logger.debug("Failed to build Anthropic span attrs", exc_info=True)
-
+        _emit_message_span_safely(kwargs=kwargs, message=message, start_ns=start_ns)
         return message
 
     return wrapper
 
 
-def _wrap_sync_stream(original):
-    """Wrap Messages.stream() for sync Anthropic client.
+def _wrap_sync_stream(original: Any) -> Any:
+    """Wrap ``Messages.stream()`` for the sync Anthropic client."""
 
-    Returns a context manager whose __exit__ emits the span once the
-    final accumulated message is available.
-    """
-
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
         stream_cm = original(self, *args, **kwargs)
 
         class _InstrumentedStream:
             """Proxy that delegates to the real MessageStream context manager."""
 
-            def __init__(self, cm):
+            def __init__(self, cm: Any) -> None:
                 self._cm = cm
                 self._stream = None
 
-            def __enter__(self):
+            def __enter__(self) -> Any:
                 self._stream = self._cm.__enter__()
                 return self._stream
 
-            def __exit__(self, exc_type, exc_val, exc_tb):
+            def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
                 result = self._cm.__exit__(exc_type, exc_val, exc_tb)
                 try:
-                    final = getattr(self._stream, "get_final_message", None)
-                    if callable(final):
-                        message = final()
-                        attrs = _build_span_attrs(kwargs, message)
-                        _emit_span(attrs, start_ns)
+                    final_message_getter = getattr(
+                        self._stream, GET_FINAL_MESSAGE_METHOD_NAME, None
+                    )
+                    if callable(final_message_getter):
+                        _emit_message_span_safely(
+                            kwargs=kwargs,
+                            message=final_message_getter(),
+                            start_ns=start_ns,
+                        )
                     elif exc_val is not None:
-                        attrs = _build_error_attrs(kwargs)
-                        _emit_span(attrs, start_ns, error_message=str(exc_val))
+                        _emit_error_span(
+                            kwargs=kwargs,
+                            start_ns=start_ns,
+                            exc=exc_val,
+                        )
                 except Exception:
                     logger.debug("Failed to emit stream span", exc_info=True)
                 return result
 
-            # Support direct iteration (non-context-manager usage)
-            def __iter__(self):
+            def __iter__(self) -> Any:
                 return iter(self._cm)
 
-        return _InstrumentedStream(stream_cm)
+        return _InstrumentedStream(cm=stream_cm)
 
     return wrapper
 
 
-def _wrap_async_stream(original):
-    """Wrap AsyncMessages.stream() for async Anthropic client."""
+def _wrap_async_stream(original: Any) -> Any:
+    """Wrap ``AsyncMessages.stream()`` for the async Anthropic client."""
 
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
         stream_cm = original(self, *args, **kwargs)
 
         class _InstrumentedAsyncStream:
             """Proxy that delegates to the real AsyncMessageStream."""
 
-            def __init__(self, cm):
+            def __init__(self, cm: Any) -> None:
                 self._cm = cm
                 self._stream = None
 
-            async def __aenter__(self):
+            async def __aenter__(self) -> Any:
                 self._stream = await self._cm.__aenter__()
                 return self._stream
 
-            async def __aexit__(self, exc_type, exc_val, exc_tb):
+            async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
                 result = await self._cm.__aexit__(exc_type, exc_val, exc_tb)
                 try:
-                    final = getattr(self._stream, "get_final_message", None)
-                    if callable(final):
-                        message = final()
-                        attrs = _build_span_attrs(kwargs, message)
-                        _emit_span(attrs, start_ns)
+                    final_message_getter = getattr(
+                        self._stream, GET_FINAL_MESSAGE_METHOD_NAME, None
+                    )
+                    if callable(final_message_getter):
+                        _emit_message_span_safely(
+                            kwargs=kwargs,
+                            message=final_message_getter(),
+                            start_ns=start_ns,
+                        )
                     elif exc_val is not None:
-                        attrs = _build_error_attrs(kwargs)
-                        _emit_span(attrs, start_ns, error_message=str(exc_val))
+                        _emit_error_span(
+                            kwargs=kwargs,
+                            start_ns=start_ns,
+                            exc=exc_val,
+                        )
                 except Exception:
                     logger.debug("Failed to emit async stream span", exc_info=True)
                 return result
 
-            # Support direct async iteration
-            def __aiter__(self):
+            def __aiter__(self) -> Any:
                 return self._cm.__aiter__()
 
-        return _InstrumentedAsyncStream(stream_cm)
+        return _InstrumentedAsyncStream(cm=stream_cm)
 
     return wrapper
-
-
-# ---------------------------------------------------------------------------
-# Managed Agents — event stream instrumentation
-# ---------------------------------------------------------------------------
-
-_original_sync_events_stream = None
-_original_async_events_stream = None
-
-
-class _ManagedAgentTurnTracker:
-    """Accumulates streamed events for one agent turn (user.message → idle).
-
-    Each ``session.status_idle`` or ``session.error`` flushes a span that
-    captures the full turn: user input, agent output, aggregated token
-    usage across all model requests, and every tool call.
-    """
-
-    def __init__(self, session_id: str) -> None:
-        self.session_id = session_id
-        self._reset()
-
-    # -- event dispatch -------------------------------------------------------
-
-    def process(self, event: Any) -> None:
-        event_type = getattr(event, "type", None)
-
-        if event_type == "user.message":
-            for block in getattr(event, "content", []):
-                text = _normalize_content_block(block)
-                if text:
-                    self.input_messages.append(text)
-
-        elif event_type == "agent.message":
-            for block in getattr(event, "content", []):
-                text = _normalize_content_block(block)
-                if text:
-                    self.output_messages.append(text)
-
-        elif event_type in (
-            "agent.tool_use",
-            "agent.mcp_tool_use",
-            "agent.custom_tool_use",
-        ):
-            tc: Dict[str, Any] = {
-                "id": getattr(event, "id", ""),
-                "type": "function",
-                "function": {
-                    "name": getattr(event, "name", ""),
-                    "arguments": _safe_json(getattr(event, "input", {})),
-                },
-            }
-            if event_type == "agent.mcp_tool_use":
-                tc["mcp_server"] = getattr(event, "mcp_server_name", "")
-            self.tool_calls.append(tc)
-
-        elif event_type == "span.model_request_end":
-            usage = getattr(event, "model_usage", None)
-            if usage:
-                self.total_input_tokens += getattr(usage, "input_tokens", 0)
-                self.total_output_tokens += getattr(usage, "output_tokens", 0)
-                self.total_cache_read += getattr(usage, "cache_read_input_tokens", 0)
-                self.total_cache_creation += getattr(
-                    usage, "cache_creation_input_tokens", 0
-                )
-
-        elif event_type == "session.status_idle":
-            stop_reason = getattr(event, "stop_reason", None)
-            self._emit(
-                stop_reason=getattr(stop_reason, "type", None) if stop_reason else None
-            )
-            self._reset()
-
-        elif event_type == "session.error":
-            self.error = str(event)
-            self._emit()
-            self._reset()
-
-        elif event_type == "session.status_running":
-            # Mark the actual start of agent work (may lag behind stream open).
-            if not self.input_messages:
-                self.start_ns = time.time_ns()
-
-    # -- span emission --------------------------------------------------------
-
-    def _emit(self, stop_reason: Optional[str] = None) -> None:
-        attrs: Dict[str, Any] = {
-            "gen_ai.system": "anthropic",
-            "llm.request.type": "chat",
-            "traceloop.entity.name": "anthropic.managed_agent",
-            "traceloop.entity.path": "anthropic.managed_agent",
-            "respan.entity.log_type": "chat",
-            "respan.managed_agent.session_id": self.session_id,
-            SpanAttributes.TRACELOOP_SPAN_KIND: LLMRequestTypeValues.CHAT.value,
-        }
-
-        if self.input_messages:
-            attrs["traceloop.entity.input"] = _safe_json(
-                [{"role": "user", "content": "\n".join(self.input_messages)}]
-            )
-
-        if self.output_messages:
-            attrs["traceloop.entity.output"] = "\n".join(self.output_messages)
-
-        if self.total_input_tokens or self.total_output_tokens:
-            attrs["gen_ai.usage.prompt_tokens"] = self.total_input_tokens
-            attrs["gen_ai.usage.completion_tokens"] = self.total_output_tokens
-
-        if self.total_cache_read:
-            attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] = (
-                self.total_cache_read
-            )
-        if self.total_cache_creation:
-            attrs[SpanAttributes.LLM_USAGE_CACHE_CREATION_INPUT_TOKENS] = (
-                self.total_cache_creation
-            )
-
-        if self.tool_calls:
-            attrs["respan.span.tool_calls"] = _safe_json(self.tool_calls)
-
-        if stop_reason:
-            attrs["respan.managed_agent.stop_reason"] = stop_reason
-
-        _emit_span(
-            attrs,
-            self.start_ns,
-            error_message=self.error,
-            name="anthropic.managed_agent",
-        )
-
-    def _reset(self) -> None:
-        self.start_ns = time.time_ns()
-        self.input_messages: List[str] = []
-        self.output_messages: List[str] = []
-        self.tool_calls: List[Dict[str, Any]] = []
-        self.total_input_tokens = 0
-        self.total_output_tokens = 0
-        self.total_cache_read = 0
-        self.total_cache_creation = 0
-        self.error: Optional[str] = None
-
-
-class _InstrumentedManagedStream:
-    """Proxy for a sync ``Stream`` that intercepts events to emit spans."""
-
-    def __init__(self, stream: Any, session_id: str) -> None:
-        self._stream = stream
-        self._tracker = _ManagedAgentTurnTracker(session_id)
-
-    def __iter__(self):
-        for event in self._stream:
-            self._tracker.process(event)
-            yield event
-
-    def __enter__(self):
-        if hasattr(self._stream, "__enter__"):
-            self._stream.__enter__()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if hasattr(self._stream, "__exit__"):
-            return self._stream.__exit__(exc_type, exc_val, exc_tb)
-        return None
-
-    def close(self):
-        if hasattr(self._stream, "close"):
-            self._stream.close()
-
-    def __getattr__(self, name: str):
-        return getattr(self._stream, name)
-
-
-class _InstrumentedAsyncManagedStream:
-    """Proxy for an async ``AsyncStream`` that intercepts events to emit spans."""
-
-    def __init__(self, stream: Any, session_id: str) -> None:
-        self._stream = stream
-        self._tracker = _ManagedAgentTurnTracker(session_id)
-
-    async def __aiter__(self):
-        async for event in self._stream:
-            self._tracker.process(event)
-            yield event
-
-    async def __aenter__(self):
-        if hasattr(self._stream, "__aenter__"):
-            await self._stream.__aenter__()
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if hasattr(self._stream, "__aexit__"):
-            return await self._stream.__aexit__(exc_type, exc_val, exc_tb)
-        return None
-
-    async def close(self):
-        if hasattr(self._stream, "close"):
-            result = self._stream.close()
-            if hasattr(result, "__await__"):
-                await result
-
-    def __getattr__(self, name: str):
-        return getattr(self._stream, name)
-
-
-def _wrap_sync_events_stream(original):
-    """Wrap ``Events.stream()`` to intercept managed agent events."""
-
-    def wrapper(self, session_id, *args, **kwargs):
-        stream = original(self, session_id, *args, **kwargs)
-        return _InstrumentedManagedStream(stream, session_id)
-
-    return wrapper
-
-
-def _wrap_async_events_stream(original):
-    """Wrap ``AsyncEvents.stream()`` to intercept managed agent events."""
-
-    async def wrapper(self, session_id, *args, **kwargs):
-        stream = await original(self, session_id, *args, **kwargs)
-        return _InstrumentedAsyncManagedStream(stream, session_id)
-
-    return wrapper
-
-
-# ---------------------------------------------------------------------------
-# Instrumentor
-# ---------------------------------------------------------------------------
 
 
 class AnthropicInstrumentor:
-    """Respan instrumentor for the Anthropic SDK.
+    """Respan instrumentor for the Anthropic SDK."""
 
-    Patches ``messages.create()`` and ``messages.stream()`` on both the
-    sync and async clients to emit OTEL spans with GenAI attributes.
-
-    Also patches ``beta.sessions.events.stream()`` to trace Managed Agents
-    sessions.  Each agent turn (user message → ``session.status_idle``)
-    produces one span with accumulated token usage, tool calls, and the
-    full agent response.
-
-    Usage::
-
-        from respan import Respan
-        from respan_instrumentation_anthropic import AnthropicInstrumentor
-
-        respan = Respan(instrumentations=[AnthropicInstrumentor()])
-    """
-
-    name = "anthropic"
+    name = ANTHROPIC_INSTRUMENTATION_NAME
 
     def __init__(self) -> None:
         self._is_instrumented = False
@@ -741,62 +237,79 @@ class AnthropicInstrumentor:
         global _original_sync_events_stream, _original_async_events_stream
 
         try:
-            import anthropic
-        except ImportError as exc:
+            Messages, AsyncMessages = _load_messages_classes()
+        except (AttributeError, ImportError) as exc:
             logger.warning(
                 "Failed to activate Anthropic instrumentation — missing dependency: %s",
                 exc,
             )
             return
-
-        try:
-            from anthropic.resources import Messages, AsyncMessages
-
-            # Patch sync messages.create
-            if _original_sync_create is None:
-                _original_sync_create = Messages.create
-            Messages.create = _wrap_sync_create(_original_sync_create)
-
-            # Patch async messages.create
-            if _original_async_create is None:
-                _original_async_create = AsyncMessages.create
-            AsyncMessages.create = _wrap_async_create(_original_async_create)
-
-            # Patch sync messages.stream
-            if hasattr(Messages, "stream"):
-                if _original_sync_stream is None:
-                    _original_sync_stream = Messages.stream
-                Messages.stream = _wrap_sync_stream(_original_sync_stream)
-
-            # Patch async messages.stream
-            if hasattr(AsyncMessages, "stream"):
-                if _original_async_stream is None:
-                    _original_async_stream = AsyncMessages.stream
-                AsyncMessages.stream = _wrap_async_stream(_original_async_stream)
-
         except Exception as exc:
             logger.warning("Failed to activate Anthropic instrumentation: %s", exc)
+            return
 
-        # ------------------------------------------------------------------
-        # Managed Agents (beta) — gracefully skip if SDK is too old
-        # ------------------------------------------------------------------
+        self._is_instrumented = True
+
         try:
-            from anthropic.resources.beta.sessions import Events, AsyncEvents
+            if _original_sync_create is None:
+                _original_sync_create = getattr(Messages, CREATE_METHOD_NAME)
+            setattr(
+                Messages,
+                CREATE_METHOD_NAME,
+                _wrap_sync_create(original=_original_sync_create),
+            )
+
+            if _original_async_create is None:
+                _original_async_create = getattr(AsyncMessages, CREATE_METHOD_NAME)
+            setattr(
+                AsyncMessages,
+                CREATE_METHOD_NAME,
+                _wrap_async_create(original=_original_async_create),
+            )
+
+            if hasattr(Messages, STREAM_METHOD_NAME):
+                if _original_sync_stream is None:
+                    _original_sync_stream = getattr(Messages, STREAM_METHOD_NAME)
+                setattr(
+                    Messages,
+                    STREAM_METHOD_NAME,
+                    _wrap_sync_stream(original=_original_sync_stream),
+                )
+
+            if hasattr(AsyncMessages, STREAM_METHOD_NAME):
+                if _original_async_stream is None:
+                    _original_async_stream = getattr(AsyncMessages, STREAM_METHOD_NAME)
+                setattr(
+                    AsyncMessages,
+                    STREAM_METHOD_NAME,
+                    _wrap_async_stream(original=_original_async_stream),
+                )
+        except Exception as exc:
+            logger.warning("Failed to activate Anthropic instrumentation: %s", exc)
+            self.deactivate()
+            return
+
+        try:
+            Events, AsyncEvents = _load_events_classes()
 
             if _original_sync_events_stream is None:
-                _original_sync_events_stream = Events.stream
-            Events.stream = _wrap_sync_events_stream(_original_sync_events_stream)
+                _original_sync_events_stream = getattr(Events, STREAM_METHOD_NAME)
+            setattr(
+                Events,
+                STREAM_METHOD_NAME,
+                _wrap_sync_events_stream(original=_original_sync_events_stream),
+            )
 
             if _original_async_events_stream is None:
-                _original_async_events_stream = AsyncEvents.stream
-            AsyncEvents.stream = _wrap_async_events_stream(
-                _original_async_events_stream
+                _original_async_events_stream = getattr(AsyncEvents, STREAM_METHOD_NAME)
+            setattr(
+                AsyncEvents,
+                STREAM_METHOD_NAME,
+                _wrap_async_events_stream(original=_original_async_events_stream),
             )
 
             logger.info("Anthropic Managed Agents instrumentation activated")
-
-        except (ImportError, AttributeError):
-            # SDK version doesn't have beta.sessions — that's fine.
+        except (AttributeError, ImportError):
             logger.debug(
                 "Managed Agents beta not available in installed anthropic SDK; skipping"
             )
@@ -805,7 +318,6 @@ class AnthropicInstrumentor:
                 "Failed to activate Managed Agents instrumentation: %s", exc
             )
 
-        self._is_instrumented = True
         logger.info("Anthropic SDK instrumentation activated")
 
     def deactivate(self) -> None:
@@ -818,41 +330,42 @@ class AnthropicInstrumentor:
             return
 
         try:
-            from anthropic.resources import Messages, AsyncMessages
+            Messages, AsyncMessages = _load_messages_classes()
 
             if _original_sync_create is not None:
-                Messages.create = _original_sync_create
+                setattr(Messages, CREATE_METHOD_NAME, _original_sync_create)
                 _original_sync_create = None
 
             if _original_async_create is not None:
-                AsyncMessages.create = _original_async_create
+                setattr(AsyncMessages, CREATE_METHOD_NAME, _original_async_create)
                 _original_async_create = None
 
             if _original_sync_stream is not None:
-                Messages.stream = _original_sync_stream
+                setattr(Messages, STREAM_METHOD_NAME, _original_sync_stream)
                 _original_sync_stream = None
 
             if _original_async_stream is not None:
-                AsyncMessages.stream = _original_async_stream
+                setattr(AsyncMessages, STREAM_METHOD_NAME, _original_async_stream)
                 _original_async_stream = None
-
         except Exception:
-            pass
+            logger.debug("Failed to restore Anthropic message methods", exc_info=True)
 
-        # Managed Agents
         try:
-            from anthropic.resources.beta.sessions import Events, AsyncEvents
+            Events, AsyncEvents = _load_events_classes()
 
             if _original_sync_events_stream is not None:
-                Events.stream = _original_sync_events_stream
+                setattr(Events, STREAM_METHOD_NAME, _original_sync_events_stream)
                 _original_sync_events_stream = None
 
             if _original_async_events_stream is not None:
-                AsyncEvents.stream = _original_async_events_stream
+                setattr(
+                    AsyncEvents,
+                    STREAM_METHOD_NAME,
+                    _original_async_events_stream,
+                )
                 _original_async_events_stream = None
-
         except Exception:
-            pass
+            logger.debug("Failed to restore Anthropic managed-agent methods", exc_info=True)
 
         self._is_instrumented = False
         logger.info("Anthropic SDK instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_managed_agents.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_managed_agents.py
@@ -1,0 +1,269 @@
+"""Anthropic managed-agent stream instrumentation helpers."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from opentelemetry.semconv_ai import SpanAttributes
+
+from respan_instrumentation_anthropic._constants import (
+    AGENT_MCP_TOOL_USE_EVENT,
+    AGENT_MESSAGE_EVENT,
+    AGENT_TOOL_USE_EVENTS,
+    ARGUMENTS_KEY,
+    ANTHROPIC_MANAGED_AGENT_SPAN_NAME,
+    CLOSE_METHOD_NAME,
+    CONTENT_KEY,
+    FUNCTION_KEY,
+    FUNCTION_TOOL_TYPE,
+    ID_KEY,
+    INPUT_KEY,
+    INPUT_TOKENS_KEY,
+    MANAGED_AGENT_SESSION_ID_ATTR,
+    MANAGED_AGENT_STOP_REASON_ATTR,
+    MCP_SERVER_KEY,
+    MCP_SERVER_NAME_KEY,
+    MODEL_REQUEST_END_EVENT,
+    NAME_KEY,
+    MODEL_USAGE_KEY,
+    OUTPUT_TOKENS_KEY,
+    ROLE_KEY,
+    SESSION_ERROR_EVENT,
+    SESSION_STATUS_IDLE_EVENT,
+    SESSION_STATUS_RUNNING_EVENT,
+    STOP_REASON_KEY,
+    TOOL_CALLS_OVERRIDE,
+    TYPE_KEY,
+    USER_ROLE,
+    USER_MESSAGE_EVENT,
+    CACHE_CREATION_INPUT_TOKENS_KEY,
+    CACHE_READ_INPUT_TOKENS_KEY,
+)
+from respan_instrumentation_anthropic._messages import (
+    _build_base_chat_attrs,
+    _emit_span,
+    _normalize_content_block,
+    _safe_json,
+)
+from respan_sdk.constants.span_attributes import (
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
+    RESPAN_SPAN_TOOL_CALLS,
+)
+
+
+class _ManagedAgentTurnTracker:
+    """Accumulate streamed managed-agent events for one agent turn."""
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self._reset()
+
+    def process(self, event: Any) -> None:
+        event_type = getattr(event, TYPE_KEY, None)
+
+        if event_type == USER_MESSAGE_EVENT:
+            for block in getattr(event, CONTENT_KEY, []):
+                normalized_text = _normalize_content_block(block=block)
+                if normalized_text:
+                    self.input_messages.append(normalized_text)
+            return
+
+        if event_type == AGENT_MESSAGE_EVENT:
+            for block in getattr(event, CONTENT_KEY, []):
+                normalized_text = _normalize_content_block(block=block)
+                if normalized_text:
+                    self.output_messages.append(normalized_text)
+            return
+
+        if event_type in AGENT_TOOL_USE_EVENTS:
+            tool_call = {
+                ID_KEY: getattr(event, ID_KEY, ""),
+                TYPE_KEY: FUNCTION_TOOL_TYPE,
+                FUNCTION_KEY: {
+                    NAME_KEY: getattr(event, NAME_KEY, ""),
+                    ARGUMENTS_KEY: _safe_json(
+                        value=getattr(event, INPUT_KEY, {}),
+                    ),
+                },
+            }
+            if event_type == AGENT_MCP_TOOL_USE_EVENT:
+                tool_call[MCP_SERVER_KEY] = getattr(event, MCP_SERVER_NAME_KEY, "")
+            self.tool_calls.append(tool_call)
+            return
+
+        if event_type == MODEL_REQUEST_END_EVENT:
+            model_usage = getattr(event, MODEL_USAGE_KEY, None)
+            if model_usage:
+                self.total_input_tokens += getattr(model_usage, INPUT_TOKENS_KEY, 0)
+                self.total_output_tokens += getattr(model_usage, OUTPUT_TOKENS_KEY, 0)
+                self.total_cache_read += getattr(
+                    model_usage,
+                    CACHE_READ_INPUT_TOKENS_KEY,
+                    0,
+                )
+                self.total_cache_creation += getattr(
+                    model_usage,
+                    CACHE_CREATION_INPUT_TOKENS_KEY,
+                    0,
+                )
+            return
+
+        if event_type == SESSION_STATUS_IDLE_EVENT:
+            stop_reason = getattr(event, STOP_REASON_KEY, None)
+            self._emit(
+                stop_reason=getattr(stop_reason, TYPE_KEY, None)
+                if stop_reason
+                else None,
+            )
+            self._reset()
+            return
+
+        if event_type == SESSION_ERROR_EVENT:
+            self.error = str(event)
+            self._emit(stop_reason=None)
+            self._reset()
+            return
+
+        if event_type == SESSION_STATUS_RUNNING_EVENT and not self.input_messages:
+            self.start_ns = time.time_ns()
+
+    def _emit(self, stop_reason: str | None) -> None:
+        attrs = _build_base_chat_attrs(span_name=ANTHROPIC_MANAGED_AGENT_SPAN_NAME)
+        attrs[MANAGED_AGENT_SESSION_ID_ATTR] = self.session_id
+
+        if self.input_messages:
+            attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(
+                value=[
+                    {
+                        ROLE_KEY: USER_ROLE,
+                        CONTENT_KEY: "\n".join(self.input_messages),
+                    }
+                ]
+            )
+
+        if self.output_messages:
+            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = "\n".join(
+                self.output_messages
+            )
+
+        if self.total_input_tokens or self.total_output_tokens:
+            attrs[LLM_USAGE_PROMPT_TOKENS] = self.total_input_tokens
+            attrs[LLM_USAGE_COMPLETION_TOKENS] = self.total_output_tokens
+
+        if self.total_cache_read:
+            attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] = (
+                self.total_cache_read
+            )
+        if self.total_cache_creation:
+            attrs[SpanAttributes.LLM_USAGE_CACHE_CREATION_INPUT_TOKENS] = (
+                self.total_cache_creation
+            )
+
+        if self.tool_calls:
+            attrs[RESPAN_SPAN_TOOL_CALLS] = _safe_json(value=self.tool_calls)
+            attrs[TOOL_CALLS_OVERRIDE] = self.tool_calls
+
+        if stop_reason:
+            attrs[MANAGED_AGENT_STOP_REASON_ATTR] = stop_reason
+
+        _emit_span(
+            attrs=attrs,
+            start_ns=self.start_ns,
+            error_message=self.error,
+            name=ANTHROPIC_MANAGED_AGENT_SPAN_NAME,
+        )
+
+    def _reset(self) -> None:
+        self.start_ns = time.time_ns()
+        self.error: str | None = None
+        self.input_messages: list[str] = []
+        self.output_messages: list[str] = []
+        self.tool_calls: list[dict[str, Any]] = []
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
+        self.total_cache_read = 0
+        self.total_cache_creation = 0
+
+
+class _InstrumentedManagedStream:
+    """Proxy for a sync stream that intercepts managed-agent events."""
+
+    def __init__(self, stream: Any, session_id: str) -> None:
+        self._stream = stream
+        self._tracker = _ManagedAgentTurnTracker(session_id=session_id)
+
+    def __iter__(self) -> Any:
+        for event in self._stream:
+            self._tracker.process(event=event)
+            yield event
+
+    def __enter__(self) -> Any:
+        if hasattr(self._stream, "__enter__"):
+            self._stream.__enter__()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
+        if hasattr(self._stream, "__exit__"):
+            return self._stream.__exit__(exc_type, exc_val, exc_tb)
+        return None
+
+    def close(self) -> None:
+        if hasattr(self._stream, CLOSE_METHOD_NAME):
+            getattr(self._stream, CLOSE_METHOD_NAME)()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+class _InstrumentedAsyncManagedStream:
+    """Proxy for an async stream that intercepts managed-agent events."""
+
+    def __init__(self, stream: Any, session_id: str) -> None:
+        self._stream = stream
+        self._tracker = _ManagedAgentTurnTracker(session_id=session_id)
+
+    async def __aiter__(self) -> Any:
+        async for event in self._stream:
+            self._tracker.process(event=event)
+            yield event
+
+    async def __aenter__(self) -> Any:
+        if hasattr(self._stream, "__aenter__"):
+            await self._stream.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
+        if hasattr(self._stream, "__aexit__"):
+            return await self._stream.__aexit__(exc_type, exc_val, exc_tb)
+        return None
+
+    async def close(self) -> None:
+        if hasattr(self._stream, CLOSE_METHOD_NAME):
+            close_result = getattr(self._stream, CLOSE_METHOD_NAME)()
+            if hasattr(close_result, "__await__"):
+                await close_result
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+def _wrap_sync_events_stream(original: Any) -> Any:
+    """Wrap ``Events.stream()`` to intercept managed-agent events."""
+
+    def wrapper(self: Any, session_id: str, *args: Any, **kwargs: Any) -> Any:
+        stream = original(self, session_id, *args, **kwargs)
+        return _InstrumentedManagedStream(stream=stream, session_id=session_id)
+
+    return wrapper
+
+
+def _wrap_async_events_stream(original: Any) -> Any:
+    """Wrap ``AsyncEvents.stream()`` to intercept managed-agent events."""
+
+    async def wrapper(self: Any, session_id: str, *args: Any, **kwargs: Any) -> Any:
+        stream = await original(self, session_id, *args, **kwargs)
+        return _InstrumentedAsyncManagedStream(stream=stream, session_id=session_id)
+
+    return wrapper

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_messages.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_messages.py
@@ -1,0 +1,802 @@
+"""Anthropic message normalization and synthetic span helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from threading import Lock
+import time
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.trace.status import StatusCode
+from opentelemetry.semconv_ai import (
+    LLMRequestTypeValues,
+    SpanAttributes,
+    TraceloopSpanKindValues,
+)
+
+from respan_instrumentation_anthropic._constants import (
+    ANTHROPIC_CHAT_SPAN_NAME,
+    ANTHROPIC_SYSTEM_NAME,
+    ARGUMENTS_KEY,
+    ASSISTANT_ROLE,
+    CACHE_CREATION_INPUT_TOKENS_KEY,
+    CACHE_READ_INPUT_TOKENS_KEY,
+    CONTENT_KEY,
+    DESCRIPTION_KEY,
+    FUNCTION_KEY,
+    FUNCTION_TOOL_TYPE,
+    GEN_AI_COMPLETION_ROLE_ATTR,
+    GEN_AI_COMPLETION_TOOL_CALLS_ATTR,
+    GEN_AI_TOOL_CALL_ID_ATTR,
+    GEN_AI_TOOL_DEFINITIONS_ATTR,
+    ID_KEY,
+    INPUT_KEY,
+    INPUT_SCHEMA_KEY,
+    INPUT_TOKENS_KEY,
+    IS_ERROR_KEY,
+    MODEL_KEY,
+    NAME_KEY,
+    OUTPUT_TOKENS_KEY,
+    MESSAGES_KEY,
+    PARAMETERS_KEY,
+    PENDING_EXPIRES_AT_NS_KEY,
+    PENDING_PARENT_ID_KEY,
+    PENDING_START_NS_KEY,
+    PENDING_TOOL_CALL_KEY,
+    PENDING_TOOL_DEFINITION_KEY,
+    ROLE_KEY,
+    SERIALIZED_CONTENT_FIELD_NAMES,
+    SYSTEM_KEY,
+    SYSTEM_ROLE,
+    TEXT_BLOCK_TYPE,
+    TEXT_KEY,
+    TOOLS_KEY,
+    TOOL_CALL_ID_KEY,
+    TOOL_CALLS_OVERRIDE,
+    TOOL_RESULT_BLOCK_TYPE,
+    TOOLS_OVERRIDE,
+    TOOL_ROLE,
+    TOOL_USE_BLOCK_TYPE,
+    TOOL_USE_ID_KEY,
+    TYPE_KEY,
+    USAGE_KEY,
+)
+from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_TOOL
+from respan_sdk.constants.span_attributes import (
+    GEN_AI_SYSTEM,
+    GEN_AI_TOOL_CALL_ARGUMENTS,
+    GEN_AI_TOOL_CALL_RESULT,
+    GEN_AI_TOOL_NAME,
+    LLM_REQUEST_MODEL,
+    LLM_REQUEST_TYPE,
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
+    RESPAN_LOG_TYPE,
+    RESPAN_SPAN_TOOL_CALLS,
+    RESPAN_SPAN_TOOLS,
+)
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+    generate_unique_id,
+)
+from respan_sdk.utils.serialization import serialize_value
+from respan_tracing.utils.span_factory import build_readable_span, inject_span
+
+logger = logging.getLogger(__name__)
+
+_PENDING_TOOL_CALL_TTL_NS = 15 * 60 * 1_000_000_000
+_PENDING_TOOL_CALLS: dict[tuple[str, str], dict[str, Any]] = {}
+_PENDING_TOOL_CALLS_LOCK = Lock()
+
+
+def _safe_json(value: Any) -> str:
+    try:
+        return json.dumps(serialize_value(value=value), default=str)
+    except Exception:
+        return str(value)
+
+
+def _block_attr(block: Any, attr: str, default: Any = None) -> Any:
+    if isinstance(block, dict):
+        return block.get(attr, default)
+    return getattr(block, attr, default)
+
+
+def _block_type(block: Any) -> Any:
+    return _block_attr(block=block, attr=TYPE_KEY)
+
+
+def _iter_content_blocks(content: Any) -> list[Any]:
+    if content is None:
+        return []
+    if isinstance(content, list):
+        return content
+    return [content]
+
+
+def _maybe_parse_json_string(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+
+    stripped_value = value.strip()
+    if not stripped_value or stripped_value[0] not in ("{", "["):
+        return value
+
+    try:
+        return json.loads(stripped_value)
+    except Exception:
+        return value
+
+
+def _serialize_content_value(value: Any) -> Any:
+    """Serialize Anthropic content while preserving structured blocks."""
+    if isinstance(value, list):
+        serialized_parts = [
+            _serialize_content_block(block=block) for block in value
+        ]
+        non_empty_parts = [
+            part for part in serialized_parts if part not in ("", None, [], {})
+        ]
+        if not non_empty_parts:
+            return ""
+        if all(isinstance(part, str) for part in non_empty_parts):
+            return "\n".join(non_empty_parts)
+        return non_empty_parts
+
+    if isinstance(value, dict):
+        if _block_type(block=value):
+            return _serialize_content_block(block=value)
+        return {
+            str(key): _serialize_content_value(value=nested_value)
+            for key, nested_value in value.items()
+        }
+
+    if _block_type(block=value):
+        return _serialize_content_block(block=value)
+
+    return serialize_value(value=value)
+
+
+def _serialize_content_block(block: Any) -> Any:
+    """Serialize a single Anthropic content block."""
+    if isinstance(block, str):
+        return block
+
+    block_type = _block_type(block=block)
+    if block_type == TEXT_BLOCK_TYPE:
+        return _block_attr(block=block, attr=TEXT_KEY, default="")
+
+    if block_type:
+        serialized_block = {TYPE_KEY: block_type}
+        for field_name in SERIALIZED_CONTENT_FIELD_NAMES:
+            if field_name == TYPE_KEY:
+                continue
+
+            field_value = _block_attr(block=block, attr=field_name, default=None)
+            if field_value is not None:
+                serialized_block[field_name] = _serialize_content_value(value=field_value)
+        return serialized_block
+
+    text_value = _block_attr(block=block, attr=TEXT_KEY, default=None)
+    if text_value is not None:
+        return text_value
+
+    return serialize_value(value=block)
+
+
+def _normalize_content_block(block: Any) -> str:
+    """Normalize a content block into human-readable text for turn tracking."""
+    serialized_value = _serialize_content_block(block=block)
+    if serialized_value in ("", None, [], {}):
+        return ""
+    if isinstance(serialized_value, str):
+        return serialized_value
+    return _safe_json(value=serialized_value)
+
+
+def _extract_text_content(content: Any) -> str:
+    """Extract joined text blocks without JSON-encoding plain strings."""
+    serialized_content = _serialize_content_value(value=content)
+    if serialized_content in ("", None, [], {}):
+        return ""
+    if isinstance(serialized_content, str):
+        return serialized_content
+    if not isinstance(serialized_content, list):
+        return ""
+
+    text_parts: list[str] = []
+    for item in serialized_content:
+        if isinstance(item, str) and item:
+            text_parts.append(item)
+        elif isinstance(item, dict) and item.get(TYPE_KEY) == TEXT_BLOCK_TYPE:
+            text_value = item.get(TEXT_KEY)
+            if isinstance(text_value, str) and text_value:
+                text_parts.append(text_value)
+    return "\n".join(text_parts)
+
+
+def _normalize_tool_result_content(content: Any) -> Any:
+    """Preserve structured tool results instead of double-stringifying JSON."""
+    normalized_content = _serialize_content_value(value=content)
+    if isinstance(normalized_content, str):
+        return _maybe_parse_json_string(value=normalized_content)
+    return normalized_content
+
+
+def _format_tool_result_output(content: Any) -> str:
+    normalized_content = _normalize_tool_result_content(content=content)
+    if isinstance(normalized_content, str):
+        return normalized_content
+    return _safe_json(value=normalized_content)
+
+
+def _extract_tool_calls_from_content(content: Any) -> list[dict[str, Any]]:
+    """Extract tool_use blocks from arbitrary Anthropic content payloads."""
+    tool_calls: list[dict[str, Any]] = []
+    for block in _iter_content_blocks(content=content):
+        if _block_type(block=block) != TOOL_USE_BLOCK_TYPE:
+            continue
+
+        tool_name = _block_attr(block=block, attr=NAME_KEY, default="")
+        if not isinstance(tool_name, str) or not tool_name:
+            continue
+
+        tool_calls.append(
+            {
+                ID_KEY: _block_attr(block=block, attr=ID_KEY, default=""),
+                TYPE_KEY: FUNCTION_TOOL_TYPE,
+                FUNCTION_KEY: {
+                    NAME_KEY: tool_name,
+                    ARGUMENTS_KEY: _safe_json(
+                        value=_block_attr(block=block, attr=INPUT_KEY, default={})
+                    ),
+                },
+            }
+        )
+
+    return tool_calls
+
+
+def _extract_tool_results(messages: list[Any]) -> list[dict[str, Any]]:
+    """Extract tool_result blocks from request messages."""
+    tool_results: list[dict[str, Any]] = []
+    for msg in messages:
+        if isinstance(msg, dict):
+            content = msg.get(CONTENT_KEY, "")
+        else:
+            content = getattr(msg, CONTENT_KEY, "")
+
+        for block in _iter_content_blocks(content=content):
+            if _block_type(block=block) != TOOL_RESULT_BLOCK_TYPE:
+                continue
+
+            tool_call_id = _block_attr(block=block, attr=TOOL_USE_ID_KEY, default="")
+            if not isinstance(tool_call_id, str) or not tool_call_id:
+                continue
+
+            tool_results.append(
+                {
+                    TOOL_CALL_ID_KEY: tool_call_id,
+                    CONTENT_KEY: _block_attr(block=block, attr=CONTENT_KEY, default=""),
+                    IS_ERROR_KEY: bool(
+                        _block_attr(block=block, attr=IS_ERROR_KEY, default=False)
+                    ),
+                }
+            )
+
+    return tool_results
+
+
+def _extract_input_tool_calls(messages: list[Any]) -> dict[str, dict[str, Any]]:
+    """Map tool call IDs from assistant input messages to normalized tool_calls."""
+    tool_calls_by_id: dict[str, dict[str, Any]] = {}
+    for msg in messages:
+        if isinstance(msg, dict):
+            role = msg.get(ROLE_KEY, "")
+            content = msg.get(CONTENT_KEY, "")
+        else:
+            role = getattr(msg, ROLE_KEY, "")
+            content = getattr(msg, CONTENT_KEY, "")
+
+        if role != ASSISTANT_ROLE:
+            continue
+
+        for tool_call in _extract_tool_calls_from_content(content=content):
+            tool_call_id = tool_call.get(ID_KEY)
+            if isinstance(tool_call_id, str) and tool_call_id:
+                tool_calls_by_id[tool_call_id] = tool_call
+
+    return tool_calls_by_id
+
+
+def _format_input_messages(messages: list[Any], system: Any = None) -> str:
+    """Normalize Anthropic messages to chat-style JSON."""
+    normalized_messages: list[dict[str, Any]] = []
+
+    if system is not None:
+        if isinstance(system, str):
+            normalized_messages.append({ROLE_KEY: SYSTEM_ROLE, CONTENT_KEY: system})
+        else:
+            normalized_messages.append(
+                {
+                    ROLE_KEY: SYSTEM_ROLE,
+                    CONTENT_KEY: _serialize_content_value(value=system),
+                }
+            )
+
+    for message in messages:
+        if isinstance(message, dict):
+            role = message.get(ROLE_KEY, "")
+            content = message.get(CONTENT_KEY, "")
+        elif hasattr(message, ROLE_KEY) and hasattr(message, CONTENT_KEY):
+            role = getattr(message, ROLE_KEY)
+            content = getattr(message, CONTENT_KEY)
+        else:
+            role = ""
+            content = str(message)
+
+        tool_calls = _extract_tool_calls_from_content(content=content)
+        if role == ASSISTANT_ROLE and tool_calls:
+            normalized_messages.append(
+                {
+                    ROLE_KEY: ASSISTANT_ROLE,
+                    CONTENT_KEY: _extract_text_content(content=content),
+                    TOOL_CALLS_OVERRIDE: tool_calls,
+                }
+            )
+            continue
+
+        tool_messages: list[dict[str, Any]] = []
+        residual_blocks: list[Any] = []
+        for block in _iter_content_blocks(content=content):
+            if _block_type(block=block) != TOOL_RESULT_BLOCK_TYPE:
+                residual_blocks.append(block)
+                continue
+
+            tool_messages.append(
+                {
+                    ROLE_KEY: TOOL_ROLE,
+                    TOOL_CALL_ID_KEY: _block_attr(
+                        block=block, attr=TOOL_USE_ID_KEY, default=""
+                    ),
+                    CONTENT_KEY: _normalize_tool_result_content(
+                        content=_block_attr(block=block, attr=CONTENT_KEY, default="")
+                    ),
+                }
+            )
+
+        if tool_messages:
+            if residual_blocks:
+                residual_content = _serialize_content_value(value=residual_blocks)
+                if residual_content not in ("", None, [], {}):
+                    normalized_messages.append(
+                        {ROLE_KEY: role, CONTENT_KEY: residual_content}
+                    )
+            normalized_messages.extend(tool_messages)
+            continue
+
+        normalized_messages.append(
+            {ROLE_KEY: role, CONTENT_KEY: _serialize_content_value(value=content)}
+        )
+
+    return _safe_json(value=normalized_messages)
+
+
+def _format_output(message: Any) -> str:
+    """Extract assistant response text from an Anthropic Message."""
+    content = getattr(message, CONTENT_KEY, None)
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+
+    text_content = _extract_text_content(content=content)
+    if text_content:
+        return text_content
+
+    if _extract_tool_calls_from_content(content=content):
+        return ""
+
+    return _safe_json(value=_serialize_content_value(value=content))
+
+
+def _extract_tool_calls(message: Any) -> list[dict[str, Any]]:
+    return _extract_tool_calls_from_content(
+        content=getattr(message, CONTENT_KEY, None)
+    )
+
+
+def _format_tools(tools: Any) -> list[dict[str, Any]]:
+    """Normalize Anthropic tool definitions into chat-completions shape."""
+    if not tools:
+        return []
+
+    normalized_tools: list[dict[str, Any]] = []
+    for tool in tools:
+        if isinstance(tool, dict):
+            name = tool.get(NAME_KEY, "")
+            description = tool.get(DESCRIPTION_KEY, "")
+            parameters = tool.get(INPUT_SCHEMA_KEY, {})
+        elif hasattr(tool, NAME_KEY):
+            name = getattr(tool, NAME_KEY)
+            description = getattr(tool, DESCRIPTION_KEY, "")
+            parameters = getattr(tool, INPUT_SCHEMA_KEY, {})
+        else:
+            continue
+
+        tool_definition: dict[str, Any] = {
+            TYPE_KEY: FUNCTION_TOOL_TYPE,
+            FUNCTION_KEY: {NAME_KEY: name},
+        }
+        if description:
+            tool_definition[FUNCTION_KEY][DESCRIPTION_KEY] = description
+        if parameters:
+            tool_definition[FUNCTION_KEY][PARAMETERS_KEY] = parameters
+        normalized_tools.append(tool_definition)
+
+    return normalized_tools
+
+
+def _build_base_chat_attrs(span_name: str) -> dict[str, Any]:
+    return {
+        GEN_AI_SYSTEM: ANTHROPIC_SYSTEM_NAME,
+        LLM_REQUEST_TYPE: LLMRequestTypeValues.CHAT.value,
+        SpanAttributes.TRACELOOP_ENTITY_NAME: span_name,
+        SpanAttributes.TRACELOOP_ENTITY_PATH: span_name,
+        RESPAN_LOG_TYPE: LOG_TYPE_CHAT,
+        SpanAttributes.TRACELOOP_SPAN_KIND: LLMRequestTypeValues.CHAT.value,
+    }
+
+
+def _apply_tool_call_attrs(attrs: dict[str, Any], tool_calls: list[dict[str, Any]]) -> None:
+    if not tool_calls:
+        return
+    attrs[RESPAN_SPAN_TOOL_CALLS] = _safe_json(value=tool_calls)
+    attrs[TOOL_CALLS_OVERRIDE] = tool_calls
+    attrs[GEN_AI_COMPLETION_TOOL_CALLS_ATTR] = tool_calls
+    attrs[GEN_AI_COMPLETION_ROLE_ATTR] = ASSISTANT_ROLE
+
+
+def _apply_tool_definition_attrs(
+    attrs: dict[str, Any], tools: list[dict[str, Any]]
+) -> None:
+    if not tools:
+        return
+    attrs[RESPAN_SPAN_TOOLS] = _safe_json(value=tools)
+    attrs[TOOLS_OVERRIDE] = tools
+    attrs[GEN_AI_TOOL_DEFINITIONS_ATTR] = _safe_json(value=tools)
+
+
+def _build_span_attrs(kwargs: dict[str, Any], message: Any) -> dict[str, Any]:
+    """Build span attributes from request kwargs and response Message."""
+    attrs = _build_base_chat_attrs(span_name=ANTHROPIC_CHAT_SPAN_NAME)
+
+    model = getattr(message, MODEL_KEY, None) or kwargs.get(MODEL_KEY)
+    if model:
+        attrs[LLM_REQUEST_MODEL] = model
+
+    messages = kwargs.get(MESSAGES_KEY, [])
+    system = kwargs.get(SYSTEM_KEY)
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _format_input_messages(
+        messages=messages,
+        system=system,
+    )
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _format_output(message=message)
+
+    usage = getattr(message, USAGE_KEY, None)
+    if usage is not None:
+        attrs[LLM_USAGE_PROMPT_TOKENS] = getattr(usage, INPUT_TOKENS_KEY, 0)
+        attrs[LLM_USAGE_COMPLETION_TOKENS] = getattr(usage, OUTPUT_TOKENS_KEY, 0)
+        cache_read_input_tokens = getattr(usage, CACHE_READ_INPUT_TOKENS_KEY, 0)
+        cache_creation_input_tokens = getattr(
+            usage, CACHE_CREATION_INPUT_TOKENS_KEY, 0
+        )
+        if cache_read_input_tokens:
+            attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] = (
+                cache_read_input_tokens
+            )
+        if cache_creation_input_tokens:
+            attrs[SpanAttributes.LLM_USAGE_CACHE_CREATION_INPUT_TOKENS] = (
+                cache_creation_input_tokens
+            )
+
+    _apply_tool_call_attrs(attrs=attrs, tool_calls=_extract_tool_calls(message=message))
+    _apply_tool_definition_attrs(
+        attrs=attrs,
+        tools=_format_tools(tools=kwargs.get(TOOLS_KEY)),
+    )
+    return attrs
+
+
+def _build_error_attrs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Build minimal span attributes for a failed Anthropic request."""
+    attrs = _build_base_chat_attrs(span_name=ANTHROPIC_CHAT_SPAN_NAME)
+    model = kwargs.get(MODEL_KEY)
+    if model:
+        attrs[LLM_REQUEST_MODEL] = model
+
+    messages = kwargs.get(MESSAGES_KEY, [])
+    system = kwargs.get(SYSTEM_KEY)
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _format_input_messages(
+        messages=messages,
+        system=system,
+    )
+    _apply_tool_definition_attrs(
+        attrs=attrs,
+        tools=_format_tools(tools=kwargs.get(TOOLS_KEY)),
+    )
+    return attrs
+
+
+def _current_trace_parent_ids() -> tuple[str | None, str | None]:
+    """Return active OTEL trace/span IDs for parenting injected spans."""
+    try:
+        current_span = trace.get_current_span()
+        span_context = current_span.get_span_context()
+    except Exception:
+        return None, None
+
+    trace_id = getattr(span_context, "trace_id", 0) or 0
+    span_id = getattr(span_context, "span_id", 0) or 0
+    if trace_id == 0 or span_id == 0:
+        return None, None
+
+    return format_trace_id(trace_id=trace_id), format_span_id(span_id=span_id)
+
+
+def _generate_trace_id() -> str:
+    return generate_unique_id()
+
+
+def _generate_span_id() -> str:
+    return generate_unique_id()[:16]
+
+
+def _resolve_injected_trace_parent_ids() -> tuple[str, str | None]:
+    trace_id, parent_id = _current_trace_parent_ids()
+    if trace_id is None:
+        trace_id = _generate_trace_id()
+    return trace_id, parent_id
+
+def _prune_expired_pending_tool_calls(*, now_ns: int | None = None) -> None:
+    expiration_cutoff_ns = now_ns if now_ns is not None else time.time_ns()
+    with _PENDING_TOOL_CALLS_LOCK:
+        expired_keys = [
+            key
+            for key, entry in _PENDING_TOOL_CALLS.items()
+            if entry.get(PENDING_EXPIRES_AT_NS_KEY, 0) <= expiration_cutoff_ns
+        ]
+        for key in expired_keys:
+            _PENDING_TOOL_CALLS.pop(key, None)
+
+
+def _emit_span(
+    attrs: dict[str, Any],
+    start_ns: int,
+    error_message: str | None = None,
+    *,
+    name: str = ANTHROPIC_CHAT_SPAN_NAME,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
+    span_id: str | None = None,
+    end_ns: int | None = None,
+    status_code: int = 200,
+) -> None:
+    """Build a ReadableSpan and inject it into the OTEL pipeline."""
+    try:
+        if error_message:
+            attrs = dict(attrs)
+            attrs.setdefault("error.message", error_message)
+            attrs.setdefault("status_code", status_code if status_code >= 400 else 500)
+
+        resolved_trace_id = trace_id
+        resolved_parent_id = parent_id
+        if resolved_trace_id is None and resolved_parent_id is None:
+            resolved_trace_id, resolved_parent_id = _current_trace_parent_ids()
+
+        span = build_readable_span(
+            name=name,
+            trace_id=resolved_trace_id,
+            span_id=span_id,
+            parent_id=resolved_parent_id,
+            start_time_ns=start_ns,
+            end_time_ns=end_ns if end_ns is not None else time.time_ns(),
+            attributes=attrs,
+            error_message=error_message,
+            status_code=status_code,
+        )
+        inject_span(span=span)
+    except Exception:
+        logger.debug("Failed to emit Anthropic span", exc_info=True)
+
+
+def _find_tool_definition(
+    tools: list[dict[str, Any]], tool_name: str
+) -> dict[str, Any]:
+    for tool in tools:
+        function = tool.get(FUNCTION_KEY)
+        if not isinstance(function, dict):
+            continue
+        if function.get(NAME_KEY) == tool_name:
+            return tool
+    return {TYPE_KEY: FUNCTION_TOOL_TYPE, FUNCTION_KEY: {NAME_KEY: tool_name}}
+
+
+def _register_pending_tool_calls(
+    *,
+    trace_id: str,
+    parent_id: str,
+    tool_calls: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+) -> None:
+    """Store tool calls until a matching tool_result arrives later."""
+    registered_at_ns = time.time_ns()
+    expires_at_ns = registered_at_ns + _PENDING_TOOL_CALL_TTL_NS
+    _prune_expired_pending_tool_calls(now_ns=registered_at_ns)
+    with _PENDING_TOOL_CALLS_LOCK:
+        for tool_call in tool_calls:
+            function = tool_call.get(FUNCTION_KEY)
+            if not isinstance(function, dict):
+                continue
+
+            tool_name = function.get(NAME_KEY)
+            tool_call_id = tool_call.get(ID_KEY)
+            if (
+                not isinstance(tool_name, str)
+                or not tool_name
+                or not isinstance(tool_call_id, str)
+                or not tool_call_id
+            ):
+                continue
+
+            _PENDING_TOOL_CALLS[(trace_id, tool_call_id)] = {
+                PENDING_TOOL_CALL_KEY: tool_call,
+                PENDING_TOOL_DEFINITION_KEY: _find_tool_definition(
+                    tools=tools, tool_name=tool_name
+                ),
+                PENDING_PARENT_ID_KEY: parent_id,
+                PENDING_START_NS_KEY: registered_at_ns,
+                PENDING_EXPIRES_AT_NS_KEY: expires_at_ns,
+            }
+
+
+def _emit_tool_span(
+    *,
+    trace_id: str,
+    parent_id: str,
+    start_ns: int,
+    end_ns: int,
+    tool_call: dict[str, Any],
+    tool_definition: dict[str, Any],
+    tool_output: str,
+    is_error: bool = False,
+) -> None:
+    function = tool_call.get(FUNCTION_KEY)
+    if not isinstance(function, dict):
+        return
+
+    tool_name = function.get(NAME_KEY)
+    if not isinstance(tool_name, str) or not tool_name:
+        return
+
+    tool_input = function.get(ARGUMENTS_KEY, "")
+    attrs = {
+        GEN_AI_TOOL_NAME: tool_name,
+        GEN_AI_TOOL_CALL_ARGUMENTS: tool_input,
+        GEN_AI_TOOL_CALL_RESULT: tool_output,
+        GEN_AI_TOOL_CALL_ID_ATTR: tool_call.get(ID_KEY, ""),
+        SpanAttributes.TRACELOOP_ENTITY_NAME: tool_name,
+        SpanAttributes.TRACELOOP_ENTITY_PATH: tool_name,
+        SpanAttributes.TRACELOOP_ENTITY_INPUT: tool_input,
+        SpanAttributes.TRACELOOP_ENTITY_OUTPUT: tool_output,
+        RESPAN_LOG_TYPE: LOG_TYPE_TOOL,
+        TOOLS_OVERRIDE: [tool_definition],
+        SpanAttributes.TRACELOOP_SPAN_KIND: TraceloopSpanKindValues.TOOL.value,
+    }
+
+    _emit_span(
+        attrs=attrs,
+        start_ns=start_ns,
+        name=tool_name,
+        trace_id=trace_id,
+        parent_id=parent_id,
+        span_id=_generate_span_id(),
+        end_ns=end_ns,
+        error_message=tool_output if is_error else None,
+        status_code=500 if is_error else 200,
+    )
+
+
+def _emit_resolved_tool_spans(
+    *,
+    kwargs: dict[str, Any],
+    trace_id: str,
+    fallback_parent_id: str,
+    end_ns: int,
+    tools: list[dict[str, Any]],
+) -> None:
+    """Emit tool spans once a later request provides matching tool_result blocks."""
+    messages = kwargs.get(MESSAGES_KEY, [])
+    _prune_expired_pending_tool_calls(now_ns=end_ns)
+    tool_results = _extract_tool_results(messages=messages)
+    if not tool_results:
+        return
+
+    input_tool_calls = _extract_input_tool_calls(messages=messages)
+    for tool_result in tool_results:
+        tool_call_id = tool_result[TOOL_CALL_ID_KEY]
+        with _PENDING_TOOL_CALLS_LOCK:
+            pending_tool_call = _PENDING_TOOL_CALLS.pop((trace_id, tool_call_id), None)
+
+        if pending_tool_call is not None:
+            tool_call = pending_tool_call[PENDING_TOOL_CALL_KEY]
+            tool_definition = pending_tool_call[PENDING_TOOL_DEFINITION_KEY]
+            parent_id = pending_tool_call[PENDING_PARENT_ID_KEY]
+            start_ns = pending_tool_call[PENDING_START_NS_KEY]
+        else:
+            tool_call = input_tool_calls.get(tool_call_id)
+            if tool_call is None:
+                continue
+
+            function = tool_call.get(FUNCTION_KEY)
+            if not isinstance(function, dict):
+                continue
+
+            tool_name = function.get(NAME_KEY)
+            if not isinstance(tool_name, str) or not tool_name:
+                continue
+
+            tool_definition = _find_tool_definition(tools=tools, tool_name=tool_name)
+            parent_id = fallback_parent_id
+            start_ns = end_ns
+
+        _emit_tool_span(
+            trace_id=trace_id,
+            parent_id=parent_id,
+            start_ns=start_ns,
+            end_ns=end_ns,
+            tool_call=tool_call,
+            tool_definition=tool_definition,
+            tool_output=_format_tool_result_output(
+                content=tool_result[CONTENT_KEY]
+            ),
+            is_error=tool_result[IS_ERROR_KEY],
+        )
+
+
+def _emit_message_spans(kwargs: dict[str, Any], message: Any, start_ns: int) -> None:
+    """Emit chat spans and resolve tool spans once tool_result content is available."""
+    attrs = _build_span_attrs(kwargs=kwargs, message=message)
+    trace_id, parent_id = _resolve_injected_trace_parent_ids()
+    chat_span_id = _generate_span_id()
+
+    _emit_span(
+        attrs=attrs,
+        start_ns=start_ns,
+        name=ANTHROPIC_CHAT_SPAN_NAME,
+        trace_id=trace_id,
+        parent_id=parent_id,
+        span_id=chat_span_id,
+    )
+
+    tools = attrs.get(TOOLS_OVERRIDE)
+    normalized_tools = tools if isinstance(tools, list) else []
+    _emit_resolved_tool_spans(
+        kwargs=kwargs,
+        trace_id=trace_id,
+        fallback_parent_id=chat_span_id,
+        end_ns=start_ns,
+        tools=normalized_tools,
+    )
+
+    tool_calls = attrs.get(TOOL_CALLS_OVERRIDE)
+    if isinstance(tool_calls, list) and tool_calls:
+        _register_pending_tool_calls(
+            trace_id=trace_id,
+            parent_id=chat_span_id,
+            tool_calls=tool_calls,
+            tools=normalized_tools,
+        )

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/tests/test_instrumentation.py
@@ -4,26 +4,40 @@ from types import SimpleNamespace
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
 
 from respan_instrumentation_anthropic import _instrumentation as instrumentation
+from respan_instrumentation_anthropic import _managed_agents as managed_agent_helpers
+from respan_instrumentation_anthropic import _messages as message_helpers
+from respan_sdk.constants.span_attributes import (
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
+    RESPAN_SESSION_ID,
+)
 
 
 TRACE_ID = "0123456789abcdef0123456789abcdef"
 SPAN_ID = "fedcba9876543210"
+TOOL_CALL_ID = "toolu_123"
+WEATHER_TOOL_NAME = "get_weather"
+WEATHER_TOOL_INPUT = {"city": "Tokyo"}
+WEATHER_TOOL_ARGUMENTS = '{"city": "Tokyo"}'
+WEATHER_TOOL_RESULT = {"city": "Tokyo", "temperature": "22C"}
 
 
 def _capture_build(monkeypatch):
-    captured = {}
+    captured = []
 
     def _fake_build_readable_span(name, **kwargs):
-        captured["name"] = name
-        captured.update(kwargs)
-        return {"name": name, **kwargs}
+        span = {"name": name, **kwargs}
+        captured.append(span)
+        return span
 
     monkeypatch.setattr(
-        "respan_tracing.utils.span_factory.build_readable_span",
+        message_helpers,
+        "build_readable_span",
         _fake_build_readable_span,
     )
     monkeypatch.setattr(
-        "respan_tracing.utils.span_factory.inject_span",
+        message_helpers,
+        "inject_span",
         lambda span: True,
     )
     return captured
@@ -39,12 +53,12 @@ def test_emit_span_uses_active_parent_context(monkeypatch):
                 span_id=int(SPAN_ID, 16),
             )
 
-    monkeypatch.setattr(instrumentation.trace, "get_current_span", lambda: _FakeSpan())
+    monkeypatch.setattr(message_helpers.trace, "get_current_span", lambda: _FakeSpan())
 
-    instrumentation._emit_span({"respan.entity.log_type": "chat"}, start_ns=123)
+    message_helpers._emit_span({"respan.entity.log_type": "chat"}, start_ns=123)
 
-    assert captured["trace_id"] == TRACE_ID
-    assert captured["parent_id"] == SPAN_ID
+    assert captured[0]["trace_id"] == TRACE_ID
+    assert captured[0]["parent_id"] == SPAN_ID
 
 
 def test_emit_span_without_active_parent_creates_root(monkeypatch):
@@ -54,14 +68,12 @@ def test_emit_span_without_active_parent_creates_root(monkeypatch):
         def get_span_context(self):
             return SimpleNamespace(trace_id=0, span_id=0)
 
-    monkeypatch.setattr(
-        instrumentation.trace, "get_current_span", lambda: _InvalidSpan()
-    )
+    monkeypatch.setattr(message_helpers.trace, "get_current_span", lambda: _InvalidSpan())
 
-    instrumentation._emit_span({"respan.entity.log_type": "chat"}, start_ns=123)
+    message_helpers._emit_span({"respan.entity.log_type": "chat"}, start_ns=123)
 
-    assert captured["trace_id"] is None
-    assert captured["parent_id"] is None
+    assert captured[0]["trace_id"] is None
+    assert captured[0]["parent_id"] is None
 
 
 def test_build_span_attrs_sets_chat_span_kind():
@@ -76,7 +88,7 @@ def test_build_span_attrs_sets_chat_span_kind():
         ),
     )
 
-    attrs = instrumentation._build_span_attrs(
+    attrs = message_helpers._build_span_attrs(
         kwargs={"messages": [{"role": "user", "content": "hi"}]},
         message=message,
     )
@@ -88,7 +100,7 @@ def test_build_span_attrs_sets_chat_span_kind():
 
 
 def test_build_error_attrs_sets_chat_span_kind():
-    attrs = instrumentation._build_error_attrs(
+    attrs = message_helpers._build_error_attrs(
         kwargs={"messages": [{"role": "user", "content": "hi"}]}
     )
 
@@ -97,7 +109,7 @@ def test_build_error_attrs_sets_chat_span_kind():
 
 
 def test_format_input_messages_preserves_tool_blocks():
-    formatted = instrumentation._format_input_messages(
+    formatted = message_helpers._format_input_messages(
         [
             {"role": "user", "content": "What's the weather in Tokyo?"},
             {
@@ -106,9 +118,9 @@ def test_format_input_messages_preserves_tool_blocks():
                     {"type": "text", "text": "I'll look that up."},
                     {
                         "type": "tool_use",
-                        "id": "toolu_123",
-                        "name": "get_weather",
-                        "input": {"city": "Tokyo"},
+                        "id": TOOL_CALL_ID,
+                        "name": WEATHER_TOOL_NAME,
+                        "input": WEATHER_TOOL_INPUT,
                     },
                 ],
             },
@@ -117,8 +129,11 @@ def test_format_input_messages_preserves_tool_blocks():
                 "content": [
                     {
                         "type": "tool_result",
-                        "tool_use_id": "toolu_123",
-                        "content": '{"city":"Tokyo","temperature":"22C"}',
+                        "tool_use_id": TOOL_CALL_ID,
+                        "content": json.dumps(
+                            WEATHER_TOOL_RESULT,
+                            separators=(",", ":"),
+                        ),
                     }
                 ],
             },
@@ -126,20 +141,25 @@ def test_format_input_messages_preserves_tool_blocks():
     )
 
     payload = json.loads(formatted)
-    assert payload[1]["content"][0] == "I'll look that up."
-    assert payload[1]["content"][1] == {
-        "type": "tool_use",
-        "id": "toolu_123",
-        "name": "get_weather",
-        "input": {"city": "Tokyo"},
+    assert payload[1] == {
+        "role": "assistant",
+        "content": "I'll look that up.",
+        "tool_calls": [
+            {
+                "id": TOOL_CALL_ID,
+                "type": "function",
+                "function": {
+                    "name": WEATHER_TOOL_NAME,
+                    "arguments": WEATHER_TOOL_ARGUMENTS,
+                },
+            }
+        ],
     }
-    assert payload[2]["content"] == [
-        {
-            "type": "tool_result",
-            "tool_use_id": "toolu_123",
-            "content": '{"city":"Tokyo","temperature":"22C"}',
-        }
-    ]
+    assert payload[2] == {
+        "role": "tool",
+        "tool_call_id": TOOL_CALL_ID,
+        "content": WEATHER_TOOL_RESULT,
+    }
 
 
 def test_format_output_preserves_tool_use_blocks():
@@ -148,18 +168,400 @@ def test_format_output_preserves_tool_use_blocks():
             SimpleNamespace(type="text", text="I'll get the weather."),
             SimpleNamespace(
                 type="tool_use",
-                id="toolu_123",
-                name="get_weather",
-                input={"city": "Tokyo"},
+                id=TOOL_CALL_ID,
+                name=WEATHER_TOOL_NAME,
+                input=WEATHER_TOOL_INPUT,
             ),
         ]
     )
 
-    payload = json.loads(instrumentation._format_output(message))
-    assert payload[0] == "I'll get the weather."
-    assert payload[1] == {
-        "type": "tool_use",
-        "id": "toolu_123",
-        "name": "get_weather",
-        "input": {"city": "Tokyo"},
-    }
+    assert message_helpers._format_output(message) == "I'll get the weather."
+
+
+def test_format_output_returns_empty_for_tool_only_response():
+    message = SimpleNamespace(
+        content=[
+            SimpleNamespace(
+                type="tool_use",
+                id=TOOL_CALL_ID,
+                name=WEATHER_TOOL_NAME,
+                input=WEATHER_TOOL_INPUT,
+            )
+        ]
+    )
+
+    assert message_helpers._format_output(message) == ""
+
+
+def test_build_span_attrs_sets_tool_metadata_overrides():
+    message = SimpleNamespace(
+        model="claude-sonnet-4-20250514",
+        content=[
+            SimpleNamespace(
+                type="tool_use",
+                id=TOOL_CALL_ID,
+                name=WEATHER_TOOL_NAME,
+                input=WEATHER_TOOL_INPUT,
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=12, output_tokens=5),
+    )
+
+    attrs = message_helpers._build_span_attrs(
+        kwargs={
+            "messages": [{"role": "user", "content": "Use the weather tool."}],
+            "tools": [
+                {
+                    "name": WEATHER_TOOL_NAME,
+                    "description": "Get the current weather.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                }
+            ],
+        },
+        message=message,
+    )
+
+    assert attrs["tool_calls"] == [
+        {
+            "id": TOOL_CALL_ID,
+            "type": "function",
+            "function": {
+                "name": WEATHER_TOOL_NAME,
+                "arguments": WEATHER_TOOL_ARGUMENTS,
+            },
+        }
+    ]
+    assert attrs["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": WEATHER_TOOL_NAME,
+                "description": "Get the current weather.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    assert attrs["gen_ai.completion.0.tool_calls"] == attrs["tool_calls"]
+    assert json.loads(attrs["respan.span.tool_calls"]) == attrs["tool_calls"]
+    assert json.loads(attrs["respan.span.tools"]) == attrs["tools"]
+
+
+def test_emit_message_spans_emits_resolved_child_tool_span(monkeypatch):
+    captured = _capture_build(monkeypatch)
+    with message_helpers._PENDING_TOOL_CALLS_LOCK:
+        message_helpers._PENDING_TOOL_CALLS.clear()
+
+    class _FakeSpan:
+        def get_span_context(self):
+            return SimpleNamespace(
+                trace_id=int(TRACE_ID, 16),
+                span_id=int(SPAN_ID, 16),
+            )
+
+    monkeypatch.setattr(message_helpers.trace, "get_current_span", lambda: _FakeSpan())
+    timestamps = iter([150, 200, 500])
+    monkeypatch.setattr(message_helpers.time, "time_ns", lambda: next(timestamps))
+
+    message_helpers._emit_message_spans(
+        kwargs={
+            "messages": [{"role": "user", "content": "Use the weather tool."}],
+            "tools": [{"name": WEATHER_TOOL_NAME, "input_schema": {"type": "object"}}],
+        },
+        message=SimpleNamespace(
+            model="claude-sonnet-4-20250514",
+            content=[
+                SimpleNamespace(
+                    type="tool_use",
+                    id=TOOL_CALL_ID,
+                    name=WEATHER_TOOL_NAME,
+                    input=WEATHER_TOOL_INPUT,
+                )
+            ],
+        ),
+        start_ns=123,
+    )
+
+    message_helpers._emit_message_spans(
+        kwargs={
+            "messages": [
+                {"role": "user", "content": "Use the weather tool."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": TOOL_CALL_ID,
+                            "name": WEATHER_TOOL_NAME,
+                            "input": WEATHER_TOOL_INPUT,
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": TOOL_CALL_ID,
+                            "content": json.dumps(
+                                WEATHER_TOOL_RESULT,
+                                separators=(",", ":"),
+                            ),
+                        }
+                    ],
+                },
+            ],
+            "tools": [{"name": WEATHER_TOOL_NAME, "input_schema": {"type": "object"}}],
+        },
+        message=SimpleNamespace(
+            model="claude-sonnet-4-20250514",
+            content=[SimpleNamespace(type="text", text="It is sunny in Tokyo.")],
+        ),
+        start_ns=456,
+    )
+
+    assert [span["name"] for span in captured] == [
+        "anthropic.chat",
+        "anthropic.chat",
+        "get_weather",
+    ]
+
+    first_chat_span, second_chat_span, tool_span = captured
+    assert first_chat_span["trace_id"] == TRACE_ID
+    assert first_chat_span["parent_id"] == SPAN_ID
+    assert second_chat_span["trace_id"] == TRACE_ID
+    assert second_chat_span["parent_id"] == SPAN_ID
+    assert tool_span["trace_id"] == TRACE_ID
+    assert tool_span["parent_id"] == first_chat_span["span_id"]
+    assert tool_span["attributes"]["respan.entity.log_type"] == "tool"
+    assert tool_span["attributes"]["gen_ai.tool.name"] == WEATHER_TOOL_NAME
+    assert tool_span["attributes"]["traceloop.entity.input"] == WEATHER_TOOL_ARGUMENTS
+    assert (
+        tool_span["attributes"]["traceloop.entity.output"]
+        == json.dumps(WEATHER_TOOL_RESULT)
+    )
+    assert "gen_ai.system" not in tool_span["attributes"]
+    assert tool_span["attributes"]["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": WEATHER_TOOL_NAME,
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+    assert tool_span["end_time_ns"] == 456
+
+
+def test_managed_agent_tracker_emits_stop_reason_and_tool_calls(monkeypatch):
+    captured = []
+
+    monkeypatch.setattr(
+        managed_agent_helpers,
+        "_emit_span",
+        lambda **kwargs: captured.append(kwargs),
+    )
+
+    tracker = managed_agent_helpers._ManagedAgentTurnTracker(session_id="sess_123")
+    tracker.process(
+        SimpleNamespace(
+            type="user.message",
+            content=[{"type": "text", "text": "Find the weather in Tokyo."}],
+        )
+    )
+    tracker.process(
+        SimpleNamespace(
+            type="agent.tool_use",
+            id=TOOL_CALL_ID,
+            name=WEATHER_TOOL_NAME,
+            input=WEATHER_TOOL_INPUT,
+        )
+    )
+    tracker.process(
+        SimpleNamespace(
+            type="agent.message",
+            content=[{"type": "text", "text": "Done."}],
+        )
+    )
+    tracker.process(
+        SimpleNamespace(
+            type="span.model_request_end",
+            model_usage=SimpleNamespace(input_tokens=3, output_tokens=4),
+        )
+    )
+    tracker.process(
+        SimpleNamespace(
+            type="session.status_idle",
+            stop_reason=SimpleNamespace(type="end_turn"),
+        )
+    )
+
+    emitted_span = captured[0]
+    attrs = emitted_span["attrs"]
+    assert attrs[RESPAN_SESSION_ID] == "sess_123"
+    assert attrs["respan.managed_agent.stop_reason"] == "end_turn"
+    assert json.loads(attrs["traceloop.entity.input"]) == [
+        {"role": "user", "content": "Find the weather in Tokyo."}
+    ]
+    assert attrs["traceloop.entity.output"] == "Done."
+    assert attrs[LLM_USAGE_PROMPT_TOKENS] == 3
+    assert attrs[LLM_USAGE_COMPLETION_TOKENS] == 4
+    assert json.loads(attrs["respan.span.tool_calls"]) == [
+        {
+            "id": TOOL_CALL_ID,
+            "type": "function",
+            "function": {
+                "name": WEATHER_TOOL_NAME,
+                "arguments": WEATHER_TOOL_ARGUMENTS,
+            },
+        }
+    ]
+
+
+def test_emit_message_spans_marks_failed_tool_span(monkeypatch):
+    captured = _capture_build(monkeypatch)
+    with message_helpers._PENDING_TOOL_CALLS_LOCK:
+        message_helpers._PENDING_TOOL_CALLS.clear()
+
+    class _FakeSpan:
+        def get_span_context(self):
+            return SimpleNamespace(
+                trace_id=int(TRACE_ID, 16),
+                span_id=int(SPAN_ID, 16),
+            )
+
+    monkeypatch.setattr(message_helpers.trace, "get_current_span", lambda: _FakeSpan())
+    timestamps = iter([150, 200, 500])
+    monkeypatch.setattr(message_helpers.time, "time_ns", lambda: next(timestamps))
+
+    message_helpers._emit_message_spans(
+        kwargs={
+            "messages": [{"role": "user", "content": "Look up the customer."}],
+            "tools": [{"name": "lookup_customer", "input_schema": {"type": "object"}}],
+        },
+        message=SimpleNamespace(
+            model="claude-sonnet-4-20250514",
+            content=[
+                SimpleNamespace(
+                    type="tool_use",
+                    id=TOOL_CALL_ID,
+                    name="lookup_customer",
+                    input={"customer_id": "cust_404"},
+                )
+            ],
+        ),
+        start_ns=123,
+    )
+
+    message_helpers._emit_message_spans(
+        kwargs={
+            "messages": [
+                {"role": "user", "content": "Look up the customer."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": TOOL_CALL_ID,
+                            "name": "lookup_customer",
+                            "input": {"customer_id": "cust_404"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": TOOL_CALL_ID,
+                            "content": "Customer not found.",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            ],
+            "tools": [{"name": "lookup_customer", "input_schema": {"type": "object"}}],
+        },
+        message=SimpleNamespace(
+            model="claude-sonnet-4-20250514",
+            content=[SimpleNamespace(type="text", text="Customer lookup failed.")],
+        ),
+        start_ns=456,
+    )
+
+    tool_span = captured[-1]
+    assert tool_span["status_code"] == 500
+    assert tool_span["error_message"] == "Customer not found."
+    assert tool_span["attributes"]["error.message"] == "Customer not found."
+    assert tool_span["attributes"]["status_code"] == 500
+
+
+
+def test_register_pending_tool_calls_prunes_expired_entries(monkeypatch):
+    with message_helpers._PENDING_TOOL_CALLS_LOCK:
+        message_helpers._PENDING_TOOL_CALLS.clear()
+        message_helpers._PENDING_TOOL_CALLS[(TRACE_ID, "expired_tool")] = {
+            "tool_call": {"id": "expired_tool"},
+            "tool_definition": {"type": "function", "function": {"name": "expired"}},
+            "parent_id": SPAN_ID,
+            "start_ns": 1,
+            "expires_at_ns": 1,
+        }
+
+    monkeypatch.setattr(message_helpers.time, "time_ns", lambda: 5)
+    message_helpers._register_pending_tool_calls(
+        trace_id=TRACE_ID,
+        parent_id=SPAN_ID,
+        tool_calls=[
+            {
+                "id": TOOL_CALL_ID,
+                "type": "function",
+                "function": {
+                    "name": WEATHER_TOOL_NAME,
+                    "arguments": WEATHER_TOOL_ARGUMENTS,
+                },
+            }
+        ],
+        tools=[{"type": "function", "function": {"name": WEATHER_TOOL_NAME}}],
+    )
+
+    with message_helpers._PENDING_TOOL_CALLS_LOCK:
+        assert (TRACE_ID, "expired_tool") not in message_helpers._PENDING_TOOL_CALLS
+        pending_entry = message_helpers._PENDING_TOOL_CALLS[(TRACE_ID, TOOL_CALL_ID)]
+    assert pending_entry["expires_at_ns"] == 5 + message_helpers._PENDING_TOOL_CALL_TTL_NS
+
+
+
+def test_activate_rolls_back_partial_patch(monkeypatch):
+    original_sync_create = object()
+    original_async_create = object()
+
+    class _Messages:
+        create = original_sync_create
+
+    class _AsyncMessages:
+        create = original_async_create
+
+    instrumentor = instrumentation.AnthropicInstrumentor()
+
+    monkeypatch.setattr(
+        instrumentation,
+        "_load_messages_classes",
+        lambda: (_Messages, _AsyncMessages),
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "_wrap_async_create",
+        lambda original: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    instrumentor.activate()
+
+    assert _Messages.create is original_sync_create
+    assert _AsyncMessages.create is original_async_create
+    assert instrumentor._is_instrumented is False


### PR DESCRIPTION
## Summary

- fix the following problems
-tool span lost
-chat span not capture any tools
-for tool span returning error, the instrumentation pass status 200 (success code)
-input role wrong
-input serializing wrong which will show LF in the content
-remove redundant wheels, split the instrumentation into parts scripts

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core span-shaping and emission logic (including cross-request pending tool-call correlation), which can impact trace correctness and volume if edge cases regress, but remains confined to the Anthropic instrumentation package.
> 
> **Overview**
> Fixes Anthropic instrumentation so **tool calls/results are represented correctly in chat spans and emit dedicated child tool spans**, including propagating tool errors with proper failure status.
> 
> This refactors the monolithic implementation into `_constants.py`, `_messages.py` (message/tool normalization, pending tool-call correlation across requests, span emission), and `_managed_agents.py` (beta session event stream turn spans with stop reason/session id). Instrumentation activation/deactivation is hardened via dynamic imports, safer wrapper logic, and rollback on partial patch failures, and the test suite is expanded to cover tool-span emission, error handling, pruning, and managed-agent tracking; adds a patch release intent for `respan-instrumentation-anthropic`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba7c306d6ecd4d4a191e5659b096d12ea935538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->