### PR TITLE
feat(vercel): populate native prompt_id column from telemetry metadata

### DIFF
--- a/.release-intents/20260616-vercel-prompt-id-promotion.json
+++ b/.release-intents/20260616-vercel-prompt-id-promotion.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Promote prompt_id/prompt_version_number/prompt_name from Vercel telemetry metadata to top-level span attributes so trace-v2 fills the native columns",
+  "packages": {
+    "@respan/instrumentation-vercel": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/span-enrichment.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/span-enrichment.ts
@@ -67,6 +67,20 @@ export function enrichMetadata(attrs: SpanAttributes): void {
       case "trace_group_identifier":
         setDefault(attrs, TRACE_GROUP_ID, String(value));
         break;
+      // Prompt linkage: promote to top-level attributes so the trace-v2 ingest
+      // fills the native prompt_id / prompt_version_number / prompt_name columns
+      // (otherwise they only live in passthrough metadata).
+      case "prompt_id":
+        setDefault(attrs, "prompt_id", String(value));
+        break;
+      case "prompt_version_number": {
+        const n = Number(value);
+        setDefault(attrs, "prompt_version_number", Number.isNaN(n) ? String(value) : n);
+        break;
+      }
+      case "prompt_name":
+        setDefault(attrs, "prompt_name", String(value));
+        break;
       case "customer_params": {
         // customer_params is a JSON-stringified object (Vercel telemetry
         // metadata values must be flat scalars, so users serialize the object).

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/tests/translator.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/tests/translator.test.mjs
@@ -41,6 +41,21 @@ test("ai.generateText.doGenerate is classified as LLM text, not task", () => {
   assert.equal(attrs["traceloop.span.kind"], undefined);
 });
 
+test("telemetry metadata prompt_id/version/name promote to top-level columns", () => {
+  const attrs = runTranslator("ai.generateText.doGenerate", {
+    ...baseLLMSpan,
+    "ai.telemetry.metadata.prompt_id": "prompt-abc-123",
+    "ai.telemetry.metadata.prompt_version_number": "3",
+    "ai.telemetry.metadata.prompt_name": "triage",
+  });
+
+  // Promoted to top-level so the trace-v2 ingest fills the native columns
+  // (prompt_id / prompt_version_number / prompt_name), not just metadata.
+  assert.equal(attrs["prompt_id"], "prompt-abc-123");
+  assert.equal(attrs["prompt_version_number"], 3);
+  assert.equal(attrs["prompt_name"], "triage");
+});
+
 test("ai.streamText.doStream is classified as LLM text, not task", () => {
   const attrs = runTranslator("ai.streamText.doStream", baseLLMSpan);
 


### PR DESCRIPTION
## What
Promote `prompt_id` / `prompt_version_number` / `prompt_name` from the Vercel AI SDK's `experimental_telemetry.metadata.*` to **top-level span attributes**, so the trace-v2 ingest fills the **native columns** (not just passthrough metadata).

## Why
On trace spans these columns were empty — prompt linkage only lived in `metadata.prompt_id`, so "logs by prompt" / dataset-export by the native field didn't catch them. Previously assumed this needed the gateway (server-side prompt resolution) or a backend change.

**Verified directly:** posting a span to `/api/v2/traces` with a top-level `prompt_id` attribute **does** populate the native `prompt_id` + `prompt_version_number` columns. So the only gap was the translator burying the value in metadata. Lifting it to top-level fixes it — no gateway, no backend change.

End-to-end confirmed on the live demo: chat log now shows `prompt_id` in the native column.

## Changes
- `enrichMetadata`: promote the three prompt keys to top-level attributes.
- Unit test for the promotion.
- Release intent (`@respan/instrumentation-vercel` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)