### PR TITLE
feat: add Flue TypeScript instrumentation

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -62,6 +62,12 @@
     },
     {
       "ecosystem": "javascript",
+      "name": "@respan/instrumentation-flue",
+      "path": "javascript-sdks/instrumentations/respan-instrumentation-flue",
+      "registry": "npm"
+    },
+    {
+      "ecosystem": "javascript",
       "name": "@respan/instrumentation-llama-index",
       "path": "javascript-sdks/instrumentations/respan-instrumentation-llama-index",
       "registry": "npm"

--- a/.release-intents/20260621-flue-typescript-instrumentation.json
+++ b/.release-intents/20260621-flue-typescript-instrumentation.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add Flue TypeScript instrumentation",
+  "packages": {
+    "@respan/instrumentation-flue": "new"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-flue/README.md
+++ b/javascript-sdks/instrumentations/respan-instrumentation-flue/README.md
@@ -1,0 +1,41 @@
+# @respan/instrumentation-flue
+
+Respan instrumentation plugin for the Flue TypeScript runtime.
+
+The instrumentor subscribes to Flue's `observe()` runtime event stream and
+translates stable Flue activity events into canonical Respan spans:
+
+- workflow run lifecycle
+- direct agent lifecycle
+- prompt, skill, task, shell, and compaction operations
+- delegated tasks
+- model turns
+- tool executions
+- structured application logs
+
+## Installation
+
+```bash
+npm install @respan/instrumentation-flue @flue/runtime
+```
+
+## Usage
+
+```ts
+import { Respan } from "@respan/respan";
+import { FlueInstrumentor } from "@respan/instrumentation-flue";
+
+const respan = new Respan({
+  apiKey: process.env.RESPAN_API_KEY,
+  instrumentations: [
+    new FlueInstrumentor({
+      workflowName: "Flue App.workflow",
+    }),
+  ],
+});
+
+await respan.initialize();
+```
+
+Register the instrumentor once during application startup before Flue handles
+workflow or agent activity.

--- a/javascript-sdks/instrumentations/respan-instrumentation-flue/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-flue/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@respan/instrumentation-flue",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Respan instrumentation plugin for the Flue TypeScript runtime",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "author": "Respan <team@respan.ai>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/instrumentations/respan-instrumentation-flue"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "yarn build && node --test tests/*.test.mjs",
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.26.0",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@respan/respan-sdk": "^1.1.7",
+    "@respan/tracing": "^1.1.6",
+    "@traceloop/ai-semantic-conventions": "^0.13.0"
+  },
+  "peerDependencies": {
+    "@flue/runtime": ">=1.0.0-beta.1"
+  },
+  "peerDependenciesMeta": {
+    "@flue/runtime": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@flue/runtime": "1.0.0-beta.2",
+    "@types/node": "^22.15.29",
+    "typescript": "^5.7.3"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-flue/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-flue/src/index.ts
@@ -1,0 +1,948 @@
+import { context, trace } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  ATTR_ERROR_MESSAGE,
+  ATTR_GEN_AI_COMPLETION,
+  ATTR_GEN_AI_PROMPT,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_SYSTEM,
+  ATTR_GEN_AI_USAGE_COMPLETION_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_PROMPT_TOKENS,
+} from "@opentelemetry/semantic-conventions/incubating";
+import {
+  RespanLogType,
+  RespanSpanAttributes,
+} from "@respan/respan-sdk";
+import {
+  buildReadableSpan,
+  ensureTraceId,
+  injectSpan,
+} from "@respan/tracing";
+import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
+import type {
+  FlueContext,
+  FlueEvent,
+  FlueEventSubscriber,
+  LlmAssistantMessage,
+  LlmMessage,
+  LlmTool,
+  LlmToolCall,
+  PromptUsage,
+} from "@flue/runtime";
+
+const PACKAGE_VERSION = "0.1.0";
+const INSTRUMENTATION_NAME = "@respan/instrumentation-flue";
+const FLUE_INSTRUMENTATION_NAME = "flue";
+const RESPAN_LOG_METHOD_TS_TRACING = "ts_tracing";
+const STATUS_CODE_ATTR = "status_code";
+
+const GEN_AI_COMPLETION_PREFIX = `${ATTR_GEN_AI_COMPLETION}.0`;
+const GEN_AI_COMPLETION_ROLE = `${GEN_AI_COMPLETION_PREFIX}.role`;
+const GEN_AI_COMPLETION_CONTENT = `${GEN_AI_COMPLETION_PREFIX}.content`;
+const GEN_AI_COMPLETION_TOOL_CALLS = `${GEN_AI_COMPLETION_PREFIX}.tool_calls`;
+
+type FlueObserve = (subscriber: FlueEventSubscriber) => () => void;
+
+export interface FlueRuntimeModule {
+  observe?: FlueObserve;
+}
+
+export interface FlueInstrumentorOptions {
+  runtimeModule?: FlueRuntimeModule;
+  workflowName?: string;
+}
+
+interface StartedEvent {
+  timestamp: string;
+  event: FlueEvent;
+}
+
+interface TurnState {
+  start?: StartedEvent;
+  request?: Extract<FlueEvent, { type: "turn_request" }>;
+}
+
+interface ToolState {
+  start?: StartedEvent;
+}
+
+interface SpanInput {
+  name: string;
+  logType: RespanLogType;
+  entityName: string;
+  event: FlueEvent;
+  attributes?: Record<string, unknown>;
+  input?: unknown;
+  output?: unknown;
+  start?: StartedEvent;
+  durationMs?: number;
+  error?: unknown;
+  parentId?: string;
+  spanId?: string;
+  statusCode?: number;
+  workflowName?: string;
+}
+
+export class FlueInstrumentor {
+  public readonly name = FLUE_INSTRUMENTATION_NAME;
+
+  private readonly _runtimeModule?: FlueRuntimeModule;
+  private readonly _fallbackWorkflowName?: string;
+  private _unsubscribe?: () => void;
+  private _isActive = false;
+
+  private readonly _traceIds = new Map<string, string>();
+  private readonly _workflowNames = new Map<string, string>();
+  private readonly _runStarts = new Map<string, StartedEvent>();
+  private readonly _agentStarts = new Map<string, StartedEvent>();
+  private readonly _operationStarts = new Map<string, StartedEvent>();
+  private readonly _taskStarts = new Map<string, StartedEvent>();
+  private readonly _toolStarts = new Map<string, ToolState>();
+  private readonly _turns = new Map<string, TurnState>();
+  private readonly _compactionStarts = new Map<string, StartedEvent>();
+
+  constructor(options: FlueInstrumentorOptions = {}) {
+    this._runtimeModule = options.runtimeModule;
+    this._fallbackWorkflowName = options.workflowName;
+  }
+
+  async activate(): Promise<void> {
+    if (this._isActive) {
+      return;
+    }
+
+    const runtime = this._runtimeModule ?? await this._resolveRuntimeModule();
+    if (!runtime?.observe) {
+      return;
+    }
+
+    this._unsubscribe = runtime.observe((event, ctx) => {
+      this.handleEvent(event, ctx);
+    });
+    this._isActive = true;
+  }
+
+  deactivate(): void {
+    this._unsubscribe?.();
+    this._unsubscribe = undefined;
+    this._isActive = false;
+    this._traceIds.clear();
+    this._workflowNames.clear();
+    this._runStarts.clear();
+    this._agentStarts.clear();
+    this._operationStarts.clear();
+    this._taskStarts.clear();
+    this._toolStarts.clear();
+    this._turns.clear();
+    this._compactionStarts.clear();
+  }
+
+  isActive(): boolean {
+    return this._isActive;
+  }
+
+  handleEvent(event: FlueEvent, _ctx?: FlueContext): void {
+    switch (event.type) {
+      case "run_start":
+        this._runStarts.set(event.runId, { event, timestamp: event.startedAt ?? event.timestamp });
+        this._workflowNames.set(this._traceKey(event), event.workflowName);
+        break;
+      case "run_resume":
+        this._runStarts.set(event.runId, { event, timestamp: event.startedAt ?? event.timestamp });
+        this._workflowNames.set(this._traceKey(event), event.workflowName);
+        break;
+      case "run_end":
+        this._emitRunEnd(event);
+        break;
+      case "agent_start":
+        this._agentStarts.set(this._agentKey(event), { event, timestamp: event.timestamp });
+        break;
+      case "agent_end":
+        this._emitAgentEnd(event);
+        break;
+      case "operation_start":
+        this._operationStarts.set(event.operationId, { event, timestamp: event.timestamp });
+        break;
+      case "operation":
+        this._emitOperation(event);
+        break;
+      case "task_start":
+        this._taskStarts.set(event.taskId, { event, timestamp: event.timestamp });
+        break;
+      case "task":
+        this._emitTask(event);
+        break;
+      case "tool_start":
+        this._toolStarts.set(this._toolKey(event), {
+          start: { event, timestamp: event.timestamp },
+        });
+        break;
+      case "tool":
+        this._emitTool(event);
+        break;
+      case "turn_start":
+        this._upsertTurn(event.turnId).start = { event, timestamp: event.timestamp };
+        break;
+      case "turn_request":
+        this._upsertTurn(event.turnId).request = event;
+        break;
+      case "turn":
+        this._emitTurn(event);
+        break;
+      case "compaction_start":
+        this._compactionStarts.set(this._compactionKey(event), { event, timestamp: event.timestamp });
+        break;
+      case "compaction":
+        this._emitCompaction(event);
+        break;
+      case "log":
+        this._emitLog(event);
+        break;
+      case "submission_settled":
+        this._emitSubmissionSettled(event);
+        break;
+      case "idle":
+      case "message_start":
+      case "message_end":
+      case "turn_messages":
+      case "text_delta":
+      case "thinking_start":
+      case "thinking_delta":
+      case "thinking_end":
+        break;
+    }
+  }
+
+  private async _resolveRuntimeModule(): Promise<FlueRuntimeModule | undefined> {
+    try {
+      return (await import("@flue/runtime")) as unknown as FlueRuntimeModule;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private _emitRunEnd(event: Extract<FlueEvent, { type: "run_end" }>): void {
+    const start = this._runStarts.get(event.runId);
+    const workflowName =
+      this._workflowNames.get(this._traceKey(event)) ??
+      startEventValue(start, "workflowName") ??
+      this._fallbackWorkflowName ??
+      "flue.workflow";
+
+    this._emitSpan({
+      name: `flue.workflow.${workflowName}`,
+      logType: RespanLogType.WORKFLOW,
+      entityName: String(workflowName),
+      event,
+      input: startEventValue(start, "payload"),
+      output: event.isError ? errorOutput(event.error) : event.result,
+      start,
+      durationMs: event.durationMs,
+      error: event.error,
+      spanId: this._workflowSpanId(event),
+      workflowName: String(workflowName),
+    });
+    this._runStarts.delete(event.runId);
+  }
+
+  private _emitAgentEnd(event: Extract<FlueEvent, { type: "agent_end" }>): void {
+    const start = this._agentStarts.get(this._agentKey(event));
+    const entityName = this._agentName(event);
+    this._emitSpan({
+      name: `flue.agent.${entityName}`,
+      logType: RespanLogType.AGENT,
+      entityName,
+      event,
+      input: this._identityInput(event),
+      output: { messages: event.messages },
+      start,
+      spanId: this._agentSpanId(event),
+      parentId: this._rootParentId(event),
+    });
+    this._agentStarts.delete(this._agentKey(event));
+  }
+
+  private _emitOperation(event: Extract<FlueEvent, { type: "operation" }>): void {
+    const start = this._operationStarts.get(event.operationId);
+    const logType = event.operationKind === "shell" ? RespanLogType.TOOL : RespanLogType.TASK;
+    this._emitSpan({
+      name: `flue.operation.${event.operationKind}`,
+      logType,
+      entityName: `flue.${event.operationKind}`,
+      event,
+      input: {
+        operationId: event.operationId,
+        operationKind: event.operationKind,
+      },
+      output: event.isError ? errorOutput(event.error) : event.result,
+      start,
+      durationMs: event.durationMs,
+      error: event.error,
+      spanId: this._operationSpanId(event),
+      parentId: this._rootParentId(event),
+      attributes: {
+        [metadataKey("flue_operation_kind")]: event.operationKind,
+      },
+    });
+    this._operationStarts.delete(event.operationId);
+  }
+
+  private _emitTask(event: Extract<FlueEvent, { type: "task" }>): void {
+    const start = this._taskStarts.get(event.taskId);
+    const taskStart = start?.event as Extract<FlueEvent, { type: "task_start" }> | undefined;
+    const entityName = taskStart?.agent ? `flue.task.${taskStart.agent}` : "flue.task";
+    this._emitSpan({
+      name: entityName,
+      logType: RespanLogType.TASK,
+      entityName,
+      event,
+      input: {
+        prompt: taskStart?.prompt,
+        agent: taskStart?.agent ?? event.agent,
+        cwd: taskStart?.cwd,
+      },
+      output: event.isError ? errorOutput(event.result) : event.result,
+      start,
+      durationMs: event.durationMs,
+      error: event.isError ? event.result : undefined,
+      spanId: this._taskSpanId(event),
+      parentId: this._operationOrRootParentId(event),
+      attributes: {
+        [metadataKey("flue_task_agent")]: taskStart?.agent ?? event.agent,
+      },
+    });
+    this._taskStarts.delete(event.taskId);
+  }
+
+  private _emitTool(event: Extract<FlueEvent, { type: "tool" }>): void {
+    const state = this._toolStarts.get(this._toolKey(event));
+    const startEvent = state?.start?.event as Extract<FlueEvent, { type: "tool_start" }> | undefined;
+    this._emitSpan({
+      name: `flue.tool.${event.toolName}`,
+      logType: RespanLogType.TOOL,
+      entityName: event.toolName,
+      event,
+      input: {
+        name: event.toolName,
+        arguments: startEvent?.args,
+      },
+      output: event.isError ? errorOutput(event.result) : event.result,
+      start: state?.start,
+      durationMs: event.durationMs,
+      error: event.isError ? event.result : undefined,
+      spanId: this._toolSpanId(event),
+      parentId: this._operationOrRootParentId(event),
+    });
+    this._toolStarts.delete(this._toolKey(event));
+  }
+
+  private _emitTurn(event: Extract<FlueEvent, { type: "turn" }>): void {
+    const state = this._turns.get(event.turnId);
+    const request = state?.request;
+    const attributes: Record<string, unknown> = {
+      [SpanAttributes.LLM_REQUEST_TYPE]: RespanLogType.CHAT,
+      [metadataKey("flue_turn_purpose")]: event.purpose,
+    };
+
+    const provider = request?.provider ?? event.provider;
+    const model = request?.model ?? event.model;
+    if (provider) {
+      attributes[ATTR_GEN_AI_SYSTEM] = normalizeProvider(provider);
+    }
+    if (model) {
+      attributes[ATTR_GEN_AI_REQUEST_MODEL] = normalizeModel(model, provider);
+    }
+    if (request?.api) {
+      attributes[metadataKey("flue_model_api")] = request.api;
+    } else if (event.api) {
+      attributes[metadataKey("flue_model_api")] = event.api;
+    }
+    if (request?.reasoning) {
+      attributes[metadataKey("flue_reasoning")] = request.reasoning;
+    }
+
+    if (request?.input) {
+      addPromptAttributes(attributes, request.input.systemPrompt, request.input.messages);
+      if (request.input.tools && request.input.tools.length > 0) {
+        attributes[SpanAttributes.LLM_REQUEST_FUNCTIONS] = safeJson(
+          request.input.tools.map(toToolDefinition),
+        );
+      }
+    }
+    if (event.output) {
+      addCompletionAttributes(attributes, event.output);
+    }
+    addUsageAttributes(attributes, event.usage);
+
+    this._emitSpan({
+      name: `flue.turn.${event.purpose}`,
+      logType: RespanLogType.CHAT,
+      entityName: `flue.${event.purpose}.turn`,
+      event,
+      input: request?.input,
+      output: event.isError ? errorOutput(event.error) : event.output,
+      start: state?.start,
+      durationMs: event.durationMs,
+      error: event.error,
+      spanId: this._turnSpanId(event),
+      parentId: this._operationOrRootParentId(event),
+      attributes,
+    });
+    this._turns.delete(event.turnId);
+  }
+
+  private _emitCompaction(event: Extract<FlueEvent, { type: "compaction" }>): void {
+    const start = this._compactionStarts.get(this._compactionKey(event));
+    const startEvent = start?.event as Extract<FlueEvent, { type: "compaction_start" }> | undefined;
+    const attributes: Record<string, unknown> = {
+      [metadataKey("flue_compaction_messages_before")]: event.messagesBefore,
+      [metadataKey("flue_compaction_messages_after")]: event.messagesAfter,
+    };
+    if (startEvent?.reason) {
+      attributes[metadataKey("flue_compaction_reason")] = startEvent.reason;
+    }
+    if (startEvent?.estimatedTokens !== undefined) {
+      attributes[metadataKey("flue_compaction_estimated_tokens")] = startEvent.estimatedTokens;
+    }
+    addUsageMetadata(attributes, event.usage);
+
+    this._emitSpan({
+      name: "flue.compaction",
+      logType: RespanLogType.TASK,
+      entityName: "flue.compaction",
+      event,
+      input: {
+        reason: startEvent?.reason,
+        estimatedTokens: startEvent?.estimatedTokens,
+      },
+      output: {
+        messagesBefore: event.messagesBefore,
+        messagesAfter: event.messagesAfter,
+      },
+      start,
+      durationMs: event.durationMs,
+      error: event.error,
+      parentId: this._operationOrRootParentId(event),
+      spanId: this._compactionSpanId(event),
+      attributes,
+    });
+    this._compactionStarts.delete(this._compactionKey(event));
+  }
+
+  private _emitLog(event: Extract<FlueEvent, { type: "log" }>): void {
+    this._emitSpan({
+      name: `flue.log.${event.level}`,
+      logType: RespanLogType.TASK,
+      entityName: `flue.log.${event.level}`,
+      event,
+      input: event.attributes ?? {},
+      output: { level: event.level, message: event.message },
+      parentId: this._operationOrRootParentId(event),
+      spanId: this._eventSpanId(event, `log:${event.eventIndex}`),
+      attributes: {
+        [metadataKey("flue_log_level")]: event.level,
+        [metadataKey("flue_log_message")]: event.message,
+      },
+    });
+  }
+
+  private _emitSubmissionSettled(event: Extract<FlueEvent, { type: "submission_settled" }>): void {
+    this._emitSpan({
+      name: `flue.submission.${event.outcome}`,
+      logType: RespanLogType.TASK,
+      entityName: `flue.submission.${event.outcome}`,
+      event,
+      input: { submissionId: event.submissionId },
+      output: {
+        outcome: event.outcome,
+        error: event.error,
+      },
+      error: event.outcome === "failed" ? event.error : undefined,
+      parentId: this._rootParentId(event),
+      spanId: this._eventSpanId(event, `submission:${event.submissionId}`),
+      attributes: {
+        [metadataKey("flue_submission_id")]: event.submissionId,
+        [metadataKey("flue_submission_outcome")]: event.outcome,
+      },
+    });
+  }
+
+  private _emitSpan(input: SpanInput): void {
+    const event = input.event;
+    const errorMessage = input.error === undefined ? undefined : errorMessageFrom(input.error);
+    const statusCode = input.statusCode ?? (errorMessage ? 500 : 200);
+    const attrs: Record<string, unknown> = {
+      [RespanSpanAttributes.RESPAN_LOG_METHOD]: RESPAN_LOG_METHOD_TS_TRACING,
+      [RespanSpanAttributes.RESPAN_LOG_TYPE]: input.logType,
+      [SpanAttributes.TRACELOOP_ENTITY_NAME]: input.entityName,
+      [SpanAttributes.TRACELOOP_ENTITY_PATH]: input.entityName,
+      ...(errorMessage
+        ? {
+            [ATTR_ERROR_MESSAGE]: errorMessage,
+            [STATUS_CODE_ATTR]: statusCode,
+          }
+        : {}),
+      [metadataKey("flue_event_type")]: event.type,
+      [metadataKey("flue_event_index")]: event.eventIndex,
+      ...identityMetadata(event),
+      ...input.attributes,
+    };
+
+    const workflowName =
+      input.workflowName ??
+      this._workflowNames.get(this._traceKey(event)) ??
+      this._fallbackWorkflowName;
+    if (workflowName) {
+      attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = workflowName;
+    }
+
+    if (input.input !== undefined) {
+      attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(input.input);
+    }
+    if (input.output !== undefined) {
+      attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson(input.output);
+    }
+
+    const traceId = this._resolveTraceId(event);
+    const activeContext = trace.getSpan(context.active())?.spanContext();
+    const parentId = input.parentId ?? (
+      activeContext?.traceId === traceId ? activeContext.spanId : undefined
+    );
+    const endTimeIso = event.timestamp;
+    const startTimeIso =
+      input.start?.timestamp ??
+      startTimeFromDuration(event.timestamp, input.durationMs) ??
+      event.timestamp;
+    const readableSpan = buildReadableSpan({
+      name: input.name,
+      traceId,
+      spanId: input.spanId,
+      parentId,
+      startTimeIso,
+      endTimeIso,
+      attributes: sanitizeAttributes(attrs),
+      statusCode,
+      errorMessage,
+    }) as ReadableSpan & {
+      instrumentationLibrary?: { name: string; version?: string };
+    };
+
+    readableSpan.instrumentationLibrary = {
+      name: INSTRUMENTATION_NAME,
+      version: PACKAGE_VERSION,
+    };
+    injectSpan(readableSpan);
+  }
+
+  private _resolveTraceId(event: FlueEvent): string {
+    const key = this._traceKey(event);
+    const existing = this._traceIds.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const activeTraceId = trace.getSpan(context.active())?.spanContext().traceId;
+    const resolved = isUsableTraceId(activeTraceId)
+      ? activeTraceId
+      : ensureTraceId(key);
+    this._traceIds.set(key, resolved);
+    return resolved;
+  }
+
+  private _upsertTurn(turnId: string): TurnState {
+    const existing = this._turns.get(turnId);
+    if (existing) {
+      return existing;
+    }
+    const state: TurnState = {};
+    this._turns.set(turnId, state);
+    return state;
+  }
+
+  private _traceKey(event: FlueEvent): string {
+    return event.runId ??
+      event.instanceId ??
+      event.dispatchId ??
+      event.submissionId ??
+      `${event.harness ?? "harness"}:${event.session ?? "session"}`;
+  }
+
+  private _agentKey(event: FlueEvent): string {
+    return `${this._traceKey(event)}:${event.instanceId ?? event.harness ?? event.session ?? "agent"}`;
+  }
+
+  private _toolKey(event: Extract<FlueEvent, { type: "tool_start" | "tool" }>): string {
+    return `${this._traceKey(event)}:${event.toolCallId}`;
+  }
+
+  private _compactionKey(event: FlueEvent): string {
+    return `${this._traceKey(event)}:${event.operationId ?? "compaction"}`;
+  }
+
+  private _agentName(event: FlueEvent): string {
+    return event.instanceId ??
+      event.harness ??
+      event.session ??
+      event.runId ??
+      "agent";
+  }
+
+  private _identityInput(event: FlueEvent): Record<string, unknown> {
+    return {
+      runId: event.runId,
+      instanceId: event.instanceId,
+      dispatchId: event.dispatchId,
+      harness: event.harness,
+      session: event.session,
+    };
+  }
+
+  private _workflowSpanId(event: FlueEvent): string {
+    return this._eventSpanId(event, "workflow");
+  }
+
+  private _agentSpanId(event: FlueEvent): string {
+    return this._eventSpanId(event, `agent:${this._agentName(event)}`);
+  }
+
+  private _operationSpanId(event: Extract<FlueEvent, { operationId: string }>): string {
+    return this._eventSpanId(event, `operation:${event.operationId}`);
+  }
+
+  private _taskSpanId(event: Extract<FlueEvent, { taskId: string }>): string {
+    return this._eventSpanId(event, `task:${event.taskId}`);
+  }
+
+  private _toolSpanId(event: Extract<FlueEvent, { toolCallId: string }>): string {
+    return this._eventSpanId(event, `tool:${event.toolCallId}`);
+  }
+
+  private _turnSpanId(event: Extract<FlueEvent, { turnId: string }>): string {
+    return this._eventSpanId(event, `turn:${event.turnId}`);
+  }
+
+  private _compactionSpanId(event: FlueEvent): string {
+    return this._eventSpanId(event, `compaction:${event.operationId ?? event.eventIndex}`);
+  }
+
+  private _eventSpanId(event: FlueEvent, suffix: string): string {
+    return `flue:${this._traceKey(event)}:${suffix}`;
+  }
+
+  private _rootParentId(event: FlueEvent): string | undefined {
+    if (event.runId) {
+      return this._workflowSpanId(event);
+    }
+    return undefined;
+  }
+
+  private _operationOrRootParentId(event: FlueEvent): string | undefined {
+    if (event.operationId) {
+      return this._operationSpanId(event as Extract<FlueEvent, { operationId: string }>);
+    }
+    return this._rootParentId(event) ?? (
+      event.instanceId ? this._agentSpanId(event) : undefined
+    );
+  }
+}
+
+export { FlueInstrumentor as RespanFlueObserver };
+
+function addPromptAttributes(
+  attrs: Record<string, unknown>,
+  systemPrompt: string | undefined,
+  messages: LlmMessage[],
+): void {
+  let index = 0;
+  if (systemPrompt) {
+    attrs[promptRoleKey(index)] = "system";
+    attrs[promptContentKey(index)] = systemPrompt;
+    index += 1;
+  }
+
+  for (const message of messages) {
+    attrs[promptRoleKey(index)] = normalizePromptRole(message.role);
+    attrs[promptContentKey(index)] = messageToContent(message);
+    const toolCalls = messageToToolCalls(message);
+    if (toolCalls.length > 0) {
+      attrs[promptToolCallsKey(index)] = safeJson(toolCalls);
+    }
+    index += 1;
+  }
+}
+
+function addCompletionAttributes(
+  attrs: Record<string, unknown>,
+  message: LlmAssistantMessage,
+): void {
+  attrs[GEN_AI_COMPLETION_ROLE] = "assistant";
+  attrs[GEN_AI_COMPLETION_CONTENT] = assistantContent(message);
+  const toolCalls = assistantToolCalls(message);
+  if (toolCalls.length > 0) {
+    attrs[GEN_AI_COMPLETION_TOOL_CALLS] = safeJson(toolCalls);
+  }
+}
+
+function addUsageAttributes(
+  attrs: Record<string, unknown>,
+  usage: PromptUsage | undefined,
+): void {
+  if (!usage) {
+    return;
+  }
+  attrs[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = usage.input;
+  attrs[ATTR_GEN_AI_USAGE_PROMPT_TOKENS] = usage.input;
+  attrs[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] = usage.output;
+  attrs[ATTR_GEN_AI_USAGE_COMPLETION_TOKENS] = usage.output;
+  attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = usage.totalTokens;
+  addUsageMetadata(attrs, usage);
+}
+
+function addUsageMetadata(
+  attrs: Record<string, unknown>,
+  usage: PromptUsage | undefined,
+): void {
+  if (!usage) {
+    return;
+  }
+  attrs[metadataKey("flue_usage_cache_read_tokens")] = usage.cacheRead;
+  attrs[metadataKey("flue_usage_cache_write_tokens")] = usage.cacheWrite;
+  attrs[metadataKey("flue_usage_cost_total")] = usage.cost.total;
+}
+
+function promptRoleKey(index: number): string {
+  return `${ATTR_GEN_AI_PROMPT}.${index}.role`;
+}
+
+function promptContentKey(index: number): string {
+  return `${ATTR_GEN_AI_PROMPT}.${index}.content`;
+}
+
+function promptToolCallsKey(index: number): string {
+  return `${ATTR_GEN_AI_PROMPT}.${index}.tool_calls`;
+}
+
+function normalizePromptRole(role: string): string {
+  if (role === "toolResult") {
+    return "tool";
+  }
+  return role;
+}
+
+function messageToContent(message: LlmMessage): string {
+  if (message.role === "toolResult") {
+    return contentBlocksToText(message.content);
+  }
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  return contentBlocksToText(message.content);
+}
+
+function messageToToolCalls(message: LlmMessage): unknown[] {
+  if (message.role !== "assistant") {
+    return [];
+  }
+  return assistantToolCalls(message);
+}
+
+function assistantContent(message: LlmAssistantMessage): string {
+  return contentBlocksToText(
+    message.content.filter((block) => block.type !== "toolCall"),
+  );
+}
+
+function assistantToolCalls(message: LlmAssistantMessage): unknown[] {
+  return message.content
+    .filter((block): block is LlmToolCall => block.type === "toolCall")
+    .map(toOpenAIToolCall);
+}
+
+function contentBlocksToText(blocks: Array<Record<string, any>>): string {
+  return blocks
+    .map((block) => {
+      if (block.type === "text") {
+        return block.text ?? "";
+      }
+      if (block.type === "thinking") {
+        return block.thinking ?? "";
+      }
+      if (block.type === "image") {
+        return `[image:${block.mimeType ?? "unknown"}]`;
+      }
+      if (block.type === "toolCall") {
+        return "";
+      }
+      return safeJson(block);
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function toOpenAIToolCall(call: LlmToolCall): unknown {
+  return {
+    id: call.id,
+    type: "function",
+    function: {
+      name: call.name,
+      arguments: safeJson(call.arguments ?? {}),
+    },
+  };
+}
+
+function toToolDefinition(tool: LlmTool): unknown {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters: toSerializableValue(tool.parameters),
+  };
+}
+
+function normalizeProvider(provider: string): string {
+  return provider.toLowerCase();
+}
+
+function normalizeModel(model: string, provider?: string): string {
+  const prefix = provider ? `${provider}/` : undefined;
+  if (prefix && model.startsWith(prefix)) {
+    return model.slice(prefix.length);
+  }
+  return model;
+}
+
+function startEventValue<T extends string>(start: StartedEvent | undefined, key: T): unknown {
+  return start?.event && key in start.event
+    ? (start.event as Record<string, unknown>)[key]
+    : undefined;
+}
+
+function startTimeFromDuration(endTimeIso: string, durationMs: number | undefined): string | undefined {
+  if (durationMs === undefined) {
+    return undefined;
+  }
+  const endMs = new Date(endTimeIso).getTime();
+  if (!Number.isFinite(endMs)) {
+    return undefined;
+  }
+  return new Date(endMs - durationMs).toISOString();
+}
+
+function errorMessageFrom(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message?: unknown }).message);
+  }
+  return safeJson(error);
+}
+
+function errorOutput(error: unknown): unknown {
+  if (error instanceof Error) {
+    return {
+      error: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+  if (error && typeof error === "object") {
+    return toSerializableValue(error);
+  }
+  return {
+    error: String(error),
+  };
+}
+
+function identityMetadata(event: FlueEvent): Record<string, unknown> {
+  return {
+    [metadataKey("flue_run_id")]: event.runId,
+    [metadataKey("flue_instance_id")]: event.instanceId,
+    [metadataKey("flue_dispatch_id")]: event.dispatchId,
+    [metadataKey("flue_submission_id")]: event.submissionId,
+    [metadataKey("flue_harness")]: event.harness,
+    [metadataKey("flue_session")]: event.session,
+    [metadataKey("flue_parent_session")]: event.parentSession,
+    [metadataKey("flue_operation_id")]: event.operationId,
+    [metadataKey("flue_turn_id")]: event.turnId,
+    [metadataKey("flue_task_id")]: event.taskId,
+  };
+}
+
+function metadataKey(key: string): string {
+  return `${RespanSpanAttributes.RESPAN_METADATA}.${key}`;
+}
+
+function sanitizeAttributes(attrs: Record<string, unknown>): Record<string, string | number | boolean | string[] | number[] | boolean[]> {
+  const sanitized: Record<string, string | number | boolean | string[] | number[] | boolean[]> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      sanitized[key] = value;
+      continue;
+    }
+    if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+      sanitized[key] = value;
+      continue;
+    }
+    if (Array.isArray(value) && value.every((item) => typeof item === "number")) {
+      sanitized[key] = value;
+      continue;
+    }
+    if (Array.isArray(value) && value.every((item) => typeof item === "boolean")) {
+      sanitized[key] = value;
+      continue;
+    }
+    sanitized[key] = safeJson(value);
+  }
+  return sanitized;
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(toSerializableValue(value), (_key, innerValue) =>
+      typeof innerValue === "bigint" ? innerValue.toString() : innerValue,
+    );
+  } catch {
+    return JSON.stringify(String(value));
+  }
+}
+
+function toSerializableValue(value: unknown): unknown {
+  if (value === undefined) {
+    return null;
+  }
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (value instanceof Error) {
+    return errorOutput(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(toSerializableValue);
+  }
+  if (typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [key, innerValue] of Object.entries(value as Record<string, unknown>)) {
+      if (typeof innerValue === "function" || typeof innerValue === "symbol") {
+        continue;
+      }
+      output[key] = toSerializableValue(innerValue);
+    }
+    return output;
+  }
+  return String(value);
+}
+
+function isUsableTraceId(value: string | undefined): value is string {
+  return Boolean(value && /^[0-9a-f]{32}$/i.test(value));
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-flue/tests/flue_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-flue/tests/flue_instrumentor.test.mjs
@@ -1,0 +1,400 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+
+import { FlueInstrumentor } from "../dist/index.js";
+
+const captureState = { spans: [] };
+const originalGetTracerProvider = trace.getTracerProvider.bind(trace);
+
+test.before(() => {
+  Object.defineProperty(trace, "getTracerProvider", {
+    configurable: true,
+    writable: true,
+    value() {
+      return {
+        activeSpanProcessor: {
+          onEnd(span) {
+            captureState.spans.push(span);
+          },
+        },
+      };
+    },
+  });
+});
+
+test.after(() => {
+  Object.defineProperty(trace, "getTracerProvider", {
+    configurable: true,
+    writable: true,
+    value: originalGetTracerProvider,
+  });
+});
+
+function event(partial) {
+  return {
+    v: 1,
+    eventIndex: partial.eventIndex ?? 1,
+    timestamp: partial.timestamp ?? "2026-06-21T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+test("exports Flue workflow, operation, model turn, and tool events as canonical spans", () => {
+  captureState.spans = [];
+  const instrumentor = new FlueInstrumentor();
+
+  instrumentor.handleEvent(event({
+    type: "run_start",
+    eventIndex: 1,
+    runId: "run-flue-1",
+    workflowName: "Flue Weather.workflow",
+    startedAt: "2026-06-21T00:00:00.000Z",
+    payload: { city: "Paris" },
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation_start",
+    eventIndex: 2,
+    timestamp: "2026-06-21T00:00:00.050Z",
+    runId: "run-flue-1",
+    operationId: "op-1",
+    operationKind: "prompt",
+  }));
+  instrumentor.handleEvent(event({
+    type: "turn_start",
+    eventIndex: 3,
+    timestamp: "2026-06-21T00:00:00.100Z",
+    runId: "run-flue-1",
+    operationId: "op-1",
+    turnId: "turn-1",
+    purpose: "agent",
+  }));
+  instrumentor.handleEvent(event({
+    type: "turn_request",
+    eventIndex: 4,
+    timestamp: "2026-06-21T00:00:00.110Z",
+    runId: "run-flue-1",
+    operationId: "op-1",
+    turnId: "turn-1",
+    purpose: "agent",
+    model: "openai/gpt-4o-mini",
+    provider: "openai",
+    api: "responses",
+    input: {
+      systemPrompt: "Answer with weather facts.",
+      messages: [
+        { role: "user", content: "Weather in Paris?" },
+      ],
+      tools: [
+        {
+          name: "lookup_weather",
+          description: "Lookup weather.",
+          parameters: { type: "object" },
+        },
+      ],
+    },
+  }));
+  instrumentor.handleEvent(event({
+    type: "tool_start",
+    eventIndex: 5,
+    timestamp: "2026-06-21T00:00:00.200Z",
+    runId: "run-flue-1",
+    operationId: "op-1",
+    turnId: "turn-1",
+    toolCallId: "tool-1",
+    toolName: "lookup_weather",
+    args: { city: "Paris" },
+  }));
+  instrumentor.handleEvent(event({
+    type: "tool",
+    eventIndex: 6,
+    timestamp: "2026-06-21T00:00:00.260Z",
+    runId: "run-flue-1",
+    operationId: "op-1",
+    turnId: "turn-1",
+    toolCallId: "tool-1",
+    toolName: "lookup_weather",
+    isError: false,
+    result: { forecast: "sunny" },
+    durationMs: 60,
+  }));
+  instrumentor.handleEvent(event({
+    type: "turn",
+    eventIndex: 7,
+    timestamp: "2026-06-21T00:00:00.900Z",
+    runId: "run-flue-1",
+    operationId: "op-1",
+    turnId: "turn-1",
+    purpose: "agent",
+    durationMs: 800,
+    model: "openai/gpt-4o-mini",
+    provider: "openai",
+    api: "responses",
+    output: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Paris is sunny." },
+        { type: "toolCall", id: "tool-1", name: "lookup_weather", arguments: { city: "Paris" } },
+      ],
+    },
+    usage: {
+      input: 20,
+      output: 8,
+      cacheRead: 2,
+      cacheWrite: 0,
+      totalTokens: 28,
+      cost: { input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0, total: 0.031 },
+    },
+    stopReason: "stop",
+    isError: false,
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation",
+    eventIndex: 8,
+    timestamp: "2026-06-21T00:00:01.000Z",
+    runId: "run-flue-1",
+    operationId: "op-1",
+    operationKind: "prompt",
+    durationMs: 950,
+    isError: false,
+    result: { text: "Paris is sunny." },
+  }));
+  instrumentor.handleEvent(event({
+    type: "run_end",
+    eventIndex: 9,
+    timestamp: "2026-06-21T00:00:01.100Z",
+    runId: "run-flue-1",
+    result: { ok: true },
+    isError: false,
+    durationMs: 1100,
+  }));
+
+  assert.equal(captureState.spans.length, 4);
+
+  const workflowSpan = captureState.spans.find(
+    (span) => span.attributes["respan.entity.log_type"] === "workflow",
+  );
+  const operationSpan = captureState.spans.find(
+    (span) => span.name === "flue.operation.prompt",
+  );
+  const modelSpan = captureState.spans.find(
+    (span) => span.attributes["respan.entity.log_type"] === "chat",
+  );
+  const toolSpan = captureState.spans.find(
+    (span) => span.attributes["respan.entity.log_type"] === "tool",
+  );
+
+  assert.ok(workflowSpan);
+  assert.ok(operationSpan);
+  assert.ok(modelSpan);
+  assert.ok(toolSpan);
+  assert.equal(modelSpan.instrumentationLibrary.name, "@respan/instrumentation-flue");
+  assert.equal(operationSpan.parentSpanId, workflowSpan.spanContext().spanId);
+  assert.equal(modelSpan.parentSpanId, operationSpan.spanContext().spanId);
+  assert.equal(toolSpan.parentSpanId, operationSpan.spanContext().spanId);
+
+  assert.equal(workflowSpan.attributes["traceloop.workflow.name"], "Flue Weather.workflow");
+  assert.equal(modelSpan.attributes["traceloop.workflow.name"], "Flue Weather.workflow");
+  assert.equal(modelSpan.attributes["gen_ai.system"], "openai");
+  assert.equal(modelSpan.attributes["gen_ai.request.model"], "gpt-4o-mini");
+  assert.equal(modelSpan.attributes["llm.request.type"], "chat");
+  assert.equal(modelSpan.attributes["gen_ai.prompt.0.role"], "system");
+  assert.equal(modelSpan.attributes["gen_ai.prompt.0.content"], "Answer with weather facts.");
+  assert.equal(modelSpan.attributes["gen_ai.prompt.1.role"], "user");
+  assert.equal(modelSpan.attributes["gen_ai.prompt.1.content"], "Weather in Paris?");
+  assert.deepEqual(JSON.parse(modelSpan.attributes["llm.request.functions"]), [
+    { name: "lookup_weather", description: "Lookup weather.", parameters: { type: "object" } },
+  ]);
+  assert.equal(modelSpan.attributes["gen_ai.completion.0.role"], "assistant");
+  assert.equal(modelSpan.attributes["gen_ai.completion.0.content"], "Paris is sunny.");
+  assert.deepEqual(JSON.parse(modelSpan.attributes["gen_ai.completion.0.tool_calls"]), [
+    {
+      id: "tool-1",
+      type: "function",
+      function: { name: "lookup_weather", arguments: JSON.stringify({ city: "Paris" }) },
+    },
+  ]);
+  assert.equal(modelSpan.attributes["gen_ai.usage.input_tokens"], 20);
+  assert.equal(modelSpan.attributes["gen_ai.usage.output_tokens"], 8);
+  assert.equal(modelSpan.attributes["gen_ai.usage.prompt_tokens"], 20);
+  assert.equal(modelSpan.attributes["gen_ai.usage.completion_tokens"], 8);
+  assert.equal(modelSpan.attributes["llm.usage.total_tokens"], 28);
+  assert.equal(modelSpan.attributes["respan.metadata.flue_usage_cache_read_tokens"], 2);
+
+  for (const span of captureState.spans) {
+    assert.equal(span.attributes["respan.span.tools"], undefined);
+    assert.equal(span.attributes["respan.span.tool_calls"], undefined);
+    assert.equal(span.attributes.tools, undefined);
+    assert.equal(span.attributes.tool_calls, undefined);
+    assert.equal(span.attributes.model, undefined);
+    assert.equal(span.attributes.prompt_tokens, undefined);
+    assert.equal(span.attributes.completion_tokens, undefined);
+  }
+});
+
+test("exports direct agent logs and compaction with fallback workflow name", () => {
+  captureState.spans = [];
+  const instrumentor = new FlueInstrumentor({
+    workflowName: "Flue Direct Agent.workflow",
+  });
+
+  instrumentor.handleEvent(event({
+    type: "agent_start",
+    eventIndex: 1,
+    instanceId: "agent-1",
+    harness: "default",
+    session: "main",
+  }));
+  instrumentor.handleEvent(event({
+    type: "log",
+    eventIndex: 2,
+    instanceId: "agent-1",
+    harness: "default",
+    session: "main",
+    level: "info",
+    message: "agent accepted input",
+    attributes: { channel: "test" },
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction_start",
+    eventIndex: 3,
+    timestamp: "2026-06-21T00:00:00.200Z",
+    instanceId: "agent-1",
+    operationId: "op-compact",
+    reason: "manual",
+    estimatedTokens: 1200,
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction",
+    eventIndex: 4,
+    timestamp: "2026-06-21T00:00:00.500Z",
+    instanceId: "agent-1",
+    operationId: "op-compact",
+    messagesBefore: 12,
+    messagesAfter: 3,
+    durationMs: 300,
+    isError: false,
+  }));
+  instrumentor.handleEvent(event({
+    type: "agent_end",
+    eventIndex: 5,
+    instanceId: "agent-1",
+    harness: "default",
+    session: "main",
+    messages: [{ role: "assistant", content: "done" }],
+  }));
+
+  assert.equal(captureState.spans.length, 3);
+  const logSpan = captureState.spans.find((span) => span.name === "flue.log.info");
+  const compactionSpan = captureState.spans.find((span) => span.name === "flue.compaction");
+  const agentSpan = captureState.spans.find(
+    (span) => span.attributes["respan.entity.log_type"] === "agent",
+  );
+
+  assert.ok(logSpan);
+  assert.ok(compactionSpan);
+  assert.ok(agentSpan);
+  assert.equal(logSpan.attributes["traceloop.workflow.name"], "Flue Direct Agent.workflow");
+  assert.equal(compactionSpan.attributes["respan.metadata.flue_compaction_reason"], "manual");
+  assert.equal(agentSpan.attributes["traceloop.entity.name"], "agent-1");
+});
+
+
+test("marks failed Flue events with error status and backend status attributes", () => {
+  captureState.spans = [];
+  const instrumentor = new FlueInstrumentor({
+    workflowName: "Flue Error.workflow",
+  });
+
+  instrumentor.handleEvent(event({
+    type: "run_start",
+    eventIndex: 1,
+    runId: "run-error-1",
+    workflowName: "Flue Error.workflow",
+    payload: { command: "cat missing-file.txt" },
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation_start",
+    eventIndex: 2,
+    runId: "run-error-1",
+    operationId: "op-shell",
+    operationKind: "shell",
+  }));
+  instrumentor.handleEvent(event({
+    type: "tool_start",
+    eventIndex: 3,
+    runId: "run-error-1",
+    operationId: "op-shell",
+    turnId: "turn-shell",
+    toolCallId: "tool-shell",
+    toolName: "shell",
+    args: { command: "cat missing-file.txt" },
+  }));
+  instrumentor.handleEvent(event({
+    type: "tool",
+    eventIndex: 4,
+    runId: "run-error-1",
+    operationId: "op-shell",
+    turnId: "turn-shell",
+    toolCallId: "tool-shell",
+    toolName: "shell",
+    isError: true,
+    result: { message: "missing-file.txt: No such file", exitCode: 1 },
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation",
+    eventIndex: 5,
+    runId: "run-error-1",
+    operationId: "op-shell",
+    operationKind: "shell",
+    isError: true,
+    error: { name: "ShellError", message: "Command failed" },
+  }));
+  instrumentor.handleEvent(event({
+    type: "run_end",
+    eventIndex: 6,
+    runId: "run-error-1",
+    isError: true,
+    error: { name: "WorkflowError", message: "Unable to read required file" },
+  }));
+
+  assert.equal(captureState.spans.length, 3);
+  const toolSpan = captureState.spans.find((span) => span.name === "flue.tool.shell");
+  const operationSpan = captureState.spans.find((span) => span.name === "flue.operation.shell");
+  const workflowSpan = captureState.spans.find(
+    (span) => span.attributes["respan.entity.log_type"] === "workflow",
+  );
+
+  for (const span of [toolSpan, operationSpan, workflowSpan]) {
+    assert.ok(span);
+    assert.equal(span.status.code, SpanStatusCode.ERROR);
+    assert.equal(span.attributes.status_code, 500);
+    assert.equal(typeof span.attributes["error.message"], "string");
+  }
+  assert.equal(operationSpan.parentSpanId, workflowSpan.spanContext().spanId);
+  assert.equal(toolSpan.parentSpanId, operationSpan.spanContext().spanId);
+});
+
+test("activate and deactivate wire the Flue observe subscriber", async () => {
+  let subscriber;
+  let unsubscribeCalls = 0;
+  const instrumentor = new FlueInstrumentor({
+    runtimeModule: {
+      observe(nextSubscriber) {
+        subscriber = nextSubscriber;
+        return () => {
+          unsubscribeCalls += 1;
+        };
+      },
+    },
+  });
+
+  await instrumentor.activate();
+  assert.equal(instrumentor.isActive(), true);
+  assert.equal(typeof subscriber, "function");
+
+  instrumentor.deactivate();
+  assert.equal(instrumentor.isActive(), false);
+  assert.equal(unsubscribeCalls, 1);
+});

--- a/javascript-sdks/instrumentations/respan-instrumentation-flue/tsconfig.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-flue/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es2022",
+    "outDir": "./dist",
+    "declaration": true,
+    "lib": ["DOM", "DOM.Iterable", "es2022"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "sourceMap": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/javascript-sdks/package.json
+++ b/javascript-sdks/package.json
@@ -13,6 +13,7 @@
     "instrumentations/respan-instrumentation-claude-agent-sdk",
     "instrumentations/respan-instrumentation-codex-sdk",
     "instrumentations/respan-instrumentation-cursor",
+    "instrumentations/respan-instrumentation-flue",
     "instrumentations/respan-instrumentation-langchain",
     "instrumentations/respan-instrumentation-llama-index",
     "instrumentations/respan-instrumentation-google-adk",


### PR DESCRIPTION
## Summary

- add Flue TypeScript instrumentation

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched
