### PR TITLE
feat: add Cursor TypeScript instrumentation

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -32,6 +32,12 @@
     },
     {
       "ecosystem": "javascript",
+      "name": "@respan/instrumentation-cursor",
+      "path": "javascript-sdks/instrumentations/respan-instrumentation-cursor",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
       "name": "@respan/instrumentation-llama-index",
       "path": "javascript-sdks/instrumentations/respan-instrumentation-llama-index",
       "registry": "npm"

--- a/.release-intents/20260621-cursor-typescript-instrumentation.json
+++ b/.release-intents/20260621-cursor-typescript-instrumentation.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add Cursor TypeScript SDK instrumentation",
+  "packages": {
+    "@respan/instrumentation-cursor": "new"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-cursor/README.md
+++ b/javascript-sdks/instrumentations/respan-instrumentation-cursor/README.md
@@ -1,0 +1,56 @@
+# Respan Cursor SDK Instrumentation
+
+Native Respan instrumentation for the Cursor TypeScript SDK (`@cursor/sdk`).
+
+The instrumentor patches the Cursor SDK module you provide and emits canonical Respan spans for:
+
+- `Agent.prompt()`
+- `Agent.create()` and `Agent.resume()`
+- `SDKAgent.send()`
+- `Run.stream()` and `Run.wait()`
+- Cursor SDK message types: assistant, user, thinking, status, task, request, and tool calls
+- per-run custom tools passed through `local.customTools`
+
+## Usage
+
+```ts
+import * as CursorSDK from "@cursor/sdk";
+import { Respan } from "@respan/respan";
+import { CursorSDKInstrumentor } from "@respan/instrumentation-cursor";
+
+const cursorSdkModule = { ...CursorSDK };
+
+const respan = new Respan({
+  instrumentations: [
+    new CursorSDKInstrumentor({
+      sdkModule: cursorSdkModule,
+      agentName: "cursor-agent",
+    }),
+  ],
+});
+
+await respan.initialize();
+
+const agent = await cursorSdkModule.Agent.create({
+  name: "Cursor docs agent",
+  model: { id: "gpt-4o" },
+});
+
+const run = await agent.send("Summarize this repository.");
+for await (const event of run.stream()) {
+  console.log(event.type);
+}
+
+await respan.flush();
+```
+
+## Constant ownership
+
+This package keeps Cursor SDK raw field names local and emits the public Respan span contract:
+
+- Traceloop keys come from `@traceloop/ai-semantic-conventions`.
+- GenAI keys come from `@opentelemetry/semantic-conventions/incubating`.
+- Respan-owned keys come from `@respan/respan-sdk`.
+- Tool definitions use `llm.request.functions`.
+- This-turn tool calls use `gen_ai.completion.0.tool_calls`.
+- Deprecated aliases such as `respan.span.tools`, `respan.span.tool_calls`, `tools`, and `tool_calls` are not emitted.

--- a/javascript-sdks/instrumentations/respan-instrumentation-cursor/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-cursor/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@respan/instrumentation-cursor",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Respan instrumentation plugin for the Cursor TypeScript SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "author": "Respan <team@respan.ai>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/instrumentations/respan-instrumentation-cursor"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "yarn build && node --test tests/*.test.mjs",
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^1.26.0",
+    "@opentelemetry/sdk-trace-base": "^1.26.0",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@respan/respan-sdk": "workspace:^",
+    "@respan/tracing": "workspace:^",
+    "@traceloop/ai-semantic-conventions": "^0.13.0"
+  },
+  "peerDependencies": {
+    "@cursor/sdk": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@cursor/sdk": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.29",
+    "typescript": "^5.7.3"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-cursor/src/_otel_emitter.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-cursor/src/_otel_emitter.ts
@@ -1,0 +1,782 @@
+import { context, trace } from "@opentelemetry/api";
+import { hrTime } from "@opentelemetry/core";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  ATTR_GEN_AI_COMPLETION,
+  ATTR_GEN_AI_PROMPT,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_SYSTEM,
+} from "@opentelemetry/semantic-conventions/incubating";
+import { RespanLogType, RespanSpanAttributes } from "@respan/respan-sdk";
+import {
+  WORKFLOW_NAME_KEY,
+  buildReadableSpan,
+  ensureSpanId,
+  ensureTraceId,
+  getPropagatedAttributes,
+  injectSpan,
+} from "@respan/tracing";
+import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
+
+const PACKAGE_VERSION = "0.1.0";
+const INSTRUMENTATION_NAME = "@respan/instrumentation-cursor";
+const RESPAN_LOG_METHOD_TS_TRACING = "ts_tracing";
+const CURSOR_SYSTEM = "cursor";
+
+const TL = SpanAttributes as unknown as Record<string, string>;
+const ATTR_TRACELOOP_ENTITY_NAME =
+  TL.TRACELOOP_ENTITY_NAME ?? "traceloop.entity.name";
+const ATTR_TRACELOOP_ENTITY_PATH =
+  TL.TRACELOOP_ENTITY_PATH ?? "traceloop.entity.path";
+const ATTR_TRACELOOP_ENTITY_INPUT =
+  TL.TRACELOOP_ENTITY_INPUT ?? "traceloop.entity.input";
+const ATTR_TRACELOOP_ENTITY_OUTPUT =
+  TL.TRACELOOP_ENTITY_OUTPUT ?? "traceloop.entity.output";
+const ATTR_TRACELOOP_WORKFLOW_NAME =
+  TL.TRACELOOP_WORKFLOW_NAME ?? "traceloop.workflow.name";
+const ATTR_LLM_REQUEST_TYPE = TL.LLM_REQUEST_TYPE ?? "llm.request.type";
+const ATTR_LLM_REQUEST_FUNCTIONS =
+  TL.LLM_REQUEST_FUNCTIONS ?? "llm.request.functions";
+
+const GEN_AI_COMPLETION_PREFIX = `${ATTR_GEN_AI_COMPLETION}.0`;
+const GEN_AI_COMPLETION_ROLE = `${GEN_AI_COMPLETION_PREFIX}.role`;
+const GEN_AI_COMPLETION_CONTENT = `${GEN_AI_COMPLETION_PREFIX}.content`;
+const GEN_AI_COMPLETION_TOOL_CALLS = `${GEN_AI_COMPLETION_PREFIX}.tool_calls`;
+
+type AnyRecord = Record<string, any>;
+
+export interface CursorRunState {
+  agentId?: string;
+  agentName: string;
+  agentSpanId: string;
+  callbackEvents: CursorTaskEvent[];
+  durationMs?: number;
+  emitted: boolean;
+  errorMessage?: string;
+  inputMessages: AnyRecord[];
+  model?: string;
+  operation: string;
+  outputTextParts: string[];
+  parentSpanId?: string;
+  pendingTools: Map<string, PendingToolState>;
+  requestId?: string;
+  result?: string;
+  runId?: string;
+  startTime: [number, number];
+  status: string;
+  statusCode: number;
+  taskEvents: CursorTaskEvent[];
+  toolCalls: AnyRecord[];
+  toolDefinitions: AnyRecord[];
+  traceId: string;
+  workflowName: string;
+}
+
+interface PendingToolState {
+  args: unknown;
+  callId: string;
+  name: string;
+  startTime: [number, number];
+}
+
+interface CursorTaskEvent {
+  input?: unknown;
+  name: string;
+  output?: unknown;
+  startTime: [number, number];
+  statusCode?: number;
+  errorMessage?: string;
+}
+
+export function createCursorRunState({
+  agent,
+  agentName,
+  agentOptions,
+  message,
+  operation,
+  options,
+}: {
+  agent?: unknown;
+  agentName?: string;
+  agentOptions?: AnyRecord;
+  message?: unknown;
+  operation: string;
+  options?: AnyRecord;
+}): CursorRunState {
+  const activeSpan = trace.getSpan(context.active());
+  const activeSpanContext = activeSpan?.spanContext();
+  const agentRecord = asRecord(agent);
+  const resolvedAgentName =
+    stringValue(agentName) ??
+    stringValue(options?.name) ??
+    stringValue(agentOptions?.name) ??
+    stringValue(agentRecord?.name) ??
+    "cursor-agent";
+  const propagated = getPropagatedAttributes();
+  const propagatedMetadata = asRecord(propagated?.metadata);
+  const workflowName =
+    stringValue(context.active().getValue(WORKFLOW_NAME_KEY)) ??
+    stringValue(propagatedMetadata?.workflow_name) ??
+    stringValue(propagated?.trace_group_identifier) ??
+    resolvedAgentName;
+
+  const inputMessages = message === undefined ? [] : [normalizeUserMessage(message)];
+  const toolDefinitions = dedupeObjects([
+    ...normalizeConfiguredTools(agentOptions),
+    ...normalizeConfiguredTools(options),
+  ]);
+
+  return {
+    agentId: stringValue(agentRecord?.agentId),
+    agentName: resolvedAgentName,
+    agentSpanId: ensureSpanId(),
+    callbackEvents: [],
+    emitted: false,
+    inputMessages,
+    model: resolveModel(options?.model ?? agentOptions?.model ?? agentRecord?.model),
+    operation,
+    outputTextParts: [],
+    parentSpanId: activeSpanContext?.spanId,
+    pendingTools: new Map(),
+    startTime: hrTime(),
+    status: "running",
+    statusCode: 200,
+    taskEvents: [],
+    toolCalls: [],
+    toolDefinitions,
+    traceId: ensureTraceId(activeSpanContext?.traceId),
+    workflowName,
+  };
+}
+
+export function registerCursorToolDefinitions(
+  state: CursorRunState,
+  tools: AnyRecord[],
+): void {
+  state.toolDefinitions = dedupeObjects([
+    ...state.toolDefinitions,
+    ...tools,
+  ]);
+}
+
+export function trackCursorMessage(
+  state: CursorRunState,
+  rawMessage: unknown,
+): void {
+  const message = asRecord(rawMessage);
+  if (!message) return;
+
+  state.agentId = stringValue(message.agent_id) ?? state.agentId;
+  state.runId = stringValue(message.run_id) ?? state.runId;
+
+  switch (message.type) {
+    case "system":
+      state.model = resolveModel(message.model) ?? state.model;
+      if (Array.isArray(message.tools)) {
+        registerCursorToolDefinitions(
+          state,
+          message.tools
+            .map((toolName) => normalizeToolDefinition(toolName))
+            .filter((tool): tool is AnyRecord => tool !== null),
+        );
+      }
+      break;
+    case "request":
+      state.requestId = stringValue(message.request_id) ?? state.requestId;
+      break;
+    case "user":
+      pushMessageIfUseful(state.inputMessages, normalizeSdkUserMessage(message.message));
+      break;
+    case "assistant":
+      trackAssistantMessage(state, message.message);
+      break;
+    case "tool_call":
+      trackToolCallMessage(state, message);
+      break;
+    case "thinking":
+      trackTaskEvent(state, {
+        name: "cursor.thinking",
+        output: message.text,
+        startTime: hrTime(),
+      });
+      break;
+    case "task":
+      trackTaskEvent(state, {
+        name: stringValue(message.status) ?? "cursor.task",
+        input: message.status,
+        output: message.text,
+        startTime: hrTime(),
+      });
+      break;
+    case "status":
+      state.status = stringValue(message.status) ?? state.status;
+      if (message.status === "ERROR" || message.status === "CANCELLED") {
+        state.statusCode = 500;
+        state.errorMessage = stringValue(message.message) ?? state.errorMessage;
+      }
+      trackTaskEvent(state, {
+        name: "cursor.status",
+        input: message.status,
+        output: message.message,
+        startTime: hrTime(),
+        statusCode: message.status === "ERROR" ? 500 : 200,
+      });
+      break;
+  }
+}
+
+export function trackCursorCallback(
+  state: CursorRunState,
+  callbackName: string,
+  payload: unknown,
+): void {
+  state.callbackEvents.push({
+    name: `cursor.${callbackName}`,
+    input: payload,
+    startTime: hrTime(),
+  });
+
+  const record = asRecord(payload);
+  const update = asRecord(record?.update);
+  if (update) {
+    trackCursorDeltaUpdate(state, update);
+  }
+}
+
+export function recordCursorRunResult(
+  state: CursorRunState,
+  result: unknown,
+): void {
+  const record = asRecord(result);
+  if (!record) return;
+
+  state.runId = stringValue(record.id) ?? state.runId;
+  state.requestId = stringValue(record.requestId) ?? state.requestId;
+  state.status = stringValue(record.status) ?? state.status;
+  state.result = stringValue(record.result) ?? state.result;
+  state.model = resolveModel(record.model) ?? state.model;
+  state.durationMs =
+    typeof record.durationMs === "number" ? record.durationMs : state.durationMs;
+
+  if (record.status === "error" || record.status === "cancelled") {
+    state.statusCode = 500;
+    state.errorMessage = state.result ?? state.errorMessage;
+  }
+
+  if (state.result && !state.outputTextParts.includes(state.result)) {
+    state.outputTextParts.push(state.result);
+  }
+}
+
+export function markCursorRunError(
+  state: CursorRunState,
+  error: unknown,
+): void {
+  state.status = "error";
+  state.statusCode = 500;
+  state.errorMessage = error instanceof Error ? error.message : String(error);
+}
+
+export function emitCursorToolExecution({
+  args,
+  callId,
+  error,
+  result,
+  state,
+  toolName,
+}: {
+  args: unknown;
+  callId?: string;
+  error?: unknown;
+  result?: unknown;
+  state: CursorRunState;
+  toolName: string;
+}): void {
+  const statusCode = error ? 500 : 200;
+  const errorMessage = error instanceof Error ? error.message : error ? String(error) : undefined;
+
+  const toolCall = normalizeToolCall({ id: callId, name: toolName, args });
+  if (toolCall) state.toolCalls.push(toolCall);
+
+  emitToolSpan({
+    args,
+    errorMessage,
+    result: error ? errorMessage : result,
+    startTime: hrTime(),
+    state,
+    statusCode,
+    toolName,
+  });
+}
+
+export function emitFinalCursorRunSpans(state: CursorRunState): void {
+  if (state.emitted) return;
+  state.emitted = true;
+
+  for (const taskEvent of [...state.taskEvents, ...state.callbackEvents]) {
+    emitTaskSpan(state, taskEvent);
+  }
+
+  emitChatSpan(state);
+  emitAgentSpan(state);
+}
+
+function trackAssistantMessage(state: CursorRunState, messagePayload: unknown): void {
+  const message = asRecord(messagePayload);
+  if (!message) return;
+
+  const content = Array.isArray(message.content) ? message.content : [];
+  const textParts: string[] = [];
+  const assistantToolCalls: AnyRecord[] = [];
+  for (const block of content) {
+    const blockRecord = asRecord(block);
+    if (!blockRecord) continue;
+    if (blockRecord.type === "text") {
+      const text = stringValue(blockRecord.text);
+      if (text) {
+        textParts.push(text);
+        state.outputTextParts.push(text);
+      }
+    }
+    if (blockRecord.type === "tool_use") {
+      const toolCall = normalizeToolCall(blockRecord);
+      if (toolCall) {
+        assistantToolCalls.push(toolCall);
+        state.toolCalls.push(toolCall);
+      }
+    }
+  }
+
+  state.inputMessages.push({
+    role: "assistant",
+    content: textParts.join(""),
+    ...(assistantToolCalls.length > 0 ? { tool_calls: dedupeObjects(assistantToolCalls) } : {}),
+  });
+}
+
+function trackToolCallMessage(state: CursorRunState, message: AnyRecord): void {
+  const callId = stringValue(message.call_id) ?? ensureSpanId();
+  const toolName = stringValue(message.name) ?? "cursor_tool";
+  const status = stringValue(message.status) ?? "";
+
+  if (status === "running") {
+    state.pendingTools.set(callId, {
+      args: message.args,
+      callId,
+      name: toolName,
+      startTime: hrTime(),
+    });
+    return;
+  }
+
+  const pending = state.pendingTools.get(callId);
+  state.pendingTools.delete(callId);
+  const isError = status === "error";
+  const result = message.result;
+  const errorMessage = isError ? stringifyValue(result ?? "Cursor tool call failed") : undefined;
+
+  const toolCall = normalizeToolCall({
+    id: callId,
+    name: toolName,
+    args: pending?.args ?? message.args,
+  });
+  if (toolCall) state.toolCalls.push(toolCall);
+
+  emitToolSpan({
+    args: pending?.args ?? message.args,
+    errorMessage,
+    result: isError ? errorMessage : result,
+    startTime: pending?.startTime ?? hrTime(),
+    state,
+    statusCode: isError ? 500 : 200,
+    toolName,
+  });
+}
+
+function trackCursorDeltaUpdate(state: CursorRunState, update: AnyRecord): void {
+  if (update.type === "tool-call-started") {
+    const callId = stringValue(update.callId) ?? ensureSpanId();
+    const toolCall = asRecord(update.toolCall);
+    state.pendingTools.set(callId, {
+      args: toolCall?.args,
+      callId,
+      name: stringValue(toolCall?.type) ?? "cursor_tool",
+      startTime: hrTime(),
+    });
+  }
+
+  if (update.type === "tool-call-completed") {
+    const callId = stringValue(update.callId) ?? ensureSpanId();
+    const pending = state.pendingTools.get(callId);
+    state.pendingTools.delete(callId);
+    const toolCall = asRecord(update.toolCall);
+    const toolName = stringValue(toolCall?.type) ?? pending?.name ?? "cursor_tool";
+    const args = pending?.args ?? toolCall?.args;
+
+    emitCursorToolExecution({
+      args,
+      callId,
+      result: toolCall?.result,
+      state,
+      toolName,
+    });
+  }
+}
+
+function trackTaskEvent(state: CursorRunState, event: CursorTaskEvent): void {
+  state.taskEvents.push(event);
+}
+
+function emitAgentSpan(state: CursorRunState): void {
+  const attrs = baseAttrs(state.agentName, "", RespanLogType.AGENT);
+  attrs[ATTR_TRACELOOP_WORKFLOW_NAME] = state.workflowName;
+  attrs[ATTR_TRACELOOP_ENTITY_INPUT] = safeJson(state.inputMessages);
+  attrs[ATTR_TRACELOOP_ENTITY_OUTPUT] = state.result ?? state.outputTextParts.join("");
+  attrs[RespanSpanAttributes.RESPAN_METADATA_AGENT_NAME] = state.agentName;
+  attrs[RespanSpanAttributes.RESPAN_LOG_METHOD] = RESPAN_LOG_METHOD_TS_TRACING;
+  attrs[ATTR_TRACELOOP_WORKFLOW_NAME] = state.workflowName;
+  setIfPresent(attrs, RespanSpanAttributes.RESPAN_SESSION_ID, state.runId);
+  setMetadata(attrs, "cursor_agent_id", state.agentId);
+  setMetadata(attrs, "cursor_run_id", state.runId);
+  setMetadata(attrs, "cursor_request_id", state.requestId);
+  setMetadata(attrs, "cursor_operation", state.operation);
+  setMetadata(attrs, "cursor_status", state.status);
+  setIfPresent(attrs, ATTR_GEN_AI_REQUEST_MODEL, state.model);
+
+  const span = buildCursorReadableSpan({
+    name: `${state.agentName}.agent`,
+    traceId: state.traceId,
+    spanId: state.agentSpanId,
+    parentId: state.parentSpanId,
+    startTimeHr: state.startTime,
+    attributes: attrs,
+    statusCode: state.statusCode,
+    errorMessage: state.errorMessage,
+  });
+  injectSpan(span);
+}
+
+function emitChatSpan(state: CursorRunState): void {
+  const output = state.result ?? state.outputTextParts.join("");
+  const toolCalls = dedupeToolCalls(state.toolCalls);
+  const tools = dedupeToolDefinitions(state.toolDefinitions);
+
+  const attrs = baseAttrs("cursor.chat", "cursor.chat", RespanLogType.CHAT);
+  attrs[ATTR_LLM_REQUEST_TYPE] = RespanLogType.CHAT;
+  attrs[ATTR_GEN_AI_SYSTEM] = CURSOR_SYSTEM;
+  setIfPresent(attrs, ATTR_GEN_AI_REQUEST_MODEL, state.model);
+  attrs[ATTR_TRACELOOP_ENTITY_INPUT] = safeJson(state.inputMessages);
+  attrs[ATTR_TRACELOOP_ENTITY_OUTPUT] = output;
+  attrs[RespanSpanAttributes.RESPAN_LOG_METHOD] = RESPAN_LOG_METHOD_TS_TRACING;
+  attrs[ATTR_TRACELOOP_WORKFLOW_NAME] = state.workflowName;
+  setIfPresent(attrs, RespanSpanAttributes.RESPAN_SESSION_ID, state.runId);
+
+  state.inputMessages.forEach((message, index) => {
+    setIfPresent(attrs, `${ATTR_GEN_AI_PROMPT}.${index}.role`, message.role);
+    setIfPresent(attrs, `${ATTR_GEN_AI_PROMPT}.${index}.content`, stringifyMessageContent(message.content));
+    if (message.tool_calls) {
+      attrs[`${ATTR_GEN_AI_PROMPT}.${index}.tool_calls`] = safeJson(message.tool_calls);
+    }
+  });
+
+  attrs[GEN_AI_COMPLETION_ROLE] = "assistant";
+  attrs[GEN_AI_COMPLETION_CONTENT] = output;
+  if (toolCalls.length > 0) attrs[GEN_AI_COMPLETION_TOOL_CALLS] = safeJson(toolCalls);
+  if (tools.length > 0) attrs[ATTR_LLM_REQUEST_FUNCTIONS] = safeJson(tools);
+
+  const span = buildCursorReadableSpan({
+    name: "cursor.chat",
+    traceId: state.traceId,
+    parentId: state.agentSpanId,
+    startTimeHr: state.startTime,
+    attributes: attrs,
+    statusCode: state.statusCode,
+    errorMessage: state.errorMessage,
+  });
+  injectSpan(span);
+}
+
+function emitToolSpan({
+  args,
+  errorMessage,
+  result,
+  startTime,
+  state,
+  statusCode,
+  toolName,
+}: {
+  args: unknown;
+  errorMessage?: string;
+  result?: unknown;
+  startTime: [number, number];
+  state: CursorRunState;
+  statusCode: number;
+  toolName: string;
+}): void {
+  const attrs = baseAttrs(toolName, toolName, RespanLogType.TOOL);
+  attrs[ATTR_TRACELOOP_ENTITY_INPUT] = safeJson({
+    name: toolName,
+    arguments: toSerializableValue(args ?? {}),
+  });
+  attrs[ATTR_TRACELOOP_ENTITY_OUTPUT] = safeJson(toSerializableValue(result ?? ""));
+  attrs[RespanSpanAttributes.RESPAN_LOG_METHOD] = RESPAN_LOG_METHOD_TS_TRACING;
+  attrs[ATTR_TRACELOOP_WORKFLOW_NAME] = state.workflowName;
+  setIfPresent(attrs, RespanSpanAttributes.RESPAN_SESSION_ID, state.runId);
+
+  const span = buildCursorReadableSpan({
+    name: `${toolName}.tool`,
+    traceId: state.traceId,
+    parentId: state.agentSpanId,
+    startTimeHr: startTime,
+    attributes: attrs,
+    statusCode,
+    errorMessage,
+  });
+  injectSpan(span);
+}
+
+function emitTaskSpan(state: CursorRunState, event: CursorTaskEvent): void {
+  const attrs = baseAttrs(event.name, event.name, RespanLogType.TASK);
+  if (event.input !== undefined) attrs[ATTR_TRACELOOP_ENTITY_INPUT] = safeJson(toSerializableValue(event.input));
+  if (event.output !== undefined) attrs[ATTR_TRACELOOP_ENTITY_OUTPUT] = safeJson(toSerializableValue(event.output));
+  attrs[RespanSpanAttributes.RESPAN_LOG_METHOD] = RESPAN_LOG_METHOD_TS_TRACING;
+  attrs[ATTR_TRACELOOP_WORKFLOW_NAME] = state.workflowName;
+  setIfPresent(attrs, RespanSpanAttributes.RESPAN_SESSION_ID, state.runId);
+
+  const span = buildCursorReadableSpan({
+    name: `${event.name}.task`,
+    traceId: state.traceId,
+    parentId: state.agentSpanId,
+    startTimeHr: event.startTime,
+    attributes: attrs,
+    statusCode: event.statusCode,
+    errorMessage: event.errorMessage,
+  });
+  injectSpan(span);
+}
+
+function baseAttrs(entityName: string, entityPath: string, logType: string): AnyRecord {
+  return {
+    [ATTR_TRACELOOP_ENTITY_NAME]: entityName,
+    [ATTR_TRACELOOP_ENTITY_PATH]: entityPath,
+    [RespanSpanAttributes.RESPAN_LOG_TYPE]: logType,
+  };
+}
+
+function buildCursorReadableSpan(options: Parameters<typeof buildReadableSpan>[0]): ReadableSpan {
+  const span = buildReadableSpan(options) as ReadableSpan & {
+    instrumentationLibrary?: { name: string; version?: string };
+  };
+  span.instrumentationLibrary = { name: INSTRUMENTATION_NAME, version: PACKAGE_VERSION };
+  return span;
+}
+
+function normalizeConfiguredTools(options?: AnyRecord): AnyRecord[] {
+  if (!options) return [];
+  const tools: AnyRecord[] = [];
+  const local = asRecord(options.local);
+  const customTools = asRecord(local?.customTools);
+  if (customTools) {
+    for (const [toolName, tool] of Object.entries(customTools)) {
+      const toolRecord = asRecord(tool);
+      const normalized = normalizeToolDefinition({
+        name: toolName,
+        description: toolRecord?.description,
+        inputSchema: toolRecord?.inputSchema,
+      });
+      if (normalized) tools.push(normalized);
+    }
+  }
+
+  const mcpServers = asRecord(options.mcpServers);
+  if (mcpServers) {
+    for (const serverName of Object.keys(mcpServers)) {
+      const normalized = normalizeToolDefinition({
+        name: `mcp__${serverName}`,
+        description: `Cursor MCP server ${serverName}`,
+      });
+      if (normalized) tools.push(normalized);
+    }
+  }
+  return tools;
+}
+
+function normalizeToolDefinition(tool: unknown): AnyRecord | null {
+  if (typeof tool === "string" && tool) {
+    return { type: "function", function: { name: tool } };
+  }
+  const record = asRecord(tool);
+  if (!record) return null;
+  const functionRecord = asRecord(record.function);
+  const name = stringValue(functionRecord?.name) ?? stringValue(record.name) ?? stringValue(record.type);
+  if (!name) return null;
+  const description = stringValue(functionRecord?.description) ?? stringValue(record.description);
+  const parameters = functionRecord?.parameters ?? record.parameters ?? record.inputSchema ?? record.input_schema;
+  return {
+    type: "function",
+    function: {
+      name,
+      ...(description ? { description } : {}),
+      ...(parameters !== undefined ? { parameters: toSerializableValue(parameters) } : {}),
+    },
+  };
+}
+
+function normalizeToolCall(rawToolCall: unknown): AnyRecord | null {
+  const record = asRecord(rawToolCall);
+  if (!record) return null;
+  const functionRecord = asRecord(record.function);
+  const toolName = stringValue(functionRecord?.name) ?? stringValue(record.name) ?? stringValue(record.toolName);
+  if (!toolName) return null;
+  const args = functionRecord?.arguments ?? record.args ?? record.arguments ?? record.input ?? {};
+  return {
+    id: stringValue(record.id) ?? stringValue(record.call_id) ?? stringValue(record.callId) ?? "",
+    type: "function",
+    function: {
+      name: toolName,
+      arguments: typeof args === "string" ? args : safeJson(args),
+    },
+  };
+}
+
+function normalizeUserMessage(message: unknown): AnyRecord {
+  if (typeof message === "string") return { role: "user", content: message };
+  const record = asRecord(message);
+  if (record && typeof record.text === "string") {
+    return {
+      role: "user",
+      content: record.text,
+      ...(Array.isArray(record.images) ? { images: toSerializableValue(record.images) } : {}),
+    };
+  }
+  return { role: "user", content: toSerializableValue(message) };
+}
+
+function normalizeSdkUserMessage(message: unknown): AnyRecord {
+  const record = asRecord(message);
+  const content = Array.isArray(record?.content) ? record?.content : [];
+  const text = content
+    .map((block: unknown) => {
+      const blockRecord = asRecord(block);
+      return stringValue(blockRecord?.text) ?? "";
+    })
+    .filter(Boolean)
+    .join("");
+  return { role: "user", content: text || toSerializableValue(message) };
+}
+
+function pushMessageIfUseful(messages: AnyRecord[], message: AnyRecord): void {
+  const serialized = safeJson(message);
+  if (messages.some((existing) => safeJson(existing) === serialized)) return;
+  messages.push(message);
+}
+
+function resolveModel(model: unknown): string | undefined {
+  if (typeof model === "string" && model) return model;
+  const record = asRecord(model);
+  return stringValue(record?.id) ?? stringValue(record?.model);
+}
+
+function setMetadata(attrs: AnyRecord, key: string, value: unknown): void {
+  if (value === undefined || value === null || value === "") return;
+  attrs[`respan.metadata.${key}`] = String(value);
+}
+
+function setIfPresent(attrs: AnyRecord, key: string, value: unknown): void {
+  if (value === undefined || value === null || value === "") return;
+  attrs[key] = typeof value === "object" ? safeJson(value) : value;
+}
+
+function stringifyMessageContent(content: unknown): string {
+  if (content === undefined || content === null) return "";
+  if (typeof content === "string") return content;
+  return safeJson(content);
+}
+
+function stringifyValue(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  return safeJson(value);
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(toSerializableValue(value), (_key, innerValue) =>
+      typeof innerValue === "bigint" ? innerValue.toString() : innerValue,
+    );
+  } catch {
+    return String(value);
+  }
+}
+
+function toSerializableValue(value: unknown): unknown {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) {
+    return value.map((item) => toSerializableValue(item)).filter((item) => item !== undefined);
+  }
+  if (typeof value === "object") {
+    const normalizedObject: AnyRecord = {};
+    Object.entries(value as AnyRecord).forEach(([key, itemValue]) => {
+      if (typeof itemValue === "function" || typeof itemValue === "symbol") return;
+      const normalizedValue = toSerializableValue(itemValue);
+      if (normalizedValue !== undefined) normalizedObject[key] = normalizedValue;
+    });
+    return normalizedObject;
+  }
+  return String(value);
+}
+
+function asRecord(value: unknown): AnyRecord | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as AnyRecord;
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value);
+  return text ? text : undefined;
+}
+
+function dedupeObjects(objects: AnyRecord[]): AnyRecord[] {
+  const seen = new Set<string>();
+  const deduped: AnyRecord[] = [];
+  for (const object of objects) {
+    const signature = safeJson(object);
+    if (seen.has(signature)) continue;
+    seen.add(signature);
+    deduped.push(object);
+  }
+  return deduped;
+}
+
+function dedupeToolDefinitions(tools: AnyRecord[]): AnyRecord[] {
+  const seen = new Set<string>();
+  const deduped: AnyRecord[] = [];
+  for (const tool of tools) {
+    const name = asRecord(tool.function)?.name ?? safeJson(tool);
+    if (seen.has(String(name))) continue;
+    seen.add(String(name));
+    deduped.push(tool);
+  }
+  return deduped;
+}
+
+function dedupeToolCalls(toolCalls: AnyRecord[]): AnyRecord[] {
+  const seen = new Set<string>();
+  const deduped: AnyRecord[] = [];
+  for (const toolCall of toolCalls) {
+    const functionRecord = asRecord(toolCall.function);
+    const signature = safeJson([
+      toolCall.id ?? "",
+      functionRecord?.name ?? "",
+      functionRecord?.arguments ?? "",
+    ]);
+    if (seen.has(signature)) continue;
+    seen.add(signature);
+    deduped.push(toolCall);
+  }
+  return deduped;
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-cursor/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-cursor/src/index.ts
@@ -1,0 +1,331 @@
+/**
+ * Respan instrumentation plugin for the Cursor TypeScript SDK.
+ *
+ * Cursor SDK's ESM namespace is immutable, so pass a mutable module copy:
+ *
+ * ```ts
+ * import * as CursorSDK from "@cursor/sdk";
+ * const cursorSdkModule = { ...CursorSDK };
+ *
+ * new CursorSDKInstrumentor({ sdkModule: cursorSdkModule });
+ * ```
+ */
+
+import {
+  createCursorRunState,
+  emitCursorToolExecution,
+  emitFinalCursorRunSpans,
+  markCursorRunError,
+  recordCursorRunResult,
+  registerCursorToolDefinitions,
+  trackCursorCallback,
+  trackCursorMessage,
+  type CursorRunState,
+} from "./_otel_emitter.js";
+
+type AnyRecord = Record<string, any>;
+type AnyFunction = (...args: any[]) => any;
+type Patch = () => void;
+
+export interface CursorSDKInstrumentorOptions {
+  agentName?: string;
+  sdkModule: Record<string, unknown>;
+}
+
+const INSTRUMENTOR_LOG_PREFIX = "[respan] CursorSDKInstrumentor";
+
+export class CursorSDKInstrumentor {
+  public readonly name = "cursor-sdk";
+
+  private readonly _agentName?: string;
+  private readonly _sdkModule: Record<string, unknown>;
+  private readonly _agentOptions = new WeakMap<object, AnyRecord | undefined>();
+  private readonly _patchedAgents = new WeakSet<object>();
+  private _patchedRuns = new WeakMap<object, CursorRunState>();
+  private _isInstrumented = false;
+  private _patches: Patch[] = [];
+  private _suppressNestedPromptInstrumentation = 0;
+
+  constructor({ sdkModule, agentName }: CursorSDKInstrumentorOptions) {
+    this._sdkModule = sdkModule;
+    this._agentName = agentName;
+  }
+
+  activate(): void {
+    if (this._isInstrumented) return;
+    const Agent = (this._sdkModule as AnyRecord).Agent;
+    if (!Agent || (typeof Agent !== "function" && typeof Agent !== "object")) {
+      throw new Error("CursorSDKInstrumentor requires sdkModule.Agent from @cursor/sdk.");
+    }
+    this._patchAgentStatics(Agent as AnyRecord);
+    this._isInstrumented = true;
+  }
+
+  deactivate(): void {
+    for (const undo of [...this._patches].reverse()) {
+      try { undo(); } catch { /* best effort */ }
+    }
+    this._patches = [];
+    this._patchedRuns = new WeakMap<object, CursorRunState>();
+    this._suppressNestedPromptInstrumentation = 0;
+    this._isInstrumented = false;
+  }
+
+  private _patchAgentStatics(Agent: AnyRecord): void {
+    this._patchMethod(Agent, "create", (original) => {
+      const instrumentor = this;
+      return async function patchedCreate(this: unknown, options?: AnyRecord) {
+        if (instrumentor._suppressNestedPromptInstrumentation > 0) {
+          return await original.call(this, options);
+        }
+        const agent = await original.call(this, instrumentor._wrapAgentOptions(options));
+        return instrumentor._wrapAgent(agent, options);
+      };
+    });
+
+    this._patchMethod(Agent, "resume", (original) => {
+      const instrumentor = this;
+      return async function patchedResume(this: unknown, agentId: string, options?: AnyRecord) {
+        if (instrumentor._suppressNestedPromptInstrumentation > 0) {
+          return await original.call(this, agentId, options);
+        }
+        const agent = await original.call(this, agentId, instrumentor._wrapAgentOptions(options));
+        return instrumentor._wrapAgent(agent, { ...(options ?? {}), agentId });
+      };
+    });
+
+    this._patchMethod(Agent, "prompt", (original) => {
+      const instrumentor = this;
+      return async function patchedPrompt(this: unknown, message: unknown, options?: AnyRecord) {
+        const state = createCursorRunState({
+          agentName: instrumentor._agentName,
+          agentOptions: options,
+          message,
+          operation: "Agent.prompt",
+          options,
+        });
+        const wrappedOptions = instrumentor._wrapAgentOptions(options, state);
+        instrumentor._suppressNestedPromptInstrumentation += 1;
+        try {
+          const result = await original.call(this, message, wrappedOptions);
+          recordCursorRunResult(state, result);
+          return result;
+        } catch (error) {
+          markCursorRunError(state, error);
+          throw error;
+        } finally {
+          instrumentor._suppressNestedPromptInstrumentation -= 1;
+          emitFinalCursorRunSpans(state);
+        }
+      };
+    });
+
+    this._patchMethod(Agent, "getRun", (original) => {
+      const instrumentor = this;
+      return async function patchedGetRun(this: unknown, runId: string, options?: AnyRecord) {
+        const run = await original.call(this, runId, options);
+        const state = createCursorRunState({
+          agentName: instrumentor._agentName,
+          operation: "Agent.getRun",
+        });
+        state.runId = runId;
+        return instrumentor._wrapRun(run, state);
+      };
+    });
+  }
+
+  private _wrapAgent(agent: unknown, agentOptions?: AnyRecord): unknown {
+    if (!agent || typeof agent !== "object") return agent;
+    const agentObject = agent as AnyRecord;
+    if (this._patchedAgents.has(agentObject)) return agent;
+    this._patchedAgents.add(agentObject);
+    this._agentOptions.set(agentObject, agentOptions);
+
+    this._patchMethod(agentObject, "send", (original) => {
+      const instrumentor = this;
+      return async function patchedSend(this: AnyRecord, message: unknown, options?: AnyRecord) {
+        if (instrumentor._suppressNestedPromptInstrumentation > 0) {
+          return await original.call(this, message, options);
+        }
+        const state = createCursorRunState({
+          agent: this,
+          agentName: instrumentor._agentName,
+          agentOptions: instrumentor._agentOptions.get(this),
+          message,
+          operation: "SDKAgent.send",
+          options,
+        });
+        const wrappedOptions = instrumentor._wrapSendOptions(options, state);
+        try {
+          const run = await original.call(this, message, wrappedOptions);
+          return instrumentor._wrapRun(run, state);
+        } catch (error) {
+          markCursorRunError(state, error);
+          emitFinalCursorRunSpans(state);
+          throw error;
+        }
+      };
+    });
+
+    return agent;
+  }
+
+  private _wrapRun(run: unknown, state: CursorRunState): unknown {
+    if (!run || typeof run !== "object") return run;
+    const runObject = run as AnyRecord;
+    if (this._patchedRuns.has(runObject)) return run;
+    this._patchedRuns.set(runObject, state);
+
+    state.runId = stringValue(runObject.id) ?? state.runId;
+    state.requestId = stringValue(runObject.requestId) ?? state.requestId;
+    state.agentId = stringValue(runObject.agentId) ?? state.agentId;
+    state.model = resolveModel(runObject.model) ?? state.model;
+
+    this._patchMethod(runObject, "stream", (original) => {
+      return function patchedStream(this: AnyRecord) {
+        const stream = original.call(this);
+        return (async function*() {
+          try {
+            for await (const message of stream as AsyncIterable<unknown>) {
+              try {
+                trackCursorMessage(state, message);
+              } catch (error) {
+                console.warn(`${INSTRUMENTOR_LOG_PREFIX} message tracking failed:`, error);
+              }
+              yield message;
+            }
+          } catch (error) {
+            markCursorRunError(state, error);
+            throw error;
+          } finally {
+            emitFinalCursorRunSpans(state);
+          }
+        })();
+      };
+    });
+
+    this._patchMethod(runObject, "wait", (original) => {
+      return async function patchedWait(this: AnyRecord) {
+        try {
+          const result = await original.call(this);
+          recordCursorRunResult(state, result);
+          return result;
+        } catch (error) {
+          markCursorRunError(state, error);
+          throw error;
+        } finally {
+          emitFinalCursorRunSpans(state);
+        }
+      };
+    });
+
+    return run;
+  }
+
+  private _wrapAgentOptions(options?: AnyRecord, state?: CursorRunState): AnyRecord | undefined {
+    if (!options) return options;
+    return this._wrapOptions(options, state);
+  }
+
+  private _wrapSendOptions(options: AnyRecord | undefined, state: CursorRunState): AnyRecord | undefined {
+    if (!options) return options;
+    return this._wrapOptions(options, state);
+  }
+
+  private _wrapOptions(options: AnyRecord, state?: CursorRunState): AnyRecord {
+    const wrapped: AnyRecord = { ...options };
+    if (typeof options.onStep === "function" && state) {
+      const originalOnStep = options.onStep;
+      wrapped.onStep = async (...args: unknown[]) => {
+        trackCursorCallback(state, "onStep", args[0]);
+        return await originalOnStep(...args);
+      };
+    }
+    if (typeof options.onDelta === "function" && state) {
+      const originalOnDelta = options.onDelta;
+      wrapped.onDelta = async (...args: unknown[]) => {
+        trackCursorCallback(state, "onDelta", args[0]);
+        return await originalOnDelta(...args);
+      };
+    }
+
+    const local = asRecord(options.local);
+    const customTools = asRecord(local?.customTools);
+    if (customTools && state) {
+      const wrappedTools: AnyRecord = {};
+      const toolDefinitions: AnyRecord[] = [];
+      for (const [toolName, tool] of Object.entries(customTools)) {
+        const toolRecord = asRecord(tool);
+        if (!toolRecord || typeof toolRecord.execute !== "function") {
+          wrappedTools[toolName] = tool;
+          continue;
+        }
+        toolDefinitions.push({
+          type: "function",
+          function: {
+            name: toolName,
+            ...(typeof toolRecord.description === "string" ? { description: toolRecord.description } : {}),
+            ...(toolRecord.inputSchema !== undefined ? { parameters: toolRecord.inputSchema } : {}),
+          },
+        });
+        const originalExecute = toolRecord.execute;
+        wrappedTools[toolName] = {
+          ...toolRecord,
+          execute: async (...args: unknown[]) => {
+            const toolArgs = args[0];
+            const context = asRecord(args[1]);
+            try {
+              const result = await originalExecute.apply(toolRecord, args);
+              emitCursorToolExecution({
+                args: toolArgs,
+                callId: stringValue(context?.toolCallId),
+                result,
+                state,
+                toolName,
+              });
+              return result;
+            } catch (error) {
+              emitCursorToolExecution({
+                args: toolArgs,
+                callId: stringValue(context?.toolCallId),
+                error,
+                state,
+                toolName,
+              });
+              throw error;
+            }
+          },
+        };
+      }
+      registerCursorToolDefinitions(state, toolDefinitions);
+      wrapped.local = { ...local, customTools: wrappedTools };
+    }
+
+    return wrapped;
+  }
+
+  private _patchMethod(target: AnyRecord, methodName: string, createWrapper: (original: AnyFunction) => AnyFunction): void {
+    const original = target[methodName];
+    if (typeof original !== "function") return;
+    const wrapped = createWrapper(original);
+    target[methodName] = wrapped;
+    this._patches.push(() => { target[methodName] = original; });
+  }
+}
+
+function asRecord(value: unknown): AnyRecord | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as AnyRecord;
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value);
+  return text ? text : undefined;
+}
+
+function resolveModel(model: unknown): string | undefined {
+  if (typeof model === "string" && model) return model;
+  const record = asRecord(model);
+  return stringValue(record?.id) ?? stringValue(record?.model);
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-cursor/tests/cursor_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-cursor/tests/cursor_instrumentor.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { trace } from "@opentelemetry/api";
+
+import { CursorSDKInstrumentor } from "../dist/index.js";
+
+const captureState = { spans: [] };
+const originalGetTracerProvider = trace.getTracerProvider.bind(trace);
+
+test.before(() => {
+  Object.defineProperty(trace, "getTracerProvider", {
+    configurable: true,
+    writable: true,
+    value() {
+      return {
+        activeSpanProcessor: {
+          onEnd(span) {
+            captureState.spans.push(span);
+          },
+        },
+      };
+    },
+  });
+});
+
+test.after(() => {
+  Object.defineProperty(trace, "getTracerProvider", {
+    configurable: true,
+    writable: true,
+    value: originalGetTracerProvider,
+  });
+});
+
+function createFakeCursorSdk() {
+  class FakeRun {
+    id = "run_123";
+    requestId = "req_123";
+    agentId = "agent_123";
+    status = "running";
+    model = { id: "cursor-small" };
+    result = undefined;
+    durationMs = undefined;
+    supports() { return true; }
+    unsupportedReason() { return undefined; }
+    async *stream() {
+      yield { type: "system", agent_id: "agent_123", run_id: "run_123", model: { id: "cursor-small" }, tools: ["search_docs"] };
+      yield { type: "user", agent_id: "agent_123", run_id: "run_123", message: { role: "user", content: [{ type: "text", text: "Search Cursor docs" }] } };
+      yield { type: "thinking", agent_id: "agent_123", run_id: "run_123", text: "I should use the docs tool." };
+      yield { type: "assistant", agent_id: "agent_123", run_id: "run_123", message: { role: "assistant", content: [{ type: "tool_use", id: "call_docs", name: "search_docs", input: { query: "Cursor SDK tracing" } }, { type: "text", text: "Cursor SDK supports agent runs." }] } };
+      yield { type: "tool_call", agent_id: "agent_123", run_id: "run_123", call_id: "call_docs", name: "search_docs", status: "running", args: { query: "Cursor SDK tracing" } };
+      yield { type: "tool_call", agent_id: "agent_123", run_id: "run_123", call_id: "call_docs", name: "search_docs", status: "completed", result: { matches: 2 } };
+      yield { type: "status", agent_id: "agent_123", run_id: "run_123", status: "FINISHED", message: "done" };
+    }
+    async wait() { return { id: "run_123", requestId: "req_123", status: "finished", result: "Cursor SDK supports agent runs.", model: { id: "cursor-small" }, durationMs: 25 }; }
+    async conversation() { return []; }
+    async cancel() {}
+    onDidChangeStatus() { return () => {}; }
+  }
+
+  class FakeAgent {
+    agentId = "agent_123";
+    model = { id: "cursor-small" };
+    async send(_message, options = {}) {
+      await options.onStep?.({ step: { type: "demo-step" } });
+      await options.onDelta?.({ update: { type: "text-delta", text: "Cursor" } });
+      return new FakeRun();
+    }
+    close() {}
+    async reload() {}
+    async [Symbol.asyncDispose]() {}
+    async listArtifacts() { return []; }
+    async downloadArtifact() { return Buffer.from(""); }
+  }
+
+  class Agent {
+    static async create(_options) { return new FakeAgent(); }
+    static async resume(_agentId, _options) { return new FakeAgent(); }
+    static async prompt(_message, _options) { return { id: "prompt_run", requestId: "prompt_req", status: "finished", result: "Prompt result", model: { id: "cursor-small" }, durationMs: 12 }; }
+    static async getRun(_runId) { return new FakeRun(); }
+  }
+
+  return { Agent };
+}
+
+test("instrumentor emits canonical spans for Agent.create, send, stream, and tool events", async () => {
+  captureState.spans = [];
+  const sdk = createFakeCursorSdk();
+  const originalCreate = sdk.Agent.create;
+  const instrumentor = new CursorSDKInstrumentor({ sdkModule: sdk, agentName: "cursor_docs_agent" });
+  instrumentor.activate();
+  assert.notEqual(sdk.Agent.create, originalCreate);
+
+  const agent = await sdk.Agent.create({ name: "cursor_docs_agent", model: { id: "cursor-small" } });
+  const run = await agent.send("Search Cursor docs", {
+    mcpServers: { docs: { type: "stdio", command: "node", args: ["docs-server.js"] } },
+    onStep: async () => undefined,
+    onDelta: async () => undefined,
+  });
+
+  const seen = [];
+  for await (const message of run.stream()) seen.push(message.type);
+  assert.deepEqual(seen, ["system", "user", "thinking", "assistant", "tool_call", "tool_call", "status"]);
+
+  const agentSpan = captureState.spans.find((span) => span.attributes["respan.entity.log_type"] === "agent");
+  const chatSpan = captureState.spans.find((span) => span.attributes["respan.entity.log_type"] === "chat");
+  const toolSpan = captureState.spans.find((span) => span.attributes["respan.entity.log_type"] === "tool");
+  const taskSpan = captureState.spans.find((span) => span.attributes["respan.entity.log_type"] === "task");
+  assert.ok(agentSpan);
+  assert.ok(chatSpan);
+  assert.ok(toolSpan);
+  assert.ok(taskSpan);
+
+  assert.equal(agentSpan.instrumentationLibrary?.name, "@respan/instrumentation-cursor");
+  assert.equal(agentSpan.attributes["traceloop.entity.name"], "cursor_docs_agent");
+  assert.equal(agentSpan.attributes["respan.metadata.cursor_run_id"], "run_123");
+  assert.equal(chatSpan.attributes["llm.request.type"], "chat");
+  assert.equal(chatSpan.attributes["gen_ai.system"], "cursor");
+  assert.equal(chatSpan.attributes["gen_ai.request.model"], "cursor-small");
+  assert.deepEqual(JSON.parse(chatSpan.attributes["llm.request.functions"]), [
+    { type: "function", function: { name: "mcp__docs", description: "Cursor MCP server docs" } },
+    { type: "function", function: { name: "search_docs" } },
+  ]);
+  assert.deepEqual(JSON.parse(chatSpan.attributes["gen_ai.completion.0.tool_calls"]), [
+    { id: "call_docs", type: "function", function: { name: "search_docs", arguments: JSON.stringify({ query: "Cursor SDK tracing" }) } },
+  ]);
+  assert.deepEqual(JSON.parse(toolSpan.attributes["traceloop.entity.input"]), { name: "search_docs", arguments: { query: "Cursor SDK tracing" } });
+  assert.deepEqual(JSON.parse(toolSpan.attributes["traceloop.entity.output"]), { matches: 2 });
+  assert.equal(toolSpan.parentSpanId, agentSpan.spanContext().spanId);
+  assert.equal(chatSpan.parentSpanId, agentSpan.spanContext().spanId);
+
+  for (const span of [agentSpan, chatSpan, toolSpan, taskSpan]) {
+    assert.equal(span.attributes["traceloop.span.kind"], undefined);
+    assert.equal(span.attributes["respan.span.tools"], undefined);
+    assert.equal(span.attributes["respan.span.tool_calls"], undefined);
+    assert.equal(span.attributes.tools, undefined);
+    assert.equal(span.attributes.tool_calls, undefined);
+    assert.equal(span.attributes.model, undefined);
+    assert.equal(span.attributes.prompt_tokens, undefined);
+    assert.equal(span.attributes.completion_tokens, undefined);
+  }
+  instrumentor.deactivate();
+  assert.equal(sdk.Agent.create, originalCreate);
+});
+
+test("custom local tools are wrapped and emitted as tool spans", async () => {
+  captureState.spans = [];
+  const sdk = createFakeCursorSdk();
+  class ToolAgent {
+    agentId = "agent_tool";
+    model = { id: "cursor-small" };
+    async send(_message, options = {}) {
+      await options.local.customTools.lookup_weather.execute({ city: "Tokyo" }, { toolCallId: "tool_custom" });
+      return {
+        id: "run_custom",
+        requestId: "req_custom",
+        agentId: "agent_tool",
+        model: { id: "cursor-small" },
+        async *stream() {},
+        async wait() { return { id: "run_custom", status: "finished", result: "Tokyo is clear.", model: { id: "cursor-small" } }; },
+      };
+    }
+  }
+  sdk.Agent.create = async () => new ToolAgent();
+  const instrumentor = new CursorSDKInstrumentor({ sdkModule: sdk });
+  instrumentor.activate();
+  const agent = await sdk.Agent.create({ name: "tool_agent" });
+  const run = await agent.send("Check weather", {
+    local: {
+      customTools: {
+        lookup_weather: {
+          description: "Look up weather",
+          inputSchema: { type: "object", properties: { city: { type: "string" } } },
+          execute: async ({ city }) => ({ city, condition: "clear" }),
+        },
+      },
+    },
+  });
+  await run.wait();
+  const toolSpan = captureState.spans.find((span) => span.attributes["respan.entity.log_type"] === "tool");
+  const chatSpan = captureState.spans.find((span) => span.attributes["respan.entity.log_type"] === "chat");
+  assert.ok(toolSpan);
+  assert.ok(chatSpan);
+  assert.equal(toolSpan.attributes["traceloop.entity.name"], "lookup_weather");
+  assert.deepEqual(JSON.parse(toolSpan.attributes["traceloop.entity.output"]), { city: "Tokyo", condition: "clear" });
+  assert.deepEqual(JSON.parse(chatSpan.attributes["llm.request.functions"]), [
+    { type: "function", function: { name: "lookup_weather", description: "Look up weather", parameters: { type: "object", properties: { city: { type: "string" } } } } },
+  ]);
+  assert.equal(chatSpan.attributes["respan.span.tools"], undefined);
+  assert.equal(chatSpan.attributes["respan.span.tool_calls"], undefined);
+});
+
+test("Agent.prompt emits summary spans and preserves the original method on deactivate", async () => {
+  captureState.spans = [];
+  const sdk = createFakeCursorSdk();
+  const originalPrompt = sdk.Agent.prompt;
+  const instrumentor = new CursorSDKInstrumentor({ sdkModule: sdk, agentName: "prompt_agent" });
+  instrumentor.activate();
+  const result = await sdk.Agent.prompt("Run once", { model: { id: "cursor-small" } });
+  assert.equal(result.result, "Prompt result");
+  const agentSpan = captureState.spans.find((span) => span.attributes["respan.entity.log_type"] === "agent");
+  const chatSpan = captureState.spans.find((span) => span.attributes["respan.entity.log_type"] === "chat");
+  assert.ok(agentSpan);
+  assert.ok(chatSpan);
+  assert.equal(agentSpan.attributes["traceloop.entity.name"], "prompt_agent");
+  assert.equal(chatSpan.attributes["traceloop.entity.output"], "Prompt result");
+  instrumentor.deactivate();
+  assert.equal(sdk.Agent.prompt, originalPrompt);
+});

--- a/javascript-sdks/instrumentations/respan-instrumentation-cursor/tsconfig.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-cursor/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es2022",
+    "outDir": "./dist",
+    "declaration": true,
+    "lib": ["DOM", "DOM.Iterable", "es2022"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "sourceMap": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/javascript-sdks/package.json
+++ b/javascript-sdks/package.json
@@ -8,6 +8,7 @@
     "instrumentations/respan-instrumentation-anthropic",
     "instrumentations/respan-instrumentation-beeai",
     "instrumentations/respan-instrumentation-claude-agent-sdk",
+    "instrumentations/respan-instrumentation-cursor",
     "instrumentations/respan-instrumentation-langchain",
     "instrumentations/respan-instrumentation-llama-index",
     "instrumentations/respan-instrumentation-mastra",


### PR DESCRIPTION
## Summary

- add Cursor TypeScript instrumentation

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched
