### PR TITLE
feat(tracing): suppressed_parent_context() helper + nested-workflow contract guards

### DIFF
--- a/.release-intents/20260501-tracing-suppressed-parent-context-helper.json
+++ b/.release-intents/20260501-tracing-suppressed-parent-context-helper.json
@@ -1,0 +1,6 @@
+{
+  "summary": "feat(tracing): add suppressed_parent_context() — a top-level context manager that suppresses the active OTel parent for a code block. Spans created inside start fresh root traces; the outer span itself is untouched. For the canonical Pulsar/Kafka/Celery batch consumer pattern: wrap each per-iteration dispatch in `with suppressed_parent_context():` so per-message work is isolated from the batch handler's @workflow span. Lets callers express the boundary explicitly without reaching into raw OTel context APIs. Also adds TestNestedWorkflowTraceContinuationContract — explicit guards for the v2 contract (nested @workflow inherits outer trace_id by default) so the same redesign that produced 3.0.0 cannot pass CI again. Pure addition; no existing behavior changes.",
+  "packages": {
+    "respan-tracing": "minor"
+  }
+}

--- a/python-sdks/respan-tracing/src/respan_tracing/__init__.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/__init__.py
@@ -3,6 +3,7 @@ from respan_tracing.core.client import RespanClient
 from respan_tracing.decorators import workflow, task, agent, tool
 from respan_tracing.contexts.span import SpanLink, span_link_to_otel, span_to_link, respan_span_attributes, attach_span_links
 from respan_tracing.instruments import Instruments
+from respan_tracing.utils.context import suppressed_parent_context
 from respan_tracing.utils.logging import get_respan_logger, get_main_logger
 from respan_sdk.respan_types.param_types import RespanParams
 from respan_sdk import FilterParamDict, MetricFilterParam, FilterBundle
@@ -11,7 +12,7 @@ __all__ = [
     "RespanTelemetry",
     "get_client",
     "RespanClient",
-    "workflow", 
+    "workflow",
     "task",
     "agent",
     "tool",
@@ -20,6 +21,7 @@ __all__ = [
     "span_to_link",
     "respan_span_attributes",
     "attach_span_links",
+    "suppressed_parent_context",
     "Instruments",
     "RespanParams",
     "FilterParamDict",

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/context.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/context.py
@@ -1,8 +1,44 @@
-from typing import Optional
+from contextlib import contextmanager
+from typing import Iterator, Optional
 from opentelemetry import context as context_api
 from opentelemetry.context import Context
 from opentelemetry.semconv_ai import SpanAttributes
 from respan_tracing.constants.context_constants import WORKFLOW_NAME_KEY, ENTITY_PATH_KEY
+
+
+@contextmanager
+def suppressed_parent_context() -> Iterator[None]:
+    """Suppress the active OTel parent context for spans created in this block.
+
+    Spans created (via @workflow / @task / @agent / @tool decorators or
+    client.start_span) while this block is active see no active parent —
+    they start fresh root traces. The OUTER span itself is untouched; only
+    spans created INSIDE the with-block get the empty context.
+
+    Use at execution boundaries where the inner work is conceptually
+    independent of the outer span — most commonly, a Pulsar / Kafka /
+    Celery batch consumer dispatching independent per-message tasks from
+    inside a batch-level @workflow span:
+
+        @workflow(name="my_consumer_handle_batch")
+        async def _handle_batch(consumer, messages):
+            for message in messages:
+                with suppressed_parent_context():
+                    await asyncio.to_thread(task.run, **message.payload)
+
+    Without this, every per-message dispatch inherits _handle_batch's
+    trace_id and downstream `count(distinct trace_unique_id)` collapses N
+    messages into one trace per batch.
+
+    Sub-workflow composition (workflow → workflow → workflow as one trace)
+    is unaffected — the @workflow decorator's standard child-of-context
+    behavior continues to work everywhere except inside this block.
+    """
+    token = context_api.attach(Context())
+    try:
+        yield
+    finally:
+        context_api.detach(token)
 
 
 def get_entity_path(ctx: Optional[Context] = None) -> Optional[str]:

--- a/python-sdks/respan-tracing/tests/test_start_span.py
+++ b/python-sdks/respan-tracing/tests/test_start_span.py
@@ -428,5 +428,252 @@ class TestSetupSpanShared:
         assert name_after is None or name_after != "outer_wf"
 
 
+class TestNestedWorkflowTraceContinuationContract:
+    """The SDK contract for nested @workflow / @agent / @task: when invoked
+    inside an active OTel context, the new span attaches as a child and
+    inherits the parent trace_id. This is the user-facing "sub-workflow
+    composition" pattern — workflow → workflow → workflow appears as one
+    trace in the UI.
+
+    These tests existed implicitly in the SDK's behavior, but had no
+    explicit test asserting them, which is why a 2026-04-30 redesign
+    attempt (3.0.0, since reverted via #189) flipped the @workflow default
+    to "fresh root per call" and shipped before being caught. Locking the
+    contract down so the same redesign can't pass CI again.
+    """
+
+    def setup_method(self):
+        self.telemetry = RespanTelemetry(
+            app_name="test-nested-continuation-contract",
+            api_key="test-key",
+            is_enabled=True,
+        )
+        self.client = get_client()
+
+    def test_nested_workflow_inherits_outer_trace_id(self):
+        """@workflow nested inside another @workflow MUST share the outer's
+        trace_id by default. This is the sub-workflow composition contract.
+        """
+        from respan_tracing import workflow
+
+        captured = {}
+
+        @workflow(name="inner_wf")
+        def inner():
+            captured["inner_trace_id"] = trace.get_current_span().get_span_context().trace_id
+            captured["inner_parent_span_id"] = trace.get_current_span().parent.span_id
+
+        @workflow(name="outer_wf")
+        def outer():
+            captured["outer_trace_id"] = trace.get_current_span().get_span_context().trace_id
+            captured["outer_span_id"] = trace.get_current_span().get_span_context().span_id
+            inner()
+
+        outer()
+
+        assert captured["outer_trace_id"] != 0
+        assert captured["inner_trace_id"] == captured["outer_trace_id"], (
+            "Nested @workflow must inherit the outer @workflow's trace_id. "
+            "If this fails, somebody broke the sub-workflow composition contract."
+        )
+        assert captured["inner_parent_span_id"] == captured["outer_span_id"], (
+            "Nested @workflow must attach as a child of the outer @workflow span."
+        )
+
+    def test_three_level_workflow_nesting_shares_trace_id(self):
+        """workflow → workflow → workflow appears as one trace."""
+        from respan_tracing import workflow
+
+        captured = []
+
+        @workflow(name="level_3")
+        def level_3():
+            captured.append(trace.get_current_span().get_span_context().trace_id)
+
+        @workflow(name="level_2")
+        def level_2():
+            captured.append(trace.get_current_span().get_span_context().trace_id)
+            level_3()
+
+        @workflow(name="level_1")
+        def level_1():
+            captured.append(trace.get_current_span().get_span_context().trace_id)
+            level_2()
+
+        level_1()
+
+        assert len(captured) == 3
+        assert captured[0] != 0
+        assert captured[0] == captured[1] == captured[2], (
+            f"Three-level @workflow nesting must share one trace_id. Got: {captured}"
+        )
+
+    def test_top_level_workflow_no_parent_gets_fresh_trace(self):
+        """@workflow with no active OTel context gets a fresh root trace.
+        The dominant case — Celery worker, gunicorn handler, CLI entry,
+        signal receiver — and unchanged from plain OTel.
+        """
+        from respan_tracing import workflow
+
+        captured = {}
+
+        @workflow(name="standalone_wf")
+        def fn():
+            captured["trace_id"] = trace.get_current_span().get_span_context().trace_id
+            captured["parent"] = trace.get_current_span().parent
+
+        fn()
+        assert captured["trace_id"] != 0
+        assert captured["parent"] is None
+
+    def test_two_top_level_workflow_calls_get_distinct_trace_ids(self):
+        """Each top-level @workflow call gets its own trace. Sanity check
+        that the inheritance contract doesn't leak across independent invocations.
+        """
+        from respan_tracing import workflow
+
+        captured = []
+
+        @workflow(name="standalone")
+        def fn():
+            captured.append(trace.get_current_span().get_span_context().trace_id)
+
+        fn()
+        fn()
+        assert len(captured) == 2
+        assert captured[0] != captured[1]
+
+    def test_imperative_start_span_workflow_kind_inherits_outer(self):
+        """client.start_span(kind='workflow') matches @workflow:
+        inherits the active trace_id when one exists.
+        """
+        with self.client.start_span("outer", kind="workflow") as outer_span:
+            outer_trace = outer_span.get_span_context().trace_id
+            with self.client.start_span("inner", kind="workflow") as inner_span:
+                assert inner_span.get_span_context().trace_id == outer_trace
+                assert inner_span.parent.span_id == outer_span.get_span_context().span_id
+
+
+class TestSuppressedParentContext:
+    """Tests for suppressed_parent_context() — the helper a caller uses to
+    isolate per-iteration work from a wrapping @workflow span (the Pulsar
+    consumer batch-handler pattern).
+    """
+
+    def setup_method(self):
+        self.telemetry = RespanTelemetry(
+            app_name="test-suppressed-parent-context",
+            api_key="test-key",
+            is_enabled=True,
+        )
+        self.client = get_client()
+
+    def test_workflow_inside_suppressed_block_starts_fresh_root(self):
+        """An @workflow called inside `with suppressed_parent_context()`
+        produces a fresh trace_id even when an outer @workflow span is active.
+        """
+        from respan_tracing import suppressed_parent_context, workflow
+
+        captured = {}
+
+        @workflow(name="inner_isolated_wf")
+        def inner():
+            captured["inner_trace_id"] = trace.get_current_span().get_span_context().trace_id
+            captured["inner_parent"] = trace.get_current_span().parent
+
+        @workflow(name="outer_wf")
+        def outer():
+            captured["outer_trace_id"] = trace.get_current_span().get_span_context().trace_id
+            with suppressed_parent_context():
+                inner()
+
+        outer()
+
+        assert captured["outer_trace_id"] != 0
+        assert captured["inner_trace_id"] != 0
+        assert captured["inner_trace_id"] != captured["outer_trace_id"], (
+            "@workflow inside suppressed_parent_context() must start a fresh "
+            "trace, not inherit the outer span's trace_id."
+        )
+        assert captured["inner_parent"] is None, (
+            "@workflow inside suppressed_parent_context() must be a root span (no parent)."
+        )
+
+    def test_outer_trace_restored_after_suppressed_block_exits(self):
+        """After the with-block exits, the outer span's trace_id is the
+        active context again.
+        """
+        from respan_tracing import suppressed_parent_context, workflow
+
+        captured = []
+
+        @workflow(name="outer_wf_restore")
+        def outer():
+            captured.append(trace.get_current_span().get_span_context().trace_id)
+            with suppressed_parent_context():
+                pass
+            captured.append(trace.get_current_span().get_span_context().trace_id)
+
+        outer()
+        assert captured[0] == captured[1], (
+            "Outer trace_id must be restored after suppressed_parent_context exits"
+        )
+
+    def test_multiple_iterations_each_get_distinct_trace_id(self):
+        """The canonical Pulsar-consumer pattern: a loop inside an outer
+        @workflow span, each iteration wraps its dispatch in
+        `with suppressed_parent_context()`. Each iteration must produce a
+        distinct trace_id (none equal to the outer span's).
+        """
+        from respan_tracing import suppressed_parent_context, workflow
+
+        captured: list[int] = []
+        outer_trace_id: dict[str, int] = {}
+        n_iterations = 10
+
+        @workflow(name="per_message_dispatch")
+        def per_message():
+            captured.append(trace.get_current_span().get_span_context().trace_id)
+
+        @workflow(name="batch_handler")
+        def batch_handler():
+            outer_trace_id["value"] = trace.get_current_span().get_span_context().trace_id
+            for _ in range(n_iterations):
+                with suppressed_parent_context():
+                    per_message()
+
+        batch_handler()
+
+        assert len(captured) == n_iterations
+        assert outer_trace_id["value"] not in captured, (
+            "A per-iteration trace_id matched the outer batch span — "
+            "suppressed_parent_context() is not isolating context."
+        )
+        assert len(set(captured)) == n_iterations, (
+            f"Expected {n_iterations} distinct trace_ids, got {len(set(captured))}. "
+            "Per-iteration spans are sharing trace_ids — the bug class this "
+            "helper exists to prevent."
+        )
+
+    def test_helper_is_a_no_op_when_no_active_context(self):
+        """Calling suppressed_parent_context() with no active OTel parent
+        is harmless. @workflow inside still produces a normal fresh trace.
+        """
+        from respan_tracing import suppressed_parent_context, workflow
+
+        captured = {}
+
+        @workflow(name="standalone")
+        def fn():
+            captured["trace_id"] = trace.get_current_span().get_span_context().trace_id
+            captured["parent"] = trace.get_current_span().parent
+
+        with suppressed_parent_context():
+            fn()
+
+        assert captured["trace_id"] != 0
+        assert captured["parent"] is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

A purely additive **minor** release (publishes as **2.17.0**) on top of the v2.16.6 baseline (after #189 reverted 3.0.0).

### 1. `suppressed_parent_context()` — top-level context manager

```python
from respan_tracing import suppressed_parent_context, workflow

@workflow(name="my_consumer_handle_batch")
async def _handle_batch(consumer, messages):
    for message in messages:
        with suppressed_parent_context():
            await asyncio.to_thread(task.run, **message.payload)
```

Inside the with-block, the active OTel parent is suppressed — spans created inside start fresh root traces. The outer span is untouched; only spans created INSIDE the block see the empty context. For Pulsar / Kafka / Celery batch consumers dispatching independent per-message tasks from inside a batch-level `@workflow` span.

Lets callers express the boundary explicitly without reaching into raw OTel context APIs (`context_api.attach(Context())` + `detach`).

### 2. `TestNestedWorkflowTraceContinuationContract`

5 explicit tests asserting the v2 contract:
- Nested `@workflow` inherits outer trace_id
- 3-level workflow nesting shares one trace_id
- Top-level `@workflow` with no active context is fresh root
- Two top-level calls get distinct trace_ids
- Imperative `client.start_span(kind="workflow")` matches the decorator

These tests exist because the previous SDK behavior was implicit. 3.0.0's redesign passed CI because nothing asserted the nested-continuation contract. Locking it down so the same redesign cannot pass CI again.

## Net effect

| Caller | Behavior |
|---|---|
| Existing v2 callers (any pin `^2.x`) | **No behavior change**, plus a new public helper. `^2.16.5` auto-picks up 2.17.0 |
| New callers using `suppressed_parent_context()` | New, opt-in isolation primitive |

## Test plan

- [x] 48/48 SDK tests pass — 39 baseline + 5 contract guards + 4 helper tests