### PR TITLE
docs(architecture): scope respan-sdk constant ownership

### DIFF
--- a/contribution/architecture.md
+++ b/contribution/architecture.md
@@ -40,7 +40,7 @@ JavaScript contract package:
 Responsibilities:
 
 - public parameter types such as `RespanLogParams`, `RespanParams`, filter types, and usage/message models
-- canonical attribute keys such as `RespanSpanAttributes`
+- canonical attribute keys for **Respan-owned** namespaces (`respan.*`) such as `RespanSpanAttributes`. Industry-standard keys (`gen_ai.*`, `llm.*`, `traceloop.*`, `openinference.*`) are imported from upstream semconv packages, not redeclared here. SDK-specific keys (LangChain callback fields, Vercel `ai.*`, n8n events, …) stay inside the instrumentation package that owns the SDK. See [`span-contract.md`](span-contract.md#source-rules).
 - OTLP field names and promotion rules used by exporters and serializers
 - low-level utility code that is safe to reuse from runtime packages
 


### PR DESCRIPTION
## Summary

- Scopes the Contract Layer's "canonical attribute keys" responsibility to Respan-owned namespaces only.
- Notes industry-standard keys (Traceloop/OpenInference) come from upstream semconv packages, and SDK-specific keys (LangChain, Vercel, n8n) live inside the owning instrumentation.
- Links to `span-contract.md` so the two docs don't drift.

## Test plan

- [x] Docs-only change; no code touched