### PR TITLE
fix: respan-instrumentation-pydantic-problems

### DIFF
--- a/.release-intents/20260424-pydantic-ai-chat-message-fixes.json
+++ b/.release-intents/20260424-pydantic-ai-chat-message-fixes.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Fix PydanticAI instrumentation to normalize parts-based chat messages, restore chat input/output payloads, and capture tool call metadata.",
+  "packages": {
+    "respan-instrumentation-pydantic-ai": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_processor.py
@@ -62,8 +62,10 @@ from respan_sdk.constants.span_attributes import (
     LLM_USAGE_PROMPT_TOKENS,
     RESPAN_LOG_METHOD,
     RESPAN_LOG_TYPE,
+    RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
 )
+from respan_sdk.utils.serialization import serialize_value
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +115,7 @@ def _json_string(value: Any) -> str | None:
         return None
     if isinstance(value, str):
         return value
-    return json.dumps(value, default=str)
+    return json.dumps(serialize_value(value), default=str)
 
 
 def _extract_request_parameters(attrs: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -126,8 +128,143 @@ def _extract_request_parameters(attrs: Mapping[str, Any]) -> dict[str, Any] | No
 def _extract_messages(attrs: Mapping[str, Any], attr_name: str) -> list[Any] | None:
     value = _safe_json_loads(attrs.get(attr_name))
     if isinstance(value, list):
-        return value
+        return _normalize_messages(value)
     return None
+
+
+def _normalize_tool_call(
+    part: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    tool_name = part.get("name")
+    if not isinstance(tool_name, str) or not tool_name:
+        return None
+
+    normalized_tool_call: dict[str, Any] = {
+        "type": "function",
+        "function": {
+            "name": tool_name,
+            "arguments": _json_string(part.get("arguments")) or "",
+        },
+    }
+    tool_call_id = part.get("id") or part.get("tool_call_id")
+    if isinstance(tool_call_id, str) and tool_call_id:
+        normalized_tool_call["id"] = tool_call_id
+    return normalized_tool_call
+
+
+def _normalize_tool_response_content(part: Mapping[str, Any]) -> str | None:
+    for key in ("result", "content", "return_value"):
+        value = part.get(key)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            return value
+        return json.dumps(serialize_value(value), default=str)
+    return None
+
+
+def _stringify_message_part(part: Mapping[str, Any]) -> str | None:
+    for key in ("content", "text"):
+        value = part.get(key)
+        if value in (None, ""):
+            continue
+        if isinstance(value, str):
+            return value
+        return json.dumps(serialize_value(value), default=str)
+
+    part_type = part.get("type")
+    if part_type in {"tool_call", "tool_call_response"}:
+        return None
+
+    return json.dumps(serialize_value(part), default=str)
+
+
+def _convert_parts_message_to_standard(message: Mapping[str, Any]) -> dict[str, Any]:
+    parts = message.get("parts")
+    if not isinstance(parts, list):
+        normalized_message = dict(message)
+        if (
+            normalized_message.get("role") == "assistant"
+            and "content" not in normalized_message
+            and "tool_calls" in normalized_message
+        ):
+            normalized_message["content"] = ""
+        return normalized_message
+
+    normalized_message: dict[str, Any] = {
+        "role": message.get("role", "user"),
+    }
+    text_segments: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+
+    for raw_part in parts:
+        if not isinstance(raw_part, Mapping):
+            continue
+
+        part_type = raw_part.get("type")
+        if part_type == "tool_call":
+            normalized_tool_call = _normalize_tool_call(raw_part)
+            if normalized_tool_call is not None:
+                tool_calls.append(normalized_tool_call)
+            continue
+
+        if part_type == "tool_call_response":
+            normalized_message["role"] = "tool"
+            tool_call_id = raw_part.get("id") or raw_part.get("tool_call_id")
+            if isinstance(tool_call_id, str) and tool_call_id:
+                normalized_message["tool_call_id"] = tool_call_id
+            tool_name = raw_part.get("name") or raw_part.get("tool_name")
+            if isinstance(tool_name, str) and tool_name:
+                normalized_message["name"] = tool_name
+            tool_response_content = _normalize_tool_response_content(raw_part)
+            if tool_response_content is not None:
+                text_segments.append(tool_response_content)
+            continue
+
+        stringified_part = _stringify_message_part(raw_part)
+        if stringified_part:
+            text_segments.append(stringified_part)
+
+    if text_segments:
+        normalized_message["content"] = (
+            "\n".join(text_segments) if len(text_segments) > 1 else text_segments[0]
+        )
+    elif tool_calls or normalized_message.get("role") == "assistant":
+        normalized_message["content"] = ""
+
+    if tool_calls:
+        normalized_message["tool_calls"] = tool_calls
+
+    return normalized_message
+
+
+def _normalize_messages(messages: list[Any]) -> list[dict[str, Any]]:
+    normalized_messages: list[dict[str, Any]] = []
+    for message in messages:
+        if isinstance(message, Mapping):
+            normalized_messages.append(_convert_parts_message_to_standard(message))
+    return normalized_messages
+
+
+def _extract_primary_completion_message(
+    messages: list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    if not messages:
+        return None
+
+    assistant_messages = [
+        message
+        for message in messages
+        if isinstance(message, Mapping) and message.get("role") == "assistant"
+    ]
+    candidate_messages = assistant_messages or messages
+
+    for message in reversed(candidate_messages):
+        content = message.get("content")
+        if content not in (None, "", [], {}) or message.get("tool_calls"):
+            return dict(message)
+
+    return dict(candidate_messages[-1])
 
 
 def _extract_tool_names(attrs: Mapping[str, Any]) -> list[str] | None:
@@ -471,17 +608,42 @@ def enrich_pydantic_ai_span(
         input_messages = _extract_messages(attrs, PYDANTIC_AI_INPUT_MESSAGES_ATTR)
         output_messages = _extract_messages(attrs, PYDANTIC_AI_OUTPUT_MESSAGES_ATTR)
         if input_messages is not None:
+            normalized_input_value = json.dumps(
+                serialize_value(input_messages),
+                default=str,
+            )
             _set_if_missing(
                 attrs,
                 SpanAttributes.TRACELOOP_ENTITY_INPUT,
-                json.dumps(input_messages, default=str),
+                normalized_input_value,
             )
+            _set_if_missing(attrs, RESPAN_OVERRIDE_INPUT_ATTR, normalized_input_value)
         if output_messages is not None:
+            normalized_output_value = json.dumps(
+                serialize_value(output_messages),
+                default=str,
+            )
             _set_if_missing(
                 attrs,
                 SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                json.dumps(output_messages, default=str),
+                normalized_output_value,
             )
+            primary_completion_message = _extract_primary_completion_message(output_messages)
+            if primary_completion_message is not None:
+                _set_if_missing(
+                    attrs,
+                    RESPAN_OVERRIDE_OUTPUT_ATTR,
+                    json.dumps(serialize_value(primary_completion_message), default=str),
+                )
+                tool_calls = primary_completion_message.get("tool_calls")
+                if isinstance(tool_calls, list) and tool_calls:
+                    _set_if_missing(
+                        attrs,
+                        RESPAN_SPAN_TOOL_CALLS,
+                        json.dumps(serialize_value(tool_calls), default=str),
+                    )
+            else:
+                _set_if_missing(attrs, RESPAN_OVERRIDE_OUTPUT_ATTR, normalized_output_value)
 
     if log_type == LOG_TYPE_AGENT and agent_name is not None:
         _set_if_missing(

--- a/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/tests/test_instrumentation.py
@@ -1,3 +1,5 @@
+import builtins
+import json
 import logging
 import sys
 from types import ModuleType, SimpleNamespace
@@ -197,6 +199,86 @@ def test_enrich_pydantic_ai_chat_span_maps_messages():
     assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == (
         '[{"role": "assistant", "content": "hello"}]'
     )
+    assert span._attributes["input"] == '[{"role": "user", "content": "hi"}]'
+    assert span._attributes["output"] == '{"role": "assistant", "content": "hello"}'
+
+
+def test_enrich_pydantic_ai_chat_span_normalizes_parts_messages():
+    span = SimpleNamespace(
+        name="chat completion",
+        _attributes={
+            "gen_ai.system": "openai",
+            "gen_ai.operation.name": "chat",
+            "gen_ai.input.messages": (
+                '[{"role":"user","parts":[{"type":"text","content":"hi"}]},'
+                '{"role":"tool","parts":[{"type":"tool_call_response","id":"call_1","name":"lookup_weather","result":{"forecast":"sunny"}}]}]'
+            ),
+            "gen_ai.output.messages": (
+                '[{"role":"assistant","parts":[{"type":"tool_call","id":"call_1","name":"lookup_weather","arguments":{"city":"Paris"}}]}]'
+            ),
+        },
+    )
+
+    enrich_pydantic_ai_span(span)
+
+    assert json.loads(span._attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "name": "lookup_weather",
+            "content": '{"forecast": "sunny"}',
+        },
+    ]
+    assert json.loads(span._attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup_weather",
+                        "arguments": '{"city": "Paris"}',
+                    },
+                }
+            ],
+        }
+    ]
+    assert json.loads(span._attributes["input"]) == [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "name": "lookup_weather",
+            "content": '{"forecast": "sunny"}',
+        },
+    ]
+    assert json.loads(span._attributes["output"]) == {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "lookup_weather",
+                    "arguments": '{"city": "Paris"}',
+                },
+            }
+        ],
+    }
+    assert json.loads(span._attributes["respan.span.tool_calls"]) == [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "lookup_weather",
+                "arguments": '{"city": "Paris"}',
+            },
+        }
+    ]
 
 
 def test_enrich_pydantic_ai_running_tools_span_maps_task_fields():
@@ -217,8 +299,19 @@ def test_enrich_pydantic_ai_running_tools_span_maps_task_fields():
     assert span._attributes["span_tools"] == ["add", "multiply"]
 
 
-def test_activate_logs_warning_when_dependencies_are_missing(caplog):
+def test_activate_logs_warning_when_dependencies_are_missing(monkeypatch, caplog):
     instrumentor = PydanticAIInstrumentor()
+    original_import = builtins.__import__
+
+    def _mock_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {
+            "pydantic_ai.agent",
+            "pydantic_ai.models.instrumented",
+        }:
+            raise ImportError("mock missing dependency")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _mock_import)
 
     with caplog.at_level(logging.WARNING):
         instrumentor.activate()


### PR DESCRIPTION
## Summary

- Fix some minor problems in pydantic instrumentation:
		Input output syntax
		Tool result combine other information
		Tool result syntax

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches span enrichment for chat traces and changes how `input`/`output` and tool-call metadata are serialized, which could affect downstream parsing/dashboards. Scope is limited to PydanticAI instrumentation and covered by updated tests.
> 
> **Overview**
> Fixes PydanticAI chat span enrichment to **normalize `parts`-based messages** into standard OpenAI-style `role`/`content`/`tool_calls` shapes, including proper handling of tool-call requests and tool-call responses.
> 
> Restores consistent Respan overrides by setting chat `input` to the full normalized message list and chat `output` to the *primary* completion message, and adds `respan.span.tool_calls` when tool calls are present. Updates serialization to use `serialize_value` for safer JSON encoding and expands tests to cover the new normalization and dependency-missing activation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f864ca75361bb82c2745bd788a912d0d835f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->