### PR TITLE
feat(tracing): preserve context across parallel workers

### DIFF
--- a/.release-intents/20260610-threadpool-context-propagation.json
+++ b/.release-intents/20260610-threadpool-context-propagation.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add thread-pool context propagation helpers for reliable parallel tracing",
+  "packages": {
+    "respan-tracing": "minor"
+  }
+}

--- a/.release-intents/20260610-threadpool-context-propagation.json
+++ b/.release-intents/20260610-threadpool-context-propagation.json
@@ -1,5 +1,5 @@
 {
-  "summary": "Add thread-pool context propagation helpers for reliable parallel tracing",
+  "summary": "Add thread-pool and asyncio executor context propagation helpers for reliable parallel tracing",
   "packages": {
     "respan-tracing": "minor"
   }

--- a/python-sdks/respan-tracing/README.md
+++ b/python-sdks/respan-tracing/README.md
@@ -209,6 +209,46 @@ kai.add_processor(
 
 See [Multi-Processor Examples](#multiple-processors) for complete examples.
 
+### ThreadPoolExecutor and Parallel Agent Steps
+
+OpenTelemetry context is thread-local. A plain `ThreadPoolExecutor` can lose
+the active Respan span, processor routing, propagated attributes, and active
+`SpanBuffer`. Use `ContextPropagatingThreadPoolExecutor` when parallel work is
+launched from inside a traced workflow or agent.
+
+```python
+from respan_tracing import ContextPropagatingThreadPoolExecutor, RespanTelemetry, task, workflow
+
+telemetry = RespanTelemetry(app_name="parallel-agent", api_key="respan-xxx")
+
+
+@task(name="score_candidate")
+def score_candidate(candidate: str) -> int:
+    return len(candidate)
+
+
+@workflow(name="rank_candidates", processors="production")
+def rank_candidates(candidates: list[str]) -> list[int]:
+    with ContextPropagatingThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(score_candidate, candidate) for candidate in candidates]
+        return [future.result() for future in futures]
+```
+
+If you already own the executor lifecycle, use `submit_with_current_context`:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+from respan_tracing import submit_with_current_context
+
+with ThreadPoolExecutor(max_workers=4) as executor:
+    future = submit_with_current_context(executor, score_candidate, "agent-output")
+    result = future.result()
+```
+
+For buffered spans, wait for submitted futures before leaving the
+`client.get_span_buffer(...)` block. The buffer is thread-safe and flushes a
+stable snapshot on exit.
+
 ### Common Configuration Patterns
 
 #### **Development (Full Visibility)**

--- a/python-sdks/respan-tracing/README.md
+++ b/python-sdks/respan-tracing/README.md
@@ -211,13 +211,19 @@ See [Multi-Processor Examples](#multiple-processors) for complete examples.
 
 ### ThreadPoolExecutor and Parallel Agent Steps
 
-OpenTelemetry context is thread-local. A plain `ThreadPoolExecutor` can lose
-the active Respan span, processor routing, propagated attributes, and active
-`SpanBuffer`. Use `ContextPropagatingThreadPoolExecutor` when parallel work is
-launched from inside a traced workflow or agent.
+OpenTelemetry context is thread-local. Plain `ThreadPoolExecutor` workers,
+raw `threading.Thread` targets, and `Future` callbacks can lose the active
+Respan span, processor routing, propagated attributes, and active `SpanBuffer`.
+Use the context propagation helpers when parallel work is launched from inside
+a traced workflow or agent.
 
 ```python
-from respan_tracing import ContextPropagatingThreadPoolExecutor, RespanTelemetry, task, workflow
+from respan_tracing import (
+    ContextPropagatingThreadPoolExecutor,
+    RespanTelemetry,
+    task,
+    workflow,
+)
 
 telemetry = RespanTelemetry(app_name="parallel-agent", api_key="respan-xxx")
 
@@ -234,16 +240,30 @@ def rank_candidates(candidates: list[str]) -> list[int]:
         return [future.result() for future in futures]
 ```
 
-If you already own the executor lifecycle, use `submit_with_current_context`:
+`executor.map(...)` is also context-aware on
+`ContextPropagatingThreadPoolExecutor`.
+
+If you already own the executor lifecycle, use `submit_with_current_context`.
+For callbacks that create spans after a future completes, use
+`add_done_callback_with_current_context`.
 
 ```python
 from concurrent.futures import ThreadPoolExecutor
-from respan_tracing import submit_with_current_context
+from respan_tracing import add_done_callback_with_current_context, submit_with_current_context
+
+
+def on_done(future):
+    with get_client().start_span("post_process_result", kind="task"):
+        consume(future.result())
+
 
 with ThreadPoolExecutor(max_workers=4) as executor:
     future = submit_with_current_context(executor, score_candidate, "agent-output")
+    add_done_callback_with_current_context(future, on_done)
     result = future.result()
 ```
+
+For raw threads, use `ContextPropagatingThread` instead of `threading.Thread`.
 
 For buffered spans, wait for submitted futures before leaving the
 `client.get_span_buffer(...)` block. The buffer is thread-safe and flushes a

--- a/python-sdks/respan-tracing/README.md
+++ b/python-sdks/respan-tracing/README.md
@@ -263,6 +263,29 @@ with ThreadPoolExecutor(max_workers=4) as executor:
     result = future.result()
 ```
 
+For async orchestration that hands blocking SDK calls to an executor, use
+`run_in_executor_with_current_context` or `to_thread_with_current_context`.
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+from respan_tracing import run_in_executor_with_current_context, task, workflow
+
+
+@task(name="blocking_retrieval")
+def blocking_retrieval(query: str) -> str:
+    return search_index(query)
+
+
+@workflow(name="async_agent", processors="production")
+async def async_agent(query: str) -> str:
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        return await run_in_executor_with_current_context(
+            executor,
+            blocking_retrieval,
+            query,
+        )
+```
+
 For raw threads, use `ContextPropagatingThread` instead of `threading.Thread`.
 
 For buffered spans, wait for submitted futures before leaving the

--- a/python-sdks/respan-tracing/examples/threadpool_context_propagation.py
+++ b/python-sdks/respan-tracing/examples/threadpool_context_propagation.py
@@ -1,17 +1,20 @@
-"""Trace parallel work launched through ThreadPoolExecutor.
+"""Trace parallel work launched through ThreadPoolExecutor and asyncio.
 
 Plain ThreadPoolExecutor workers start with a fresh thread-local context.
 Use ContextPropagatingThreadPoolExecutor when parallel agent steps should stay
 attached to the parent Respan workflow and inherit processor routing.
 """
 
+import asyncio
 from respan_tracing import (
     ContextPropagatingThread,
     ContextPropagatingThreadPoolExecutor,
     RespanTelemetry,
     add_done_callback_with_current_context,
     get_client,
+    run_in_executor_with_current_context,
     task,
+    to_thread_with_current_context,
     workflow,
 )
 
@@ -44,6 +47,23 @@ def parallel_retrieval_agent(queries: list[str]) -> list[int]:
         return [future.result() for future in scoring]
 
 
+@workflow(name="async_parallel_retrieval_agent", processors="debug")
+async def async_parallel_retrieval_agent(queries: list[str]) -> list[int]:
+    with ContextPropagatingThreadPoolExecutor(max_workers=4) as executor:
+        contexts = await asyncio.gather(
+            *[
+                run_in_executor_with_current_context(executor, retrieve_context, query)
+                for query in queries
+            ]
+        )
+        return await asyncio.gather(
+            *[
+                to_thread_with_current_context(score_context, context)
+                for context in contexts
+            ]
+        )
+
+
 if __name__ == "__main__":
     warmup = ContextPropagatingThread(
         target=lambda: parallel_retrieval_agent(["warmup"])
@@ -52,4 +72,5 @@ if __name__ == "__main__":
     warmup.join()
 
     print(parallel_retrieval_agent(["pricing", "latency", "tool failures"]))
+    print(asyncio.run(async_parallel_retrieval_agent(["pricing", "latency"])))
     telemetry.flush()

--- a/python-sdks/respan-tracing/examples/threadpool_context_propagation.py
+++ b/python-sdks/respan-tracing/examples/threadpool_context_propagation.py
@@ -6,8 +6,11 @@ attached to the parent Respan workflow and inherit processor routing.
 """
 
 from respan_tracing import (
+    ContextPropagatingThread,
     ContextPropagatingThreadPoolExecutor,
     RespanTelemetry,
+    add_done_callback_with_current_context,
+    get_client,
     task,
     workflow,
 )
@@ -25,6 +28,11 @@ def score_context(context: str) -> int:
     return len(context)
 
 
+def record_final_count(_future) -> None:
+    with get_client().start_span("record_final_count", kind="task"):
+        pass
+
+
 @workflow(name="parallel_retrieval_agent", processors="debug")
 def parallel_retrieval_agent(queries: list[str]) -> list[int]:
     with ContextPropagatingThreadPoolExecutor(max_workers=4) as executor:
@@ -32,9 +40,16 @@ def parallel_retrieval_agent(queries: list[str]) -> list[int]:
         contexts = [future.result() for future in retrievals]
 
         scoring = [executor.submit(score_context, context) for context in contexts]
+        add_done_callback_with_current_context(scoring[-1], record_final_count)
         return [future.result() for future in scoring]
 
 
 if __name__ == "__main__":
+    warmup = ContextPropagatingThread(
+        target=lambda: parallel_retrieval_agent(["warmup"])
+    )
+    warmup.start()
+    warmup.join()
+
     print(parallel_retrieval_agent(["pricing", "latency", "tool failures"]))
     telemetry.flush()

--- a/python-sdks/respan-tracing/examples/threadpool_context_propagation.py
+++ b/python-sdks/respan-tracing/examples/threadpool_context_propagation.py
@@ -1,0 +1,40 @@
+"""Trace parallel work launched through ThreadPoolExecutor.
+
+Plain ThreadPoolExecutor workers start with a fresh thread-local context.
+Use ContextPropagatingThreadPoolExecutor when parallel agent steps should stay
+attached to the parent Respan workflow and inherit processor routing.
+"""
+
+from respan_tracing import (
+    ContextPropagatingThreadPoolExecutor,
+    RespanTelemetry,
+    task,
+    workflow,
+)
+
+telemetry = RespanTelemetry(app_name="threadpool-agent")
+
+
+@task(name="retrieve_context")
+def retrieve_context(query: str) -> str:
+    return f"context for {query}"
+
+
+@task(name="score_context")
+def score_context(context: str) -> int:
+    return len(context)
+
+
+@workflow(name="parallel_retrieval_agent", processors="debug")
+def parallel_retrieval_agent(queries: list[str]) -> list[int]:
+    with ContextPropagatingThreadPoolExecutor(max_workers=4) as executor:
+        retrievals = [executor.submit(retrieve_context, query) for query in queries]
+        contexts = [future.result() for future in retrievals]
+
+        scoring = [executor.submit(score_context, context) for context in contexts]
+        return [future.result() for future in scoring]
+
+
+if __name__ == "__main__":
+    print(parallel_retrieval_agent(["pricing", "latency", "tool failures"]))
+    telemetry.flush()

--- a/python-sdks/respan-tracing/src/respan_tracing/__init__.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/__init__.py
@@ -11,7 +11,9 @@ from respan_tracing.contexts.span import (
 from respan_tracing.instruments import Instruments
 from respan_tracing.utils.context import (
     ContextPropagatingThreadPoolExecutor,
+    ContextPropagatingThread,
     RespanContextSnapshot,
+    add_done_callback_with_current_context,
     capture_context,
     submit_with_current_context,
     suppressed_parent_context,
@@ -35,7 +37,9 @@ __all__ = [
     "respan_span_attributes",
     "attach_span_links",
     "ContextPropagatingThreadPoolExecutor",
+    "ContextPropagatingThread",
     "RespanContextSnapshot",
+    "add_done_callback_with_current_context",
     "capture_context",
     "submit_with_current_context",
     "suppressed_parent_context",

--- a/python-sdks/respan-tracing/src/respan_tracing/__init__.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/__init__.py
@@ -1,9 +1,22 @@
 from respan_tracing.main import RespanTelemetry, get_client
 from respan_tracing.core.client import RespanClient
 from respan_tracing.decorators import workflow, task, agent, tool
-from respan_tracing.contexts.span import SpanLink, span_link_to_otel, span_to_link, respan_span_attributes, attach_span_links
+from respan_tracing.contexts.span import (
+    SpanLink,
+    span_link_to_otel,
+    span_to_link,
+    respan_span_attributes,
+    attach_span_links,
+)
 from respan_tracing.instruments import Instruments
-from respan_tracing.utils.context import suppressed_parent_context
+from respan_tracing.utils.context import (
+    ContextPropagatingThreadPoolExecutor,
+    RespanContextSnapshot,
+    capture_context,
+    submit_with_current_context,
+    suppressed_parent_context,
+    wrap_with_current_context,
+)
 from respan_tracing.utils.logging import get_respan_logger, get_main_logger
 from respan_sdk.respan_types.param_types import RespanParams
 from respan_sdk import FilterParamDict, MetricFilterParam, FilterBundle
@@ -21,7 +34,12 @@ __all__ = [
     "span_to_link",
     "respan_span_attributes",
     "attach_span_links",
+    "ContextPropagatingThreadPoolExecutor",
+    "RespanContextSnapshot",
+    "capture_context",
+    "submit_with_current_context",
     "suppressed_parent_context",
+    "wrap_with_current_context",
     "Instruments",
     "RespanParams",
     "FilterParamDict",

--- a/python-sdks/respan-tracing/src/respan_tracing/__init__.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/__init__.py
@@ -15,8 +15,10 @@ from respan_tracing.utils.context import (
     RespanContextSnapshot,
     add_done_callback_with_current_context,
     capture_context,
+    run_in_executor_with_current_context,
     submit_with_current_context,
     suppressed_parent_context,
+    to_thread_with_current_context,
     wrap_with_current_context,
 )
 from respan_tracing.utils.logging import get_respan_logger, get_main_logger
@@ -41,8 +43,10 @@ __all__ = [
     "RespanContextSnapshot",
     "add_done_callback_with_current_context",
     "capture_context",
+    "run_in_executor_with_current_context",
     "submit_with_current_context",
     "suppressed_parent_context",
+    "to_thread_with_current_context",
     "wrap_with_current_context",
     "Instruments",
     "RespanParams",

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -3,10 +3,15 @@ import random
 from typing import Optional, Callable, Dict, Any, List, Sequence
 from contextvars import ContextVar
 import logging
+from threading import RLock
 
 from opentelemetry import context as context_api, trace
 from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor, SpanExporter, SpanExportResult
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    SimpleSpanProcessor,
+    SpanExporter,
+)
 from opentelemetry.context import Context
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 from opentelemetry.semconv_ai import SpanAttributes
@@ -16,11 +21,13 @@ from respan_sdk.respan_types.span_types import SpanLink
 from respan_sdk.utils.data_processing.id_processing import format_span_id
 from respan_tracing.contexts.span import span_link_to_otel
 from respan_tracing.constants.generic_constants import SDK_PREFIX
-from respan_tracing.constants.tracing import EXPORT_FILTER_ATTR, PROCESSORS_ATTR, SAMPLE_RATE_ATTR, SPAN_BUFFER_TRACER_NAME
-from respan_tracing.constants.context_constants import (
-    TRACE_GROUP_ID_KEY,
-    PARAMS_KEY
+from respan_tracing.constants.tracing import (
+    EXPORT_FILTER_ATTR,
+    PROCESSORS_ATTR,
+    SAMPLE_RATE_ATTR,
+    SPAN_BUFFER_TRACER_NAME,
 )
+from respan_tracing.constants.context_constants import TRACE_GROUP_ID_KEY, PARAMS_KEY
 from respan_tracing.filters import evaluate_export_filter
 from respan_tracing.utils.preprocessing.span_processing import is_processable_span
 from respan_tracing.utils.context import get_entity_path
@@ -52,7 +59,9 @@ class RespanSpanProcessor:
         """Called when a span is started - add Respan metadata"""
         # Check if this span is being created within an entity context
         # If so, add the entityPath attribute so it gets preserved by our filtering
-        entity_path = get_entity_path(parent_context)  # Use active context like JS version
+        entity_path = get_entity_path(
+            parent_context
+        )  # Use active context like JS version
         if entity_path and not span.attributes.get(SpanAttributes.TRACELOOP_SPAN_KIND):
             # This is an auto-instrumentation span within an entity context
             # Add the entityPath attribute so it doesn't get filtered out
@@ -67,16 +76,18 @@ class RespanSpanProcessor:
             span.set_attribute(SpanAttributes.TRACELOOP_WORKFLOW_NAME, workflow_name)
 
         # Add entity path if present in context (for redundancy)
-        entity_path_from_context = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH)
+        entity_path_from_context = context_api.get_value(
+            SpanAttributes.TRACELOOP_ENTITY_PATH
+        )
         if entity_path_from_context:
-            span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path_from_context)
+            span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path_from_context
+            )
 
         # Add trace group identifier if present
         trace_group_id = context_api.get_value(TRACE_GROUP_ID_KEY)
         if trace_group_id:
-            span.set_attribute(
-                RESPAN_TRACE_GROUP_ID, trace_group_id
-            )
+            span.set_attribute(RESPAN_TRACE_GROUP_ID, trace_group_id)
 
         # Inherit processors from parent span when child doesn't have its own.
         # This enables a parent @workflow(processors="dogfood,production") to
@@ -100,7 +111,9 @@ class RespanSpanProcessor:
             if not span.attributes.get(PROCESSORS_ATTR):
                 active_buffer = _active_span_buffer.get(None)
                 if active_buffer:
-                    buffer_processors = getattr(active_buffer, "continuation_processors", None)
+                    buffer_processors = getattr(
+                        active_buffer, "continuation_processors", None
+                    )
                     if buffer_processors:
                         span.set_attribute(PROCESSORS_ATTR, buffer_processors)
 
@@ -136,25 +149,37 @@ class RespanSpanProcessor:
         if span.attributes:
             sample_rate = span.attributes.get(SAMPLE_RATE_ATTR)
             if sample_rate is not None and random.random() >= sample_rate:
-                logger.debug(f"[Respan Debug] Sample rate ({sample_rate}) dropped span: {span.name}")
+                logger.debug(
+                    f"[Respan Debug] Sample rate ({sample_rate}) dropped span: {span.name}"
+                )
                 return
 
         # Apply export_filter if present on this span
-        filter_json = span.attributes.get(EXPORT_FILTER_ATTR) if span.attributes else None
+        filter_json = (
+            span.attributes.get(EXPORT_FILTER_ATTR) if span.attributes else None
+        )
         if filter_json:
             try:
                 export_filter = json.loads(filter_json)
                 span_data = dict(span.attributes) if span.attributes else {}
-                span_data["status_code"] = span.status.status_code.name if span.status else "UNSET"
+                span_data["status_code"] = (
+                    span.status.status_code.name if span.status else "UNSET"
+                )
                 span_data["name"] = span.name
-                if not evaluate_export_filter(span_data=span_data, export_filter=export_filter):
-                    logger.debug(f"[Respan Debug] Export filter dropped span: {span.name}")
+                if not evaluate_export_filter(
+                    span_data=span_data, export_filter=export_filter
+                ):
+                    logger.debug(
+                        f"[Respan Debug] Export filter dropped span: {span.name}"
+                    )
                     return
             except (json.JSONDecodeError, Exception) as e:
                 # Fail-open: invalid/malformed filters still export the span.
                 # This matches the codebase's infrastructure fail-open principle —
                 # a broken filter should not silently drop telemetry data.
-                logger.warning(f"[Respan Debug] Failed to evaluate export filter, exporting span anyway: {e}")
+                logger.warning(
+                    f"[Respan Debug] Failed to evaluate export filter, exporting span anyway: {e}"
+                )
 
         self.processor.on_end(span)
 
@@ -179,65 +204,65 @@ class RespanSpanProcessor:
 
 
 # Context variable to track the active SpanBuffer for the current context
-_active_span_buffer: ContextVar[Optional['SpanBuffer']] = ContextVar(
-    'active_span_buffer', default=None
+_active_span_buffer: ContextVar[Optional["SpanBuffer"]] = ContextVar(
+    "active_span_buffer", default=None
 )
 
 
 class BufferingSpanProcessor(SpanProcessor):
     """
     OpenTelemetry-compliant span processor that can buffer spans when requested.
-    
+
     This processor checks if there's an active SpanBuffer in the current context.
     If there is, spans go to that buffer's local queue. Otherwise, spans are
     passed through to the original processor for normal export.
-    
+
     This follows OpenTelemetry patterns by using a single processor that can
     conditionally buffer spans based on context, rather than swapping processors.
     """
-    
+
     def __init__(self, original_processor: SpanProcessor):
         """
         Initialize the buffering processor.
-        
+
         Args:
             original_processor: The original processor to fall back to when
                               no active SpanBuffer is present
         """
         self.original_processor = original_processor
-    
+
     def on_start(self, span, parent_context: Optional[Context] = None):
         """
         Called when a span starts.
-        
+
         Forward to original processor (needed for proper span initialization).
         """
         self.original_processor.on_start(span, parent_context)
-    
+
     def on_end(self, span: ReadableSpan):
         """
         Called when a span ends.
-        
+
         If there's an active SpanBuffer in the current context, route the span
         to its local queue. Otherwise, pass through to the original processor.
-        
+
         Args:
             span: The span that ended
         """
         # Check if there's an active SpanBuffer in this context
         buffer = _active_span_buffer.get()
-        
+
         if buffer is not None and buffer._is_buffering:
             # Route to the buffer's local queue (deduplicated)
             buffer.buffer_span(span)
         else:
             # No active buffer - use original processor (normal export)
             self.original_processor.on_end(span)
-    
+
     def shutdown(self):
         """Shutdown the processor."""
         return self.original_processor.shutdown()
-    
+
     def force_flush(self, timeout_millis: int = 30000):
         """Force flush the processor."""
         return self.original_processor.force_flush(timeout_millis)
@@ -246,10 +271,10 @@ class BufferingSpanProcessor(SpanProcessor):
 class FilteringSpanProcessor(SpanProcessor):
     """
     OpenTelemetry-compliant span processor that filters spans based on attributes.
-    
+
     This processor checks span attributes against filter criteria and only exports
     spans that match. This is the standard OTEL pattern for selective exporting.
-    
+
     Example:
         # Only export spans with exporter="debug" attribute
         processor = FilteringSpanProcessor(
@@ -257,7 +282,7 @@ class FilteringSpanProcessor(SpanProcessor):
             filter_fn=lambda span: span.attributes.get("exporter") == "debug"
         )
     """
-    
+
     def __init__(
         self,
         exporter: SpanExporter,
@@ -267,7 +292,7 @@ class FilteringSpanProcessor(SpanProcessor):
     ):
         """
         Initialize the filtering processor.
-        
+
         Args:
             exporter: The SpanExporter to use for matching spans
             filter_fn: Optional function to determine if a span should be exported.
@@ -275,23 +300,23 @@ class FilteringSpanProcessor(SpanProcessor):
             is_batching_enabled: Whether to use batch processing
             span_postprocess_callback: Optional callback for span postprocessing
         """
-        
+
         self.filter_fn = filter_fn or (lambda span: True)
-        
+
         # Create base processor
         if is_batching_enabled:
             base_processor = BatchSpanProcessor(exporter)
         else:
             base_processor = SimpleSpanProcessor(exporter)
-        
+
         # Wrap with Respan processor for metadata injection
         self.processor = RespanSpanProcessor(base_processor, span_postprocess_callback)
-    
+
     def on_start(self, span, parent_context: Optional[Context] = None):
         """Called when a span starts."""
         # Always call on_start for proper initialization
         self.processor.on_start(span, parent_context)
-    
+
     def on_end(self, span: ReadableSpan):
         """Called when a span ends - only export if filter matches."""
         if self.filter_fn(span):
@@ -299,11 +324,11 @@ class FilteringSpanProcessor(SpanProcessor):
             self.processor.on_end(span)
         else:
             logger.debug(f"[FilteringProcessor] Filtering out span: {span.name}")
-    
+
     def shutdown(self):
         """Shutdown the processor."""
         return self.processor.shutdown()
-    
+
     def force_flush(self, timeout_millis: int = 30000):
         """Force flush the processor."""
         return self.processor.force_flush(timeout_millis)
@@ -312,15 +337,15 @@ class FilteringSpanProcessor(SpanProcessor):
 class SpanBuffer:
     """
     OpenTelemetry-compliant context manager for buffering spans.
-    
+
     SpanBuffer collects spans in a local queue without processing them.
     After collection, you can process them through any processor using
     the process_spans() method.
-    
+
     This follows OpenTelemetry patterns by separating span collection
     from span processing, allowing full control over when and how spans
     are processed.
-    
+
     This enables:
     1. Batch buffering of multiple spans
     2. Manual processing timing control
@@ -328,7 +353,7 @@ class SpanBuffer:
     4. Route buffered spans to any processor
     5. Thread-safe isolation (each context has its own buffer)
     """
-    
+
     def __init__(
         self,
         trace_id: str,
@@ -353,13 +378,14 @@ class SpanBuffer:
         self.trace_id = trace_id
         self._local_queue: List[ReadableSpan] = []
         self._seen_span_ids: set = set()
+        self._queue_lock = RLock()
         self._is_buffering = False
         self._context_token = None
         self._parent_context_token = None
         self._tracer_provider = tracer_provider
         self._parent_trace_id = parent_trace_id
         self._parent_span_id = parent_span_id
-    
+
     def __enter__(self):
         """
         Enter context: Set this buffer as active in the current context.
@@ -376,7 +402,9 @@ class SpanBuffer:
         Returns:
             self for context manager usage
         """
-        logger.debug(f"[SpanBuffer] Entering buffering context for trace {self.trace_id}")
+        logger.debug(
+            f"[SpanBuffer] Entering buffering context for trace {self.trace_id}"
+        )
 
         # Inject trace context so all spans in this buffer share the
         # caller's trace ID. Without this, the OTel SDK generates a
@@ -416,7 +444,9 @@ class SpanBuffer:
             # Initial path: use the caller's trace_id as the OTel trace.
             # A synthetic root span ID seeds the trace context — the real
             # root span becomes a child and inherits this trace_id.
-            inject_trace_id = int(self.trace_id, 16) if len(self.trace_id) == 32 else None
+            inject_trace_id = (
+                int(self.trace_id, 16) if len(self.trace_id) == 32 else None
+            )
             inject_span_id = None
         else:
             inject_trace_id = None
@@ -452,7 +482,7 @@ class SpanBuffer:
         logger.debug(f"[SpanBuffer] Activated buffer for trace {self.trace_id}")
 
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
         Exit context: Deactivate this buffer and auto-flush spans.
@@ -468,7 +498,9 @@ class SpanBuffer:
         buffer (still _is_buffering=True) and re-buffers them there instead
         of forwarding to the real processor chain.
         """
-        logger.debug(f"[SpanBuffer] Exiting buffering context for trace {self.trace_id}")
+        logger.debug(
+            f"[SpanBuffer] Exiting buffering context for trace {self.trace_id}"
+        )
 
         # Mark as not buffering FIRST so replayed spans don't re-enter
         # THIS buffer via BufferingSpanProcessor.on_end
@@ -480,7 +512,7 @@ class SpanBuffer:
         # falls through to the real processor (FilteringSpanProcessor →
         # exporter). If we reset first, the parent buffer would catch
         # the replayed spans instead.
-        if self._tracer_provider is not None and self._local_queue:
+        if self._tracer_provider is not None and self.get_span_count():
             self.process_spans(self._tracer_provider)
 
         # NOW safe to reset — flush is done, no more spans to replay
@@ -494,28 +526,28 @@ class SpanBuffer:
             self._parent_context_token = None
 
         logger.debug(f"[SpanBuffer] Deactivated buffer for trace {self.trace_id}")
-    
+
     def create_span(
-        self, 
-        span_name: str, 
+        self,
+        span_name: str,
         attributes: Optional[Dict[str, Any]] = None,
         kind: Optional[trace.SpanKind] = None,
         links: Optional[Sequence[SpanLink | trace.Link]] = None,
     ) -> str:
         """
         Create a span that goes to the local queue (not auto-exported).
-        
+
         Args:
             span_name: Name of the span
             attributes: Optional attributes to set on the span
             kind: Optional span kind (default: INTERNAL)
             links: Optional list of SDK SpanLink or OpenTelemetry Link objects
-        
+
         Returns:
             The span ID as a hex string
         """
         tracer = trace.get_tracer(SPAN_BUFFER_TRACER_NAME)
-        
+
         # Set span kind
         span_kind = kind or trace.SpanKind.INTERNAL
         otel_links: List[trace.Link] = []
@@ -529,7 +561,7 @@ class SpanBuffer:
             raise TypeError(
                 "links must contain SpanLink or opentelemetry.trace.Link instances"
             )
-        
+
         # Create span in context
         with tracer.start_as_current_span(
             span_name,
@@ -538,7 +570,7 @@ class SpanBuffer:
         ) as span:
             # Set trace ID if we can (note: trace_id is already set by the tracer)
             # We just use the provided trace_id for logging/tracking purposes
-            
+
             # Set attributes
             if attributes:
                 for key, value in attributes.items():
@@ -548,13 +580,13 @@ class SpanBuffer:
                         logger.warning(
                             f"[SpanBuffer] Failed to set attribute {key}={value}: {e}"
                         )
-            
+
             # Span goes to local queue when this context exits
             span_id = format_span_id(span.get_span_context().span_id)
             logger.debug(f"[SpanBuffer] Created span '{span_name}' with ID {span_id}")
-            
+
         return span_id
-    
+
     def buffer_span(self, span: ReadableSpan) -> bool:
         """
         Add a span to the buffer, deduplicating by span_id.
@@ -570,17 +602,18 @@ class SpanBuffer:
             True if the span was added, False if it was a duplicate.
         """
         span_id = span.get_span_context().span_id
-        if span_id in self._seen_span_ids:
-            logger.debug(
-                f"[SpanBuffer] Skipping duplicate span '{span.name}' "
-                f"(span_id={format_span_id(span_id)}) for trace {self.trace_id}"
-            )
-            return False
-        self._seen_span_ids.add(span_id)
-        self._local_queue.append(span)
+        with self._queue_lock:
+            if span_id in self._seen_span_ids:
+                logger.debug(
+                    f"[SpanBuffer] Skipping duplicate span '{span.name}' "
+                    f"(span_id={format_span_id(span_id)}) for trace {self.trace_id}"
+                )
+                return False
+            self._seen_span_ids.add(span_id)
+            self._local_queue.append(span)
+
         logger.debug(
-            f"[SpanBuffer] Buffering span '{span.name}' "
-            f"for trace {self.trace_id}"
+            f"[SpanBuffer] Buffering span '{span.name}' for trace {self.trace_id}"
         )
         return True
 
@@ -591,66 +624,69 @@ class SpanBuffer:
         Returns:
             List of all buffered spans
         """
-        return self._local_queue.copy()
-    
+        with self._queue_lock:
+            return self._local_queue.copy()
+
     def process_spans(self, tracer_provider) -> int:
         """
         Process all buffered spans through the tracer's processors.
-        
+
         This sends spans through the standard OTEL processing pipeline,
         allowing processors to filter, transform, and export as configured.
-        
+
         Args:
             tracer_provider: The TracerProvider with registered processors
-        
+
         Returns:
             Number of spans processed
         """
-        if not self._local_queue:
+        with self._queue_lock:
+            spans_to_process = self._local_queue.copy()
+
+        if not spans_to_process:
             logger.debug(f"[SpanBuffer] No spans to process for trace {self.trace_id}")
             return 0
-        
-        span_count = len(self._local_queue)
+
+        span_count = len(spans_to_process)
         logger.info(
-            f"[SpanBuffer] Processing {span_count} spans "
-            f"for trace {self.trace_id}"
+            f"[SpanBuffer] Processing {span_count} spans for trace {self.trace_id}"
         )
-        
+
         try:
             # Get all registered processors from tracer provider
-            if hasattr(tracer_provider, '_active_span_processor'):
+            if hasattr(tracer_provider, "_active_span_processor"):
                 # Send each span through the processor pipeline
-                for span in self._local_queue:
+                for span in spans_to_process:
                     tracer_provider._active_span_processor.on_end(span)
-                
-                logger.info(
-                    f"[SpanBuffer] Successfully processed {span_count} spans"
-                )
+
+                logger.info(f"[SpanBuffer] Successfully processed {span_count} spans")
                 return span_count
             else:
                 logger.error("[SpanBuffer] No active span processor found")
                 return 0
-            
+
         except Exception as e:
             logger.exception(f"[SpanBuffer] Exception during processing: {e}")
             return 0
-    
+
     def clear_spans(self):
         """
         Clear all spans from the local queue without exporting.
 
         Useful for discarding buffered spans if you decide not to export them.
         """
-        span_count = len(self._local_queue)
-        self._local_queue.clear()
-        self._seen_span_ids.clear()
+        with self._queue_lock:
+            span_count = len(self._local_queue)
+            self._local_queue.clear()
+            self._seen_span_ids.clear()
         logger.debug(f"[SpanBuffer] Cleared {span_count} spans from queue")
-    
+
     def get_span_count(self) -> int:
         """
         Get the number of spans in the local queue.
-        
+
         Returns:
             Number of buffered spans
         """
-        return len(self._local_queue)
+        with self._queue_lock:
+            return len(self._local_queue)

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/context.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/context.py
@@ -1,9 +1,90 @@
+import contextvars
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Iterator, Optional
+from dataclasses import dataclass
+from typing import Callable, Iterator, Optional, ParamSpec, TypeVar
+
 from opentelemetry import context as context_api
 from opentelemetry.context import Context
 from opentelemetry.semconv_ai import SpanAttributes
-from respan_tracing.constants.context_constants import WORKFLOW_NAME_KEY, ENTITY_PATH_KEY
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@dataclass(frozen=True)
+class RespanContextSnapshot:
+    """Captured Python and OpenTelemetry context for work crossing threads."""
+
+    python_context: contextvars.Context
+    otel_context: Context
+
+    def run(self, fn: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+        """Run ``fn`` with the context that was active when this snapshot was made."""
+
+        def invoke() -> R:
+            token = context_api.attach(self.otel_context)
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                context_api.detach(token)
+
+        return self.python_context.run(invoke)
+
+    def wrap(self, fn: Callable[P, R]) -> Callable[P, R]:
+        """Return a callable that always runs in this captured context."""
+
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+            return self.run(fn, *args, **kwargs)
+
+        return wrapped
+
+
+def capture_context() -> RespanContextSnapshot:
+    """Capture the active Respan, Python contextvars, and OpenTelemetry context."""
+
+    return RespanContextSnapshot(
+        python_context=contextvars.copy_context(),
+        otel_context=context_api.get_current(),
+    )
+
+
+def wrap_with_current_context(fn: Callable[P, R]) -> Callable[P, R]:
+    """Wrap ``fn`` so it runs with the context active at wrap time."""
+
+    return capture_context().wrap(fn)
+
+
+def submit_with_current_context(
+    executor: Executor,
+    fn: Callable[P, R],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> Future[R]:
+    """Submit work to an executor while preserving the current tracing context."""
+
+    snapshot = capture_context()
+    return executor.submit(snapshot.run, fn, *args, **kwargs)
+
+
+class ContextPropagatingThreadPoolExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor that preserves Respan and OpenTelemetry context.
+
+    Use this when parallel agent or workflow steps are launched from inside a
+    Respan span or SpanBuffer. Each submitted task receives the context that was
+    active at submit time, so child spans stay attached to the right trace and
+    buffered spans are flushed with the parent buffer.
+    """
+
+    def submit(
+        self,
+        fn: Callable[P, R],
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> Future[R]:
+        snapshot = capture_context()
+        return super().submit(snapshot.run, fn, *args, **kwargs)
 
 
 @contextmanager
@@ -45,21 +126,25 @@ def get_entity_path(ctx: Optional[Context] = None) -> Optional[str]:
     """
     Retrieves the current entity path from the active context.
     This builds the hierarchical path like "workflow.task.subtask".
-    
+
     Args:
         ctx: The context to read from (defaults to current active context)
-        
+
     Returns:
         The entity path string or None if not set
     """
     if ctx is None:
         ctx = context_api.get_current()
-    
+
     # First check for full entity path (set by TOOL/TASK spans)
-    entity_path = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_PATH, context=ctx)
+    entity_path = context_api.get_value(
+        SpanAttributes.TRACELOOP_ENTITY_PATH, context=ctx
+    )
     if entity_path:
         return entity_path
-    
-    # Fall back to workflow name (set by WORKFLOW/AGENT spans)  
-    workflow_name = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME, context=ctx)
-    return workflow_name 
+
+    # Fall back to workflow name (set by WORKFLOW/AGENT spans)
+    workflow_name = context_api.get_value(
+        SpanAttributes.TRACELOOP_ENTITY_NAME, context=ctx
+    )
+    return workflow_name

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/context.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/context.py
@@ -1,9 +1,11 @@
 import contextvars
+import asyncio
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
+from functools import partial
 from threading import Thread
-from typing import Callable, Iterator, Optional, ParamSpec, TypeVar
+from typing import Awaitable, Callable, Iterator, Optional, ParamSpec, TypeVar
 
 from opentelemetry import context as context_api
 from opentelemetry.context import Context
@@ -81,6 +83,38 @@ def submit_with_current_context(
 
     snapshot = capture_context()
     return executor.submit(snapshot.run, fn, *args, **kwargs)
+
+
+def run_in_executor_with_current_context(
+    executor: Executor | None,
+    fn: Callable[P, R],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> Awaitable[R]:
+    """Run blocking work through asyncio while preserving tracing context.
+
+    ``asyncio`` tasks preserve contextvars, but many agent workflows still cross
+    into blocking SDK calls through ``loop.run_in_executor``. This helper
+    captures the Respan/OpenTelemetry context before that handoff so spans
+    created inside the executor keep the active parent, entity path, SpanBuffer,
+    and processor routing.
+    """
+
+    loop = asyncio.get_running_loop()
+    snapshot = capture_context()
+    work = partial(snapshot.run, fn, *args, **kwargs)
+    return loop.run_in_executor(executor, work)
+
+
+async def to_thread_with_current_context(
+    fn: Callable[P, R],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> R:
+    """Async ``to_thread`` helper that preserves the active tracing context."""
+
+    snapshot = capture_context()
+    return await asyncio.to_thread(snapshot.run, fn, *args, **kwargs)
 
 
 class ContextPropagatingThread(Thread):

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/context.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/context.py
@@ -2,6 +2,7 @@ import contextvars
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
+from threading import Thread
 from typing import Callable, Iterator, Optional, ParamSpec, TypeVar
 
 from opentelemetry import context as context_api
@@ -55,6 +56,21 @@ def wrap_with_current_context(fn: Callable[P, R]) -> Callable[P, R]:
     return capture_context().wrap(fn)
 
 
+def add_done_callback_with_current_context(
+    future: Future[R],
+    callback: Callable[[Future[R]], object],
+) -> Future[R]:
+    """Register a Future callback that runs with the current tracing context."""
+
+    snapshot = capture_context()
+
+    def wrapped(done: Future[R]) -> None:
+        snapshot.run(callback, done)
+
+    future.add_done_callback(wrapped)
+    return future
+
+
 def submit_with_current_context(
     executor: Executor,
     fn: Callable[P, R],
@@ -65,6 +81,32 @@ def submit_with_current_context(
 
     snapshot = capture_context()
     return executor.submit(snapshot.run, fn, *args, **kwargs)
+
+
+class ContextPropagatingThread(Thread):
+    """Thread that preserves the Respan and OpenTelemetry context from creation."""
+
+    def __init__(
+        self,
+        group=None,
+        target: Optional[Callable[..., object]] = None,
+        name: Optional[str] = None,
+        args=(),
+        kwargs=None,
+        *,
+        daemon: Optional[bool] = None,
+        context_snapshot: Optional[RespanContextSnapshot] = None,
+    ) -> None:
+        snapshot = context_snapshot or capture_context()
+        wrapped_target = snapshot.wrap(target) if target is not None else None
+        super().__init__(
+            group=group,
+            target=wrapped_target,
+            name=name,
+            args=args,
+            kwargs=kwargs or {},
+            daemon=daemon,
+        )
 
 
 class ContextPropagatingThreadPoolExecutor(ThreadPoolExecutor):

--- a/python-sdks/respan-tracing/tests/test_threadpool_context.py
+++ b/python-sdks/respan-tracing/tests/test_threadpool_context.py
@@ -1,8 +1,10 @@
 from concurrent.futures import ThreadPoolExecutor
 
 from respan_tracing import (
+    ContextPropagatingThread,
     ContextPropagatingThreadPoolExecutor,
     RespanTelemetry,
+    add_done_callback_with_current_context,
     get_client,
     submit_with_current_context,
     task,
@@ -36,11 +38,22 @@ class TestThreadPoolContextPropagation:
         self.telemetry.flush()
         return [span.name for span in self.exporter.get_finished_spans()]
 
+    def exported_spans(self):
+        self.telemetry.flush()
+        return self.exporter.get_finished_spans()
+
     def assert_exported(self, names: list[str], span_name: str):
         assert any(name.startswith(span_name) for name in names)
 
     def assert_not_exported(self, names: list[str], span_name: str):
         assert not any(name.startswith(span_name) for name in names)
+
+    def span_by_prefix(self, prefix: str):
+        matches = [
+            span for span in self.exported_spans() if span.name.startswith(f"{prefix}.")
+        ]
+        assert len(matches) == 1, [span.name for span in self.exported_spans()]
+        return matches[0]
 
     def test_regular_threadpool_loses_processor_routing(self):
         @task(name="threadpool_worker")
@@ -78,6 +91,29 @@ class TestThreadPoolContextPropagation:
         self.assert_exported(names, "parent_workflow")
         self.assert_exported(names, "threadpool_worker")
 
+        parent = self.span_by_prefix("parent_workflow")
+        worker_span = self.span_by_prefix("threadpool_worker")
+        assert worker_span.context.trace_id == parent.context.trace_id
+        assert worker_span.parent.span_id == parent.context.span_id
+
+    def test_context_propagating_threadpool_map_preserves_routing(self):
+        @task(name="mapped_worker")
+        def worker(index: int):
+            return index * 2
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            with ContextPropagatingThreadPoolExecutor(max_workers=3) as executor:
+                assert list(executor.map(worker, range(6))) == [0, 2, 4, 6, 8, 10]
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        assert sum(name.startswith("mapped_worker") for name in names) == 6
+
     def test_submit_with_current_context_preserves_routing(self):
         @task(name="submitted_worker")
         def worker():
@@ -95,6 +131,58 @@ class TestThreadPoolContextPropagation:
 
         self.assert_exported(names, "parent_workflow")
         self.assert_exported(names, "submitted_worker")
+
+    def test_context_propagating_thread_preserves_routing(self):
+        @task(name="thread_worker")
+        def worker():
+            return "done"
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            thread = ContextPropagatingThread(target=worker)
+            thread.start()
+            thread.join()
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        self.assert_exported(names, "thread_worker")
+
+        parent = self.span_by_prefix("parent_workflow")
+        worker_span = self.span_by_prefix("thread_worker")
+        assert worker_span.context.trace_id == parent.context.trace_id
+        assert worker_span.parent.span_id == parent.context.span_id
+
+    def test_future_done_callback_preserves_routing(self):
+        def complete_work():
+            return "done"
+
+        def callback(_future):
+            with self.client.start_span("future_callback", kind="task"):
+                pass
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(complete_work)
+                add_done_callback_with_current_context(future, callback)
+                assert future.result() == "done"
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        self.assert_exported(names, "future_callback")
+
+        parent = self.span_by_prefix("parent_workflow")
+        callback_span = self.span_by_prefix("future_callback")
+        assert callback_span.context.trace_id == parent.context.trace_id
+        assert callback_span.parent.span_id == parent.context.span_id
 
     def test_threadpool_spans_inside_span_buffer_flush_with_parent_context(self):
         def worker(index: int):
@@ -119,3 +207,9 @@ class TestThreadPoolContextPropagation:
         self.assert_exported(names, "parent_workflow")
         for index in range(12):
             self.assert_exported(names, f"buffered_worker_{index}")
+
+        parent = self.span_by_prefix("parent_workflow")
+        for index in range(12):
+            worker_span = self.span_by_prefix(f"buffered_worker_{index}")
+            assert worker_span.context.trace_id == parent.context.trace_id
+            assert worker_span.parent.span_id == parent.context.span_id

--- a/python-sdks/respan-tracing/tests/test_threadpool_context.py
+++ b/python-sdks/respan-tracing/tests/test_threadpool_context.py
@@ -1,0 +1,121 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from respan_tracing import (
+    ContextPropagatingThreadPoolExecutor,
+    RespanTelemetry,
+    get_client,
+    submit_with_current_context,
+    task,
+)
+from respan_tracing.core.tracer import RespanTracer
+from respan_tracing.testing.exporters import InMemorySpanExporter
+
+
+class TestThreadPoolContextPropagation:
+    @classmethod
+    def setup_class(cls):
+        RespanTracer.reset_instance()
+        cls.exporter = InMemorySpanExporter()
+        cls.telemetry = RespanTelemetry(
+            app_name="test-threadpool-context",
+            is_batching_enabled=False,
+            is_auto_instrument=False,
+            is_enabled=True,
+        )
+        cls.telemetry.add_processor(cls.exporter, name="dogfood")
+        cls.client = get_client()
+
+    @classmethod
+    def teardown_class(cls):
+        RespanTracer.reset_instance()
+
+    def setup_method(self):
+        self.exporter.clear()
+
+    def exported_names(self) -> list[str]:
+        self.telemetry.flush()
+        return [span.name for span in self.exporter.get_finished_spans()]
+
+    def assert_exported(self, names: list[str], span_name: str):
+        assert any(name.startswith(span_name) for name in names)
+
+    def assert_not_exported(self, names: list[str], span_name: str):
+        assert not any(name.startswith(span_name) for name in names)
+
+    def test_regular_threadpool_loses_processor_routing(self):
+        @task(name="threadpool_worker")
+        def worker():
+            return "done"
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                assert executor.submit(worker).result() == "done"
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        self.assert_not_exported(names, "threadpool_worker")
+
+    def test_context_propagating_threadpool_preserves_routing(self):
+        @task(name="threadpool_worker")
+        def worker():
+            return "done"
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            with ContextPropagatingThreadPoolExecutor(max_workers=1) as executor:
+                assert executor.submit(worker).result() == "done"
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        self.assert_exported(names, "threadpool_worker")
+
+    def test_submit_with_current_context_preserves_routing(self):
+        @task(name="submitted_worker")
+        def worker():
+            return "done"
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                assert submit_with_current_context(executor, worker).result() == "done"
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        self.assert_exported(names, "submitted_worker")
+
+    def test_threadpool_spans_inside_span_buffer_flush_with_parent_context(self):
+        def worker(index: int):
+            with self.client.start_span(f"buffered_worker_{index}", kind="task"):
+                return index
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            trace_id = self.client.get_current_trace_id()
+            with self.client.get_span_buffer(trace_id) as buffer:
+                with ContextPropagatingThreadPoolExecutor(max_workers=4) as executor:
+                    futures = [executor.submit(worker, i) for i in range(12)]
+                    assert [future.result() for future in futures] == list(range(12))
+
+            assert buffer.get_span_count() == 12
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        for index in range(12):
+            self.assert_exported(names, f"buffered_worker_{index}")

--- a/python-sdks/respan-tracing/tests/test_threadpool_context.py
+++ b/python-sdks/respan-tracing/tests/test_threadpool_context.py
@@ -1,3 +1,7 @@
+import asyncio
+
+import pytest
+
 from concurrent.futures import ThreadPoolExecutor
 
 from respan_tracing import (
@@ -6,8 +10,10 @@ from respan_tracing import (
     RespanTelemetry,
     add_done_callback_with_current_context,
     get_client,
+    run_in_executor_with_current_context,
     submit_with_current_context,
     task,
+    to_thread_with_current_context,
 )
 from respan_tracing.core.tracer import RespanTracer
 from respan_tracing.testing.exporters import InMemorySpanExporter
@@ -213,3 +219,73 @@ class TestThreadPoolContextPropagation:
             worker_span = self.span_by_prefix(f"buffered_worker_{index}")
             assert worker_span.context.trace_id == parent.context.trace_id
             assert worker_span.parent.span_id == parent.context.span_id
+
+    @pytest.mark.asyncio
+    async def test_plain_asyncio_run_in_executor_loses_processor_routing(self):
+        @task(name="async_executor_worker")
+        def worker():
+            return "done"
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                loop = asyncio.get_running_loop()
+                assert await loop.run_in_executor(executor, worker) == "done"
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        self.assert_not_exported(names, "async_executor_worker")
+
+    @pytest.mark.asyncio
+    async def test_run_in_executor_with_current_context_preserves_routing(self):
+        @task(name="async_executor_worker")
+        def worker(value: int, *, scale: int):
+            return value * scale
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                assert (
+                    await run_in_executor_with_current_context(
+                        executor,
+                        worker,
+                        7,
+                        scale=6,
+                    )
+                    == 42
+                )
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        self.assert_exported(names, "async_executor_worker")
+
+        parent = self.span_by_prefix("parent_workflow")
+        worker_span = self.span_by_prefix("async_executor_worker")
+        assert worker_span.context.trace_id == parent.context.trace_id
+        assert worker_span.parent.span_id == parent.context.span_id
+
+    @pytest.mark.asyncio
+    async def test_to_thread_with_current_context_preserves_routing(self):
+        @task(name="to_thread_worker")
+        def worker():
+            return "done"
+
+        with self.client.start_span(
+            "parent_workflow",
+            kind="workflow",
+            processors="dogfood",
+        ):
+            assert await to_thread_with_current_context(worker) == "done"
+
+        names = self.exported_names()
+
+        self.assert_exported(names, "parent_workflow")
+        self.assert_exported(names, "to_thread_worker")


### PR DESCRIPTION
Fixes #153.

This adds a supported reliability layer for traced work that crosses Python parallel execution boundaries. Plain thread pools, raw threading.Thread targets, and Future callbacks can start with fresh thread-local OpenTelemetry context, so child spans can lose processor routing, propagated attributes, parent trace linkage, and active SpanBuffer routing. That is easy to hit in parallel agent, evaluator, retrieval, and dogfood workloads.

What changed

- Add ContextPropagatingThreadPoolExecutor for submit-time Respan and OTel context capture
- Preserve context through ThreadPoolExecutor.submit and executor.map
- Add ContextPropagatingThread for raw thread targets
- Add add_done_callback_with_current_context for Future callbacks that create spans after work completes
- Add capture_context, wrap_with_current_context, and submit_with_current_context helpers for existing executor lifecycles
- Make SpanBuffer queue and span-id dedup tracking thread-safe with a lock
- Replay buffered spans from a stable snapshot during flush
- Add regression tests showing regular ThreadPoolExecutor drops processor-routed spans while the new helpers preserve them
- Assert parent trace id and parent span id continuity across worker threads, callbacks, and buffered parallel spans
- Add a runnable parallel-agent example and README guidance
- Add release intent for respan-tracing

Validation

- python3 scripts/release_inventory.py --validate
- python3 scripts/release_intents.py validate
- git diff --check
- uv run --python 3.11 --with ruff --with-editable . ruff check touched files
- uv run --python 3.11 --with ruff --with-editable . ruff format --check touched files
- uv run --python 3.11 --with pytest --with-editable . pytest tests/test_threadpool_context.py tests/test_span_buffer_flush.py -q
- python3 -m compileall python-sdks/respan-tracing/src/respan_tracing python-sdks/respan-tracing/tests/test_threadpool_context.py python-sdks/respan-tracing/examples/threadpool_context_propagation.py
- uv build

Note

I tried the full respan-tracing test directory too, but collection currently stops on unrelated pre-existing issues in this checkout, including missing respan_tracing.core.span_collector, missing is_root_span_candidate, optional dotenv integration tests, and missing opentelemetry.instrumentation.openai.