### PR TITLE
feat(js): Semantic span names vercel js

### DIFF
--- a/.release-intents/20260625-semantic-span-names-core-js.json
+++ b/.release-intents/20260625-semantic-span-names-core-js.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Add opt-in semantic span-name formatting for shared TypeScript tracing packages",
+  "packages": {
+    "@respan/respan-sdk": "minor",
+    "@respan/tracing": "minor",
+    "@respan/respan": "minor"
+  }
+}

--- a/.release-intents/20260625-vercel-semantic-span-names-js.json
+++ b/.release-intents/20260625-vercel-semantic-span-names-js.json
@@ -1,6 +1,6 @@
 {
-  "summary": "Add semantic span-name hints to Vercel AI SDK instrumentation",
+  "summary": "Patch semantic span-name hints for Vercel AI SDK instrumentation",
   "packages": {
-    "@respan/instrumentation-vercel": "minor"
+    "@respan/instrumentation-vercel": "patch"
   }
 }

--- a/.release-intents/20260625-vercel-semantic-span-names-js.json
+++ b/.release-intents/20260625-vercel-semantic-span-names-js.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add semantic span-name hints to Vercel AI SDK instrumentation",
+  "packages": {
+    "@respan/instrumentation-vercel": "minor"
+  }
+}

--- a/contribution/writing-instrumentations.md
+++ b/contribution/writing-instrumentations.md
@@ -149,6 +149,102 @@ Examples of keys that stay inside the instrumentation package:
 - Vercel AI SDK `ai.*` raw attribute keys
 - n8n / Langflow / vendor-specific event payload keys
 
+## Semantic Span Name Prefixes
+
+Respan supports a semantic span-name style for integrations that want a
+consistent trace tree across SDKs. The exported name format is:
+
+```text
+<operation>.<detail>
+```
+
+Examples:
+
+- `generate.doGenerate`
+- `agent.triage-service`
+- `tool.send_notification`
+- `handoff.triage_to_identity`
+- `guardrail.content_safety`
+
+This is a naming rule only. Do not change log-type, span-kind, input/output,
+or metadata mapping just to make the name look right. A chat span should still
+be exported as a chat log type even when its semantic span name is
+`generate.chat`.
+
+### Prefix Rules
+
+Use the operation prefix to describe the span's function, not the vendor,
+package, product, or brand. Put stable details in the suffix.
+
+Recommended operation prefixes:
+
+- `workflow.<name>` for workflow/root spans
+- `agent.<name>` for agent execution spans
+- `task.<name>` for generic task spans
+- `generate.<operation>` for LLM chat/text/response/generation calls
+- `stream.<operation>` for streamed generation calls when the SDK exposes them
+- `embed.<operation>` for embedding calls
+- `transcribe.<operation>` for transcription calls
+- `speech.<operation>` for speech-generation calls
+- `tool.<name>` for tool/function-tool execution
+- `function.<name>` for non-tool function spans
+- `handoff.<from>_to_<to>` for agent handoffs
+- `guardrail.<name>` for guardrail checks
+- `span.<name>` only as a fallback when no better operation exists
+
+Suffixes should be stable, human-readable identifiers such as SDK operation
+names, agent names, tool names, or guardrail names. Do not put prompt text,
+user input, full URLs, request IDs, customer IDs, secrets, timestamps, or other
+high-cardinality values in `span.name`.
+
+The span-name transformer sanitizes whitespace and unsupported punctuation, but
+instrumentations should still provide concise suffixes up front.
+
+### Import And Hint Rules
+
+Prefer existing semantic attributes before adding Respan-specific naming hints:
+
+1. Set `traceloop.span.kind` and `traceloop.entity.name` from
+   `@traceloop/ai-semantic-conventions` when they accurately describe the span.
+2. Set `RespanSpanAttributes.RESPAN_LOG_TYPE` with `RespanLogType` from
+   `@respan/respan-sdk` for backend classification.
+3. Add semantic span-name hints only when the desired prefix/detail cannot be
+   derived from the normal span kind, entity name, log type, or raw SDK span
+   name.
+
+When hints are needed, import the keys from `@respan/respan-sdk`:
+
+```ts
+import {
+  RespanLogType,
+  RespanSpanAttributes,
+} from "@respan/respan-sdk";
+
+attrs[RespanSpanAttributes.RESPAN_LOG_TYPE] = RespanLogType.TOOL;
+attrs[RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_KIND] = "tool";
+attrs[RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_DETAIL] = toolName;
+```
+
+Rules:
+
+- Do not hard-code `respan.internal.span_name.kind` or
+  `respan.internal.span_name.detail` string literals in instrumentation code.
+- Do not use a brand or package prefix such as `respan.*`, `openai.*`, or
+  `vercel.*` for semantic span names.
+- Do not duplicate the internal hint constants locally. Import them from
+  `RespanSpanAttributes`.
+- Treat `RESPAN_INTERNAL_SPAN_NAME_KIND` and
+  `RESPAN_INTERNAL_SPAN_NAME_DETAIL` as exporter hints only. They must not
+  appear in exported customer-visible span attributes; `respan-tracing` strips
+  them before export.
+- Keep hints close to the translator/emitter code that knows the SDK event
+  shape. Do not promote SDK-specific name maps into `respan-sdk`.
+- Preserve legacy behavior. Semantic renaming must only apply when users set
+  `spanNameStyle: "semantic"` or `RESPAN_SPAN_NAME_STYLE=semantic`; the legacy
+  style preserves the original instrumentation span names.
+- Add focused tests for both semantic and legacy behavior when an
+  instrumentation sets span-name hints.
+
 ## JavaScript Guidance
 
 JS instrumentation packages should generally:

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator.ts
@@ -38,8 +38,10 @@ import {
   isVercelAISpan,
   metadataKey,
   resolveLogType,
+  resolveSemanticSpanNameHint,
   safeJsonStr,
   setDefault,
+  setSemanticSpanNameHint,
 } from "./_translator/shared.js";
 import { enrichMetadata, enrichModel, enrichPerformanceMetrics, enrichTokens, stripRedundantAttrs } from "./_translator/span-enrichment.js";
 
@@ -83,6 +85,8 @@ export class VercelAITranslator implements SpanProcessor {
     const config = VERCEL_SPAN_CONFIG[name];
     const parentLogType = VERCEL_PARENT_SPANS[name];
     const logType = resolveLogType(name, attrs);
+    const semanticName = resolveSemanticSpanNameHint(name, attrs, logType);
+    setSemanticSpanNameHint(attrs, semanticName.kind, semanticName.detail);
 
     // Embedding spans (span-contract.md): input = embedded text, output = the
     // embedding vector(s) — captured, not dropped (debuggable RAG data; size is

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator.ts
@@ -25,8 +25,11 @@ import {
 import {
   AI_AGENT_ID,
   AI_MODEL_ID,
+  AI_OPERATION_ID,
   AI_PREFIX,
   LLM_REQUEST_TYPE,
+  RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+  RESPAN_INTERNAL_SPAN_NAME_KIND,
   RESPAN_LOG_TYPE,
   RESPAN_METADATA_AGENT_NAME,
   TL_SPAN_KIND,
@@ -44,6 +47,52 @@ import {
   setSemanticSpanNameHint,
 } from "./_translator/shared.js";
 import { enrichMetadata, enrichModel, enrichPerformanceMetrics, enrichTokens, stripRedundantAttrs } from "./_translator/span-enrichment.js";
+
+function setVercelSpanNameHint(
+  attrs: Record<string, any>,
+  name: string,
+  logType: string,
+  isLLM = false
+): void {
+  attrs[RESPAN_INTERNAL_SPAN_NAME_KIND] = semanticKindForLogType(logType, isLLM);
+  attrs[RESPAN_INTERNAL_SPAN_NAME_DETAIL] = semanticDetailForVercelSpan(attrs, name);
+}
+
+function semanticKindForLogType(logType: string, isLLM: boolean): string {
+  if (isLLM) return "llm";
+
+  switch (logType) {
+    case RespanLogType.CHAT:
+    case RespanLogType.TEXT:
+    case RespanLogType.RESPONSE:
+    case RespanLogType.GENERATION:
+      return "llm";
+    case RespanLogType.EMBEDDING:
+      return "embed";
+    case RespanLogType.FUNCTION:
+      return "function";
+    default:
+      return logType;
+  }
+}
+
+function semanticDetailForVercelSpan(attrs: Record<string, any>, name: string): string {
+  const toolName = attrs["ai.toolCall.name"];
+  if (toolName !== undefined && toolName !== null && String(toolName).trim()) {
+    return String(toolName);
+  }
+
+  const agentName = attrs["ai.agent.name"] ?? attrs[AI_AGENT_ID];
+  if (agentName !== undefined && agentName !== null && String(agentName).trim()) {
+    return String(agentName);
+  }
+
+  const operationId = attrs[AI_OPERATION_ID];
+  const source = operationId !== undefined && operationId !== null ? String(operationId) : name;
+  const parts = source.split(".").filter(Boolean);
+  return parts.at(-1) ?? source;
+}
+
 
 /**
  * SpanProcessor that translates Vercel AI SDK attributes to Traceloop/OpenLLMetry.
@@ -110,11 +159,13 @@ export class VercelAITranslator implements SpanProcessor {
 
     if (parentLogType !== undefined && !config) {
       setDefault(attrs, RESPAN_LOG_TYPE, logType);
+      setVercelSpanNameHint(attrs, name, logType);
       stripRedundantAttrs(attrs);
       return;
     }
 
     attrs[RESPAN_LOG_TYPE] = logType;
+    setVercelSpanNameHint(attrs, name, logType, config?.isLLM ?? false);
 
     if (config) {
       // Do NOT set traceloop.span.kind for auto-emitted Vercel SDK spans.

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/shared.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/src/_translator/shared.ts
@@ -19,6 +19,8 @@ export const RESPAN_SPAN_TOOLS = RespanSpanAttributes.RESPAN_SPAN_TOOLS;
 export const RESPAN_SPAN_TOOL_CALLS = RespanSpanAttributes.RESPAN_SPAN_TOOL_CALLS;
 export const RESPAN_METADATA_AGENT_NAME = RespanSpanAttributes.RESPAN_METADATA_AGENT_NAME;
 export const RESPAN_METADATA_PREFIX = RespanSpanAttributes.RESPAN_METADATA;
+export const RESPAN_INTERNAL_SPAN_NAME_KIND = RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_KIND;
+export const RESPAN_INTERNAL_SPAN_NAME_DETAIL = RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_DETAIL;
 
 export const TL_SPAN_KIND = "traceloop.span.kind";
 export const TL_ENTITY_INPUT = "traceloop.entity.input";
@@ -69,6 +71,99 @@ export function setDefault(attrs: SpanAttributes, key: string, value: any): void
   if (attrs[key] === undefined && value !== undefined && value !== null) {
     attrs[key] = value;
   }
+}
+
+export function setSemanticSpanNameHint(
+  attrs: SpanAttributes,
+  kind: string,
+  detail: string
+): void {
+  setDefault(attrs, RESPAN_INTERNAL_SPAN_NAME_KIND, kind);
+  setDefault(attrs, RESPAN_INTERNAL_SPAN_NAME_DETAIL, detail);
+}
+
+export function resolveSemanticSpanNameHint(
+  name: string,
+  attrs: SpanAttributes,
+  logType: string
+): { kind: string; detail: string } {
+  if (logType === RespanLogType.TOOL) {
+    return {
+      kind: "tool",
+      detail: stringOrFallback(attrs[AI_TOOL_CALL_NAME], lastSegment(name)),
+    };
+  }
+
+  if (logType === RespanLogType.AGENT) {
+    return {
+      kind: "agent",
+      detail: stringOrFallback(attrs["ai.agent.name"] ?? attrs[AI_AGENT_ID], lastSegment(name)),
+    };
+  }
+
+  if (logType === RespanLogType.WORKFLOW) {
+    return {
+      kind: "workflow",
+      detail: stringOrFallback(attrs[AI_WORKFLOW_ID], lastSegment(name)),
+    };
+  }
+
+  const explicit = VERCEL_SEMANTIC_SPAN_NAMES[name];
+  if (explicit) {
+    return explicit;
+  }
+
+  const operationId = attrs[AI_OPERATION_ID]?.toString();
+  if (operationId && VERCEL_SEMANTIC_SPAN_NAMES[operationId]) {
+    return VERCEL_SEMANTIC_SPAN_NAMES[operationId];
+  }
+
+  if (logType === RespanLogType.EMBEDDING) {
+    return { kind: "embed", detail: lastSegment(name) };
+  }
+
+  if (logType === RespanLogType.TRANSCRIPTION) {
+    return { kind: "transcribe", detail: lastSegment(name) };
+  }
+
+  if (logType === RespanLogType.SPEECH) {
+    return { kind: "speech", detail: lastSegment(name) };
+  }
+
+  if (name.startsWith("ai.stream")) {
+    return { kind: "stream", detail: lastSegment(name) };
+  }
+
+  if (name.startsWith("ai.")) {
+    return { kind: "generate", detail: lastSegment(name) };
+  }
+
+  return { kind: logType || "span", detail: lastSegment(name) };
+}
+const VERCEL_SEMANTIC_SPAN_NAMES: Record<string, { kind: string; detail: string }> = {
+  "ai.generateText": { kind: "generate", detail: "generateText" },
+  "ai.generateText.doGenerate": { kind: "generate", detail: "doGenerate" },
+  "ai.streamText": { kind: "stream", detail: "streamText" },
+  "ai.streamText.doStream": { kind: "stream", detail: "doStream" },
+  "ai.generateObject": { kind: "generate", detail: "generateObject" },
+  "ai.generateObject.doGenerate": { kind: "generate", detail: "doGenerate" },
+  "ai.streamObject": { kind: "stream", detail: "streamObject" },
+  "ai.streamObject.doStream": { kind: "stream", detail: "doStream" },
+  "ai.embed": { kind: "embed", detail: "embed" },
+  "ai.embed.doEmbed": { kind: "embed", detail: "doEmbed" },
+  "ai.embedMany": { kind: "embed", detail: "embedMany" },
+  "ai.embedMany.doEmbed": { kind: "embed", detail: "doEmbed" },
+  "ai.toolCall": { kind: "tool", detail: "toolCall" },
+};
+
+function lastSegment(name: string): string {
+  const parts = name.split(".");
+  return parts[parts.length - 1] || name;
+}
+
+function stringOrFallback(value: unknown, fallback: string): string {
+  if (value === undefined || value === null || value === "") return fallback;
+  return String(value);
 }
 
 export function safeJsonStr(value: unknown): string {

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/tests/translator.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/tests/translator.test.mjs
@@ -39,7 +39,7 @@ test("ai.generateText.doGenerate is classified as LLM text, not task", () => {
   assert.equal(attrs["llm.request.type"], "chat");
   assert.equal(attrs["gen_ai.request.model"], "gpt-4o-mini");
   assert.equal(attrs["traceloop.span.kind"], undefined);
-  assert.equal(attrs["respan.internal.span_name.kind"], "generate");
+  assert.equal(attrs["respan.internal.span_name.kind"], "llm");
   assert.equal(attrs["respan.internal.span_name.detail"], "doGenerate");
 });
 
@@ -50,8 +50,26 @@ test("ai.streamText.doStream is classified as LLM text, not task", () => {
   assert.equal(attrs["llm.request.type"], "chat");
   assert.equal(attrs["gen_ai.request.model"], "gpt-4o-mini");
   assert.equal(attrs["traceloop.span.kind"], undefined);
-  assert.equal(attrs["respan.internal.span_name.kind"], "stream");
+  assert.equal(attrs["respan.internal.span_name.kind"], "llm");
   assert.equal(attrs["respan.internal.span_name.detail"], "doStream");
+});
+
+test("sets semantic span-name hints for Vercel AI SDK spans", () => {
+  const llmAttrs = runTranslator("ai.generateText.doGenerate", baseLLMSpan);
+  assert.equal(llmAttrs["respan.internal.span_name.kind"], "llm");
+  assert.equal(llmAttrs["respan.internal.span_name.detail"], "doGenerate");
+
+  const parentAttrs = runTranslator("ai.generateText", {
+    "ai.model.id": "gpt-4o-mini",
+  });
+  assert.equal(parentAttrs["respan.internal.span_name.kind"], "llm");
+  assert.equal(parentAttrs["respan.internal.span_name.detail"], "generateText");
+
+  const toolAttrs = runTranslator("ai.toolCall", {
+    "ai.toolCall.name": "lookup_weather",
+  });
+  assert.equal(toolAttrs["respan.internal.span_name.kind"], "tool");
+  assert.equal(toolAttrs["respan.internal.span_name.detail"], "lookup_weather");
 });
 
 test("ai.embed.doEmbed is classified as embedding without synthetic usage fields", () => {

--- a/javascript-sdks/instrumentations/respan-instrumentation-vercel/tests/translator.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vercel/tests/translator.test.mjs
@@ -39,6 +39,8 @@ test("ai.generateText.doGenerate is classified as LLM text, not task", () => {
   assert.equal(attrs["llm.request.type"], "chat");
   assert.equal(attrs["gen_ai.request.model"], "gpt-4o-mini");
   assert.equal(attrs["traceloop.span.kind"], undefined);
+  assert.equal(attrs["respan.internal.span_name.kind"], "generate");
+  assert.equal(attrs["respan.internal.span_name.detail"], "doGenerate");
 });
 
 test("ai.streamText.doStream is classified as LLM text, not task", () => {
@@ -48,6 +50,8 @@ test("ai.streamText.doStream is classified as LLM text, not task", () => {
   assert.equal(attrs["llm.request.type"], "chat");
   assert.equal(attrs["gen_ai.request.model"], "gpt-4o-mini");
   assert.equal(attrs["traceloop.span.kind"], undefined);
+  assert.equal(attrs["respan.internal.span_name.kind"], "stream");
+  assert.equal(attrs["respan.internal.span_name.detail"], "doStream");
 });
 
 test("ai.embed.doEmbed is classified as embedding without synthetic usage fields", () => {
@@ -78,6 +82,8 @@ test("ai.embed.doEmbed is classified as embedding without synthetic usage fields
   assert.ok(attrs["traceloop.entity.input"]?.includes("embed this"));
   assert.ok(attrs["traceloop.entity.output"]?.includes("0.1"));
   assert.equal(attrs["ai.values"], undefined);
+  assert.equal(attrs["respan.internal.span_name.kind"], "embed");
+  assert.equal(attrs["respan.internal.span_name.detail"], "doEmbed");
 });
 
 test("LLM spans emit tool definitions and tool calls in canonical fields only", () => {
@@ -200,4 +206,6 @@ test("ai.toolCall spans carry input/output only — no tool_calls aliases", () =
   assert.equal(attrs.tool_calls, undefined);
   assert.equal(attrs["respan.span.tool_calls"], undefined);
   assert.equal(attrs.span_tools, undefined);
+  assert.equal(attrs["respan.internal.span_name.kind"], "tool");
+  assert.equal(attrs["respan.internal.span_name.detail"], "weather");
 });

--- a/javascript-sdks/respan-sdk/src/types/spanTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/spanTypes.ts
@@ -33,6 +33,10 @@ export enum RespanSpanAttributes {
     // Processor routing (used by decorators to target specific processors)
     RESPAN_PROCESSORS = "respan.processors",
 
+    // Internal runtime hints. These are stripped before export.
+    RESPAN_INTERNAL_SPAN_NAME_KIND = "respan.internal.span_name.kind",
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL = "respan.internal.span_name.detail",
+
     // Logging
     RESPAN_LOG_METHOD = "respan.entity.log_method",
     RESPAN_LOG_TYPE = "respan.entity.log_type",
@@ -85,6 +89,8 @@ export const RESPAN_SPAN_ATTRIBUTES_MAP: { [key: string]: string } = {
     prompt: RespanSpanAttributes.RESPAN_PROMPT,
     environment: RespanSpanAttributes.RESPAN_ENVIRONMENT,
 };
+
+export type RespanSpanNameStyle = "legacy" | "semantic";
 
 // Type for valid span attribute values
 export type SpanAttributeValue = string | number | boolean | Array<string | number | boolean>;

--- a/javascript-sdks/respan-sdk/src/types/tracingTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/tracingTypes.ts
@@ -1,3 +1,5 @@
+import type { RespanSpanNameStyle } from "./spanTypes.js";
+
 export interface TracingDecoratorConfig {
   name: string;
   version?: number;
@@ -55,6 +57,14 @@ export interface TracingOptions {
    * Defaults to true.
    */
   tracingEnabled?: boolean;
+
+  /**
+   * Controls exported span.name formatting.
+   * - legacy: preserve instrumentation span names
+   * - semantic: use operation-prefixed names like agent.triage or generate.doGenerate
+   * Defaults to legacy. Can also be set with RESPAN_SPAN_NAME_STYLE=semantic.
+   */
+  spanNameStyle?: RespanSpanNameStyle;
 
   /**
    * Explicitly specify modules to instrument. Optional.

--- a/javascript-sdks/respan-tracing/src/main.ts
+++ b/javascript-sdks/respan-tracing/src/main.ts
@@ -82,6 +82,9 @@ export class RespanTelemetry {
             instrumentModules: options.instrumentModules || {},
             disabledInstrumentations: options.disabledInstrumentations || [],
             tracingEnabled: options.tracingEnabled !== false,
+            spanNameStyle: (options.spanNameStyle ||
+                process.env.RESPAN_SPAN_NAME_STYLE ||
+                "legacy") as RespanOptions["spanNameStyle"],
             traceContent: options.traceContent !== false,
             logLevel: options.logLevel || "error",
             silenceInitializationMessage: options.silenceInitializationMessage || false,

--- a/javascript-sdks/respan-tracing/src/processor/manager.ts
+++ b/javascript-sdks/respan-tracing/src/processor/manager.ts
@@ -5,7 +5,14 @@ import {
   SpanExporter,
   BatchSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { RespanSpanAttributes } from "@respan/respan-sdk";
+import {
+  RespanSpanAttributes,
+  type RespanSpanNameStyle,
+} from "@respan/respan-sdk";
+import {
+  resolveSpanNameStyle,
+  SpanNameTransformingExporter,
+} from "./spanName.js";
 
 /**
  * Configuration for a processor
@@ -52,13 +59,22 @@ export class MultiProcessorManager implements SpanProcessor {
     processor: SpanProcessor;
     config: ProcessorConfig;
   }> = [];
+  private readonly spanNameStyle: RespanSpanNameStyle;
+
+  constructor(options: { spanNameStyle?: RespanSpanNameStyle | string } = {}) {
+    this.spanNameStyle = resolveSpanNameStyle(options.spanNameStyle);
+  }
 
   /**
    * Add a new processor with routing configuration
    * @param config - Processor configuration
    */
   addProcessor(config: ProcessorConfig): void {
-    const processor = new BatchSpanProcessor(config.exporter);
+    const exporter = new SpanNameTransformingExporter(
+      config.exporter,
+      this.spanNameStyle
+    );
+    const processor = new BatchSpanProcessor(exporter);
     
     // Insert in priority order (higher priority first)
     const priority = config.priority ?? 0;

--- a/javascript-sdks/respan-tracing/src/processor/spanName.ts
+++ b/javascript-sdks/respan-tracing/src/processor/spanName.ts
@@ -1,0 +1,249 @@
+import type { ExportResult } from "@opentelemetry/core";
+import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
+import {
+  SpanAttributes,
+  TraceloopSpanKindValues,
+} from "@traceloop/ai-semantic-conventions";
+import {
+  RespanLogType,
+  RespanSpanAttributes,
+  type RespanSpanNameStyle,
+} from "@respan/respan-sdk";
+
+type SpanAttrs = Record<string, unknown>;
+
+const INTERNAL_KIND_ATTR = RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_KIND;
+const INTERNAL_DETAIL_ATTR = RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_DETAIL;
+
+const INTERNAL_SPAN_NAME_ATTRS = [
+  INTERNAL_KIND_ATTR,
+  INTERNAL_DETAIL_ATTR,
+] as const;
+
+export function resolveSpanNameStyle(
+  value?: RespanSpanNameStyle | string
+): RespanSpanNameStyle {
+  return value === "semantic" ? "semantic" : "legacy";
+}
+
+export function transformReadableSpanName(
+  span: ReadableSpan,
+  style: RespanSpanNameStyle | string | undefined
+): ReadableSpan {
+  const resolvedStyle = resolveSpanNameStyle(style);
+  const attributes = stripInternalSemanticNameAttrs(span.attributes as SpanAttrs);
+  const name =
+    resolvedStyle === "semantic" ? semanticSpanNameForSpan(span) : span.name;
+
+  if (name === span.name && attributes === span.attributes) {
+    return span;
+  }
+
+  return cloneReadableSpan(span, name, attributes);
+}
+
+export function semanticSpanNameForSpan(span: ReadableSpan): string {
+  const attrs = span.attributes as SpanAttrs;
+  const operation = resolveOperation(attrs, span.name);
+  const detail = resolveDetail(attrs, span.name, operation);
+
+  const hasInternalHint =
+    attrs[INTERNAL_KIND_ATTR] !== undefined || attrs[INTERNAL_DETAIL_ATTR] !== undefined;
+
+  if (!hasInternalHint && span.name.startsWith(`${operation}.`)) {
+    return span.name;
+  }
+
+  return `${operation}.${detail}`;
+}
+
+export class SpanNameTransformingExporter implements SpanExporter {
+  constructor(
+    private readonly delegate: SpanExporter,
+    private readonly style: RespanSpanNameStyle
+  ) {}
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ): void {
+    this.delegate.export(
+      spans.map((span) => transformReadableSpanName(span, this.style)),
+      resultCallback
+    );
+  }
+
+  shutdown(): Promise<void> {
+    return this.delegate.shutdown();
+  }
+
+  forceFlush(): Promise<void> {
+    const maybeFlush = (this.delegate as { forceFlush?: () => Promise<void> })
+      .forceFlush;
+    return maybeFlush ? maybeFlush.call(this.delegate) : Promise.resolve();
+  }
+}
+
+function stripInternalSemanticNameAttrs(attrs: SpanAttrs): SpanAttrs {
+  let next: SpanAttrs | undefined;
+
+  for (const key of INTERNAL_SPAN_NAME_ATTRS) {
+    if (attrs[key] !== undefined) {
+      next ??= { ...attrs };
+      delete next[key];
+    }
+  }
+
+  return next ?? attrs;
+}
+
+function cloneReadableSpan(
+  span: ReadableSpan,
+  name: string,
+  attributes: SpanAttrs
+): ReadableSpan {
+  const clone = Object.create(Object.getPrototypeOf(span));
+  Object.assign(clone, span);
+  Object.defineProperty(clone, "name", {
+    value: name,
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(clone, "attributes", {
+    value: attributes,
+    enumerable: true,
+    configurable: true,
+  });
+  return clone as ReadableSpan;
+}
+
+function resolveOperation(attrs: SpanAttrs, spanName: string): string {
+  const hintedKind = stringAttr(attrs, INTERNAL_KIND_ATTR);
+  if (hintedKind) {
+    return sanitizeNamePart(mapOperation(hintedKind), "span");
+  }
+
+  const tlKind = stringAttr(attrs, SpanAttributes.TRACELOOP_SPAN_KIND);
+  if (tlKind) {
+    return sanitizeNamePart(mapOperation(tlKind), "span");
+  }
+
+  const logType = stringAttr(attrs, RespanSpanAttributes.RESPAN_LOG_TYPE);
+  if (logType) {
+    return sanitizeNamePart(mapOperation(logType), "span");
+  }
+
+  return sanitizeNamePart(inferOperationFromName(spanName), "span");
+}
+
+function resolveDetail(
+  attrs: SpanAttrs,
+  spanName: string,
+  operation: string
+): string {
+  const hintedDetail = stringAttr(attrs, INTERNAL_DETAIL_ATTR);
+  if (hintedDetail) {
+    return sanitizeNamePart(hintedDetail, "operation");
+  }
+
+  const entityName = stringAttr(attrs, SpanAttributes.TRACELOOP_ENTITY_NAME);
+  if (entityName) {
+    return sanitizeNamePart(entityName, "operation");
+  }
+
+  return sanitizeNamePart(detailFromRawName(spanName, operation), "operation");
+}
+
+function stringAttr(attrs: SpanAttrs, key: string): string | undefined {
+  const value = attrs[key];
+  if (value === undefined || value === null) return undefined;
+  return String(value);
+}
+
+function mapOperation(value: string): string {
+  const normalized = value.toLowerCase();
+
+  switch (normalized) {
+    case TraceloopSpanKindValues.WORKFLOW:
+    case RespanLogType.WORKFLOW:
+      return "workflow";
+    case TraceloopSpanKindValues.AGENT:
+    case RespanLogType.AGENT:
+      return "agent";
+    case TraceloopSpanKindValues.TASK:
+    case RespanLogType.TASK:
+      return "task";
+    case TraceloopSpanKindValues.TOOL:
+    case RespanLogType.TOOL:
+      return "tool";
+    case RespanLogType.FUNCTION:
+      return "function";
+    case RespanLogType.HANDOFF:
+      return "handoff";
+    case RespanLogType.GUARDRAIL:
+      return "guardrail";
+    case RespanLogType.EMBEDDING:
+    case "embedding":
+      return "embed";
+    case RespanLogType.TRANSCRIPTION:
+      return "transcribe";
+    case RespanLogType.SPEECH:
+      return "speech";
+    case RespanLogType.CHAT:
+    case RespanLogType.TEXT:
+    case RespanLogType.RESPONSE:
+    case RespanLogType.GENERATION:
+    case "llm":
+      return "generate";
+    case RespanLogType.CUSTOM:
+    case RespanLogType.UNKNOWN:
+      return "span";
+    default:
+      return value;
+  }
+}
+
+function inferOperationFromName(spanName: string): string {
+  if (spanName.startsWith("ai.stream")) return "stream";
+  if (spanName.startsWith("ai.embed")) return "embed";
+  if (spanName.startsWith("ai.generate") || spanName.startsWith("ai.")) {
+    return "generate";
+  }
+
+  const suffix = spanName.split(".").at(-1);
+  if (suffix) {
+    return mapOperation(suffix);
+  }
+
+  return "span";
+}
+
+function detailFromRawName(spanName: string, operation: string): string {
+  if (spanName.startsWith("ai.")) {
+    return spanName.split(".").at(-1) ?? spanName;
+  }
+
+  if (spanName.endsWith(`.${operation}`)) {
+    return spanName.slice(0, -(operation.length + 1));
+  }
+
+  if (spanName.startsWith(`${operation}.`)) {
+    return spanName.slice(operation.length + 1);
+  }
+
+  if (operation === "handoff") {
+    return spanName.replace(/^handoff\s*[:.-]?\s*/i, "");
+  }
+
+  return spanName;
+}
+
+function sanitizeNamePart(value: string, fallback: string): string {
+  const sanitized = value
+    .trim()
+    .replace(/\s*(?:→|->)\s*/g, "_")
+    .replace(/[^\w.-]+/g, "_")
+    .replace(/^[_\-.]+|[_\-.]+$/g, "");
+
+  return sanitized || fallback;
+}

--- a/javascript-sdks/respan-tracing/src/types/clientTypes.ts
+++ b/javascript-sdks/respan-tracing/src/types/clientTypes.ts
@@ -1,5 +1,6 @@
 import { SpanExporter, SpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { TextMapPropagator, ContextManager } from "@opentelemetry/api";
+import type { RespanSpanNameStyle } from "@respan/respan-sdk";
 
 /**
  * Available instrumentation names for consistent camelCase naming.
@@ -115,6 +116,14 @@ export interface RespanOptions {
      * Defaults to true.
      */
     tracingEnabled?: boolean;
+
+    /**
+     * Controls exported span.name formatting.
+     * - legacy: preserve instrumentation span names
+     * - semantic: use operation-prefixed names like agent.triage or generate.doGenerate
+     * Defaults to legacy. Can also be set with RESPAN_SPAN_NAME_STYLE=semantic.
+     */
+    spanNameStyle?: RespanSpanNameStyle;
 
     /**
      * Additional resource attributes to attach to all spans. Optional.

--- a/javascript-sdks/respan-tracing/src/utils/tracing.ts
+++ b/javascript-sdks/respan-tracing/src/utils/tracing.ts
@@ -71,6 +71,7 @@ export const startTracing = async (options: RespanOptions) => {
     contextManager,
     silenceInitializationMessage = false,
     tracingEnabled = true,
+    spanNameStyle = process.env.RESPAN_SPAN_NAME_STYLE,
     instrumentModules,
     traceContent = true,
     disabledInstrumentations = [],
@@ -84,6 +85,7 @@ export const startTracing = async (options: RespanOptions) => {
     baseURL,
     logLevel,
     tracingEnabled,
+    spanNameStyle,
     traceContent,
     hasApiKey: !!apiKey,
     apiKeyLength: apiKey?.length || 0,
@@ -210,7 +212,7 @@ export const startTracing = async (options: RespanOptions) => {
   console.debug("[Respan Debug] Created OTLP trace exporter");
 
   // Initialize multi-processor manager
-  const processorManager = new MultiProcessorManager();
+  const processorManager = new MultiProcessorManager({ spanNameStyle });
   
   // Add default Respan processor to the manager
   // This ensures backward compatibility: spans without a `processors` attribute

--- a/javascript-sdks/respan-tracing/tests/span-name-style.test.mjs
+++ b/javascript-sdks/respan-tracing/tests/span-name-style.test.mjs
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  semanticSpanNameForSpan,
+  transformReadableSpanName,
+} from "../dist/processor/spanName.js";
+
+function span(name, attributes = {}) {
+  return {
+    name,
+    attributes,
+  };
+}
+
+test("semantic span names use operation prefix and entity detail", () => {
+  assert.equal(
+    semanticSpanNameForSpan(
+      span("triage-service.agent", {
+        "traceloop.span.kind": "agent",
+        "traceloop.entity.name": "triage-service",
+      })
+    ),
+    "agent.triage-service"
+  );
+
+  assert.equal(
+    semanticSpanNameForSpan(
+      span("send_notification.tool", {
+        "traceloop.span.kind": "tool",
+        "traceloop.entity.name": "send_notification",
+      })
+    ),
+    "tool.send_notification"
+  );
+});
+
+test("semantic span names use integration hints and strip internal attrs", () => {
+  const transformed = transformReadableSpanName(
+    span("ai.generateText.doGenerate", {
+      "respan.internal.span_name.kind": "generate",
+      "respan.internal.span_name.detail": "doGenerate",
+      "respan.entity.log_type": "text",
+    }),
+    "semantic"
+  );
+
+  assert.equal(transformed.name, "generate.doGenerate");
+  assert.equal(transformed.attributes["respan.internal.span_name.kind"], undefined);
+  assert.equal(transformed.attributes["respan.internal.span_name.detail"], undefined);
+  assert.equal(transformed.attributes["respan.entity.log_type"], "text");
+});
+
+test("legacy span names only strip internal semantic hint attrs", () => {
+  const transformed = transformReadableSpanName(
+    span("ai.embed.doEmbed", {
+      "respan.internal.span_name.kind": "embed",
+      "respan.internal.span_name.detail": "doEmbed",
+      "respan.entity.log_type": "embedding",
+    }),
+    "legacy"
+  );
+
+  assert.equal(transformed.name, "ai.embed.doEmbed");
+  assert.equal(transformed.attributes["respan.internal.span_name.kind"], undefined);
+  assert.equal(transformed.attributes["respan.internal.span_name.detail"], undefined);
+  assert.equal(transformed.attributes["respan.entity.log_type"], "embedding");
+});
+
+
+test("semantic span names let integration hints override generic operation-prefixed names", () => {
+  const transformed = transformReadableSpanName(
+    span("handoff.task", {
+      "respan.internal.span_name.kind": "handoff",
+      "respan.internal.span_name.detail": "triage-service_to_bank-service",
+      "respan.entity.log_type": "handoff",
+    }),
+    "semantic"
+  );
+
+  assert.equal(transformed.name, "handoff.triage-service_to_bank-service");
+  assert.equal(transformed.attributes["respan.internal.span_name.kind"], undefined);
+  assert.equal(transformed.attributes["respan.internal.span_name.detail"], undefined);
+});

--- a/javascript-sdks/respan/src/_core.ts
+++ b/javascript-sdks/respan/src/_core.ts
@@ -1,6 +1,6 @@
 import { RespanTelemetry, propagateAttributes, buildReadableSpan, injectSpan, ensureSpanId } from "@respan/tracing";
 import { RespanSpanAttributes, RespanLogType } from "@respan/respan-sdk";
-import type { RespanParams } from "@respan/respan-sdk";
+import type { RespanParams, RespanSpanNameStyle } from "@respan/respan-sdk";
 import type { ProcessorConfig } from "@respan/tracing";
 import type { RespanInstrumentation } from "./_types.js";
 
@@ -13,6 +13,7 @@ export interface RespanOptions {
   traceContent?: boolean;
   logLevel?: "debug" | "info" | "warn" | "error";
   silenceInitializationMessage?: boolean;
+  spanNameStyle?: RespanSpanNameStyle;
 }
 
 /**
@@ -76,6 +77,7 @@ export class Respan {
       logLevel: options.logLevel,
       disabledInstrumentations,
       silenceInitializationMessage: options.silenceInitializationMessage,
+      spanNameStyle: options.spanNameStyle,
     });
   }
 


### PR DESCRIPTION
## Summary

-  Semantic span names vercel js

This should be merged and worked after #276 merged 

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched


