### PR TITLE
fix: haystack attributes parsing problem

### DIFF
--- a/.release-intents/20260613-haystack-span-io.json
+++ b/.release-intents/20260613-haystack-span-io.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Fix Haystack instrumentation span input and output normalization",
+  "packages": {
+    "respan-instrumentation-haystack": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_instrumentation.py
@@ -2,11 +2,13 @@
 
 import contextvars
 import importlib
+import json
 import logging
 from dataclasses import dataclass, field
 from typing import Any
 
 from opentelemetry import trace
+from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 from respan_instrumentation_haystack._constants import (
     HAYSTACK_ASYNC_PIPELINE_CLASS_NAME,
@@ -338,6 +340,152 @@ def _suppress_haystack_native_span_export(span: Any) -> None:
         attributes.pop(attribute_name, None)
 
 
+def _parse_json_attr(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return value
+
+
+def _json_attr(value: Any) -> str:
+    return json.dumps(value, default=str, separators=(",", ":"))
+
+
+def _message_content(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, list):
+        text_parts: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if text is None:
+                    text = item.get("content")
+                if text is not None:
+                    text_parts.append(str(text))
+            elif item is not None:
+                text_parts.append(str(item))
+        return "\n".join(text_parts)
+
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _normalize_haystack_message(value: Any, *, fallback_role: str) -> dict[str, Any] | None:
+    if isinstance(value, str):
+        return {"role": fallback_role, "content": value}
+
+    if not isinstance(value, dict):
+        return None
+
+    role = value.get("role") or fallback_role
+    content = _message_content(value.get("content"))
+    message: dict[str, Any] = {"role": str(role), "content": content}
+
+    name = value.get("name")
+    if name is not None:
+        message["name"] = name
+
+    return message
+
+
+def _haystack_input_messages(attrs: dict[str, Any]) -> list[dict[str, Any]]:
+    payload = _parse_json_attr(attrs.get("haystack.component.input"))
+    if not isinstance(payload, dict):
+        return []
+
+    messages = payload.get("messages")
+    if isinstance(messages, list):
+        normalized = [
+            message
+            for item in messages
+            if (
+                message := _normalize_haystack_message(
+                    item,
+                    fallback_role="user",
+                )
+            )
+            is not None
+        ]
+        if normalized:
+            return normalized
+
+    for key in ("query", "question", "prompt"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return [{"role": "user", "content": value}]
+
+    return []
+
+
+def _haystack_completion_message(attrs: dict[str, Any]) -> dict[str, Any] | None:
+    payload = _parse_json_attr(attrs.get("haystack.component.output"))
+    if not isinstance(payload, dict):
+        return None
+
+    replies = payload.get("replies")
+    if isinstance(replies, list):
+        for item in reversed(replies):
+            message = _normalize_haystack_message(item, fallback_role="assistant")
+            if message is not None and message.get("content"):
+                return message
+        for item in reversed(replies):
+            message = _normalize_haystack_message(item, fallback_role="assistant")
+            if message is not None:
+                return message
+
+    answers = payload.get("answers")
+    if isinstance(answers, list):
+        for item in reversed(answers):
+            if isinstance(item, dict):
+                data = item.get("data") or item.get("answer")
+                if data is not None:
+                    return {"role": "assistant", "content": str(data)}
+            elif isinstance(item, str):
+                return {"role": "assistant", "content": item}
+
+    return None
+
+
+def _set_indexed_messages(
+    attrs: dict[str, Any],
+    *,
+    prefix: str,
+    messages: list[dict[str, Any]],
+) -> None:
+    for index, message in enumerate(messages):
+        role = message.get("role")
+        if role is not None:
+            attrs[f"{prefix}.{index}.role"] = str(role)
+        content = message.get("content")
+        if content is not None:
+            attrs[f"{prefix}.{index}.content"] = str(content)
+
+
+def _enrich_haystack_io_attrs(attrs: dict[str, Any]) -> None:
+    input_messages = _haystack_input_messages(attrs)
+    if input_messages:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _json_attr(input_messages)
+        _set_indexed_messages(
+            attrs,
+            prefix=SpanAttributes.LLM_PROMPTS,
+            messages=input_messages,
+        )
+
+    completion_message = _haystack_completion_message(attrs)
+    if completion_message is not None:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _json_attr(completion_message)
+        _set_indexed_messages(
+            attrs,
+            prefix=SpanAttributes.LLM_COMPLETIONS,
+            messages=[completion_message],
+        )
+
+
 class _HaystackParentSpanProcessor(SpanProcessor):
     """Suppress native Haystack spans while preserving parent remapping.
 
@@ -379,6 +527,10 @@ class _HaystackParentSpanProcessor(SpanProcessor):
         if _is_haystack_native_span(span):
             _suppress_haystack_native_span_export(span)
             return
+
+        attributes = getattr(span, "_attributes", None)
+        if attributes is not None:
+            _enrich_haystack_io_attrs(attributes)
 
         parent_id = _get_parent_span_id(span)
         component_context = (

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/tests/test_instrumentation.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sys
 from types import ModuleType, SimpleNamespace
@@ -339,6 +340,89 @@ def test_haystack_parent_span_processor_keeps_openinference_span_exportable():
         RESPAN_LOG_TYPE: "task",
     }
     assert is_processable_span(translated_component) is True
+
+
+def test_haystack_parent_span_processor_promotes_component_chat_io():
+    processor = _HaystackParentSpanProcessor()
+    span = _FakeSpan(
+        "haystack.openai.chat",
+        "4000000000000004",
+        attributes={
+            SpanAttributes.TRACELOOP_ENTITY_INPUT: "{}",
+            SpanAttributes.TRACELOOP_ENTITY_OUTPUT: "replies",
+            "haystack.component.input": json.dumps(
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [{"text": "Who created Python?"}],
+                        }
+                    ],
+                    "generation_kwargs": {
+                        "extra_body": {
+                            "prompt": {
+                                "prompt_id": "prompt-123",
+                                "variables": {"question": "Who created Python?"},
+                            }
+                        }
+                    },
+                }
+            ),
+            "haystack.component.output": json.dumps(
+                {
+                    "replies": [
+                        {
+                            "role": "assistant",
+                            "content": [
+                                {"text": "Python was created by Guido van Rossum."}
+                            ],
+                        }
+                    ]
+                }
+            ),
+        },
+    )
+
+    processor.on_start(span)
+    processor.on_end(span)
+
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == [
+        {"role": "user", "content": "Who created Python?"}
+    ]
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "role": "assistant",
+        "content": "Python was created by Guido van Rossum.",
+    }
+    assert span.attributes["gen_ai.prompt.0.role"] == "user"
+    assert span.attributes["gen_ai.prompt.0.content"] == "Who created Python?"
+    assert span.attributes["gen_ai.completion.0.role"] == "assistant"
+    assert (
+        span.attributes["gen_ai.completion.0.content"]
+        == "Python was created by Guido van Rossum."
+    )
+
+
+def test_haystack_parent_span_processor_promotes_string_replies():
+    processor = _HaystackParentSpanProcessor()
+    span = _FakeSpan(
+        "OpenAIGenerator.run",
+        "4000000000000004",
+        attributes={
+            "haystack.component.input": json.dumps({"prompt": "Say hi"}),
+            "haystack.component.output": json.dumps({"replies": ["Hi"]}),
+        },
+    )
+
+    processor.on_start(span)
+    processor.on_end(span)
+
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == [
+        {"role": "user", "content": "Say hi"}
+    ]
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "role": "assistant",
+        "content": "Hi",
+    }
 
 
 def test_haystack_parent_span_processor_uses_pipeline_graph_parent():


### PR DESCRIPTION
## Summary

- fix: haystack attributes parsing problem

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched
