### PR TITLE
chore(tracing): alphabetize dependencies in package.json

### DIFF
--- a/.release-intents/20260507-tracing-deps-alphabetize.json
+++ b/.release-intents/20260507-tracing-deps-alphabetize.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Alphabetize @respan/respan-sdk in respan-tracing package.json (no functional change, no version bump)",
+  "packages": {
+    "@respan/tracing": "none"
+  }
+}

--- a/javascript-sdks/respan-tracing/package.json
+++ b/javascript-sdks/respan-tracing/package.json
@@ -30,7 +30,6 @@
   "author": "Respan <team@respan.ai>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@respan/respan-sdk": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.56.0",
@@ -39,6 +38,7 @@
     "@opentelemetry/sdk-trace-base": "^1.26.0",
     "@opentelemetry/sdk-trace-node": "^1.26.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@respan/respan-sdk": "^1.0.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Move \`@respan/respan-sdk\` into alphabetical order between the \`@opentelemetry/*\` block and \`@traceloop/ai-semantic-conventions\` in \`respan-tracing/package.json\`.

No functional change. yarn.lock unaffected.

Replaces #184 (which bundled this 2-line fix with a stale version bump and ~5000 lines of yarn.lock churn).

## Test plan

- [x] One-line diff
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)