### PR TITLE
feat: add CrewAI and Haystack instrumentation packages

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -119,6 +119,18 @@
       "name": "respan-instrumentation-pydantic-ai",
       "path": "python-sdks/instrumentations/respan-instrumentation-pydantic-ai",
       "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-crewai",
+      "path": "python-sdks/instrumentations/respan-instrumentation-crewai",
+      "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-haystack",
+      "path": "python-sdks/instrumentations/respan-instrumentation-haystack",
+      "registry": "pypi"
     }
   ]
 }

--- a/.release-intents/20260427-crewai-haystack-initial.json
+++ b/.release-intents/20260427-crewai-haystack-initial.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Initial release of CrewAI and Haystack instrumentation packages (0.1.0 published manually; CI bumps to 0.1.1)",
+  "packages": {
+    "respan-instrumentation-crewai": "patch",
+    "respan-instrumentation-haystack": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-crewai/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-crewai/README.md
@@ -1,0 +1,61 @@
+# respan-instrumentation-crewai
+
+Respan instrumentation plugin for CrewAI. Wraps `opentelemetry-instrumentation-crewai` to automatically trace agent runs, task executions, and tool calls.
+
+## Configuration
+
+### 1. Install
+
+```bash
+pip install respan-instrumentation-crewai
+```
+
+### 2. Set Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `RESPAN_API_KEY` | Yes | Your Respan API key. |
+| `RESPAN_BASE_URL` | No | Defaults to `https://api.respan.ai`. |
+
+## Quickstart
+
+### 3. Run Script
+
+```python
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from respan import Respan
+from respan_instrumentation_crewai import CrewAIInstrumentor
+
+respan = Respan(instrumentations=[CrewAIInstrumentor()])
+
+from crewai import Agent, Task, Crew
+
+agent = Agent(
+    role="Poet",
+    goal="Write a short haiku about recursion in programming",
+    backstory="You are a programmer who writes haikus.",
+)
+
+task = Task(
+    description="Write a haiku about recursion in programming.",
+    expected_output="A single haiku (3 lines: 5-7-5 syllables).",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+result = crew.kickoff()
+print(result.raw)
+
+respan.flush()
+```
+
+### 4. View Dashboard
+
+After running the script, traces appear on your [Respan dashboard](https://platform.respan.ai).
+
+## Further Reading
+
+See the [examples/crewai/](../../examples/crewai/) directory for runnable examples.

--- a/python-sdks/instrumentations/respan-instrumentation-crewai/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-crewai/README.md
@@ -16,15 +16,22 @@ pip install respan-instrumentation-crewai
 |----------|----------|-------------|
 | `RESPAN_API_KEY` | Yes | Your Respan API key. |
 | `RESPAN_BASE_URL` | No | Defaults to `https://api.respan.ai`. |
+| `OPENAI_API_KEY` | Yes | Required by CrewAI's default LLM provider. Set to your Respan API key to route through the Respan gateway. |
+| `OPENAI_BASE_URL` | No | Set to `https://api.respan.ai/api` to route OpenAI traffic through the Respan gateway. |
 
 ## Quickstart
 
 ### 3. Run Script
 
 ```python
+import os
 from dotenv import load_dotenv
 
 load_dotenv()
+
+# Route OpenAI traffic through the Respan gateway (no separate OpenAI key needed)
+os.environ["OPENAI_API_KEY"] = os.environ["RESPAN_API_KEY"]
+os.environ["OPENAI_BASE_URL"] = os.getenv("RESPAN_BASE_URL", "https://api.respan.ai/api")
 
 from respan import Respan
 from respan_instrumentation_crewai import CrewAIInstrumentor
@@ -37,6 +44,7 @@ agent = Agent(
     role="Poet",
     goal="Write a short haiku about recursion in programming",
     backstory="You are a programmer who writes haikus.",
+    llm="gpt-4o-mini",
 )
 
 task = Task(
@@ -58,4 +66,4 @@ After running the script, traces appear on your [Respan dashboard](https://platf
 
 ## Further Reading
 
-See the [examples/crewai/](../../examples/crewai/) directory for runnable examples.
+See the [examples/](./examples/) directory for runnable examples.

--- a/python-sdks/instrumentations/respan-instrumentation-crewai/examples/basic_crew.py
+++ b/python-sdks/instrumentations/respan-instrumentation-crewai/examples/basic_crew.py
@@ -1,0 +1,56 @@
+"""
+Basic CrewAI example with Respan tracing and gateway.
+
+Traces agent runs, task executions, and tool calls automatically.
+Routes LLM calls through the Respan gateway (no separate OpenAI key needed).
+
+Prerequisites:
+    pip install respan-instrumentation-crewai
+
+Environment variables:
+    RESPAN_API_KEY   - Your Respan API key (used for both tracing and gateway)
+    RESPAN_BASE_URL  - Respan API endpoint (default: https://api.respan.ai)
+"""
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+respan_api_key = os.environ["RESPAN_API_KEY"]
+respan_base_url = os.getenv("RESPAN_BASE_URL", "https://api.respan.ai/api")
+
+# Point OpenAI traffic through Respan gateway (same base URL)
+os.environ["OPENAI_API_KEY"] = respan_api_key
+os.environ["OPENAI_BASE_URL"] = respan_base_url
+
+from respan import Respan
+from respan_instrumentation_crewai import CrewAIInstrumentor
+
+# Initialize Respan BEFORE importing CrewAI
+respan = Respan(
+    api_key=respan_api_key,
+    base_url=respan_base_url,
+    instrumentations=[CrewAIInstrumentor()],
+)
+
+from crewai import Agent, Task, Crew
+
+agent = Agent(
+    role="Poet",
+    goal="Write a short haiku about recursion in programming",
+    backstory="You are a programmer who expresses ideas through haikus.",
+    llm="gpt-4o-mini",
+)
+
+task = Task(
+    description="Write a haiku about recursion in programming.",
+    expected_output="A single haiku (3 lines: 5-7-5 syllables).",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+result = crew.kickoff()
+print(result.raw)
+
+respan.flush()

--- a/python-sdks/instrumentations/respan-instrumentation-crewai/examples/crew_with_tools.py
+++ b/python-sdks/instrumentations/respan-instrumentation-crewai/examples/crew_with_tools.py
@@ -1,0 +1,94 @@
+"""
+CrewAI example with custom tools and Respan tracing.
+
+Shows how tool calls are traced alongside agent and task spans.
+Routes LLM calls through the Respan gateway.
+
+Prerequisites:
+    pip install respan-instrumentation-crewai
+
+Environment variables:
+    RESPAN_API_KEY   - Your Respan API key (used for both tracing and gateway)
+    RESPAN_BASE_URL  - Respan API endpoint (default: https://api.respan.ai)
+"""
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+respan_api_key = os.environ["RESPAN_API_KEY"]
+respan_base_url = os.getenv("RESPAN_BASE_URL", "https://api.respan.ai/api")
+
+# Point OpenAI traffic through Respan gateway (same base URL)
+os.environ["OPENAI_API_KEY"] = respan_api_key
+os.environ["OPENAI_BASE_URL"] = respan_base_url
+
+from respan import Respan
+from respan_instrumentation_crewai import CrewAIInstrumentor
+
+# Initialize Respan BEFORE importing CrewAI
+respan = Respan(
+    api_key=respan_api_key,
+    base_url=respan_base_url,
+    instrumentations=[CrewAIInstrumentor()],
+)
+
+from crewai import Agent, Task, Crew
+from crewai.tools import tool
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    # Stub — replace with a real API call
+    return f"Sunny, 22C in {city}"
+
+
+@tool
+def get_population(city: str) -> str:
+    """Get the population of a city."""
+    populations = {
+        "Paris": "2.1 million",
+        "Tokyo": "13.9 million",
+        "New York": "8.3 million",
+    }
+    return populations.get(city, "Unknown")
+
+
+researcher = Agent(
+    role="City Researcher",
+    goal="Gather weather and population data for a given city",
+    backstory="You are a researcher that collects city data using available tools.",
+    tools=[get_weather, get_population],
+    llm="gpt-4o-mini",
+)
+
+writer = Agent(
+    role="Travel Writer",
+    goal="Write a short travel summary based on research data",
+    backstory="You turn raw city data into engaging travel blurbs.",
+    llm="gpt-4o-mini",
+)
+
+research_task = Task(
+    description="Research the weather and population of Paris.",
+    expected_output="Weather and population data for Paris.",
+    agent=researcher,
+)
+
+writing_task = Task(
+    description="Write a 2-sentence travel blurb about Paris using the research.",
+    expected_output="A short, engaging travel blurb.",
+    agent=writer,
+)
+
+crew = Crew(
+    agents=[researcher, writer],
+    tasks=[research_task, writing_task],
+)
+
+result = crew.kickoff()
+print(result.raw)
+
+respan.flush()

--- a/python-sdks/instrumentations/respan-instrumentation-crewai/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-crewai/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.poetry]
+name = "respan-instrumentation-crewai"
+version = "0.1.0"
+description = "Respan instrumentation plugin for CrewAI"
+authors = ["Respan <team@respan.ai>"]
+license = "Apache 2.0"
+readme = "README.md"
+packages = [
+    { include = "respan_instrumentation_crewai", from = "./src" },
+]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<3.14"
+respan-tracing = "^2.15.2"
+crewai = ">=0.80.0"
+opentelemetry-instrumentation-crewai = ">=0.40.0"
+
+[tool.poetry.plugins."respan.instrumentations"]
+crewai = "respan_instrumentation_crewai:CrewAIInstrumentor"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: live network tests (requires API keys)",
+]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/instrumentations/respan-instrumentation-crewai/src/respan_instrumentation_crewai/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-crewai/src/respan_instrumentation_crewai/__init__.py
@@ -1,0 +1,5 @@
+"""Respan instrumentation plugin for CrewAI."""
+
+from respan_instrumentation_crewai._instrumentation import CrewAIInstrumentor
+
+__all__ = ["CrewAIInstrumentor"]

--- a/python-sdks/instrumentations/respan-instrumentation-crewai/src/respan_instrumentation_crewai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-crewai/src/respan_instrumentation_crewai/_instrumentation.py
@@ -1,0 +1,55 @@
+"""CrewAI instrumentation plugin for Respan.
+
+Thin wrapper around ``opentelemetry-instrumentation-crewai`` (Traceloop/OpenLLMetry).
+Spans carry GenAI semantic conventions and pass ``is_processable_span()`` natively.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CrewAIInstrumentor:
+    """Respan instrumentor for CrewAI.
+
+    Activates OTEL auto-instrumentation for the ``crewai`` package so
+    that agent runs, task executions, and tool calls are traced automatically.
+
+    Usage::
+
+        from respan import Respan
+        from respan_instrumentation_crewai import CrewAIInstrumentor
+
+        respan = Respan(instrumentations=[CrewAIInstrumentor()])
+    """
+
+    name = "crewai"
+
+    def __init__(self) -> None:
+        self._is_instrumented = False
+
+    def activate(self) -> None:
+        """Instrument CrewAI via the Traceloop OTEL instrumentor."""
+        try:
+            from opentelemetry.instrumentation.crewai import CrewAIInstrumentor as OTELCrewAI
+
+            instrumentor = OTELCrewAI()
+            if not instrumentor.is_instrumented_by_opentelemetry:
+                instrumentor.instrument()
+            self._is_instrumented = True
+            logger.info("CrewAI instrumentation activated")
+        except ImportError as exc:
+            logger.warning(
+                "Failed to activate CrewAI instrumentation — missing dependency: %s", exc
+            )
+
+    def deactivate(self) -> None:
+        """Deactivate the instrumentation."""
+        if self._is_instrumented:
+            try:
+                from opentelemetry.instrumentation.crewai import CrewAIInstrumentor as OTELCrewAI
+                OTELCrewAI().uninstrument()
+            except Exception:
+                pass
+            self._is_instrumented = False
+        logger.info("CrewAI instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/README.md
@@ -1,0 +1,54 @@
+# respan-instrumentation-haystack
+
+Respan instrumentation plugin for Haystack by deepset. Wraps `opentelemetry-instrumentation-haystack` to automatically trace pipeline runs, component executions, and LLM calls.
+
+## Configuration
+
+### 1. Install
+
+```bash
+pip install respan-instrumentation-haystack
+```
+
+### 2. Set Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `RESPAN_API_KEY` | Yes | Your Respan API key. |
+| `RESPAN_BASE_URL` | No | Defaults to `https://api.respan.ai`. |
+
+## Quickstart
+
+### 3. Run Script
+
+```python
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from respan import Respan
+from respan_instrumentation_haystack import HaystackInstrumentor
+
+respan = Respan(instrumentations=[HaystackInstrumentor()])
+
+from haystack import Pipeline
+from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import PromptBuilder
+
+template = """Answer the following question: {{question}}"""
+
+pipe = Pipeline()
+pipe.add_component("prompt_builder", PromptBuilder(template=template))
+pipe.add_component("llm", OpenAIGenerator(model="gpt-4o-mini"))
+pipe.connect("prompt_builder", "llm")
+
+result = pipe.run({"prompt_builder": {"question": "What is the capital of France?"}})
+print(result["llm"]["replies"][0])
+
+respan.flush()
+```
+
+### 4. View Dashboard
+
+After running the script, traces appear on your [Respan dashboard](https://platform.respan.ai).

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/examples/basic_pipeline.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/examples/basic_pipeline.py
@@ -1,0 +1,54 @@
+"""
+Basic Haystack pipeline example with Respan tracing and gateway.
+
+Traces pipeline runs, component executions, and LLM calls automatically.
+Routes LLM calls through the Respan gateway (no separate OpenAI key needed).
+
+Prerequisites:
+    pip install respan-instrumentation-haystack
+
+Environment variables:
+    RESPAN_API_KEY   - Your Respan API key (used for both tracing and gateway)
+    RESPAN_BASE_URL  - Respan API endpoint (default: https://api.respan.ai)
+"""
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+respan_api_key = os.environ["RESPAN_API_KEY"]
+respan_base_url = os.getenv("RESPAN_BASE_URL", "https://api.respan.ai/api")
+
+# Point OpenAI traffic through Respan gateway (same base URL)
+os.environ["OPENAI_API_KEY"] = respan_api_key
+os.environ["OPENAI_BASE_URL"] = respan_base_url
+
+from respan import Respan
+from respan_instrumentation_haystack import HaystackInstrumentor
+
+# Initialize Respan BEFORE importing Haystack components
+respan = Respan(
+    api_key=respan_api_key,
+    base_url=respan_base_url,
+    instrumentations=[HaystackInstrumentor()],
+)
+
+from haystack import Pipeline
+from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import PromptBuilder
+
+template = """Answer the following question concisely: {{question}}"""
+
+pipe = Pipeline()
+pipe.add_component("prompt_builder", PromptBuilder(template=template))
+pipe.add_component(
+    "llm",
+    OpenAIGenerator(model="gpt-4o-mini"),
+)
+pipe.connect("prompt_builder", "llm")
+
+result = pipe.run({"prompt_builder": {"question": "What is the capital of France?"}})
+print(result["llm"]["replies"][0])
+
+respan.flush()

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/examples/rag_pipeline.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/examples/rag_pipeline.py
@@ -1,0 +1,84 @@
+"""
+Haystack RAG pipeline example with Respan tracing and gateway.
+
+Demonstrates a simple retrieval-augmented generation pipeline using
+an in-memory document store. All pipeline components are traced.
+Routes LLM calls through the Respan gateway.
+
+Prerequisites:
+    pip install respan-instrumentation-haystack
+
+Environment variables:
+    RESPAN_API_KEY   - Your Respan API key (used for both tracing and gateway)
+    RESPAN_BASE_URL  - Respan API endpoint (default: https://api.respan.ai)
+"""
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+respan_api_key = os.environ["RESPAN_API_KEY"]
+respan_base_url = os.getenv("RESPAN_BASE_URL", "https://api.respan.ai/api")
+
+# Point OpenAI traffic through Respan gateway (same base URL)
+os.environ["OPENAI_API_KEY"] = respan_api_key
+os.environ["OPENAI_BASE_URL"] = respan_base_url
+
+from respan import Respan
+from respan_instrumentation_haystack import HaystackInstrumentor
+
+# Initialize Respan BEFORE importing Haystack components
+respan = Respan(
+    api_key=respan_api_key,
+    base_url=respan_base_url,
+    instrumentations=[HaystackInstrumentor()],
+)
+
+from haystack import Document, Pipeline
+from haystack.components.builders import PromptBuilder
+from haystack.components.generators import OpenAIGenerator
+from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+# Build a small document store
+doc_store = InMemoryDocumentStore()
+doc_store.write_documents(
+    [
+        Document(content="Python was created by Guido van Rossum and first released in 1991."),
+        Document(content="Rust is a systems programming language focused on safety and performance."),
+        Document(content="TypeScript is a typed superset of JavaScript developed by Microsoft."),
+    ]
+)
+
+template = """
+Given the following documents, answer the question.
+
+Documents:
+{% for doc in documents %}
+- {{ doc.content }}
+{% endfor %}
+
+Question: {{question}}
+Answer:
+"""
+
+pipe = Pipeline()
+pipe.add_component("retriever", InMemoryBM25Retriever(document_store=doc_store, top_k=2))
+pipe.add_component("prompt_builder", PromptBuilder(template=template))
+pipe.add_component(
+    "llm",
+    OpenAIGenerator(model="gpt-4o-mini"),
+)
+pipe.connect("retriever.documents", "prompt_builder.documents")
+pipe.connect("prompt_builder", "llm")
+
+result = pipe.run(
+    {
+        "retriever": {"query": "Who created Python?"},
+        "prompt_builder": {"question": "Who created Python?"},
+    }
+)
+print(result["llm"]["replies"][0])
+
+respan.flush()

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.poetry]
+name = "respan-instrumentation-haystack"
+version = "0.1.0"
+description = "Respan instrumentation plugin for Haystack"
+authors = ["Respan <team@respan.ai>"]
+license = "Apache 2.0"
+readme = "README.md"
+packages = [
+    { include = "respan_instrumentation_haystack", from = "./src" },
+]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<3.14"
+respan-tracing = "^2.15.2"
+haystack-ai = ">=2.0.0"
+opentelemetry-instrumentation-haystack = ">=0.40.0"
+
+[tool.poetry.plugins."respan.instrumentations"]
+haystack = "respan_instrumentation_haystack:HaystackInstrumentor"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: live network tests (requires API keys)",
+]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/__init__.py
@@ -1,0 +1,5 @@
+"""Respan instrumentation plugin for Haystack."""
+
+from respan_instrumentation_haystack._instrumentation import HaystackInstrumentor
+
+__all__ = ["HaystackInstrumentor"]

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_instrumentation.py
@@ -1,0 +1,55 @@
+"""Haystack instrumentation plugin for Respan.
+
+Thin wrapper around ``opentelemetry-instrumentation-haystack`` (Traceloop/OpenLLMetry).
+Spans carry GenAI semantic conventions and pass ``is_processable_span()`` natively.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class HaystackInstrumentor:
+    """Respan instrumentor for Haystack.
+
+    Activates OTEL auto-instrumentation for the ``haystack-ai`` package so
+    that pipeline runs, component executions, and LLM calls are traced automatically.
+
+    Usage::
+
+        from respan import Respan
+        from respan_instrumentation_haystack import HaystackInstrumentor
+
+        respan = Respan(instrumentations=[HaystackInstrumentor()])
+    """
+
+    name = "haystack"
+
+    def __init__(self) -> None:
+        self._is_instrumented = False
+
+    def activate(self) -> None:
+        """Instrument Haystack via the Traceloop OTEL instrumentor."""
+        try:
+            from opentelemetry.instrumentation.haystack import HaystackInstrumentor as OTELHaystack
+
+            instrumentor = OTELHaystack()
+            if not instrumentor.is_instrumented_by_opentelemetry:
+                instrumentor.instrument()
+            self._is_instrumented = True
+            logger.info("Haystack instrumentation activated")
+        except ImportError as exc:
+            logger.warning(
+                "Failed to activate Haystack instrumentation — missing dependency: %s", exc
+            )
+
+    def deactivate(self) -> None:
+        """Deactivate the instrumentation."""
+        if self._is_instrumented:
+            try:
+                from opentelemetry.instrumentation.haystack import HaystackInstrumentor as OTELHaystack
+                OTELHaystack().uninstrument()
+            except Exception:
+                pass
+            self._is_instrumented = False
+        logger.info("Haystack instrumentation deactivated")


### PR DESCRIPTION
## Summary

- Add `respan-instrumentation-crewai` — thin OTEL wrapper around `opentelemetry-instrumentation-crewai` (Traceloop/OpenLLMetry)
- Add `respan-instrumentation-haystack` — thin OTEL wrapper around `opentelemetry-instrumentation-haystack`
- Both packages registered in `.github/release-packages.json` for CI/CD
- Each includes two examples tested end-to-end with real traces confirmed in Respan

## Test plan

- [ ] `cd python-sdks/instrumentations/respan-instrumentation-crewai && poetry install && poetry run python examples/basic_crew.py`
- [ ] `cd python-sdks/instrumentations/respan-instrumentation-haystack && poetry install && poetry run python examples/basic_pipeline.py`
- [ ] Verify traces appear in Respan platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new optional Python instrumentation packages and release metadata, without changing existing runtime behavior unless consumers install/enable them.
> 
> **Overview**
> Adds new Python instrumentation packages `respan-instrumentation-crewai` and `respan-instrumentation-haystack`, each providing a small `*Instrumentor` wrapper that activates/deactivates the corresponding OpenTelemetry auto-instrumentation.
> 
> Updates release automation by registering both packages in `.github/release-packages.json` and adding a `.release-intents` entry, and includes READMEs plus runnable examples demonstrating tracing and (for examples) routing OpenAI traffic through the Respan gateway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 881626c7417d413322e889f580028e84750b0049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->