### PR TITLE
feat(instrumentation/openai): native, Traceloop-free OpenAI SDK instrumentation

### DIFF
--- a/.release-intents/20260629-openai-native-instrumentation.json
+++ b/.release-intents/20260629-openai-native-instrumentation.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Rewrite respan-instrumentation-openai as a native (Traceloop-free) instrumentation so OpenAI chat/responses/completions/embeddings spans emit llm.request.type and roll up tokens/cost instead of being mislabeled as generic tasks",
+  "packages": {
+    "respan-instrumentation-openai": "minor"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-openai/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/README.md
@@ -1,6 +1,6 @@
 # respan-instrumentation-openai
 
-Respan instrumentation plugin for direct OpenAI SDK usage. Wraps `opentelemetry-instrumentation-openai` with Respan-specific prompt capture and trace export.
+Respan instrumentation plugin for direct OpenAI SDK usage. A native, Traceloop-free instrumentation: it patches the OpenAI SDK directly and emits Respan's own LLM span conventions (`llm.request.type`, `gen_ai.*`, `traceloop.entity.*`, `respan.entity.log_type`), so chat, responses, completions, and embeddings calls are traced as real LLM calls with token/cost roll-up. Covers sync, async, and streaming.
 
 ## Configuration
 

--- a/python-sdks/instrumentations/respan-instrumentation-openai/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "respan-instrumentation-openai"
-version = "1.0.0"
-description = "Respan instrumentation plugin for direct OpenAI SDK usage"
+version = "1.1.0"
+description = "Respan instrumentation plugin for direct OpenAI SDK usage (native, Traceloop-free)"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"
 readme = "README.md"
@@ -12,8 +12,8 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
 respan-tracing = "^2.3.0"
+respan-sdk = ">=2.6.0"
 openai = ">=1.0.0"
-opentelemetry-instrumentation-openai = ">=0.48.0"
 
 [tool.poetry.plugins."respan.instrumentations"]
 openai = "respan_instrumentation_openai:OpenAIInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_constants.py
@@ -1,0 +1,70 @@
+"""Constants for the native OpenAI SDK instrumentation.
+
+This package is deliberately independent of Traceloop's
+``opentelemetry-instrumentation-openai`` / ``opentelemetry-semantic-conventions-ai``.
+Every attribute-name string the backend ingests is defined *here* (the SDK owns
+its own convention constants), while the few genuinely shared ones come from
+``respan_sdk.constants`` (the SDK core, not Traceloop).
+"""
+
+from __future__ import annotations
+
+# --- system + span names ----------------------------------------------------
+
+OPENAI_SYSTEM = "openai"
+
+CHAT_SPAN_NAME = "openai.chat"
+EMBEDDING_SPAN_NAME = "openai.embeddings"
+COMPLETION_SPAN_NAME = "openai.completion"
+RESPONSE_SPAN_NAME = "openai.response"
+
+# --- SDK module / class / method targets to monkey-patch --------------------
+
+CHAT_MODULE = "openai.resources.chat.completions"
+EMBEDDINGS_MODULE = "openai.resources.embeddings"
+COMPLETIONS_MODULE = "openai.resources.completions"
+RESPONSES_MODULE = "openai.resources.responses.responses"
+
+SYNC_CHAT_CLASS = "Completions"
+ASYNC_CHAT_CLASS = "AsyncCompletions"
+SYNC_EMBEDDINGS_CLASS = "Embeddings"
+ASYNC_EMBEDDINGS_CLASS = "AsyncEmbeddings"
+SYNC_COMPLETIONS_CLASS = "Completions"
+ASYNC_COMPLETIONS_CLASS = "AsyncCompletions"
+SYNC_RESPONSES_CLASS = "Responses"
+ASYNC_RESPONSES_CLASS = "AsyncResponses"
+
+CREATE_METHOD = "create"
+
+# --- request-type values (what the backend keys on via llm.request.type) ----
+
+REQUEST_TYPE_CHAT = "chat"
+REQUEST_TYPE_COMPLETION = "completion"
+REQUEST_TYPE_EMBEDDING = "embedding"
+
+# --- attribute-name strings (the documented ingest contract) ----------------
+# These mirror the wire format the Respan backend parses. We define them here so
+# the package carries no Traceloop dependency.
+
+TRACELOOP_SPAN_KIND = "traceloop.span.kind"
+TRACELOOP_ENTITY_NAME = "traceloop.entity.name"
+TRACELOOP_ENTITY_PATH = "traceloop.entity.path"
+TRACELOOP_ENTITY_INPUT = "traceloop.entity.input"
+TRACELOOP_ENTITY_OUTPUT = "traceloop.entity.output"
+
+LLM_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
+LLM_PROMPTS = "gen_ai.prompt"
+LLM_COMPLETIONS = "gen_ai.completion"
+LLM_REQUEST_FUNCTIONS = "llm.request.functions"
+LLM_RESPONSE_MODEL = "gen_ai.response.model"
+LLM_RESPONSE_ID = "gen_ai.response.id"
+
+SPAN_KIND_LLM = "llm"
+
+# --- response / message field keys ------------------------------------------
+
+ROLE_KEY = "role"
+CONTENT_KEY = "content"
+TOOL_CALLS_KEY = "tool_calls"
+USER_ROLE = "user"
+ASSISTANT_ROLE = "assistant"

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
@@ -1,185 +1,248 @@
-"""OpenAI SDK instrumentation plugin for Respan.
+"""Native OpenAI SDK instrumentation for Respan.
 
-Self-contained plugin that enables ``opentelemetry-instrumentation-openai``
-and applies a sync prompt-capture patch. Spans carry proper GenAI semantic
-conventions and pass ``is_processable_span()`` natively — no conversion needed.
+Monkey-patches the ``create`` method of the OpenAI SDK's chat-completions,
+completions, responses, and embeddings resources (sync + async) and emits a
+Respan span per call via ``_otel_emitter``. No Traceloop dependency: spans are
+built directly with Respan's documented LLM conventions, so the backend
+classifies them as real LLM calls (``llm.request.type``) with token/cost
+roll-up — not generic "task" spans.
 """
 
-import copy
-import json
+from __future__ import annotations
+
+import importlib
 import logging
-import traceback
+import time
+from typing import Any, Callable
+
+from respan_instrumentation_openai._constants import (
+    ASYNC_CHAT_CLASS,
+    ASYNC_COMPLETIONS_CLASS,
+    ASYNC_EMBEDDINGS_CLASS,
+    ASYNC_RESPONSES_CLASS,
+    CHAT_MODULE,
+    COMPLETIONS_MODULE,
+    CREATE_METHOD,
+    EMBEDDINGS_MODULE,
+    RESPONSES_MODULE,
+    SYNC_CHAT_CLASS,
+    SYNC_COMPLETIONS_CLASS,
+    SYNC_EMBEDDINGS_CLASS,
+    SYNC_RESPONSES_CLASS,
+)
+from respan_instrumentation_openai import _otel_emitter as emitter
 
 logger = logging.getLogger(__name__)
 
+_original_methods: dict[tuple[type[Any], str], Any] = {}
+
 
 # ---------------------------------------------------------------------------
-# Sync prompt-capture patch
+# Stream aggregation (best-effort; never breaks the caller's stream)
 # ---------------------------------------------------------------------------
 
 
-def _patch_chat_prompt_capture():
-    """Replace the async chat _handle_request with a sync version.
+def _aggregate_chat(chunks: list[Any]) -> dict[str, Any]:
+    parts: list[str] = []
+    usage = model = rid = None
+    for ch in chunks:
+        model = getattr(ch, "model", None) or model
+        rid = getattr(ch, "id", None) or rid
+        u = getattr(ch, "usage", None)
+        if u is not None:
+            usage = u
+        choices = getattr(ch, "choices", None) or []
+        if choices:
+            delta = getattr(choices[0], "delta", None)
+            content = getattr(delta, "content", None) if delta is not None else None
+            if content:
+                parts.append(content)
+    return {
+        "model": model,
+        "id": rid,
+        "usage": usage,
+        "choices": [{"message": {"role": "assistant", "content": "".join(parts)}}],
+    }
 
-    Root cause: opentelemetry-instrumentation-openai v0.52+ has _handle_request
-    as async def (for optional base64 image upload). In sync contexts, it runs
-    through run_async() which either calls asyncio.run() or spawns a thread.
-    Both paths can silently lose prompt attributes when:
-      - _set_request_attributes (NOT @dont_throw) raises on response_format
-        handling, killing the entire _handle_request before _set_prompts runs
-      - asyncio.run() / thread path has environment-specific issues (Lambda, etc.)
 
-    The embeddings wrapper is fully sync and works correctly. This patch makes
-    the chat path match the embeddings path: fully synchronous with fault
-    isolation between each section.
+def _aggregate_completion(chunks: list[Any]) -> dict[str, Any]:
+    parts: list[str] = []
+    usage = model = rid = None
+    for ch in chunks:
+        model = getattr(ch, "model", None) or model
+        rid = getattr(ch, "id", None) or rid
+        u = getattr(ch, "usage", None)
+        if u is not None:
+            usage = u
+        choices = getattr(ch, "choices", None) or []
+        if choices:
+            text = getattr(choices[0], "text", None)
+            if text:
+                parts.append(text)
+    return {"model": model, "id": rid, "usage": usage, "choices": [{"text": "".join(parts)}]}
 
-    The only async code in _set_prompts was for Config.upload_base64_image
-    (rarely used). For list content (multimodal), we json.dumps as-is — the
-    base64 data stays inline, which is the default behavior anyway.
+
+def _aggregate_response(events: list[Any]) -> Any:
+    """Responses-API streaming: the final event carries the full ``response``."""
+    final = None
+    for ev in events:
+        r = getattr(ev, "response", None)
+        if r is not None:
+            final = r
+    return final
+
+
+# kind -> (emit_fn, aggregator | None)
+_KINDS: dict[str, tuple[Callable[..., None], Callable[[list[Any]], Any] | None]] = {
+    "chat": (emitter.emit_chat_span, _aggregate_chat),
+    "completion": (emitter.emit_completion_span, _aggregate_completion),
+    "response": (emitter.emit_response_span, _aggregate_response),
+    "embedding": (emitter.emit_embedding_span, None),
+}
+
+
+def _is_stream(obj: Any) -> bool:
+    """Detect an OpenAI streaming response.
+
+    Note: Pydantic v2 models define ``__iter__``, so a plain ``hasattr`` check
+    would misfire on every non-streaming response. We match OpenAI's real
+    ``Stream``/``AsyncStream`` types, plus ``__aiter__`` (which pydantic models
+    do *not* have) as a fallback for async streams.
     """
     try:
-        from opentelemetry.instrumentation.openai.shared import chat_wrappers as cw
-        from opentelemetry.instrumentation.openai.shared import (
-            _set_request_attributes,
-            _set_client_attributes,
-            _set_functions_attributes,
-            _set_span_attribute,
-            set_tools_attributes,
-            model_as_dict,
-            propagate_trace_context,
-        )
-        from opentelemetry.instrumentation.openai.shared.config import Config
-        from opentelemetry.instrumentation.openai.utils import (
-            should_send_prompts,
-            should_emit_events,
-            is_openai_v1,
-        )
-        from opentelemetry.semconv._incubating.attributes import (
-            gen_ai_attributes as GenAIAttributes,
-        )
-        from opentelemetry.semconv_ai import SpanAttributes
+        from openai import AsyncStream, Stream
 
-        def _set_prompts_sync(span, messages):
-            if not span.is_recording() or messages is None:
-                return
-
-            for i, msg in enumerate(messages):
-                prefix = f"{GenAIAttributes.GEN_AI_PROMPT}.{i}"
-                msg = msg if isinstance(msg, dict) else model_as_dict(msg)
-
-                _set_span_attribute(span, f"{prefix}.role", msg.get("role"))
-                if msg.get("content"):
-                    content = copy.deepcopy(msg.get("content"))
-                    if isinstance(content, list):
-                        content = json.dumps(content)
-                    _set_span_attribute(span, f"{prefix}.content", content)
-                if msg.get("tool_call_id"):
-                    _set_span_attribute(
-                        span, f"{prefix}.tool_call_id", msg.get("tool_call_id")
-                    )
-                tool_calls = msg.get("tool_calls")
-                if tool_calls:
-                    for j, tool_call in enumerate(tool_calls):
-                        if is_openai_v1():
-                            tool_call = model_as_dict(tool_call)
-                        function = tool_call.get("function")
-                        _set_span_attribute(
-                            span, f"{prefix}.tool_calls.{j}.id", tool_call.get("id")
-                        )
-                        _set_span_attribute(
-                            span, f"{prefix}.tool_calls.{j}.name", function.get("name")
-                        )
-                        _set_span_attribute(
-                            span,
-                            f"{prefix}.tool_calls.{j}.arguments",
-                            function.get("arguments"),
-                        )
-
-        def _handle_request_sync(span, kwargs, instance):
-            # Section 1: Request attributes (fault-isolated from prompts)
-            try:
-                _set_request_attributes(span, kwargs, instance)
-            except Exception:
-                logging.warning(
-                    "respan: _set_request_attributes failed (response_format may be incompatible). "
-                    "Request attributes like model/temperature may be incomplete on this span. "
-                    "Error: %s",
-                    traceback.format_exc(),
-                )
-
-            try:
-                _set_client_attributes(span, instance)
-            except Exception:
-                pass
-
-            # Section 2: Prompt/event capture
-            try:
-                if should_emit_events():
-                    from opentelemetry.instrumentation.openai.shared.event_emitter import emit_event
-                    from opentelemetry.instrumentation.openai.shared.event_models import MessageEvent
-                    for message in kwargs.get("messages", []):
-                        emit_event(
-                            MessageEvent(
-                                content=message.get("content"),
-                                role=message.get("role"),
-                                tool_calls=cw._parse_tool_calls(
-                                    message.get("tool_calls", None)
-                                ),
-                            )
-                        )
-                else:
-                    if should_send_prompts():
-                        _set_prompts_sync(span, kwargs.get("messages"))
-                        if kwargs.get("functions"):
-                            _set_functions_attributes(span, kwargs.get("functions"))
-                        elif kwargs.get("tools"):
-                            set_tools_attributes(span, kwargs.get("tools"))
-            except Exception:
-                logging.warning(
-                    "respan: chat prompt capture failed. "
-                    "Input messages may not appear on the dashboard for this span. "
-                    "Error: %s",
-                    traceback.format_exc(),
-                )
-
-            # Section 3: Trace propagation + reasoning
-            try:
-                if Config.enable_trace_context_propagation:
-                    propagate_trace_context(span, kwargs)
-                reasoning_effort = kwargs.get("reasoning_effort")
-                _set_span_attribute(
-                    span,
-                    SpanAttributes.LLM_REQUEST_REASONING_EFFORT,
-                    reasoning_effort or (),
-                )
-            except Exception:
-                pass
-
-        async def _noop():
-            pass
-
-        def _patched_handle_request(span, kwargs, instance):
-            _handle_request_sync(span, kwargs, instance)
-            return _noop()
-
-        cw._handle_request = _patched_handle_request
-        logger.debug("Patched chat prompt capture to sync path")
-
-    except Exception as e:
-        logger.warning("Failed to patch chat prompt capture: %s", e)
+        if isinstance(obj, (Stream, AsyncStream)):
+            return True
+    except Exception:
+        pass
+    return hasattr(obj, "__aiter__")
 
 
 # ---------------------------------------------------------------------------
-# Instrumentor
+# Iterator wrappers
 # ---------------------------------------------------------------------------
+
+
+def _wrap_sync_stream(iterator, *, kind, request_kwargs, start_ns):
+    emit_fn, aggregate = _KINDS[kind]
+    chunks: list[Any] = []
+    try:
+        for chunk in iterator:
+            chunks.append(chunk)
+            yield chunk
+    except Exception as exc:
+        response = aggregate(chunks) if aggregate else None
+        emit_fn(request_kwargs=request_kwargs, start_ns=start_ns, response=response,
+                error_message=str(exc), status_code=500)
+        raise
+    else:
+        response = aggregate(chunks) if aggregate else None
+        emit_fn(request_kwargs=request_kwargs, start_ns=start_ns, response=response)
+
+
+async def _wrap_async_stream(aiterator, *, kind, request_kwargs, start_ns):
+    emit_fn, aggregate = _KINDS[kind]
+    chunks: list[Any] = []
+    try:
+        async for chunk in aiterator:
+            chunks.append(chunk)
+            yield chunk
+    except Exception as exc:
+        response = aggregate(chunks) if aggregate else None
+        emit_fn(request_kwargs=request_kwargs, start_ns=start_ns, response=response,
+                error_message=str(exc), status_code=500)
+        raise
+    else:
+        response = aggregate(chunks) if aggregate else None
+        emit_fn(request_kwargs=request_kwargs, start_ns=start_ns, response=response)
+
+
+# ---------------------------------------------------------------------------
+# Method wrappers
+# ---------------------------------------------------------------------------
+
+
+def _make_sync_wrapper(original: Any, *, kind: str) -> Any:
+    emit_fn, _ = _KINDS[kind]
+
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        start_ns = time.time_ns()
+        try:
+            response = original(self, *args, **kwargs)
+        except Exception as exc:
+            emit_fn(request_kwargs=kwargs, start_ns=start_ns, error_message=str(exc), status_code=500)
+            raise
+        if kind != "embedding" and _is_stream(response):
+            return _wrap_sync_stream(response, kind=kind, request_kwargs=kwargs, start_ns=start_ns)
+        emit_fn(request_kwargs=kwargs, start_ns=start_ns, response=response)
+        return response
+
+    return wrapper
+
+
+def _make_async_wrapper(original: Any, *, kind: str) -> Any:
+    emit_fn, _ = _KINDS[kind]
+
+    async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        start_ns = time.time_ns()
+        try:
+            pending = original(self, *args, **kwargs)
+            response = pending if hasattr(pending, "__aiter__") else await pending
+        except Exception as exc:
+            emit_fn(request_kwargs=kwargs, start_ns=start_ns, error_message=str(exc), status_code=500)
+            raise
+        if kind != "embedding" and _is_stream(response):
+            return _wrap_async_stream(response, kind=kind, request_kwargs=kwargs, start_ns=start_ns)
+        emit_fn(request_kwargs=kwargs, start_ns=start_ns, response=response)
+        return response
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Patch plumbing
+# ---------------------------------------------------------------------------
+
+
+def _load_class(module_path: str, class_name: str) -> type[Any] | None:
+    try:
+        module = importlib.import_module(module_path)
+    except Exception as exc:
+        logger.debug("OpenAI module %s unavailable: %s", module_path, exc)
+        return None
+    return getattr(module, class_name, None)
+
+
+def _patch(target_class: type[Any] | None, *, kind: str, is_async: bool) -> None:
+    if target_class is None:
+        return
+    original = getattr(target_class, CREATE_METHOD, None)
+    if original is None:
+        return
+    key = (target_class, CREATE_METHOD)
+    if key in _original_methods:
+        return
+    _original_methods[key] = original
+    factory = _make_async_wrapper if is_async else _make_sync_wrapper
+    setattr(target_class, CREATE_METHOD, factory(original, kind=kind))
+
+
+# (module, class, kind, is_async)
+_TARGETS = [
+    (CHAT_MODULE, SYNC_CHAT_CLASS, "chat", False),
+    (CHAT_MODULE, ASYNC_CHAT_CLASS, "chat", True),
+    (COMPLETIONS_MODULE, SYNC_COMPLETIONS_CLASS, "completion", False),
+    (COMPLETIONS_MODULE, ASYNC_COMPLETIONS_CLASS, "completion", True),
+    (RESPONSES_MODULE, SYNC_RESPONSES_CLASS, "response", False),
+    (RESPONSES_MODULE, ASYNC_RESPONSES_CLASS, "response", True),
+    (EMBEDDINGS_MODULE, SYNC_EMBEDDINGS_CLASS, "embedding", False),
+    (EMBEDDINGS_MODULE, ASYNC_EMBEDDINGS_CLASS, "embedding", True),
+]
 
 
 class OpenAIInstrumentor:
     """Respan instrumentor for direct OpenAI SDK usage.
-
-    Activates OTEL auto-instrumentation for the ``openai`` package so
-    that all ``ChatCompletion``, ``Completion``, and ``Embedding`` calls
-    are traced automatically.
 
     Usage::
 
@@ -195,34 +258,30 @@ class OpenAIInstrumentor:
         self._is_instrumented = False
 
     def activate(self) -> None:
-        """Instrument the OpenAI SDK via OTEL and patch prompt capture."""
+        if self._is_instrumented:
+            return
         try:
-            from opentelemetry.instrumentation.openai import OpenAIInstrumentor as OTELOpenAI
-
-            instrumentor = OTELOpenAI()
-            if not instrumentor.is_instrumented_by_opentelemetry:
-                instrumentor.instrument()
-            self._is_instrumented = True
-
-            # Apply sync prompt-capture patch
-            try:
-                _patch_chat_prompt_capture()
-            except Exception as exc:
-                logger.debug("Prompt capture patch not applied: %s", exc)
-
-            logger.info("OpenAI SDK instrumentation activated")
+            import openai  # noqa: F401
         except ImportError as exc:
-            logger.warning(
-                "Failed to activate OpenAI instrumentation — missing dependency: %s", exc
-            )
+            logger.warning("Failed to activate OpenAI instrumentation — openai not installed: %s", exc)
+            return
+        try:
+            for module_path, class_name, kind, is_async in _TARGETS:
+                _patch(_load_class(module_path, class_name), kind=kind, is_async=is_async)
+        except Exception as exc:
+            logger.warning("Failed to activate OpenAI instrumentation: %s", exc)
+            self.deactivate()
+            return
+        self._is_instrumented = True
+        logger.info("OpenAI SDK instrumentation activated")
 
     def deactivate(self) -> None:
-        """Deactivate the instrumentation."""
-        if self._is_instrumented:
+        for (target_class, method_name), original in list(_original_methods.items()):
             try:
-                from opentelemetry.instrumentation.openai import OpenAIInstrumentor as OTELOpenAI
-                OTELOpenAI().uninstrument()
+                setattr(target_class, method_name, original)
             except Exception:
-                pass
-            self._is_instrumented = False
+                logger.debug("Failed to restore %s.%s", target_class, method_name, exc_info=True)
+            finally:
+                _original_methods.pop((target_class, method_name), None)
+        self._is_instrumented = False
         logger.info("OpenAI SDK instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
@@ -44,6 +44,7 @@ _original_methods: dict[tuple[type[Any], str], Any] = {}
 
 def _aggregate_chat(chunks: list[Any]) -> dict[str, Any]:
     parts: list[str] = []
+    tool_calls: dict[int, dict[str, Any]] = {}
     usage = model = rid = None
     for ch in chunks:
         model = getattr(ch, "model", None) or model
@@ -52,17 +53,32 @@ def _aggregate_chat(chunks: list[Any]) -> dict[str, Any]:
         if u is not None:
             usage = u
         choices = getattr(ch, "choices", None) or []
-        if choices:
-            delta = getattr(choices[0], "delta", None)
-            content = getattr(delta, "content", None) if delta is not None else None
-            if content:
-                parts.append(content)
-    return {
-        "model": model,
-        "id": rid,
-        "usage": usage,
-        "choices": [{"message": {"role": "assistant", "content": "".join(parts)}}],
-    }
+        if not choices:
+            continue
+        delta = getattr(choices[0], "delta", None)
+        if delta is None:
+            continue
+        content = getattr(delta, "content", None)
+        if content:
+            parts.append(content)
+        # Accumulate streamed tool-call deltas by index (name once, args in fragments).
+        for tcd in getattr(delta, "tool_calls", None) or []:
+            idx = getattr(tcd, "index", 0) or 0
+            slot = tool_calls.setdefault(
+                idx, {"id": None, "type": "function", "function": {"name": "", "arguments": ""}}
+            )
+            if getattr(tcd, "id", None):
+                slot["id"] = tcd.id
+            fn = getattr(tcd, "function", None)
+            if fn is not None:
+                if getattr(fn, "name", None):
+                    slot["function"]["name"] = fn.name
+                if getattr(fn, "arguments", None):
+                    slot["function"]["arguments"] += fn.arguments
+    message: dict[str, Any] = {"role": "assistant", "content": "".join(parts) or None}
+    if tool_calls:
+        message["tool_calls"] = [tool_calls[i] for i in sorted(tool_calls)]
+    return {"model": model, "id": rid, "usage": usage, "choices": [{"message": message}]}
 
 
 def _aggregate_completion(chunks: list[Any]) -> dict[str, Any]:

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_otel_emitter.py
@@ -1,0 +1,274 @@
+"""Emit OpenAI SDK calls as OTEL ReadableSpan objects.
+
+Each ``emit_*`` builds a ``ReadableSpan`` carrying Respan's documented LLM
+conventions (``llm.request.type``, ``gen_ai.system``, ``gen_ai.usage.*``,
+``traceloop.entity.*``, ``respan.log_type``) and injects it into the single
+OTEL pipeline via ``inject_span()``. The span nests under the current OTEL
+span when one is active (e.g. a ``@workflow``/``@task`` decorator), otherwise
+it is a root span (its own trace).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from opentelemetry import trace
+
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_COMPLETION,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_RESPONSE,
+)
+from respan_sdk.constants.span_attributes import (
+    GEN_AI_SYSTEM,
+    LLM_REQUEST_MODEL,
+    LLM_REQUEST_TYPE,
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
+    RESPAN_LOG_TYPE,
+    RESPAN_SPAN_TOOL_CALLS,
+)
+from respan_sdk.utils.data_processing.id_processing import format_span_id, format_trace_id
+from respan_tracing.utils.span_factory import build_readable_span, inject_span
+
+from respan_instrumentation_openai._constants import (
+    ASSISTANT_ROLE,
+    CHAT_SPAN_NAME,
+    COMPLETION_SPAN_NAME,
+    EMBEDDING_SPAN_NAME,
+    LLM_COMPLETIONS,
+    LLM_PROMPTS,
+    LLM_REQUEST_FUNCTIONS,
+    LLM_RESPONSE_ID,
+    LLM_RESPONSE_MODEL,
+    LLM_USAGE_TOTAL_TOKENS,
+    OPENAI_SYSTEM,
+    REQUEST_TYPE_CHAT,
+    REQUEST_TYPE_COMPLETION,
+    REQUEST_TYPE_EMBEDDING,
+    RESPONSE_SPAN_NAME,
+    SPAN_KIND_LLM,
+    TRACELOOP_ENTITY_INPUT,
+    TRACELOOP_ENTITY_NAME,
+    TRACELOOP_ENTITY_OUTPUT,
+    TRACELOOP_ENTITY_PATH,
+    TRACELOOP_SPAN_KIND,
+)
+from respan_instrumentation_openai import _translator as tr
+
+logger = logging.getLogger(__name__)
+
+_PROMPT_PREFIX = f"{LLM_PROMPTS}."
+_COMPLETION_PREFIX = f"{LLM_COMPLETIONS}."
+
+
+# ---------------------------------------------------------------------------
+# Trace context (nesting)
+# ---------------------------------------------------------------------------
+
+
+def _current_trace_parent_ids() -> tuple[str | None, str | None]:
+    """Return (trace_id, parent_id) hex strings from the active OTEL span.
+
+    When no live span is active the call is standalone → (None, None) → the
+    emitted span becomes a root (its own trace).
+    """
+    try:
+        ctx = trace.get_current_span().get_span_context()
+    except Exception:
+        return None, None
+    tid = getattr(ctx, "trace_id", 0) or 0
+    sid = getattr(ctx, "span_id", 0) or 0
+    if not tid or not sid:
+        return None, None
+    return format_trace_id(trace_id=tid), format_span_id(span_id=sid)
+
+
+# ---------------------------------------------------------------------------
+# Attribute builders
+# ---------------------------------------------------------------------------
+
+
+def _base_attrs(*, span_name: str, log_type: str, request_type: str) -> dict[str, Any]:
+    return {
+        TRACELOOP_SPAN_KIND: SPAN_KIND_LLM,
+        TRACELOOP_ENTITY_NAME: span_name,
+        TRACELOOP_ENTITY_PATH: span_name,
+        GEN_AI_SYSTEM: OPENAI_SYSTEM,
+        LLM_REQUEST_TYPE: request_type,
+        RESPAN_LOG_TYPE: log_type,
+    }
+
+
+def _set_model(attrs: dict[str, Any], request_kwargs: dict[str, Any], response: Any) -> None:
+    model = tr.request_model(request_kwargs)
+    if model:
+        attrs[LLM_REQUEST_MODEL] = model
+    resp_model = tr.response_model(response)
+    if resp_model:
+        attrs[LLM_RESPONSE_MODEL] = resp_model
+    rid = tr.response_id(response)
+    if rid:
+        attrs[LLM_RESPONSE_ID] = rid
+
+
+def _set_prompt_attrs(attrs: dict[str, Any], messages: list[dict[str, Any]]) -> None:
+    for i, msg in enumerate(messages):
+        role = msg.get("role")
+        content = msg.get("content")
+        if role is not None:
+            attrs[f"{_PROMPT_PREFIX}{i}.role"] = str(role)
+        if content is not None:
+            attrs[f"{_PROMPT_PREFIX}{i}.content"] = tr.to_attr_value(content)
+
+
+def _set_completion_attrs(attrs: dict[str, Any], content: str) -> None:
+    attrs[f"{_COMPLETION_PREFIX}0.role"] = ASSISTANT_ROLE
+    attrs[f"{_COMPLETION_PREFIX}0.content"] = content
+
+
+def _set_usage(attrs: dict[str, Any], response: Any) -> None:
+    usage = tr.extract_usage(response)
+    if "prompt" in usage:
+        attrs[LLM_USAGE_PROMPT_TOKENS] = usage["prompt"]
+    if "completion" in usage:
+        attrs[LLM_USAGE_COMPLETION_TOKENS] = usage["completion"]
+    if "total" in usage:
+        attrs[LLM_USAGE_TOTAL_TOKENS] = usage["total"]
+
+
+def build_chat_attrs(*, request_kwargs: dict[str, Any], response: Any = None) -> dict[str, Any]:
+    attrs = _base_attrs(span_name=CHAT_SPAN_NAME, log_type=LOG_TYPE_CHAT, request_type=REQUEST_TYPE_CHAT)
+    messages = tr.normalize_chat_messages(request_kwargs.get("messages"))
+    attrs[TRACELOOP_ENTITY_INPUT] = tr.format_input_messages(messages)
+    _set_prompt_attrs(attrs, messages)
+    tools = tr.normalize_tools(request_kwargs.get("tools"))
+    if tools:
+        attrs[LLM_REQUEST_FUNCTIONS] = tr.safe_json(tools)
+    _set_model(attrs, request_kwargs, response)
+    if response is not None:
+        attrs[TRACELOOP_ENTITY_OUTPUT] = tr.format_chat_output(response)
+        _set_completion_attrs(attrs, tr.format_chat_output(response))
+        tool_calls = tr.extract_chat_tool_calls(response)
+        if tool_calls:
+            attrs[RESPAN_SPAN_TOOL_CALLS] = tr.safe_json(tool_calls)
+            attrs[f"{_COMPLETION_PREFIX}0.tool_calls"] = tr.safe_json(tool_calls)
+        _set_usage(attrs, response)
+    return attrs
+
+
+def build_completion_attrs(*, request_kwargs: dict[str, Any], response: Any = None) -> dict[str, Any]:
+    attrs = _base_attrs(
+        span_name=COMPLETION_SPAN_NAME, log_type=LOG_TYPE_COMPLETION, request_type=REQUEST_TYPE_COMPLETION
+    )
+    messages = tr.normalize_text_prompts(request_kwargs.get("prompt"))
+    attrs[TRACELOOP_ENTITY_INPUT] = tr.format_input_messages(messages)
+    _set_prompt_attrs(attrs, messages)
+    _set_model(attrs, request_kwargs, response)
+    if response is not None:
+        output = tr.format_completion_output(response)
+        attrs[TRACELOOP_ENTITY_OUTPUT] = output
+        _set_completion_attrs(attrs, output)
+        _set_usage(attrs, response)
+    return attrs
+
+
+def build_response_attrs(*, request_kwargs: dict[str, Any], response: Any = None) -> dict[str, Any]:
+    attrs = _base_attrs(span_name=RESPONSE_SPAN_NAME, log_type=LOG_TYPE_RESPONSE, request_type=REQUEST_TYPE_CHAT)
+    messages = tr.normalize_responses_input(request_kwargs.get("input"))
+    attrs[TRACELOOP_ENTITY_INPUT] = tr.format_input_messages(messages)
+    _set_prompt_attrs(attrs, messages)
+    tools = tr.normalize_tools(request_kwargs.get("tools"))
+    if tools:
+        attrs[LLM_REQUEST_FUNCTIONS] = tr.safe_json(tools)
+    _set_model(attrs, request_kwargs, response)
+    if response is not None:
+        output = tr.format_responses_output(response)
+        attrs[TRACELOOP_ENTITY_OUTPUT] = output
+        _set_completion_attrs(attrs, output)
+        _set_usage(attrs, response)
+    return attrs
+
+
+def build_embedding_attrs(*, request_kwargs: dict[str, Any], response: Any = None) -> dict[str, Any]:
+    attrs = _base_attrs(
+        span_name=EMBEDDING_SPAN_NAME, log_type=LOG_TYPE_EMBEDDING, request_type=REQUEST_TYPE_EMBEDDING
+    )
+    inputs = tr.normalize_embedding_inputs(request_kwargs.get("input"))
+    attrs[TRACELOOP_ENTITY_INPUT] = tr.safe_json(inputs)
+    attrs[f"{_PROMPT_PREFIX}0.content"] = tr.safe_json(inputs)
+    _set_model(attrs, request_kwargs, response)
+    if response is not None:
+        summary = tr.embedding_summary(response)
+        if summary:
+            attrs[TRACELOOP_ENTITY_OUTPUT] = tr.safe_json(summary)
+        _set_usage(attrs, response)
+    return attrs
+
+
+# ---------------------------------------------------------------------------
+# Emit
+# ---------------------------------------------------------------------------
+
+
+def emit_span(
+    *,
+    span_name: str,
+    attrs: dict[str, Any],
+    start_ns: int,
+    error_message: str | None = None,
+    status_code: int = 200,
+) -> None:
+    try:
+        trace_id, parent_id = _current_trace_parent_ids()
+        span = build_readable_span(
+            name=span_name,
+            trace_id=trace_id,
+            parent_id=parent_id,
+            start_time_ns=start_ns,
+            end_time_ns=time.time_ns(),
+            attributes=attrs,
+            error_message=error_message,
+            status_code=status_code,
+        )
+        inject_span(span=span)
+    except Exception:
+        logger.debug("Failed to emit OpenAI span %r", span_name, exc_info=True)
+
+
+def _emit(builder, span_name, *, request_kwargs, response, start_ns, error_message, status_code) -> None:
+    try:
+        attrs = builder(request_kwargs=request_kwargs, response=response)
+    except Exception:
+        logger.debug("Failed to build attrs for %r", span_name, exc_info=True)
+        attrs = {}
+    emit_span(
+        span_name=span_name,
+        attrs=attrs,
+        start_ns=start_ns,
+        error_message=error_message,
+        status_code=status_code,
+    )
+
+
+def emit_chat_span(*, request_kwargs, start_ns, response=None, error_message=None, status_code=200) -> None:
+    _emit(build_chat_attrs, CHAT_SPAN_NAME, request_kwargs=request_kwargs, response=response,
+          start_ns=start_ns, error_message=error_message, status_code=status_code)
+
+
+def emit_completion_span(*, request_kwargs, start_ns, response=None, error_message=None, status_code=200) -> None:
+    _emit(build_completion_attrs, COMPLETION_SPAN_NAME, request_kwargs=request_kwargs, response=response,
+          start_ns=start_ns, error_message=error_message, status_code=status_code)
+
+
+def emit_response_span(*, request_kwargs, start_ns, response=None, error_message=None, status_code=200) -> None:
+    _emit(build_response_attrs, RESPONSE_SPAN_NAME, request_kwargs=request_kwargs, response=response,
+          start_ns=start_ns, error_message=error_message, status_code=status_code)
+
+
+def emit_embedding_span(*, request_kwargs, start_ns, response=None, error_message=None, status_code=200) -> None:
+    _emit(build_embedding_attrs, EMBEDDING_SPAN_NAME, request_kwargs=request_kwargs, response=response,
+          start_ns=start_ns, error_message=error_message, status_code=status_code)

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_translator.py
@@ -1,0 +1,255 @@
+"""Translate OpenAI SDK request/response objects into span-ready primitives.
+
+Pure functions, no OTEL imports — everything here turns OpenAI's pydantic
+objects (or dicts) into JSON-safe Python values that ``_otel_emitter`` maps
+onto span attributes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from respan_sdk.utils.serialization import serialize_value
+
+from respan_instrumentation_openai._constants import (
+    ASSISTANT_ROLE,
+    CONTENT_KEY,
+    ROLE_KEY,
+    USER_ROLE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Generic helpers
+# ---------------------------------------------------------------------------
+
+
+def _dump(value: Any) -> Any:
+    """Best-effort convert an OpenAI pydantic object / dict to plain data."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    for attr in ("model_dump", "to_dict", "dict"):
+        fn = getattr(value, attr, None)
+        if callable(fn):
+            try:
+                return fn()
+            except Exception:
+                continue
+    return serialize_value(value=value)
+
+
+def safe_json(value: Any) -> str:
+    try:
+        return json.dumps(_dump(value), default=str)
+    except Exception:
+        return str(value)
+
+
+def to_attr_value(value: Any) -> str:
+    return value if isinstance(value, str) else safe_json(value)
+
+
+def _coerce_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return safe_json(value)
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from a dict or a pydantic/attr object."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def request_model(request_kwargs: dict[str, Any]) -> str | None:
+    model = request_kwargs.get("model")
+    return str(model) if model else None
+
+
+def response_model(response: Any) -> str | None:
+    model = _get(response, "model")
+    return str(model) if model else None
+
+
+def response_id(response: Any) -> str | None:
+    rid = _get(response, "id")
+    return str(rid) if rid else None
+
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+
+def extract_usage(response: Any) -> dict[str, int]:
+    """Return ``{prompt, completion, total}`` tokens from any OpenAI response.
+
+    Handles both Chat/Completions usage (``prompt_tokens``/``completion_tokens``)
+    and Responses-API usage (``input_tokens``/``output_tokens``).
+    """
+    usage = _get(response, "usage")
+    if usage is None:
+        return {}
+    prompt = _get(usage, "prompt_tokens")
+    completion = _get(usage, "completion_tokens")
+    if prompt is None:
+        prompt = _get(usage, "input_tokens")
+    if completion is None:
+        completion = _get(usage, "output_tokens")
+    total = _get(usage, "total_tokens")
+    out: dict[str, int] = {}
+    if prompt is not None:
+        out["prompt"] = int(prompt)
+    if completion is not None:
+        out["completion"] = int(completion)
+    if total is not None:
+        out["total"] = int(total)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Chat completions
+# ---------------------------------------------------------------------------
+
+
+def normalize_chat_messages(messages: Any) -> list[dict[str, Any]]:
+    if messages is None:
+        return []
+    if isinstance(messages, dict):
+        messages = [messages]
+    normalized: list[dict[str, Any]] = []
+    for msg in messages or []:
+        role = _get(msg, ROLE_KEY) or USER_ROLE
+        content = _get(msg, CONTENT_KEY)
+        entry: dict[str, Any] = {ROLE_KEY: role, CONTENT_KEY: _dump(content)}
+        tool_calls = _get(msg, "tool_calls")
+        if tool_calls:
+            entry["tool_calls"] = _dump(tool_calls)
+        normalized.append(entry)
+    return normalized
+
+
+def format_input_messages(messages: list[dict[str, Any]]) -> str:
+    return safe_json(messages)
+
+
+def _first_choice(response: Any) -> Any:
+    choices = _get(response, "choices") or []
+    if isinstance(choices, (list, tuple)) and choices:
+        return choices[0]
+    return None
+
+
+def format_chat_output(response: Any) -> str:
+    choice = _first_choice(response)
+    message = _get(choice, "message") if choice is not None else None
+    content = _get(message, CONTENT_KEY) if message is not None else None
+    return _coerce_text(content)
+
+
+def extract_chat_tool_calls(response: Any) -> list[dict[str, Any]] | None:
+    choice = _first_choice(response)
+    message = _get(choice, "message") if choice is not None else None
+    tool_calls = _get(message, "tool_calls") if message is not None else None
+    if not tool_calls:
+        return None
+    return _dump(tool_calls)
+
+
+def normalize_tools(tools: Any) -> list[dict[str, Any]] | None:
+    if not tools:
+        return None
+    return _dump(tools)
+
+
+# ---------------------------------------------------------------------------
+# Legacy completions
+# ---------------------------------------------------------------------------
+
+
+def normalize_text_prompts(prompt: Any) -> list[dict[str, Any]]:
+    if prompt is None:
+        return []
+    if isinstance(prompt, (list, tuple)):
+        return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(p)} for p in prompt]
+    return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(prompt)}]
+
+
+def format_completion_output(response: Any) -> str:
+    choice = _first_choice(response)
+    return _coerce_text(_get(choice, "text") if choice is not None else None)
+
+
+# ---------------------------------------------------------------------------
+# Responses API
+# ---------------------------------------------------------------------------
+
+
+def normalize_responses_input(value: Any) -> list[dict[str, Any]]:
+    """Normalize the Responses-API ``input`` (str or message list)."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: value}]
+    if isinstance(value, dict):
+        return [{ROLE_KEY: _get(value, ROLE_KEY) or USER_ROLE, CONTENT_KEY: _dump(_get(value, CONTENT_KEY))}]
+    normalized: list[dict[str, Any]] = []
+    for item in value or []:
+        if isinstance(item, (dict,)) or hasattr(item, "role"):
+            normalized.append({ROLE_KEY: _get(item, ROLE_KEY) or USER_ROLE, CONTENT_KEY: _dump(_get(item, CONTENT_KEY))})
+        else:
+            normalized.append({ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(item)})
+    return normalized
+
+
+def format_responses_output(response: Any) -> str:
+    """Prefer ``output_text``; fall back to serializing ``output``."""
+    text = _get(response, "output_text")
+    if isinstance(text, str) and text:
+        return text
+    output = _get(response, "output")
+    if output is None:
+        return ""
+    return safe_json(output)
+
+
+# ---------------------------------------------------------------------------
+# Embeddings
+# ---------------------------------------------------------------------------
+
+
+def normalize_embedding_inputs(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [_coerce_text(v) for v in value]
+    return [_coerce_text(value)]
+
+
+def embedding_summary(response: Any) -> dict[str, Any]:
+    data = _get(response, "data") or []
+    summary: dict[str, Any] = {}
+    if isinstance(data, (list, tuple)):
+        summary["vector_count"] = len(data)
+        first = data[0] if data else None
+        emb = _get(first, "embedding") if first is not None else None
+        if isinstance(emb, (list, tuple)):
+            summary["dimension"] = len(emb)
+    return summary
+
+
+# re-export so the emitter doesn't need to know the role constant
+ASSISTANT = ASSISTANT_ROLE

--- a/python-sdks/instrumentations/respan-instrumentation-openai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/tests/test_instrumentation.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from respan_instrumentation_openai import _otel_emitter as emitter
+from respan_instrumentation_openai import _instrumentation as instr
 from respan_instrumentation_openai._instrumentation import OpenAIInstrumentor
 
 
@@ -100,6 +101,43 @@ def test_emit_chat_injects_one_span(monkeypatch):
     assert span.name == "openai.chat"
     assert span.attributes["llm.request.type"] == "chat"
     assert span.attributes["gen_ai.usage.total_tokens"] == 11
+
+
+# --- streaming aggregation --------------------------------------------------
+
+
+def _chunk(content=None, tool_deltas=None, usage=None, model="gpt-4.1-nano", cid="c1"):
+    delta = SimpleNamespace(content=content, tool_calls=tool_deltas)
+    return SimpleNamespace(id=cid, model=model, usage=usage, choices=[SimpleNamespace(delta=delta)])
+
+
+def test_aggregate_chat_joins_text_and_usage():
+    chunks = [
+        _chunk(content="Hel"),
+        _chunk(content="lo"),
+        _chunk(usage=SimpleNamespace(prompt_tokens=4, completion_tokens=2, total_tokens=6)),
+    ]
+    agg = instr._aggregate_chat(chunks)
+    assert agg["choices"][0]["message"]["content"] == "Hello"
+    assert emitter.tr.extract_usage(agg) == {"prompt": 4, "completion": 2, "total": 6}
+
+
+def test_aggregate_chat_reassembles_streamed_tool_calls():
+    def td(index, *, tid=None, name=None, args=None):
+        fn = SimpleNamespace(name=name, arguments=args)
+        return SimpleNamespace(index=index, id=tid, function=fn)
+
+    chunks = [
+        _chunk(tool_deltas=[td(0, tid="call_1", name="get_weather", args='{"ci')]),
+        _chunk(tool_deltas=[td(0, args='ty": "Tokyo"}')]),
+        _chunk(usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)),
+    ]
+    agg = instr._aggregate_chat(chunks)
+    calls = agg["choices"][0]["message"]["tool_calls"]
+    assert len(calls) == 1
+    assert calls[0]["id"] == "call_1"
+    assert calls[0]["function"]["name"] == "get_weather"
+    assert calls[0]["function"]["arguments"] == '{"city": "Tokyo"}'
 
 
 # --- instrumentor lifecycle -------------------------------------------------

--- a/python-sdks/instrumentations/respan-instrumentation-openai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/tests/test_instrumentation.py
@@ -1,0 +1,125 @@
+"""Unit tests for the native OpenAI instrumentation (no network)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from respan_instrumentation_openai import _otel_emitter as emitter
+from respan_instrumentation_openai._instrumentation import OpenAIInstrumentor
+
+
+# --- fakes ------------------------------------------------------------------
+
+
+def _chat_response():
+    return SimpleNamespace(
+        id="chatcmpl-123",
+        model="gpt-4.1-nano-2025-04-14",
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Hello there", tool_calls=None))],
+        usage=SimpleNamespace(prompt_tokens=8, completion_tokens=3, total_tokens=11),
+    )
+
+
+def _embedding_response():
+    return SimpleNamespace(
+        model="text-embedding-3-small",
+        data=[SimpleNamespace(embedding=[0.1, 0.2, 0.3])],
+        usage=SimpleNamespace(prompt_tokens=5, total_tokens=5),
+    )
+
+
+def _responses_response():
+    return SimpleNamespace(
+        id="resp-1",
+        model="gpt-4.1-mini",
+        output_text="done",
+        usage=SimpleNamespace(input_tokens=12, output_tokens=4, total_tokens=16),
+    )
+
+
+# --- attribute builders -----------------------------------------------------
+
+
+def test_chat_attrs_are_typed_as_llm_with_tokens():
+    attrs = emitter.build_chat_attrs(
+        request_kwargs={"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "hi"}]},
+        response=_chat_response(),
+    )
+    assert attrs["llm.request.type"] == "chat"
+    assert attrs["gen_ai.system"] == "openai"
+    assert attrs["respan.entity.log_type"] == "chat"
+    assert attrs["gen_ai.request.model"] == "gpt-4.1-nano"
+    assert attrs["gen_ai.usage.prompt_tokens"] == 8
+    assert attrs["gen_ai.usage.completion_tokens"] == 3
+    assert attrs["gen_ai.usage.total_tokens"] == 11
+    assert "Hello there" in attrs["traceloop.entity.output"]
+    # input is round-trippable JSON
+    assert json.loads(attrs["traceloop.entity.input"])[0]["content"] == "hi"
+
+
+def test_embedding_attrs_typed_as_embedding():
+    attrs = emitter.build_embedding_attrs(
+        request_kwargs={"model": "text-embedding-3-small", "input": "reset password"},
+        response=_embedding_response(),
+    )
+    assert attrs["llm.request.type"] == "embedding"
+    assert attrs["respan.entity.log_type"] == "embedding"
+    assert attrs["gen_ai.usage.prompt_tokens"] == 5
+    assert json.loads(attrs["traceloop.entity.output"])["vector_count"] == 1
+    assert json.loads(attrs["traceloop.entity.output"])["dimension"] == 3
+
+
+def test_responses_attrs_map_input_output_tokens():
+    attrs = emitter.build_response_attrs(
+        request_kwargs={"model": "gpt-4.1-mini", "input": "hi"},
+        response=_responses_response(),
+    )
+    assert attrs["llm.request.type"] == "chat"
+    assert attrs["respan.entity.log_type"] == "response"
+    assert attrs["gen_ai.usage.prompt_tokens"] == 12  # mapped from input_tokens
+    assert attrs["gen_ai.usage.completion_tokens"] == 4  # mapped from output_tokens
+    assert attrs["traceloop.entity.output"] == "done"
+
+
+# --- emit path --------------------------------------------------------------
+
+
+def test_emit_chat_injects_one_span(monkeypatch):
+    captured = []
+    monkeypatch.setattr(emitter, "inject_span", lambda span: captured.append(span))
+    emitter.emit_chat_span(
+        request_kwargs={"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "hi"}]},
+        start_ns=1,
+        response=_chat_response(),
+    )
+    assert len(captured) == 1
+    span = captured[0]
+    assert span.name == "openai.chat"
+    assert span.attributes["llm.request.type"] == "chat"
+    assert span.attributes["gen_ai.usage.total_tokens"] == 11
+
+
+# --- instrumentor lifecycle -------------------------------------------------
+
+
+def test_activate_patches_and_deactivate_restores():
+    pytest.importorskip("openai")
+    from openai.resources.chat.completions import Completions
+    from openai.resources.embeddings import Embeddings
+
+    original_chat = Completions.create
+    original_embed = Embeddings.create
+
+    instr = OpenAIInstrumentor()
+    instr.activate()
+    try:
+        assert Completions.create is not original_chat
+        assert Embeddings.create is not original_embed
+    finally:
+        instr.deactivate()
+
+    assert Completions.create is original_chat
+    assert Embeddings.create is original_embed


### PR DESCRIPTION
## Summary

Rewrites `respan-instrumentation-openai` as a **native, Traceloop-free** instrumentation. The package wrapped Traceloop's `opentelemetry-instrumentation-openai`, which migrated to the new OTEL GenAI conventions (`gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.usage.input_tokens`). The Respan exporter keys off the older convention (`gen_ai.system` → `llm.request.type`), so freshly installed spans lacked `llm.request.type` and the backend filed **every direct OpenAI LLM call as a generic "task" with $0 cost / 0 tokens**. The dependency was unpinned, so this broke silently on new installs.

The rewrite monkey-patches the OpenAI SDK directly and emits Respan's own documented conventions via the shared `span_factory` — no Traceloop dependency. Public API (`OpenAIInstrumentor`) unchanged; drop-in.

### What's covered
- **chat completions**, **responses**, **legacy completions**, **embeddings** — sync, async, and streaming
- Emits `llm.request.type`, `gen_ai.system`, `gen_ai.usage.*`, `traceloop.entity.*`, `respan.entity.log_type`
- **Tool calls** captured (non-streaming + streaming, with index-keyed delta reassembly), plus request tool/function defs and multi-turn tool-result inputs
- Spans **nest** under the active OTEL span when present, else become their own root trace
- Error paths emit a span with `StatusCode.ERROR` and re-raise

### Removed
- `opentelemetry-instrumentation-openai` dependency (the source of the drift)

## Verification

Verified end-to-end **on the live platform via MCP** (`get_trace_tree` / `list_logs`), not just at the SDK boundary:

| Surface | Before | After (confirmed on platform) |
|---|---|---|
| `openai.chat` (sync/async/stream) | `task`, $0, 0 tok | **`log_type=chat`**, real model, cost, tokens |
| `openai.embeddings` | task / orphan | **`log_type=embedding`**, classified as LLM call |
| tool calls (stream + non-stream) | — | stored in span output; request functions in metadata |

- Unit tests: **7 passed** (attribute builders for chat/embedding/responses, emit path, streamed text+usage, streamed tool-call reassembly, activate/deactivate lifecycle).
- Example raw platform span (streamed tool call): `log_type=chat`, 47/30 tokens, cost $0.0000167, `tool_calls` in output, `llm.request.functions` in metadata.

## Release Intent

Adds `.release-intents/20260629-openai-native-instrumentation.json` → `respan-instrumentation-openai`: **minor** (same public API, new internals + dependency removal). Bumps `1.0.x → 1.1.0`.

## Known follow-ups (not blocking)
- **Responses-API tool calls** aren't yet extracted into the structured `respan.span.tool_calls` attr (they land inside `traceloop.entity.output` JSON).
- **Legacy completions** not live-tested (model not enabled on the test gateway account); builder + patch are in place.
- **Embedding token/cost = 0** on the backend — pre-existing behavior identical to the old path (a backend embedding-attribution detail, not introduced here).
- **`respan-instrumentation-cohere`** has the identical unpinned-Traceloop drift and likely needs the same treatment.
- Trace-summary `llm_call_count` reads 0 for these spans even though each span is correctly `log_type=chat` with cost/tokens — a backend trace-summary counter detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)