### PR TITLE
fix: problems of instrumentation-vercel

### DIFF
--- a/.release-intents/20260425-vercel-instrumentation-patch.json
+++ b/.release-intents/20260425-vercel-instrumentation-patch.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Patch the Vercel AI SDK instrumentation package",
+  "packages": {
+    "@respan/instrumentation-vercel": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator.ts
@@ -116,7 +116,6 @@ export class VercelAITranslator implements SpanProcessor {
           const tools = safeJsonStr(toolsValue);
           attrs[RESPAN_SPAN_TOOLS] = tools;
           attrs[TL_REQUEST_FUNCTIONS] = tools;
-          attrs.tools = toolsValue;
         }
 
         const toolChoice = parseToolChoice(attrs);

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator.ts
@@ -8,659 +8,34 @@
  * Two-phase enrichment:
  * - onStart(): Sets RESPAN_LOG_TYPE so the span passes CompositeProcessor filtering
  * - onEnd():   Full attribute translation (model, messages, tokens, metadata, etc.)
- *
- * Vercel attrs are preserved (additive enrichment via setDefault, not destructive).
- *
- * Ported from @respan/exporter-vercel — all exporter features are replicated:
- * - Model normalization (Gemini, Claude, DeepSeek, O3-mini)
- * - Prompt message parsing (ai.prompt.messages + ai.prompt fallback)
- * - Completion message building (ai.response.text, ai.response.object, tool calls)
- * - Token count normalization (input/output → prompt/completion)
- * - Tool definitions (ai.prompt.tools) and tool choice (ai.prompt.toolChoice)
- * - Customer params (ai.telemetry.metadata.customer_* + customer_params JSON)
- * - General metadata (ai.telemetry.metadata.* → respan.metadata.*)
- * - Stream detection, environment, cost, TTFT, generation time, unit prices
- * - Log type detection with operationId + attribute-based fallbacks
  */
 
 import type { Context } from "@opentelemetry/api";
-import type { SpanProcessor, ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
-import { RespanSpanAttributes, RespanLogType } from "@respan/respan-sdk";
-import { VERCEL_SPAN_CONFIG, VERCEL_PARENT_SPANS } from "./constants/index.js";
-
-// ── Attribute keys (single source of truth from SDK) ─────────────────────────
-
-const RESPAN_LOG_TYPE = RespanSpanAttributes.RESPAN_LOG_TYPE;
-const GEN_AI_REQUEST_MODEL = RespanSpanAttributes.GEN_AI_REQUEST_MODEL;
-const GEN_AI_USAGE_PROMPT_TOKENS = RespanSpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS;
-const GEN_AI_USAGE_COMPLETION_TOKENS = RespanSpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS;
-const LLM_REQUEST_TYPE = RespanSpanAttributes.LLM_REQUEST_TYPE;
-const CUSTOMER_ID = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_ID;
-const CUSTOMER_EMAIL = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_EMAIL;
-const CUSTOMER_NAME = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_NAME;
-const THREAD_ID = RespanSpanAttributes.RESPAN_THREADS_ID;
-// RESPAN_SESSION_ID not yet published in @respan/respan-sdk — use wire value directly
-const SESSION_ID = "respan.sessions.session_identifier";
-const TRACE_GROUP_ID = RespanSpanAttributes.RESPAN_TRACE_GROUP_ID;
-const RESPAN_SPAN_TOOLS = RespanSpanAttributes.RESPAN_SPAN_TOOLS;
-const RESPAN_METADATA_AGENT_NAME = RespanSpanAttributes.RESPAN_METADATA_AGENT_NAME;
-const RESPAN_METADATA_PREFIX = RespanSpanAttributes.RESPAN_METADATA; // "respan.metadata"
-
-/** Build a respan.metadata.<key> attribute name. */
-function metadataKey(key: string): string {
-  return `${RESPAN_METADATA_PREFIX}.${key}`;
-}
-
-// Traceloop wire-format keys
-const TL_SPAN_KIND = "traceloop.span.kind";
-const TL_ENTITY_NAME = "traceloop.entity.name";
-const TL_ENTITY_INPUT = "traceloop.entity.input";
-const TL_ENTITY_OUTPUT = "traceloop.entity.output";
-const TL_ENTITY_PATH = "traceloop.entity.path";
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-function setDefault(attrs: Record<string, any>, key: string, value: any): void {
-  if (attrs[key] === undefined && value !== undefined && value !== null) {
-    attrs[key] = value;
-  }
-}
-
-function safeJsonStr(value: unknown): string {
-  if (value === undefined || value === null) return "";
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function safeJsonParse(value: unknown): unknown {
-  if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-}
-
-/**
- * Detect whether a span is from the Vercel AI SDK.
- *
- * Primary check: instrumentation scope name === "ai" (set by the Vercel AI SDK).
- * Fallback: ai.sdk attribute or ai.* span name.
- *
- * Does NOT match on gen_ai.* attributes alone — those may come from other
- * instrumentations (OpenInference, Traceloop) and must not be stripped.
- */
-function isVercelAISpan(span: ReadableSpan): boolean {
-  // Primary: check OTEL instrumentation scope (most reliable, no false positives)
-  if (span.instrumentationLibrary?.name === "ai") return true;
-  // Fallback: explicit Vercel marker or span name convention
-  if (span.attributes["ai.sdk"] !== undefined) return true;
-  if (span.name.startsWith("ai.")) return true;
-  return false;
-}
-
-// ── Log type detection (with operationId + attribute fallbacks) ──────────────
-
-/**
- * Resolve the Respan log type for a Vercel AI SDK span.
- * Replicates the full fallback chain from the exporter's parseLogType().
- */
-function resolveLogType(name: string, attrs: Record<string, any>): string {
-  // 1. Direct span name match
-  const config = VERCEL_SPAN_CONFIG[name];
-  if (config) return config.logType;
-
-  const parentType = VERCEL_PARENT_SPANS[name];
-  if (parentType) return parentType;
-
-  // 2. operationId attribute fallback
-  const operationId = attrs["ai.operationId"]?.toString();
-  if (operationId) {
-    const opConfig = VERCEL_SPAN_CONFIG[operationId];
-    if (opConfig) return opConfig.logType;
-    const opParent = VERCEL_PARENT_SPANS[operationId];
-    if (opParent) return opParent;
-  }
-
-  // 3. Attribute-based fallback detection (same heuristics as exporter)
-  if (
-    attrs["ai.embedding"] || attrs["ai.embeddings"] ||
-    name.includes("embed") || operationId?.includes("embed")
-  ) {
-    return RespanLogType.EMBEDDING;
-  }
-
-  if (
-    attrs["ai.toolCall.id"] || attrs["ai.toolCall.name"] ||
-    attrs["ai.toolCall.args"] || attrs["ai.toolCall.result"] ||
-    attrs["ai.response.toolCalls"] ||
-    name.includes("tool") || operationId?.includes("tool")
-  ) {
-    return RespanLogType.TOOL;
-  }
-
-  if (
-    attrs["ai.agent.id"] ||
-    name.includes("agent") || operationId?.includes("agent")
-  ) {
-    return RespanLogType.AGENT;
-  }
-
-  if (
-    attrs["ai.workflow.id"] ||
-    name.includes("workflow") || operationId?.includes("workflow")
-  ) {
-    return RespanLogType.WORKFLOW;
-  }
-
-  if (
-    attrs["ai.transcript"] ||
-    name.includes("transcript") || operationId?.includes("transcript")
-  ) {
-    return RespanLogType.TRANSCRIPTION;
-  }
-
-  if (
-    attrs["ai.speech"] ||
-    name.includes("speech") || operationId?.includes("speech")
-  ) {
-    return RespanLogType.SPEECH;
-  }
-
-  // 4. Generation span fallback (doGenerate/doStream)
-  if (name.includes("doGenerate") || name.includes("doStream")) {
-    return RespanLogType.TEXT;
-  }
-
-  return RespanLogType.UNKNOWN;
-}
-
-// ── Model normalization ──────────────────────────────────────────────────────
-
-/**
- * Normalize the model ID from Vercel's ai.model.id to a standard model name.
- * Replicates the logic from the existing exporter.
- */
-function normalizeModel(modelId: string): string {
-  const model = modelId.toLowerCase();
-
-  if (model.includes("gemini-2.0-flash-001")) return "gemini/gemini-2.0-flash";
-  if (model.includes("gemini-2.0-pro")) return "gemini/gemini-2.0-pro-exp-02-05";
-  if (model.includes("claude-3-5-sonnet")) return "claude-3-5-sonnet-20241022";
-  if (model.includes("deepseek")) return "deepseek/" + model;
-  if (model.includes("o3-mini")) return "o3-mini";
-
-  return model;
-}
-
-// ── Prompt/completion message formatting ─────────────────────────────────────
-
-/**
- * Parse ai.prompt.messages into a JSON string suitable for traceloop.entity.input.
- * Falls back to ai.prompt as a single user message.
- */
-function formatPromptInput(attrs: Record<string, any>): string | undefined {
-  const messages = attrs["ai.prompt.messages"];
-  if (messages) {
-    try {
-      const parsed = typeof messages === "string" ? JSON.parse(messages) : messages;
-      return safeJsonStr(parsed);
-    } catch {
-      // fall through
-    }
-  }
-
-  const prompt = attrs["ai.prompt"];
-  if (prompt) {
-    return safeJsonStr([{ role: "user", content: String(prompt) }]);
-  }
-
-  return undefined;
-}
-
-/**
- * Build completion output from ai.response.text, ai.response.object, and tool calls.
- * Also includes tool result messages when present (for tool call spans).
- */
-function formatCompletionOutput(attrs: Record<string, any>): string | undefined {
-  let content = "";
-
-  if (attrs["ai.response.object"]) {
-    try {
-      const rawObject = attrs["ai.response.object"];
-      const parsed = typeof rawObject === "string" ? JSON.parse(rawObject) : rawObject;
-      // generateObject returns the object directly (no `response` wrapper).
-      // Prefer known wrappers when present, otherwise serialize the object itself.
-      const normalized =
-        parsed?.response ?? parsed?.object ?? parsed?.output ?? parsed?.result ?? parsed;
-      content = safeJsonStr(normalized);
-    } catch {
-      content = String(attrs["ai.response.text"] ?? "");
-    }
-  } else {
-    content = String(attrs["ai.response.text"] ?? "");
-  }
-
-  // Build assistant message with optional tool calls
-  const toolCalls = parseToolCalls(attrs);
-
-  // Bail only when there's no text AND no tool calls
-  if (!content && (!toolCalls || toolCalls.length === 0)) return undefined;
-
-  const message: Record<string, any> = { role: "assistant", content };
-  if (toolCalls && toolCalls.length > 0) {
-    message.tool_calls = toolCalls;
-  }
-
-  // Include tool result as a separate message if present
-  const messages: any[] = [message];
-  if (attrs["ai.toolCall.result"]) {
-    messages.push({
-      role: "tool",
-      tool_call_id: String(attrs["ai.toolCall.id"] || ""),
-      content: String(attrs["ai.toolCall.result"] || ""),
-    });
-  }
-
-  return safeJsonStr(messages.length === 1 ? message : messages);
-}
-
-/**
- * Parse tool call data from various Vercel AI SDK attribute formats.
- */
-function parseToolCalls(attrs: Record<string, any>): any[] | undefined {
-  // Try array formats first
-  for (const key of ["ai.response.toolCalls", "ai.toolCall", "ai.toolCalls"]) {
-    if (!attrs[key]) continue;
-    try {
-      const parsed = typeof attrs[key] === "string" ? JSON.parse(attrs[key]) : attrs[key];
-      const calls = Array.isArray(parsed) ? parsed : [parsed];
-      return calls.map((call: any) => {
-        if (!call || typeof call !== "object") return { type: "function" };
-        const result = { ...call };
-        if (!result.type) result.type = "function";
-        if (!result.id && (result.toolCallId || result.tool_call_id)) {
-          result.id = result.toolCallId || result.tool_call_id;
-        }
-        return result;
-      });
-    } catch {
-      continue;
-    }
-  }
-
-  // Try individual tool call attributes
-  if (attrs["ai.toolCall.id"] || attrs["ai.toolCall.name"] || attrs["ai.toolCall.args"]) {
-    const toolCall: Record<string, any> = { type: "function" };
-    for (const [key, value] of Object.entries(attrs)) {
-      if (key.startsWith("ai.toolCall.")) {
-        toolCall[key.replace("ai.toolCall.", "")] = value;
-      }
-    }
-    return [toolCall];
-  }
-
-  return undefined;
-}
-
-/**
- * Format tool call span input/output for traceloop.entity.input/output.
- */
-function formatToolInput(attrs: Record<string, any>): string | undefined {
-  const name = attrs["ai.toolCall.name"];
-  const args = attrs["ai.toolCall.args"];
-  if (!name && !args) return undefined;
-
-  const input: Record<string, any> = {};
-  if (name) input.name = name;
-  if (args) {
-    input.args = typeof args === "string" ? safeJsonParse(args) : args;
-  }
-  return safeJsonStr(input);
-}
-
-function formatToolOutput(attrs: Record<string, any>): string | undefined {
-  const result = attrs["ai.toolCall.result"];
-  if (result === undefined) return undefined;
-  return safeJsonStr(typeof result === "string" ? safeJsonParse(result) : result);
-}
-
-// ── Tools & tool choice (from exporter's parseTools / parseToolChoice) ───────
-
-/**
- * Parse ai.prompt.tools into a normalized tool definition array.
- * Accepts both nested ({type:"function",function:{...}}) and flat shapes.
- */
-function parseTools(attrs: Record<string, any>): string | undefined {
-  try {
-    const tools = attrs["ai.prompt.tools"];
-    if (!tools) return undefined;
-    const raw = Array.isArray(tools) ? tools : [tools];
-    const parsed = raw
-      .map((tool: any) => {
-        try {
-          return typeof tool === "string" ? JSON.parse(tool) : tool;
-        } catch {
-          return undefined;
-        }
-      })
-      .filter(Boolean)
-      .map((tool: any) => {
-        // Accept both nested and flat shapes; normalize to nested
-        if (tool && tool.type === "function") {
-          if (tool.function && typeof tool.function === "object") {
-            // Already nested — move top-level inputSchema into function.parameters
-            // (Vercel AI SDK puts inputSchema at the top level, backend expects function.parameters)
-            if (tool.inputSchema && !tool.function.parameters) {
-              const { inputSchema, ...rest } = tool;
-              return { ...rest, function: { ...tool.function, parameters: inputSchema } };
-            }
-            return tool;
-          }
-          const { name, description, parameters, inputSchema, ...rest } = tool;
-          const params = parameters ?? inputSchema;
-          return {
-            ...rest,
-            type: "function",
-            function: {
-              name,
-              ...(description ? { description } : {}),
-              ...(params ? { parameters: params } : {}),
-            },
-          };
-        }
-        return tool;
-      });
-    if (parsed.length === 0) return undefined;
-    return safeJsonStr(parsed);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Parse tool choice from Vercel's ai.prompt.toolChoice attribute.
- */
-function parseToolChoice(attrs: Record<string, any>): string | undefined {
-  try {
-    const toolChoice = attrs["ai.prompt.toolChoice"];
-    if (!toolChoice) return undefined;
-    const parsed = typeof toolChoice === "string" ? JSON.parse(toolChoice) : toolChoice;
-    if (parsed.function?.name) {
-      return safeJsonStr({
-        type: String(parsed.type),
-        function: { name: String(parsed.function.name) },
-      });
-    }
-    return safeJsonStr({ type: String(parsed.type) });
-  } catch {
-    return undefined;
-  }
-}
-
-// ── Metadata / customer params ───────────────────────────────────────────────
-
-/**
- * Extract ai.telemetry.metadata.* and map customer/thread params to Respan attrs.
- * Also handles prompt_unit_price, completion_unit_price, and span_type metadata.
- */
-function enrichMetadata(attrs: Record<string, any>, spanName: string): void {
-  for (const [key, value] of Object.entries(attrs)) {
-    if (!key.startsWith("ai.telemetry.metadata.")) continue;
-    const cleanKey = key.slice("ai.telemetry.metadata.".length);
-
-    // Map well-known keys to Respan span attributes
-    switch (cleanKey) {
-      case "customer_identifier":
-        setDefault(attrs, CUSTOMER_ID, String(value));
-        break;
-      case "customer_email":
-        setDefault(attrs, CUSTOMER_EMAIL, String(value));
-        break;
-      case "customer_name":
-        setDefault(attrs, CUSTOMER_NAME, String(value));
-        break;
-      case "session_identifier":
-        setDefault(attrs, SESSION_ID, String(value));
-        break;
-      case "thread_identifier":
-        setDefault(attrs, THREAD_ID, String(value));
-        break;
-      case "trace_group_identifier":
-        setDefault(attrs, TRACE_GROUP_ID, String(value));
-        break;
-      case "customer_params": {
-        // customer_params can be a JSON object with all three fields
-        try {
-          const parsed = typeof value === "string" ? JSON.parse(value) : value;
-          if (parsed?.customer_identifier) setDefault(attrs, CUSTOMER_ID, parsed.customer_identifier);
-          if (parsed?.customer_email) setDefault(attrs, CUSTOMER_EMAIL, parsed.customer_email);
-          if (parsed?.customer_name) setDefault(attrs, CUSTOMER_NAME, parsed.customer_name);
-        } catch {
-          // ignore
-        }
-        break;
-      }
-      case "prompt_unit_price":
-        setDefault(attrs, metadataKey("prompt_unit_price"), String(value));
-        break;
-      case "completion_unit_price":
-        setDefault(attrs, metadataKey("completion_unit_price"), String(value));
-        break;
-      case "userId":
-        // userId is a fallback for customer_identifier (backward compat with exporter)
-        setDefault(attrs, CUSTOMER_ID, String(value));
-        setDefault(attrs, metadataKey(cleanKey), String(value ?? ""));
-        break;
-      default:
-        // All other metadata → respan.metadata.<key>
-        setDefault(attrs, metadataKey(cleanKey), String(value ?? ""));
-        break;
-    }
-  }
-
-}
-
-// ── Token count normalization ────────────────────────────────────────────────
-
-function enrichTokens(attrs: Record<string, any>): void {
-  // Vercel AI SDK may use gen_ai.usage.input_tokens / gen_ai.usage.output_tokens
-  // Respan backend expects gen_ai.usage.prompt_tokens / gen_ai.usage.completion_tokens
-  const inputTokens =
-    attrs["gen_ai.usage.input_tokens"] ??
-    attrs["gen_ai.usage.prompt_tokens"];
-  const outputTokens =
-    attrs["gen_ai.usage.output_tokens"] ??
-    attrs["gen_ai.usage.completion_tokens"];
-
-  if (inputTokens !== undefined) {
-    setDefault(attrs, GEN_AI_USAGE_PROMPT_TOKENS, Number(inputTokens));
-  }
-  if (outputTokens !== undefined) {
-    setDefault(attrs, GEN_AI_USAGE_COMPLETION_TOKENS, Number(outputTokens));
-  }
-}
-
-// ── Performance / cost metrics ───────────────────────────────────────────────
-
-/**
- * Enrich performance and cost attributes that the exporter handled explicitly.
- * These are Vercel-specific attrs that the backend needs in standard locations.
- */
-function enrichPerformanceMetrics(attrs: Record<string, any>, spanName: string): void {
-  // Stream detection from span name
-  setDefault(attrs, metadataKey("stream"), String(spanName.includes("doStream")));
-
-  // Time to first token from ai.response.msToFinish (Vercel-specific)
-  const msToFinish = attrs["ai.response.msToFinish"];
-  if (msToFinish !== undefined) {
-    setDefault(attrs, metadataKey("time_to_first_token"), String(Number(msToFinish) / 1000));
-  }
-
-  // Cost (gen_ai.usage.cost is standard but ensure it's present)
-  const cost = attrs["gen_ai.usage.cost"];
-  if (cost !== undefined) {
-    setDefault(attrs, metadataKey("cost"), String(cost));
-  }
-
-  // TTFT (gen_ai.usage.ttft)
-  const ttft = attrs["gen_ai.usage.ttft"];
-  if (ttft !== undefined) {
-    setDefault(attrs, metadataKey("ttft"), String(ttft));
-  }
-
-  // Generation time
-  const genTime = attrs["gen_ai.usage.generation_time"];
-  if (genTime !== undefined) {
-    setDefault(attrs, metadataKey("generation_time"), String(genTime));
-  }
-
-  // Warnings
-  const warnings = attrs["gen_ai.usage.warnings"];
-  if (warnings !== undefined) {
-    setDefault(attrs, metadataKey("warnings"), String(warnings));
-  }
-
-  // Response type (text/json_schema/json_object)
-  const type = attrs["gen_ai.usage.type"];
-  if (type !== undefined) {
-    setDefault(attrs, metadataKey("type"), String(type));
-  }
-
-}
-
-// ── Cleanup: strip redundant Vercel attrs after translation ──────────────────
-
-/**
- * Vercel AI SDK attributes that have been translated to Traceloop/GenAI/Respan
- * equivalents. These are deleted after translation to keep spans clean.
- */
-const VERCEL_ATTRS_TO_STRIP = [
-  // ── Vercel AI SDK attrs (translated to Traceloop/GenAI equivalents) ────
-
-  // Model (translated to gen_ai.request.model)
-  "ai.model.id",
-  "ai.model.provider",
-  "ai.response.model",
-
-  // Prompt/completion (translated to traceloop.entity.input/output)
-  "ai.prompt",
-  "ai.prompt.messages",
-  "ai.prompt.format",
-  "ai.response.text",
-  "ai.response.object",
-
-  // Tokens — old names (v5) + new names (v6)
-  "ai.usage.promptTokens",
-  "ai.usage.completionTokens",
-  "ai.usage.inputTokens",
-  "ai.usage.outputTokens",
-  "ai.usage.totalTokens",
-  "ai.usage.reasoningTokens",
-  "ai.usage.cachedInputTokens",
-
-  // Response metadata (redundant with standard OTEL/GenAI attrs)
-  "ai.response.finishReason",
-  "ai.response.id",
-  "ai.response.timestamp",
-  "ai.response.providerMetadata",
-  "ai.response.msToFinish",
-  "ai.response.msToFirstChunk",
-  "ai.response.avgOutputTokensPerSecond",
-  "ai.response.avgCompletionTokensPerSecond",
-
-  // Request metadata
-  "ai.request.headers.user-agent",
-
-  // Tool choice (translated to respan.metadata.tool_choice)
-  "ai.prompt.toolChoice",
-
-  // SDK internals (no user value)
-  "ai.operationId",
-  "ai.settings.maxRetries",
-  "ai.settings.maxSteps",
-  "ai.sdk",
-  "operation.name",
-
-  // Tool calls (translated to traceloop.entity.input/output for tool spans)
-  "ai.toolCall.id",
-  "ai.toolCall.name",
-  "ai.toolCall.args",
-  "ai.toolCall.result",
-  "ai.response.toolCalls",
-
-  // GenAI duplicates (already consumed by backend as top-level fields)
-  "gen_ai.response.finish_reasons",
-  "gen_ai.response.id",
-  "gen_ai.usage.input_tokens",
-  "gen_ai.usage.output_tokens",
-  "gen_ai.system",
-
-  // ── Traceloop routing attrs (Vercel-specific, not user-facing) ──────────
-  // Keep traceloop.span.kind and respan.entity.log_type — backend needs them.
-  // Keep respan.environment — may be set by user via propagateAttributes().
-  "traceloop.entity.name",
-  "traceloop.entity.path",
-
-  // ── OTEL resource / process noise (no user value in metadata) ──────────
-  "service.name",
-  "telemetry.sdk.language",
-  "telemetry.sdk.name",
-  "telemetry.sdk.version",
-  "process.pid",
-  "process.executable.name",
-  "process.executable.path",
-  "process.command_args",
-  "process.runtime.version",
-  "process.runtime.name",
-  "process.runtime.description",
-  "process.command",
-  "process.owner",
-  "host.name",
-  "host.arch",
-  "host.id",
-  "otel.scope.name",
-  "otel.scope.version",
-
-  // ── Next.js auto-instrumentation noise ─────────────────────────────────
-  "next.span_name",
-  "next.span_type",
-  "http.url",
-  "http.method",
-  "net.peer.name",
-];
-
-/**
- * Remove redundant Vercel AI SDK attributes after translation.
- * Also strips ai.telemetry.metadata.* keys that have been mapped to respan.* attrs.
- */
-function stripRedundantAttrs(attrs: Record<string, any>): void {
-  for (const key of VERCEL_ATTRS_TO_STRIP) {
-    delete attrs[key];
-  }
-  for (const key of Object.keys(attrs)) {
-    // Strip ai.telemetry.metadata.* (already mapped to respan.metadata.* / respan.customer_params.*)
-    if (key.startsWith("ai.telemetry.metadata.")) {
-      delete attrs[key];
-      continue;
-    }
-    // Strip ai.usage.*Details.* (e.g. inputTokenDetails.noCacheTokens, outputTokenDetails.textTokens)
-    if (key.startsWith("ai.usage.") && key.includes("Details.")) {
-      delete attrs[key];
-      continue;
-    }
-  }
-  // Strip ai.prompt.tools (translated to respan.span.tools)
-  if (attrs["ai.prompt.tools"] !== undefined) {
-    delete attrs["ai.prompt.tools"];
-  }
-}
-
-// ── Main processor ───────────────────────────────────────────────────────────
+import type { ReadableSpan, Span, SpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { RespanLogType } from "@respan/respan-sdk";
+import { VERCEL_PARENT_SPANS, VERCEL_SPAN_CONFIG } from "./constants/index.js";
+import { formatCompletionOutput, formatPromptInput, formatToolInput, formatToolOutput, parseToolChoice, parseToolsValue } from "./_translator/messages.js";
+import {
+  AI_AGENT_ID,
+  AI_MODEL_ID,
+  AI_PREFIX,
+  GEN_AI_REQUEST_MODEL,
+  LLM_REQUEST_TYPE,
+  RESPAN_LOG_TYPE,
+  RESPAN_METADATA_AGENT_NAME,
+  RESPAN_SPAN_TOOLS,
+  TL_ENTITY_INPUT,
+  TL_ENTITY_OUTPUT,
+  TL_REQUEST_FUNCTIONS,
+  TL_SPAN_KIND,
+  isVercelAISpan,
+  metadataKey,
+  normalizeModel,
+  resolveLogType,
+  safeJsonStr,
+  setDefault,
+} from "./_translator/shared.js";
+import { enrichMetadata, enrichPerformanceMetrics, enrichTokens, stripRedundantAttrs } from "./_translator/span-enrichment.js";
 
 /**
  * SpanProcessor that translates Vercel AI SDK attributes to Traceloop/OpenLLMetry.
@@ -671,137 +46,150 @@ function stripRedundantAttrs(attrs: Record<string, any>): void {
  */
 export class VercelAITranslator implements SpanProcessor {
   onStart(span: Span, _parentContext: Context): void {
-    // Cast to access attributes (Span interface doesn't expose them, but the impl does)
-    const s = span as any;
-    const name: string = s.name ?? "";
-    if (!name.startsWith("ai.")) return;
+    const writableSpan = span as any;
+    const name: string = writableSpan.name ?? "";
+    if (!name.startsWith(AI_PREFIX)) {
+      return;
+    }
 
-    // Set RESPAN_LOG_TYPE early so CompositeProcessor accepts this span
     const config = VERCEL_SPAN_CONFIG[name];
     if (config) {
-      s.setAttribute(RESPAN_LOG_TYPE, config.logType);
-    } else if (VERCEL_PARENT_SPANS[name] !== undefined) {
-      s.setAttribute(RESPAN_LOG_TYPE, VERCEL_PARENT_SPANS[name]);
-    } else {
-      // Unknown ai.* span — use full fallback detection
-      // At onStart, attributes may be sparse, so set a generic type.
-      // The precise type will be resolved in onEnd() with full attributes.
-      s.setAttribute(RESPAN_LOG_TYPE, RespanLogType.TASK);
+      writableSpan.setAttribute(RESPAN_LOG_TYPE, config.logType);
+      return;
     }
+
+    const parentLogType = VERCEL_PARENT_SPANS[name];
+    if (parentLogType !== undefined) {
+      writableSpan.setAttribute(RESPAN_LOG_TYPE, parentLogType);
+      return;
+    }
+
+    writableSpan.setAttribute(RESPAN_LOG_TYPE, RespanLogType.TASK);
   }
 
   onEnd(span: ReadableSpan): void {
     const attrs = (span as any).attributes as Record<string, any> | undefined;
-    if (!attrs) return;
-
-    if (!isVercelAISpan(span as any)) return;
+    if (!attrs || !isVercelAISpan(span)) {
+      return;
+    }
 
     const name = span.name;
     const config = VERCEL_SPAN_CONFIG[name];
     const parentLogType = VERCEL_PARENT_SPANS[name];
-
-    // Resolve the log type using full fallback chain (name → operationId → attributes)
     const logType = resolveLogType(name, attrs);
 
-    // ── Always: metadata, customer params, environment ────────────────────
-    enrichMetadata(attrs, name);
+    enrichMetadata(attrs);
 
-    // ── Parent wrapper spans: minimal enrichment only ─────────────────────
     if (parentLogType !== undefined && !config) {
       setDefault(attrs, RESPAN_LOG_TYPE, logType);
       stripRedundantAttrs(attrs);
       return;
     }
 
-    // ── Detailed / leaf spans: full enrichment ────────────────────────────
-
-    // Update RESPAN_LOG_TYPE with the resolved type (may be more accurate than onStart)
     attrs[RESPAN_LOG_TYPE] = logType;
 
     if (config) {
       setDefault(attrs, TL_SPAN_KIND, config.kind);
 
-      // LLM-specific enrichment
       if (config.isLLM) {
         setDefault(attrs, LLM_REQUEST_TYPE, RespanLogType.CHAT);
 
-        // Model
-        const modelId = attrs["ai.model.id"];
+        const modelId = attrs[AI_MODEL_ID];
         if (modelId) {
           setDefault(attrs, GEN_AI_REQUEST_MODEL, normalizeModel(String(modelId)));
         }
 
-        // Prompt messages → entity input
         const input = formatPromptInput(attrs);
-        if (input) setDefault(attrs, TL_ENTITY_INPUT, input);
+        if (input) {
+          setDefault(attrs, TL_ENTITY_INPUT, input);
+        }
 
-        // Completion → entity output
         const output = formatCompletionOutput(attrs);
-        if (output) setDefault(attrs, TL_ENTITY_OUTPUT, output);
+        if (output) {
+          setDefault(attrs, TL_ENTITY_OUTPUT, output);
+        }
 
-        // Token counts
         enrichTokens(attrs);
 
-        // Tool definitions
-        const tools = parseTools(attrs);
-        if (tools) setDefault(attrs, RESPAN_SPAN_TOOLS, tools);
+        const toolsValue = parseToolsValue(attrs);
+        if (toolsValue) {
+          const tools = safeJsonStr(toolsValue);
+          attrs[RESPAN_SPAN_TOOLS] = tools;
+          attrs[TL_REQUEST_FUNCTIONS] = tools;
+          attrs.tools = toolsValue;
+        }
 
-        // Tool choice
         const toolChoice = parseToolChoice(attrs);
-        if (toolChoice) setDefault(attrs, metadataKey("tool_choice"), toolChoice);
+        if (toolChoice) {
+          setDefault(attrs, metadataKey("tool_choice"), toolChoice);
+        }
 
-        // Performance metrics (stream, TTFT, cost, etc.)
         enrichPerformanceMetrics(attrs, name);
       }
 
-      // Tool call spans
       if (config.logType === RespanLogType.TOOL || logType === RespanLogType.TOOL) {
         const toolInput = formatToolInput(attrs);
-        if (toolInput) setDefault(attrs, TL_ENTITY_INPUT, toolInput);
+        if (toolInput) {
+          setDefault(attrs, TL_ENTITY_INPUT, toolInput);
+        }
 
         const toolOutput = formatToolOutput(attrs);
-        if (toolOutput) setDefault(attrs, TL_ENTITY_OUTPUT, toolOutput);
+        if (toolOutput) {
+          setDefault(attrs, TL_ENTITY_OUTPUT, toolOutput);
+        }
       }
 
-      // Agent spans
       if (config.logType === RespanLogType.AGENT || logType === RespanLogType.AGENT) {
-        const agentName = attrs["ai.agent.name"] ?? attrs["ai.agent.id"] ?? name;
+        const agentName = attrs["ai.agent.name"] ?? attrs[AI_AGENT_ID] ?? name;
         setDefault(attrs, RESPAN_METADATA_AGENT_NAME, String(agentName));
       }
     } else {
-      // Unknown ai.* span — enrich with fallback-resolved type
-
-      // If fallback detected it as an LLM span, add model + tokens
       if (logType === RespanLogType.TEXT || logType === RespanLogType.EMBEDDING) {
-        const modelId = attrs["ai.model.id"];
+        const modelId = attrs[AI_MODEL_ID];
         if (modelId) {
           setDefault(attrs, GEN_AI_REQUEST_MODEL, normalizeModel(String(modelId)));
         }
+
         enrichTokens(attrs);
 
         if (logType === RespanLogType.TEXT) {
           setDefault(attrs, LLM_REQUEST_TYPE, RespanLogType.CHAT);
+
           const input = formatPromptInput(attrs);
-          if (input) setDefault(attrs, TL_ENTITY_INPUT, input);
+          if (input) {
+            setDefault(attrs, TL_ENTITY_INPUT, input);
+          }
+
           const output = formatCompletionOutput(attrs);
-          if (output) setDefault(attrs, TL_ENTITY_OUTPUT, output);
+          if (output) {
+            setDefault(attrs, TL_ENTITY_OUTPUT, output);
+          }
+
           enrichPerformanceMetrics(attrs, name);
         }
       }
 
-      // If fallback detected tool, add tool input/output
       if (logType === RespanLogType.TOOL) {
         const toolInput = formatToolInput(attrs);
-        if (toolInput) setDefault(attrs, TL_ENTITY_INPUT, toolInput);
+        if (toolInput) {
+          setDefault(attrs, TL_ENTITY_INPUT, toolInput);
+        }
+
         const toolOutput = formatToolOutput(attrs);
-        if (toolOutput) setDefault(attrs, TL_ENTITY_OUTPUT, toolOutput);
+        if (toolOutput) {
+          setDefault(attrs, TL_ENTITY_OUTPUT, toolOutput);
+        }
       }
     }
 
-    // ── Cleanup: remove redundant Vercel attrs that have been translated ──
     stripRedundantAttrs(attrs);
   }
 
-  async shutdown(): Promise<void> {}
-  async forceFlush(): Promise<void> {}
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/messages.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/messages.ts
@@ -182,7 +182,7 @@ function isMessageLike(value: unknown): value is MessagePayload {
 }
 
 function isMessageArray(value: unknown): value is MessagePayload[] {
-  return Array.isArray(value) && value.every((item) => isMessageLike(item));
+  return Array.isArray(value) && value.length > 0 && value.every((item) => isMessageLike(item));
 }
 
 function unwrapKnownResponseWrapper(value: unknown): unknown {
@@ -388,20 +388,50 @@ function collapseSingleMessagePayload(messages: MessagePayload[]): unknown {
   return messages.length === 1 ? messages[0] : messages;
 }
 
+function buildToolResultMessage(attrs: SpanAttributes): MessagePayload | undefined {
+  if (!attrs[AI_TOOL_CALL_RESULT]) {
+    return undefined;
+  }
+
+  return {
+    role: "tool",
+    tool_call_id: String(attrs[AI_TOOL_CALL_ID] || ""),
+    content: String(attrs[AI_TOOL_CALL_RESULT] || ""),
+  };
+}
+
+function hasToolResultMessage(payload: unknown, toolResult: MessagePayload): boolean {
+  const messages = Array.isArray(payload) ? payload : [payload];
+  return messages.some((message) => {
+    if (!isRecord(message) || message.role !== "tool") {
+      return false;
+    }
+
+    if (toolResult.tool_call_id) {
+      return message.tool_call_id === toolResult.tool_call_id || message.toolCallId === toolResult.tool_call_id;
+    }
+
+    return message.content === toolResult.content;
+  });
+}
+
+function appendToolResultMessage(payload: unknown, attrs: SpanAttributes): unknown {
+  const toolResult = buildToolResultMessage(attrs);
+  if (!toolResult || hasToolResultMessage(payload, toolResult)) {
+    return payload;
+  }
+
+  return Array.isArray(payload) ? [...payload, toolResult] : [payload, toolResult];
+}
+
 function selectPrimaryAssistantMessage(value: unknown): MessagePayload | undefined {
   if (isMessageLike(value)) {
-    return value;
+    return value.role === "assistant" ? value : undefined;
   }
 
   if (Array.isArray(value)) {
     for (const item of value) {
       if (isMessageLike(item) && item.role === "assistant") {
-        return item;
-      }
-    }
-
-    for (const item of value) {
-      if (isMessageLike(item)) {
         return item;
       }
     }
@@ -416,7 +446,7 @@ function enrichCompletionAttrs(attrs: SpanAttributes, payload: unknown): void {
     return;
   }
 
-  attrs["gen_ai.completion.0.role"] = String(message.role || "assistant");
+  attrs["gen_ai.completion.0.role"] = "assistant";
   attrs["gen_ai.completion.0.content"] =
     typeof message.content === "string"
       ? message.content
@@ -430,7 +460,6 @@ function enrichCompletionAttrs(attrs: SpanAttributes, payload: unknown): void {
     parseToolCalls(attrs);
   if (toolCalls && toolCalls.length > 0) {
     attrs["gen_ai.completion.0.tool_calls"] = toolCalls;
-    attrs["tool_calls"] = toolCalls;
     attrs[RESPAN_SPAN_TOOL_CALLS] = safeJsonStr(toolCalls);
     attrs["has_tool_calls"] = true;
     attrs["parallel_tool_calls"] = toolCalls.length > 1;
@@ -457,28 +486,24 @@ export function formatPromptInput(attrs: SpanAttributes): string | undefined {
 }
 
 export function formatCompletionOutput(attrs: SpanAttributes): string | undefined {
-  // `ai.response.object` may contain arbitrary structured JSON from generateObject().
-  // Preserve that payload as-is in the fallback path instead of collapsing nested
-  // `message` fields into a synthetic assistant reply.
+  // `ai.response.text` may itself be a JSON-encoded chat message. Normalize that
+  // shape first so assistant messages and tool calls are preserved for the backend.
   const existingPayload = extractMessagePayload(attrs[AI_RESPONSE_TEXT]);
   if (existingPayload !== undefined) {
     const normalizedMessages = normalizeMessageCollection(collapseNestedMessageWrapper(existingPayload));
     const normalizedPayload = normalizedMessages
       ? collapseSingleMessagePayload(normalizedMessages)
       : collapseNestedMessageWrapper(existingPayload);
-    enrichCompletionAttrs(attrs, normalizedPayload);
-    return safeJsonStr(normalizedPayload);
+    const outputPayload = appendToolResultMessage(normalizedPayload, attrs);
+    enrichCompletionAttrs(attrs, outputPayload);
+    return safeJsonStr(outputPayload);
   }
 
   let content = "";
 
   if (attrs[AI_RESPONSE_OBJECT]) {
-    try {
-      const parsed = unwrapKnownResponseWrapper(safeJsonParse(attrs[AI_RESPONSE_OBJECT]));
-      content = safeJsonStr(parsed);
-    } catch {
-      content = String(attrs[AI_RESPONSE_TEXT] ?? "");
-    }
+    const parsed = unwrapKnownResponseWrapper(safeJsonParse(attrs[AI_RESPONSE_OBJECT]));
+    content = safeJsonStr(parsed);
   } else {
     content = String(attrs[AI_RESPONSE_TEXT] ?? "");
   }
@@ -493,16 +518,7 @@ export function formatCompletionOutput(attrs: SpanAttributes): string | undefine
     message.tool_calls = toolCalls;
   }
 
-  const messages: Record<string, any>[] = [message];
-  if (attrs[AI_TOOL_CALL_RESULT]) {
-    messages.push({
-      role: "tool",
-      tool_call_id: String(attrs[AI_TOOL_CALL_ID] || ""),
-      content: String(attrs[AI_TOOL_CALL_RESULT] || ""),
-    });
-  }
-
-  const normalizedPayload = messages.length === 1 ? message : messages;
+  const normalizedPayload = appendToolResultMessage(message, attrs);
   enrichCompletionAttrs(attrs, normalizedPayload);
   return safeJsonStr(normalizedPayload);
 }

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/messages.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/messages.ts
@@ -1,0 +1,533 @@
+import {
+  AI_PROMPT,
+  AI_PROMPT_MESSAGES,
+  AI_PROMPT_TOOLS,
+  AI_PROMPT_TOOL_CHOICE,
+  AI_RESPONSE_OBJECT,
+  AI_RESPONSE_TEXT,
+  AI_RESPONSE_TOOL_CALLS,
+  AI_TOOL_CALL,
+  AI_TOOL_CALLS,
+  AI_TOOL_CALL_ARGS,
+  AI_TOOL_CALL_ID,
+  AI_TOOL_CALL_NAME,
+  AI_TOOL_CALL_PREFIX,
+  AI_TOOL_CALL_RESULT,
+  RESPAN_SPAN_TOOL_CALLS,
+  isRecord,
+  safeJsonParse,
+  safeJsonStr,
+  type SpanAttributes,
+} from "./shared.js";
+
+type MessagePayload = Record<string, any>;
+
+function normalizeToolCallShape(call: unknown): Record<string, any> | undefined {
+  if (!isRecord(call)) {
+    return undefined;
+  }
+
+  const callFunction = isRecord(call.function) ? call.function : undefined;
+  const rawName =
+    callFunction?.name ??
+    call.name ??
+    call.toolName ??
+    call.tool_name;
+  const rawArguments =
+    callFunction?.arguments ??
+    callFunction?.args ??
+    call.args ??
+    call.arguments ??
+    call.input;
+  const rawId = call.id ?? call.toolCallId ?? call.tool_call_id;
+
+  const normalized: Record<string, any> = { type: "function" };
+  if (rawId !== undefined) {
+    normalized.id = String(rawId);
+  }
+
+  const functionPayload: Record<string, any> = {};
+  if (rawName !== undefined) {
+    functionPayload.name = String(rawName);
+  }
+  if (rawArguments !== undefined) {
+    functionPayload.arguments =
+      typeof rawArguments === "string"
+        ? rawArguments
+        : safeJsonStr(rawArguments);
+  }
+  if (Object.keys(functionPayload).length > 0) {
+    normalized.function = functionPayload;
+  }
+
+  return normalized;
+}
+
+function normalizeToolCallList(value: unknown): Record<string, any>[] | undefined {
+  const parsed = safeJsonParse(value);
+  const rawCalls = Array.isArray(parsed) ? parsed : parsed !== undefined ? [parsed] : [];
+  const normalized = rawCalls
+    .map((call) => normalizeToolCallShape(call))
+    .filter((call): call is Record<string, any> => Boolean(call));
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function parseToolCalls(attrs: SpanAttributes): Record<string, any>[] | undefined {
+  for (const key of [AI_RESPONSE_TOOL_CALLS, AI_TOOL_CALL, AI_TOOL_CALLS]) {
+    if (!attrs[key]) {
+      continue;
+    }
+
+    const normalized = normalizeToolCallList(attrs[key]);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  if (attrs[AI_TOOL_CALL_ID] || attrs[AI_TOOL_CALL_NAME] || attrs[AI_TOOL_CALL_ARGS]) {
+    const toolCall: Record<string, any> = { type: "function" };
+    for (const [key, value] of Object.entries(attrs)) {
+      if (key.startsWith(AI_TOOL_CALL_PREFIX)) {
+        toolCall[key.replace(AI_TOOL_CALL_PREFIX, "")] = value;
+      }
+    }
+    return normalizeToolCallList(toolCall);
+  }
+
+  return undefined;
+}
+
+function parseToolDefinition(tool: unknown): unknown {
+  const parsedTool = typeof tool === "string" ? safeJsonParse(tool) : tool;
+  if (!isRecord(parsedTool) || parsedTool.type !== "function") {
+    return parsedTool;
+  }
+
+  if (isRecord(parsedTool.function)) {
+    if (parsedTool.inputSchema && !parsedTool.function.parameters) {
+      const { inputSchema, ...rest } = parsedTool;
+      return {
+        ...rest,
+        function: { ...parsedTool.function, parameters: inputSchema },
+      };
+    }
+
+    return parsedTool;
+  }
+
+  const { name, description, parameters, inputSchema, ...rest } = parsedTool;
+  const resolvedParameters = parameters ?? inputSchema;
+  return {
+    ...rest,
+    type: "function",
+    function: {
+      name,
+      ...(description ? { description } : {}),
+      ...(resolvedParameters ? { parameters: resolvedParameters } : {}),
+    },
+  };
+}
+
+export function parseToolsValue(attrs: SpanAttributes): unknown[] | undefined {
+  try {
+    const tools = attrs[AI_PROMPT_TOOLS];
+    if (!tools) {
+      return undefined;
+    }
+
+    const rawTools = Array.isArray(tools) ? tools : [tools];
+    const parsedTools = rawTools
+      .map((tool) => parseToolDefinition(tool))
+      .filter(Boolean);
+
+    return parsedTools.length > 0 ? parsedTools : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseToolChoice(attrs: SpanAttributes): string | undefined {
+  try {
+    const toolChoice = attrs[AI_PROMPT_TOOL_CHOICE];
+    if (!toolChoice) {
+      return undefined;
+    }
+
+    const parsed = typeof toolChoice === "string" ? JSON.parse(toolChoice) : toolChoice;
+    if (parsed.function?.name) {
+      return safeJsonStr({
+        type: String(parsed.type),
+        function: { name: String(parsed.function.name) },
+      });
+    }
+
+    return safeJsonStr({ type: String(parsed.type) });
+  } catch {
+    return undefined;
+  }
+}
+
+function isMessageLike(value: unknown): value is MessagePayload {
+  if (!isRecord(value) || typeof value.role !== "string") {
+    return false;
+  }
+
+  return (
+    "content" in value ||
+    "tool_calls" in value ||
+    "toolCalls" in value ||
+    "tool_call_id" in value ||
+    "toolCallId" in value
+  );
+}
+
+function isMessageArray(value: unknown): value is MessagePayload[] {
+  return Array.isArray(value) && value.every((item) => isMessageLike(item));
+}
+
+function unwrapKnownResponseWrapper(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return value.response ?? value.object ?? value.output ?? value.result ?? value;
+}
+
+function extractMessagePayload(value: unknown): unknown {
+  const parsed = safeJsonParse(value);
+
+  if (typeof parsed === "string") {
+    const nested = safeJsonParse(parsed);
+    return nested === parsed ? undefined : extractMessagePayload(nested);
+  }
+
+  if (isMessageLike(parsed) || isMessageArray(parsed)) {
+    return parsed;
+  }
+
+  if (Array.isArray(parsed)) {
+    for (const item of parsed) {
+      const nested = extractMessagePayload(item);
+      if (nested !== undefined) {
+        return nested;
+      }
+    }
+    return undefined;
+  }
+
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  const unwrapped = unwrapKnownResponseWrapper(parsed);
+  if (unwrapped !== parsed) {
+    const nested = extractMessagePayload(unwrapped);
+    if (nested !== undefined) {
+      return nested;
+    }
+  }
+
+  for (const key of ["message", "messages", "text", "content", "value"]) {
+    if (!(key in parsed)) {
+      continue;
+    }
+
+    const nested = extractMessagePayload(parsed[key]);
+    if (nested !== undefined) {
+      return nested;
+    }
+  }
+
+  return undefined;
+}
+
+function collapseNestedMessageWrapper(value: unknown): unknown {
+  if (!isMessageLike(value)) {
+    return value;
+  }
+
+  const hasTopLevelMessageFields =
+    "tool_calls" in value ||
+    "toolCalls" in value ||
+    "tool_call_id" in value ||
+    "toolCallId" in value ||
+    "name" in value;
+  if (hasTopLevelMessageFields) {
+    return value;
+  }
+
+  const nested = extractMessagePayload(value.content);
+  return nested ?? value;
+}
+
+function isContentBlockType(block: unknown, type: string): block is MessagePayload {
+  return isRecord(block) && block.type === type;
+}
+
+function normalizeToolResultMessage(block: MessagePayload): MessagePayload {
+  const result = block.result ?? block.content ?? block.output ?? "";
+  const message: MessagePayload = {
+    role: "tool",
+    content: typeof result === "string" ? result : safeJsonStr(result),
+  };
+
+  const toolCallId = block.toolCallId ?? block.tool_call_id ?? block.id;
+  if (toolCallId !== undefined) {
+    message.tool_call_id = String(toolCallId);
+  }
+
+  const toolName = block.toolName ?? block.tool_name ?? block.name;
+  if (toolName !== undefined) {
+    message.name = String(toolName);
+  }
+
+  return message;
+}
+
+function normalizeMessageForBackend(message: unknown): MessagePayload[] {
+  if (!isRecord(message)) {
+    return [];
+  }
+
+  const normalizedToolCalls =
+    normalizeToolCallList(message.tool_calls) ??
+    normalizeToolCallList(message.toolCalls);
+
+  if (!Array.isArray(message.content)) {
+    const normalized = { ...message };
+    if (normalizedToolCalls) {
+      normalized.tool_calls = normalizedToolCalls;
+    }
+    delete normalized.toolCalls;
+
+    if (normalized.role === "tool") {
+      if (normalized.toolCallId !== undefined && normalized.tool_call_id === undefined) {
+        normalized.tool_call_id = String(normalized.toolCallId);
+      }
+      delete normalized.toolCallId;
+      if (normalized.content !== undefined && typeof normalized.content !== "string") {
+        normalized.content = safeJsonStr(normalized.content);
+      }
+    }
+
+    return [normalized];
+  }
+
+  const textParts: string[] = [];
+  const toolCallBlocks = message.content.filter((block) => isContentBlockType(block, "tool-call"));
+  const toolResultBlocks = message.content.filter((block) => isContentBlockType(block, "tool-result"));
+  const unknownBlocks = message.content.filter((block) => {
+    if (typeof block === "string") {
+      return false;
+    }
+    if (!isRecord(block)) {
+      return true;
+    }
+    return !["text", "output_text", "tool-call", "tool-result"].includes(String(block.type ?? ""));
+  });
+
+  for (const block of message.content) {
+    if (typeof block === "string") {
+      textParts.push(block);
+      continue;
+    }
+    if (!isRecord(block)) {
+      continue;
+    }
+    if ((block.type === "text" || block.type === "output_text") && typeof block.text === "string") {
+      textParts.push(block.text);
+    }
+  }
+
+  const textContent = textParts.join("\n");
+
+  if (message.role === "assistant" && (toolCallBlocks.length > 0 || normalizedToolCalls)) {
+    const normalizedMessage: MessagePayload = {
+      ...message,
+      content: textContent,
+    };
+    const toolCalls = normalizeToolCallList(toolCallBlocks) ?? normalizedToolCalls;
+    if (toolCalls) {
+      normalizedMessage.tool_calls = toolCalls;
+    }
+    delete normalizedMessage.toolCalls;
+    return [normalizedMessage];
+  }
+
+  if (message.role === "tool" && toolResultBlocks.length > 0) {
+    return toolResultBlocks.map((block) => normalizeToolResultMessage(block));
+  }
+
+  if (unknownBlocks.length === 0) {
+    return [{ ...message, content: textContent }];
+  }
+
+  return [{ ...message, content: message.content }];
+}
+
+function normalizeMessageCollection(value: unknown): MessagePayload[] | undefined {
+  const parsed = safeJsonParse(value);
+  if (parsed === undefined || parsed === null) {
+    return undefined;
+  }
+
+  if (Array.isArray(parsed)) {
+    const normalized = parsed.flatMap((message) => normalizeMessageForBackend(message));
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  if (isRecord(parsed)) {
+    const normalized = normalizeMessageForBackend(parsed);
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  return undefined;
+}
+
+function collapseSingleMessagePayload(messages: MessagePayload[]): unknown {
+  return messages.length === 1 ? messages[0] : messages;
+}
+
+function selectPrimaryAssistantMessage(value: unknown): MessagePayload | undefined {
+  if (isMessageLike(value)) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (isMessageLike(item) && item.role === "assistant") {
+        return item;
+      }
+    }
+
+    for (const item of value) {
+      if (isMessageLike(item)) {
+        return item;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function enrichCompletionAttrs(attrs: SpanAttributes, payload: unknown): void {
+  const message = selectPrimaryAssistantMessage(payload);
+  if (!message) {
+    return;
+  }
+
+  attrs["gen_ai.completion.0.role"] = String(message.role || "assistant");
+  attrs["gen_ai.completion.0.content"] =
+    typeof message.content === "string"
+      ? message.content
+      : message.content !== undefined
+        ? safeJsonStr(message.content)
+        : "";
+
+  const toolCalls =
+    normalizeToolCallList(message.tool_calls) ||
+    normalizeToolCallList(message.toolCalls) ||
+    parseToolCalls(attrs);
+  if (toolCalls && toolCalls.length > 0) {
+    attrs["gen_ai.completion.0.tool_calls"] = toolCalls;
+    attrs["tool_calls"] = toolCalls;
+    attrs[RESPAN_SPAN_TOOL_CALLS] = safeJsonStr(toolCalls);
+    attrs["has_tool_calls"] = true;
+    attrs["parallel_tool_calls"] = toolCalls.length > 1;
+  }
+}
+
+function parsePromptInputValue(attrs: SpanAttributes): Record<string, any>[] | undefined {
+  const normalizedMessages = normalizeMessageCollection(attrs[AI_PROMPT_MESSAGES]);
+  if (normalizedMessages && normalizedMessages.length > 0) {
+    return normalizedMessages;
+  }
+
+  const prompt = attrs[AI_PROMPT];
+  if (prompt) {
+    return [{ role: "user", content: String(prompt) }];
+  }
+
+  return undefined;
+}
+
+export function formatPromptInput(attrs: SpanAttributes): string | undefined {
+  const messages = parsePromptInputValue(attrs);
+  return messages ? safeJsonStr(messages) : undefined;
+}
+
+export function formatCompletionOutput(attrs: SpanAttributes): string | undefined {
+  // `ai.response.object` may contain arbitrary structured JSON from generateObject().
+  // Preserve that payload as-is in the fallback path instead of collapsing nested
+  // `message` fields into a synthetic assistant reply.
+  const existingPayload = extractMessagePayload(attrs[AI_RESPONSE_TEXT]);
+  if (existingPayload !== undefined) {
+    const normalizedMessages = normalizeMessageCollection(collapseNestedMessageWrapper(existingPayload));
+    const normalizedPayload = normalizedMessages
+      ? collapseSingleMessagePayload(normalizedMessages)
+      : collapseNestedMessageWrapper(existingPayload);
+    enrichCompletionAttrs(attrs, normalizedPayload);
+    return safeJsonStr(normalizedPayload);
+  }
+
+  let content = "";
+
+  if (attrs[AI_RESPONSE_OBJECT]) {
+    try {
+      const parsed = unwrapKnownResponseWrapper(safeJsonParse(attrs[AI_RESPONSE_OBJECT]));
+      content = safeJsonStr(parsed);
+    } catch {
+      content = String(attrs[AI_RESPONSE_TEXT] ?? "");
+    }
+  } else {
+    content = String(attrs[AI_RESPONSE_TEXT] ?? "");
+  }
+
+  const toolCalls = parseToolCalls(attrs);
+  if (!content && (!toolCalls || toolCalls.length === 0)) {
+    return undefined;
+  }
+
+  const message: Record<string, any> = { role: "assistant", content };
+  if (toolCalls && toolCalls.length > 0) {
+    message.tool_calls = toolCalls;
+  }
+
+  const messages: Record<string, any>[] = [message];
+  if (attrs[AI_TOOL_CALL_RESULT]) {
+    messages.push({
+      role: "tool",
+      tool_call_id: String(attrs[AI_TOOL_CALL_ID] || ""),
+      content: String(attrs[AI_TOOL_CALL_RESULT] || ""),
+    });
+  }
+
+  const normalizedPayload = messages.length === 1 ? message : messages;
+  enrichCompletionAttrs(attrs, normalizedPayload);
+  return safeJsonStr(normalizedPayload);
+}
+
+export function formatToolInput(attrs: SpanAttributes): string | undefined {
+  const name = attrs[AI_TOOL_CALL_NAME];
+  const args = attrs[AI_TOOL_CALL_ARGS];
+  if (!name && !args) {
+    return undefined;
+  }
+
+  const input: Record<string, any> = {};
+  if (name) {
+    input.name = name;
+  }
+  if (args) {
+    input.args = typeof args === "string" ? safeJsonParse(args) : args;
+  }
+  return safeJsonStr(input);
+}
+
+export function formatToolOutput(attrs: SpanAttributes): string | undefined {
+  const result = attrs[AI_TOOL_CALL_RESULT];
+  if (result === undefined) {
+    return undefined;
+  }
+  return safeJsonStr(typeof result === "string" ? safeJsonParse(result) : result);
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/shared.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/shared.ts
@@ -1,0 +1,190 @@
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { RespanLogType, RespanSpanAttributes } from "@respan/respan-sdk";
+import { VERCEL_PARENT_SPANS, VERCEL_SPAN_CONFIG } from "../constants/index.js";
+
+export type SpanAttributes = Record<string, any>;
+
+export const RESPAN_LOG_TYPE = RespanSpanAttributes.RESPAN_LOG_TYPE;
+export const GEN_AI_REQUEST_MODEL = RespanSpanAttributes.GEN_AI_REQUEST_MODEL;
+export const GEN_AI_USAGE_PROMPT_TOKENS = RespanSpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS;
+export const GEN_AI_USAGE_COMPLETION_TOKENS = RespanSpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS;
+export const LLM_REQUEST_TYPE = RespanSpanAttributes.LLM_REQUEST_TYPE;
+export const CUSTOMER_ID = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_ID;
+export const CUSTOMER_EMAIL = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_EMAIL;
+export const CUSTOMER_NAME = RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_NAME;
+export const THREAD_ID = RespanSpanAttributes.RESPAN_THREADS_ID;
+export const SESSION_ID = "respan.sessions.session_identifier";
+export const TRACE_GROUP_ID = RespanSpanAttributes.RESPAN_TRACE_GROUP_ID;
+export const RESPAN_SPAN_TOOLS = RespanSpanAttributes.RESPAN_SPAN_TOOLS;
+export const RESPAN_SPAN_TOOL_CALLS = RespanSpanAttributes.RESPAN_SPAN_TOOL_CALLS;
+export const RESPAN_METADATA_AGENT_NAME = RespanSpanAttributes.RESPAN_METADATA_AGENT_NAME;
+export const RESPAN_METADATA_PREFIX = RespanSpanAttributes.RESPAN_METADATA;
+
+export const TL_SPAN_KIND = "traceloop.span.kind";
+export const TL_ENTITY_INPUT = "traceloop.entity.input";
+export const TL_ENTITY_OUTPUT = "traceloop.entity.output";
+export const TL_REQUEST_FUNCTIONS = "llm.request.functions";
+
+export const AI_PREFIX = "ai.";
+export const AI_SDK = "ai.sdk";
+export const AI_OPERATION_ID = "ai.operationId";
+export const AI_MODEL_ID = "ai.model.id";
+export const AI_EMBEDDING = "ai.embedding";
+export const AI_EMBEDDINGS = "ai.embeddings";
+export const AI_AGENT_ID = "ai.agent.id";
+export const AI_WORKFLOW_ID = "ai.workflow.id";
+export const AI_TRANSCRIPT = "ai.transcript";
+export const AI_SPEECH = "ai.speech";
+export const AI_TELEMETRY_METADATA_PREFIX = "ai.telemetry.metadata.";
+export const AI_PROMPT = "ai.prompt";
+export const AI_PROMPT_MESSAGES = "ai.prompt.messages";
+export const AI_PROMPT_TOOLS = "ai.prompt.tools";
+export const AI_PROMPT_TOOL_CHOICE = "ai.prompt.toolChoice";
+export const AI_RESPONSE_OBJECT = "ai.response.object";
+export const AI_RESPONSE_TEXT = "ai.response.text";
+export const AI_RESPONSE_TOOL_CALLS = "ai.response.toolCalls";
+export const AI_RESPONSE_MS_TO_FINISH = "ai.response.msToFinish";
+export const AI_TOOL_CALL = "ai.toolCall";
+export const AI_TOOL_CALLS = "ai.toolCalls";
+export const AI_TOOL_CALL_PREFIX = "ai.toolCall.";
+export const AI_TOOL_CALL_ID = "ai.toolCall.id";
+export const AI_TOOL_CALL_NAME = "ai.toolCall.name";
+export const AI_TOOL_CALL_ARGS = "ai.toolCall.args";
+export const AI_TOOL_CALL_RESULT = "ai.toolCall.result";
+export const GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens";
+export const GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens";
+export const GEN_AI_USAGE_COST = "gen_ai.usage.cost";
+export const GEN_AI_USAGE_TTFT = "gen_ai.usage.ttft";
+export const GEN_AI_USAGE_GENERATION_TIME = "gen_ai.usage.generation_time";
+export const GEN_AI_USAGE_WARNINGS = "gen_ai.usage.warnings";
+export const GEN_AI_USAGE_TYPE = "gen_ai.usage.type";
+
+export function metadataKey(key: string): string {
+  return `${RESPAN_METADATA_PREFIX}.${key}`;
+}
+
+export function setDefault(attrs: SpanAttributes, key: string, value: any): void {
+  if (attrs[key] === undefined && value !== undefined && value !== null) {
+    attrs[key] = value;
+  }
+}
+
+export function safeJsonStr(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function safeJsonParse(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+export function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isVercelAISpan(span: ReadableSpan): boolean {
+  if (span.instrumentationLibrary?.name === "ai") {
+    return true;
+  }
+  if (span.attributes[AI_SDK] !== undefined) {
+    return true;
+  }
+  return span.name.startsWith(AI_PREFIX);
+}
+
+export function resolveLogType(name: string, attrs: SpanAttributes): string {
+  const config = VERCEL_SPAN_CONFIG[name];
+  if (config) {
+    return config.logType;
+  }
+
+  const parentType = VERCEL_PARENT_SPANS[name];
+  if (parentType) {
+    return parentType;
+  }
+
+  const operationId = attrs[AI_OPERATION_ID]?.toString();
+  if (operationId) {
+    const operationConfig = VERCEL_SPAN_CONFIG[operationId];
+    if (operationConfig) {
+      return operationConfig.logType;
+    }
+
+    const operationParentType = VERCEL_PARENT_SPANS[operationId];
+    if (operationParentType) {
+      return operationParentType;
+    }
+  }
+
+  if (
+    attrs[AI_EMBEDDING] || attrs[AI_EMBEDDINGS] ||
+    name.includes("embed") || operationId?.includes("embed")
+  ) {
+    return RespanLogType.EMBEDDING;
+  }
+
+  if (
+    attrs[AI_TOOL_CALL_ID] || attrs[AI_TOOL_CALL_NAME] ||
+    attrs[AI_TOOL_CALL_ARGS] || attrs[AI_TOOL_CALL_RESULT] ||
+    attrs[AI_RESPONSE_TOOL_CALLS] ||
+    name.includes("tool") || operationId?.includes("tool")
+  ) {
+    return RespanLogType.TOOL;
+  }
+
+  if (
+    attrs[AI_AGENT_ID] ||
+    name.includes("agent") || operationId?.includes("agent")
+  ) {
+    return RespanLogType.AGENT;
+  }
+
+  if (
+    attrs[AI_WORKFLOW_ID] ||
+    name.includes("workflow") || operationId?.includes("workflow")
+  ) {
+    return RespanLogType.WORKFLOW;
+  }
+
+  if (
+    attrs[AI_TRANSCRIPT] ||
+    name.includes("transcript") || operationId?.includes("transcript")
+  ) {
+    return RespanLogType.TRANSCRIPTION;
+  }
+
+  if (
+    attrs[AI_SPEECH] ||
+    name.includes("speech") || operationId?.includes("speech")
+  ) {
+    return RespanLogType.SPEECH;
+  }
+
+  if (name.includes("doGenerate") || name.includes("doStream")) {
+    return RespanLogType.TEXT;
+  }
+
+  return RespanLogType.UNKNOWN;
+}
+
+export function normalizeModel(modelId: string): string {
+  const model = modelId.toLowerCase();
+
+  if (model.includes("gemini-2.0-flash-001")) return "gemini/gemini-2.0-flash";
+  if (model.includes("gemini-2.0-pro")) return "gemini/gemini-2.0-pro-exp-02-05";
+  if (model.includes("claude-3-5-sonnet")) return "claude-3-5-sonnet-20241022";
+  if (model.includes("deepseek")) return `deepseek/${model}`;
+  if (model.includes("o3-mini")) return "o3-mini";
+
+  return model;
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/span-enrichment.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/span-enrichment.ts
@@ -1,0 +1,229 @@
+import {
+  AI_MODEL_ID,
+  AI_OPERATION_ID,
+  AI_PROMPT,
+  AI_PROMPT_MESSAGES,
+  AI_PROMPT_TOOL_CHOICE,
+  AI_PROMPT_TOOLS,
+  AI_RESPONSE_OBJECT,
+  AI_RESPONSE_MS_TO_FINISH,
+  AI_RESPONSE_TEXT,
+  AI_RESPONSE_TOOL_CALLS,
+  AI_SDK,
+  AI_TELEMETRY_METADATA_PREFIX,
+  AI_TOOL_CALL_ARGS,
+  AI_TOOL_CALL_ID,
+  AI_TOOL_CALL_NAME,
+  AI_TOOL_CALL_RESULT,
+  CUSTOMER_EMAIL,
+  CUSTOMER_ID,
+  CUSTOMER_NAME,
+  GEN_AI_USAGE_COST,
+  GEN_AI_USAGE_GENERATION_TIME,
+  GEN_AI_USAGE_INPUT_TOKENS,
+  GEN_AI_USAGE_OUTPUT_TOKENS,
+  GEN_AI_USAGE_TTFT,
+  GEN_AI_USAGE_TYPE,
+  GEN_AI_USAGE_WARNINGS,
+  GEN_AI_USAGE_COMPLETION_TOKENS,
+  GEN_AI_USAGE_PROMPT_TOKENS,
+  SESSION_ID,
+  THREAD_ID,
+  TRACE_GROUP_ID,
+  metadataKey,
+  setDefault,
+  type SpanAttributes,
+} from "./shared.js";
+
+export function enrichMetadata(attrs: SpanAttributes): void {
+  for (const [key, value] of Object.entries(attrs)) {
+    if (!key.startsWith(AI_TELEMETRY_METADATA_PREFIX)) {
+      continue;
+    }
+
+    const cleanKey = key.slice(AI_TELEMETRY_METADATA_PREFIX.length);
+    switch (cleanKey) {
+      case "customer_identifier":
+        setDefault(attrs, CUSTOMER_ID, String(value));
+        break;
+      case "customer_email":
+        setDefault(attrs, CUSTOMER_EMAIL, String(value));
+        break;
+      case "customer_name":
+        setDefault(attrs, CUSTOMER_NAME, String(value));
+        break;
+      case "session_identifier":
+        setDefault(attrs, SESSION_ID, String(value));
+        break;
+      case "thread_identifier":
+        setDefault(attrs, THREAD_ID, String(value));
+        break;
+      case "trace_group_identifier":
+        setDefault(attrs, TRACE_GROUP_ID, String(value));
+        break;
+      case "customer_params": {
+        try {
+          const parsed = typeof value === "string" ? JSON.parse(value) : value;
+          if (parsed?.customer_identifier) setDefault(attrs, CUSTOMER_ID, parsed.customer_identifier);
+          if (parsed?.customer_email) setDefault(attrs, CUSTOMER_EMAIL, parsed.customer_email);
+          if (parsed?.customer_name) setDefault(attrs, CUSTOMER_NAME, parsed.customer_name);
+        } catch {
+          // Ignore malformed customer_params metadata.
+        }
+        break;
+      }
+      case "prompt_unit_price":
+        setDefault(attrs, metadataKey("prompt_unit_price"), String(value));
+        break;
+      case "completion_unit_price":
+        setDefault(attrs, metadataKey("completion_unit_price"), String(value));
+        break;
+      case "userId":
+        setDefault(attrs, CUSTOMER_ID, String(value));
+        setDefault(attrs, metadataKey(cleanKey), String(value ?? ""));
+        break;
+      default:
+        setDefault(attrs, metadataKey(cleanKey), String(value ?? ""));
+        break;
+    }
+  }
+}
+
+export function enrichTokens(attrs: SpanAttributes): void {
+  const inputTokens =
+    attrs[GEN_AI_USAGE_INPUT_TOKENS] ??
+    attrs["gen_ai.usage.prompt_tokens"];
+  const outputTokens =
+    attrs[GEN_AI_USAGE_OUTPUT_TOKENS] ??
+    attrs["gen_ai.usage.completion_tokens"];
+
+  if (inputTokens !== undefined) {
+    setDefault(attrs, GEN_AI_USAGE_PROMPT_TOKENS, Number(inputTokens));
+  }
+  if (outputTokens !== undefined) {
+    setDefault(attrs, GEN_AI_USAGE_COMPLETION_TOKENS, Number(outputTokens));
+  }
+}
+
+export function enrichPerformanceMetrics(attrs: SpanAttributes, spanName: string): void {
+  setDefault(attrs, metadataKey("stream"), String(spanName.includes("doStream")));
+
+  const msToFinish = attrs[AI_RESPONSE_MS_TO_FINISH];
+  if (msToFinish !== undefined) {
+    setDefault(attrs, metadataKey("time_to_first_token"), String(Number(msToFinish) / 1000));
+  }
+
+  const cost = attrs[GEN_AI_USAGE_COST];
+  if (cost !== undefined) {
+    setDefault(attrs, metadataKey("cost"), String(cost));
+  }
+
+  const ttft = attrs[GEN_AI_USAGE_TTFT];
+  if (ttft !== undefined) {
+    setDefault(attrs, metadataKey("ttft"), String(ttft));
+  }
+
+  const generationTime = attrs[GEN_AI_USAGE_GENERATION_TIME];
+  if (generationTime !== undefined) {
+    setDefault(attrs, metadataKey("generation_time"), String(generationTime));
+  }
+
+  const warnings = attrs[GEN_AI_USAGE_WARNINGS];
+  if (warnings !== undefined) {
+    setDefault(attrs, metadataKey("warnings"), String(warnings));
+  }
+
+  const responseType = attrs[GEN_AI_USAGE_TYPE];
+  if (responseType !== undefined) {
+    setDefault(attrs, metadataKey("type"), String(responseType));
+  }
+}
+
+const VERCEL_ATTRS_TO_STRIP = [
+  AI_MODEL_ID,
+  "ai.model.provider",
+  "ai.response.model",
+  AI_PROMPT,
+  AI_PROMPT_MESSAGES,
+  "ai.prompt.format",
+  AI_RESPONSE_TEXT,
+  AI_RESPONSE_OBJECT,
+  "ai.usage.promptTokens",
+  "ai.usage.completionTokens",
+  "ai.usage.inputTokens",
+  "ai.usage.outputTokens",
+  "ai.usage.totalTokens",
+  "ai.usage.reasoningTokens",
+  "ai.usage.cachedInputTokens",
+  "ai.response.finishReason",
+  "ai.response.id",
+  "ai.response.timestamp",
+  "ai.response.providerMetadata",
+  AI_RESPONSE_MS_TO_FINISH,
+  "ai.response.msToFirstChunk",
+  "ai.response.avgOutputTokensPerSecond",
+  "ai.response.avgCompletionTokensPerSecond",
+  "ai.request.headers.user-agent",
+  AI_PROMPT_TOOL_CHOICE,
+  AI_OPERATION_ID,
+  "ai.settings.maxRetries",
+  "ai.settings.maxSteps",
+  AI_SDK,
+  "operation.name",
+  AI_TOOL_CALL_ID,
+  AI_TOOL_CALL_NAME,
+  AI_TOOL_CALL_ARGS,
+  AI_TOOL_CALL_RESULT,
+  AI_RESPONSE_TOOL_CALLS,
+  "gen_ai.response.finish_reasons",
+  "gen_ai.response.id",
+  "gen_ai.usage.input_tokens",
+  "gen_ai.usage.output_tokens",
+  "gen_ai.system",
+  "traceloop.entity.name",
+  "traceloop.entity.path",
+  "service.name",
+  "telemetry.sdk.language",
+  "telemetry.sdk.name",
+  "telemetry.sdk.version",
+  "process.pid",
+  "process.executable.name",
+  "process.executable.path",
+  "process.command_args",
+  "process.runtime.version",
+  "process.runtime.name",
+  "process.runtime.description",
+  "process.command",
+  "process.owner",
+  "host.name",
+  "host.arch",
+  "host.id",
+  "otel.scope.name",
+  "otel.scope.version",
+  "next.span_name",
+  "next.span_type",
+  "http.url",
+  "http.method",
+  "net.peer.name",
+];
+
+export function stripRedundantAttrs(attrs: SpanAttributes): void {
+  for (const key of VERCEL_ATTRS_TO_STRIP) {
+    delete attrs[key];
+  }
+
+  for (const key of Object.keys(attrs)) {
+    if (key.startsWith(AI_TELEMETRY_METADATA_PREFIX)) {
+      delete attrs[key];
+      continue;
+    }
+
+    if (key.startsWith("ai.usage.") && key.includes("Details.")) {
+      delete attrs[key];
+    }
+  }
+
+  if (attrs[AI_PROMPT_TOOLS] !== undefined) {
+    delete attrs[AI_PROMPT_TOOLS];
+  }
+}


### PR DESCRIPTION
## Summary

Fix the following problem of respan-instrumentation-vercel
	-tool span lost
	-tool input and output values leaks into span input and output
	-input and output syntax problem
	-duplicate task children tree built under special circumstances
	-vercel embed cases wrong
	-wrong empty span created after multiple tool calls

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core span translation/attribute normalization logic, which can change what telemetry data is emitted and how tool calls/messages are represented. Main risk is regressions in downstream parsing due to new message/tool-call shaping and attribute stripping.
> 
> **Overview**
> **Vercel AI span translation is refactored and tightened.** The monolithic `_translator.ts` logic is split into `shared.ts`, `messages.ts`, and `span-enrichment.ts`, while keeping the same two-phase `SpanProcessor` flow.
> 
> **Tool calls and message payloads are now normalized more robustly.** The translator now extracts/normalizes tool-call shapes across multiple Vercel formats, populates additional completion/tool-call attributes (e.g. `gen_ai.completion.*`, `respan.span.tool_calls`), and avoids emitting empty/invalid LLM input/output payloads.
> 
> **Tool definitions are propagated to more destinations and redundant attributes are stripped consistently.** Parsed tools are written to `respan.span.tools`, `llm.request.functions`, and a structured `tools` field, while cleanup is centralized to remove translated Vercel/metadata noise after enrichment.
> 
> Adds a release intent to publish a **patch** for `@respan/instrumentation-vercel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac961a473bbb4ade8122466267cb22358b9374f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->