### PR TITLE
feat(python-sdk): remove deprecated posthog_integration field + bump 2.6.27

### DIFF
--- a/.release-intents/20260605-respan-sdk-remove-posthog-integration.json
+++ b/.release-intents/20260605-respan-sdk-remove-posthog-integration.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Remove deprecated posthog_integration field and PostHogIntegration type from respan-sdk; PostHog now uses the stored technical-partnership integration instead of passing credentials in the request payload",
+  "packages": {
+    "respan-sdk": "patch"
+  }
+}

--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-sdk"
-version = "2.6.27"
+version = "2.6.26"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-sdk"
-version = "2.6.26"
+version = "2.6.27"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
@@ -13,7 +13,6 @@ from .param_types import (
     CacheOptions,
     Customer,
     PromptParam,
-    PostHogIntegration,
 )
 from .services_types.hyperspell_types import (
     HyperspellAddMemoryParams,
@@ -73,7 +72,6 @@ __all__ = [
     "CacheOptions",
     "Customer",
     "PromptParam",
-    "PostHogIntegration",
     "HyperspellAddMemoryParams",
     "HyperspellSearchMemoriesParams",
     "HyperspellParams",

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
@@ -27,7 +27,6 @@ from .param_types import (
     LoadBalanceGroup,
     LoadBalanceModel,
     RetryParams,
-    PostHogIntegration,
 )
 from ..constants.llm_logging import LogType
 from .services_types.linkup_types import LinkupParams
@@ -185,7 +184,6 @@ class RespanLogParams(PreprocessLogDataMixin, RespanBaseModel):
     linkup_params: Optional[LinkupParams] = None
     mem0_params: Optional[Mem0Params] = None
     moda_params: Optional[ModaParams] = None
-    posthog_integration: Optional[PostHogIntegration] = None
     # endregion: technical integrations
 
     # region: tracing

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
@@ -112,11 +112,6 @@ class LoadBalanceGroup(RespanBaseModel):
         return super().model_dump(*args, **kwargs)
 
 
-class PostHogIntegration(RespanBaseModel):
-    posthog_api_key: str
-    posthog_base_url: str
-
-
 class Customer(RespanBaseModel):
     customer_identifier: Union[str, int, None] = None
     name: Optional[Union[str, None]] = None
@@ -423,7 +418,6 @@ class RespanParams(RespanBaseModel, PreprocessLogDataMixin):
     linkup_params: Optional[LinkupParams] = None
     mem0_params: Optional[Mem0Params] = None
     moda_params: Optional[ModaParams] = None
-    posthog_integration: Optional[PostHogIntegration] = None
     # endregion: technical integrations
 
     # region: custom properties


### PR DESCRIPTION
Removes the secret-bearing `posthog_integration` field (and the orphaned `PostHogIntegration` type) from the Python SDK. PostHog credentials are no longer accepted in the request payload — they now live **encrypted server-side** in the Technical Partnership Integration store (`provider=posthog`), and the request only carries the non-secret `posthog_params` trigger (mirrors `moda_params`).

## What
- Remove `posthog_integration` field from `RespanFullLogParams` (`log_types.py`) and the params type (`param_types.py`).
- Remove the now-orphaned `PostHogIntegration` model + its import/export.
- Bump `2.6.26 → 2.6.27`.

## Context / safety
- The backend already neutralizes the field at runtime (`Field(exclude=True)` override) and migrated PostHog to the stored, encrypted credential store. This PR removes the field at the **source** so it's no longer part of the SDK contract.
- A usage probe confirmed **0 active PostHog users** before the cut, so removing the public field/type has no customer impact.

## Follow-up
- Once `2.6.27` is published, the backend bumps `respan-sdk` to it and drops the `Field(exclude=True)` override (the SDK base no longer declares the field → `extra="ignore"` drops it on input).
- The JS SDK likely carries the same field — separate follow-up if so.