### PR TITLE
release(tracing): republish 2.17.0 from clean v2 baseline

### DIFF
--- a/.release-intents/20260501-tracing-republish-2-17-0.json
+++ b/.release-intents/20260501-tracing-republish-2-17-0.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Republish respan-tracing as 2.17.0 (continuing the v2 line). The mistakenly-published 3.0.0 (broken, reverted in #189) and 3.1.0 (correctly featured but accidentally published in the v3 line because the publish floor was max(pyproject, pypi)) are being removed from PyPI. This PR rolls pyproject.toml back to 2.16.6 so the publish pipeline computes 2.17.0 from a clean v2 baseline. Pure additive content: suppressed_parent_context() helper + nested-workflow contract guards (already merged via #190).",
+  "packages": {
+    "respan-tracing": "minor"
+  }
+}

--- a/python-sdks/respan-tracing/pyproject.toml
+++ b/python-sdks/respan-tracing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-tracing"
-version = "3.1.0"
+version = "2.16.6"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Rolls `pyproject.toml` `3.1.0 → 2.16.6` and adds a fresh `"minor"` release-intent so the publish pipeline computes **2.17.0** (continuing the v2 line) instead of 3.2.0.

## Why this isn't trivial

The publish pipeline floors version at `max(pyproject.toml, latest_pypi)` — see `scripts/release_intents.py:259` (`resolved_base_version` with `prefer_registry=True`) and `.github/workflows/publish.yml:141`. As long as PyPI's `info.version` for `respan-tracing` is `3.1.0`, the floor wins and any new publish lands as 3.x.

`latest_registry_version()` reads `https://pypi.org/pypi/respan-tracing/json` `info.version`, which **still includes yanked releases**. So the only way to get `info.version = 2.16.6` is to **fully delete** 3.0.0 and 3.1.0.

## Order of operations (DO NOT MERGE OUT OF ORDER)

1. **You (project owner): delete `respan-tracing 3.0.0` AND `3.1.0` from PyPI** via the web UI (within 24h of upload — both fall inside this window). Yanking is **not** sufficient.
2. Verify deletion: `pip index versions respan-tracing` should show `2.16.6` as `LATEST`.
3. Merge this PR (squash).
4. CI on main → publish workflow → publishes **2.17.0**.

## Diff

```
python-sdks/respan-tracing/pyproject.toml         | 2 +-
.release-intents/20260501-tracing-republish-2-17-0.json | (new)
```

Two-line change, zero code change. The helper + contract guards already landed in #190.

## After publish

- Confirm `pip index versions respan-tracing` shows `2.17.0` as `LATEST`
- Backend `^2.16.5` pin auto-picks up 2.17.0 — no backend dep bump needed
- Existing v2 callers see no behavior change + the new `suppressed_parent_context()` helper