### PR TITLE
fix(respan-ai): bundle direct-LLM-SDK auto-instrument packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,19 +221,24 @@ jobs:
           import importlib.metadata as md
           import importlib.util
 
-          # 1. All 6 native instrumentors are bundled / discoverable.
-          expected = {"openai", "anthropic", "aws-bedrock", "vertexai", "together", "ollama"}
+          # 1. All native instrumentors are bundled / discoverable.
+          expected = {"openai", "anthropic", "aws-bedrock", "vertexai", "google-genai", "together", "ollama"}
           discovered = {ep.name for ep in md.entry_points(group="respan.instrumentations")}
           missing = expected - discovered
           assert not missing, f"native instrumentors not bundled: {sorted(missing)}"
 
           # 2. No provider SDK leaked in (they are optional, brought by the app).
+          def _installed(module):
+              try:
+                  return importlib.util.find_spec(module) is not None
+              except Exception:
+                  return False
           leaked = [
-              m for m in ("openai", "anthropic", "botocore", "vertexai", "together", "ollama")
-              if importlib.util.find_spec(m) is not None
+              m for m in ("openai", "anthropic", "botocore", "vertexai", "google.genai", "together", "ollama")
+              if _installed(m)
           ]
           assert not leaked, f"provider SDKs must not be installed by respan-ai: {leaked}"
-          print("OK: 6 instrumentors bundled, no provider SDK leaked")
+          print("OK: instrumentors bundled, no provider SDK leaked")
           PY
           # 3. Install one provider SDK and assert that instrumentor actually traces.
           python -m pip install openai

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,7 @@ jobs:
             ../instrumentations/respan-instrumentation-anthropic \
             ../instrumentations/respan-instrumentation-aws-bedrock \
             ../instrumentations/respan-instrumentation-vertexai \
+            ../instrumentations/respan-instrumentation-google-genai \
             ../instrumentations/respan-instrumentation-together \
             ../instrumentations/respan-instrumentation-ollama \
             dist/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,35 @@ jobs:
               raise ModuleNotFoundError(os.environ["IMPORT_NAME"])
           importlib.metadata.version(os.environ["DIST_NAME"])
           PY
+
+      # A1: respan-ai bundles the native respan-instrumentation-* plugins so a
+      # bare Respan() auto-traces the direct LLM SDKs. Unlike the --no-deps smoke
+      # check above, this installs WITH dependencies (also guarding against an
+      # A9-style resolution blow-up) and asserts the plugins are discovered and
+      # auto-activated.
+      - name: respan-ai auto-instrument smoke check
+        if: ${{ matrix.name == 'respan-ai' }}
+        working-directory: ${{ matrix.path }}
+        env:
+          RESPAN_API_KEY: ci-test-key
+        run: |
+          python3 -m venv .ci-autoinstrument-venv
+          . .ci-autoinstrument-venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          import importlib.metadata as md
+
+          expected = {"openai", "anthropic", "aws-bedrock", "vertexai", "together", "ollama"}
+
+          discovered = {ep.name for ep in md.entry_points(group="respan.instrumentations")}
+          missing = expected - discovered
+          assert not missing, f"native instrumentors not bundled: {sorted(missing)}"
+
+          from respan import Respan
+          respan = Respan()
+          activated = set(getattr(respan, "_instrumentations", {}))
+          not_active = expected - activated
+          assert not not_active, f"bare Respan() did not auto-activate: {sorted(not_active)}"
+          print("OK: all 6 native instrumentors bundled and auto-activated")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,9 @@ jobs:
           . .ci-autoinstrument-venv/bin/activate
           python -m pip install --upgrade pip
           # Install the bundled native instrumentors from local source (this PR makes
-          # their provider SDKs optional; the published versions don't yet), plus
-          # respan-ai. The provider SDKs (openai, boto3, ...) must NOT come along.
+          # their provider SDKs optional; the published versions don't yet). Installed
+          # with deps, so respan-tracing + OTEL come along but the provider SDKs
+          # (openai, boto3, ...) must NOT.
           python -m pip install \
             ../instrumentations/respan-instrumentation-openai \
             ../instrumentations/respan-instrumentation-anthropic \
@@ -216,8 +217,14 @@ jobs:
             ../instrumentations/respan-instrumentation-vertexai \
             ../instrumentations/respan-instrumentation-google-genai \
             ../instrumentations/respan-instrumentation-together \
-            ../instrumentations/respan-instrumentation-ollama \
-            dist/*.whl
+            ../instrumentations/respan-instrumentation-ollama
+          # respan-ai's floors point at the first optional-SDK releases (e.g.
+          # anthropic >=1.0.2), which aren't published yet and are newer than the
+          # local source installed above, so a normal resolve of respan-ai's deps
+          # would fail (ResolutionImpossible). Install it --no-deps: the instrumentors
+          # it bundles are already present from source, and the floors are validated
+          # against real releases post-publish, not against local working copies.
+          python -m pip install --no-deps dist/*.whl
           python - <<'PY'
           import importlib.metadata as md
           import importlib.util

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,11 +193,10 @@ jobs:
           importlib.metadata.version(os.environ["DIST_NAME"])
           PY
 
-      # A1: respan-ai bundles the native respan-instrumentation-* plugins so a
-      # bare Respan() auto-traces the direct LLM SDKs. Unlike the --no-deps smoke
-      # check above, this installs WITH dependencies (also guarding against an
-      # A9-style resolution blow-up) and asserts the plugins are discovered and
-      # auto-activated.
+      # A1: respan-ai bundles the native respan-instrumentation-* plugins so a bare
+      # Respan() auto-traces the direct LLM SDKs. The provider SDKs are optional
+      # (the app brings them), so this asserts the instrumentors are bundled with no
+      # SDK leakage, then installs openai and asserts that instrumentor actually traces.
       - name: respan-ai auto-instrument smoke check
         if: ${{ matrix.name == 'respan-ai' }}
         working-directory: ${{ matrix.path }}
@@ -207,20 +206,65 @@ jobs:
           python3 -m venv .ci-autoinstrument-venv
           . .ci-autoinstrument-venv/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install dist/*.whl
+          # Install the bundled native instrumentors from local source (this PR makes
+          # their provider SDKs optional; the published versions don't yet), plus
+          # respan-ai. The provider SDKs (openai, boto3, ...) must NOT come along.
+          python -m pip install \
+            ../instrumentations/respan-instrumentation-openai \
+            ../instrumentations/respan-instrumentation-anthropic \
+            ../instrumentations/respan-instrumentation-aws-bedrock \
+            ../instrumentations/respan-instrumentation-vertexai \
+            ../instrumentations/respan-instrumentation-together \
+            ../instrumentations/respan-instrumentation-ollama \
+            dist/*.whl
           python - <<'PY'
           import importlib.metadata as md
+          import importlib.util
 
+          # 1. All 6 native instrumentors are bundled / discoverable.
           expected = {"openai", "anthropic", "aws-bedrock", "vertexai", "together", "ollama"}
-
           discovered = {ep.name for ep in md.entry_points(group="respan.instrumentations")}
           missing = expected - discovered
           assert not missing, f"native instrumentors not bundled: {sorted(missing)}"
 
+          # 2. No provider SDK leaked in (they are optional, brought by the app).
+          leaked = [
+              m for m in ("openai", "anthropic", "botocore", "vertexai", "together", "ollama")
+              if importlib.util.find_spec(m) is not None
+          ]
+          assert not leaked, f"provider SDKs must not be installed by respan-ai: {leaked}"
+          print("OK: 6 instrumentors bundled, no provider SDK leaked")
+          PY
+          # 3. Install one provider SDK and assert that instrumentor actually traces.
+          python -m pip install openai
+          python - <<'PY'
+          import os
+          os.environ.setdefault("RESPAN_API_KEY", "ci-test-key")
+
           from respan import Respan
-          respan = Respan()
-          activated = set(getattr(respan, "_instrumentations", {}))
-          not_active = expected - activated
-          assert not not_active, f"bare Respan() did not auto-activate: {sorted(not_active)}"
-          print("OK: all 6 native instrumentors bundled and auto-activated")
+          from opentelemetry import trace
+          from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+          from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+              InMemorySpanExporter,
+          )
+
+          Respan(is_batching_enabled=False)
+          mem = InMemorySpanExporter()
+          trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(mem))
+
+          import openai
+          try:
+              openai.OpenAI(
+                  api_key="x", base_url="http://127.0.0.1:1/v1", max_retries=0
+              ).chat.completions.create(
+                  model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}]
+              )
+          except Exception:
+              pass
+
+          names = [s.name for s in mem.get_finished_spans()]
+          assert any("openai" in n or "chat" in n.lower() for n in names), (
+              f"openai not instrumented after install; spans={names}"
+          )
+          print("OK: openai instrumented after install ->", names)
           PY

--- a/.release-intents/20260629-respan-ai-bundle-native-autoinstrument.json
+++ b/.release-intents/20260629-respan-ai-bundle-native-autoinstrument.json
@@ -1,0 +1,6 @@
+{
+  "summary": "respan-ai bundles the native (Traceloop-free) respan-instrumentation-* plugins for OpenAI/Anthropic/Bedrock/VertexAI/Together/Ollama and auto-activates them on a bare Respan(), so direct LLM SDKs are traced with correct llm.request.type/tokens/cost out of the box (A1). cohere/mistral/groq are excluded until they are rewritten native (mistral/groq's openinference deps cap at Python <3.13).",
+  "packages": {
+    "respan-ai": "minor"
+  }
+}

--- a/.release-intents/20260629-respan-ai-bundle-native-autoinstrument.json
+++ b/.release-intents/20260629-respan-ai-bundle-native-autoinstrument.json
@@ -1,11 +1,12 @@
 {
-  "summary": "respan-ai bundles the native (Traceloop-free) respan-instrumentation-* plugins for OpenAI/Anthropic/Bedrock/VertexAI/Together/Ollama and auto-activates them on a bare Respan(), so direct LLM SDKs are traced with correct llm.request.type/tokens/cost out of the box (A1). The 6 native packages now mark their provider SDK optional (the app brings it) so respan-ai pulls only the instrumentors, not boto3/google-cloud-aiplatform/openai/etc. cohere/mistral/groq are excluded until rewritten native (mistral/groq's openinference deps cap at Python <3.13).",
+  "summary": "respan-ai bundles the native (Traceloop-free) respan-instrumentation-* plugins for OpenAI/Anthropic/Bedrock/VertexAI/Google-GenAI/Together/Ollama and auto-activates them on a bare Respan(), so direct LLM SDKs are traced with correct llm.request.type/tokens/cost out of the box (A1). This covers Gemini both via Vertex AI and via the Google GenAI SDK. The native packages mark their provider SDK optional (the app brings it) so respan-ai pulls only the instrumentors, not boto3/google-cloud-aiplatform/google-genai/openai/etc. cohere/mistral/groq are excluded until rewritten native (mistral/groq's openinference deps cap at Python <3.13).",
   "packages": {
     "respan-ai": "minor",
     "respan-instrumentation-openai": "patch",
     "respan-instrumentation-anthropic": "patch",
     "respan-instrumentation-aws-bedrock": "patch",
     "respan-instrumentation-vertexai": "patch",
+    "respan-instrumentation-google-genai": "patch",
     "respan-instrumentation-together": "patch",
     "respan-instrumentation-ollama": "patch"
   }

--- a/.release-intents/20260629-respan-ai-bundle-native-autoinstrument.json
+++ b/.release-intents/20260629-respan-ai-bundle-native-autoinstrument.json
@@ -1,6 +1,12 @@
 {
-  "summary": "respan-ai bundles the native (Traceloop-free) respan-instrumentation-* plugins for OpenAI/Anthropic/Bedrock/VertexAI/Together/Ollama and auto-activates them on a bare Respan(), so direct LLM SDKs are traced with correct llm.request.type/tokens/cost out of the box (A1). cohere/mistral/groq are excluded until they are rewritten native (mistral/groq's openinference deps cap at Python <3.13).",
+  "summary": "respan-ai bundles the native (Traceloop-free) respan-instrumentation-* plugins for OpenAI/Anthropic/Bedrock/VertexAI/Together/Ollama and auto-activates them on a bare Respan(), so direct LLM SDKs are traced with correct llm.request.type/tokens/cost out of the box (A1). The 6 native packages now mark their provider SDK optional (the app brings it) so respan-ai pulls only the instrumentors, not boto3/google-cloud-aiplatform/openai/etc. cohere/mistral/groq are excluded until rewritten native (mistral/groq's openinference deps cap at Python <3.13).",
   "packages": {
-    "respan-ai": "minor"
+    "respan-ai": "minor",
+    "respan-instrumentation-openai": "patch",
+    "respan-instrumentation-anthropic": "patch",
+    "respan-instrumentation-aws-bedrock": "patch",
+    "respan-instrumentation-vertexai": "patch",
+    "respan-instrumentation-together": "patch",
+    "respan-instrumentation-ollama": "patch"
   }
 }

--- a/.release-intents/20260629-respan-ai-bundle-native-autoinstrument.json
+++ b/.release-intents/20260629-respan-ai-bundle-native-autoinstrument.json
@@ -1,7 +1,8 @@
 {
-  "summary": "respan-ai bundles the native (Traceloop-free) respan-instrumentation-* plugins for OpenAI/Anthropic/Bedrock/VertexAI/Google-GenAI/Together/Ollama and auto-activates them on a bare Respan(), so direct LLM SDKs are traced with correct llm.request.type/tokens/cost out of the box (A1). This covers Gemini both via Vertex AI and via the Google GenAI SDK. The native packages mark their provider SDK optional (the app brings it) so respan-ai pulls only the instrumentors, not boto3/google-cloud-aiplatform/google-genai/openai/etc. cohere/mistral/groq are excluded until rewritten native (mistral/groq's openinference deps cap at Python <3.13).",
+  "summary": "respan-ai bundles the native (Traceloop-free) respan-instrumentation-* plugins for OpenAI/Anthropic/Bedrock/VertexAI/Google-GenAI/Together/Ollama and auto-activates them on a bare Respan(), so direct LLM SDKs are traced with correct llm.request.type/tokens/cost out of the box (A1). This covers Gemini both via Vertex AI and via the Google GenAI SDK. The native packages mark their provider SDK optional (the app brings it) so respan-ai pulls only the instrumentors, not boto3/google-cloud-aiplatform/google-genai/openai/etc. cohere/mistral/groq are excluded until rewritten native (mistral/groq's openinference deps cap at Python <3.13). respan-tracing gets a patch: its enum->entry-point map now resolves BEDROCK/VERTEXAI to Traceloop's actual entry-point names (boto3/google_cloud_aiplatform) so the auto-mode OTEL-twin dedup actually blocks those two providers; respan-ai raises its respan-tracing floor to the release containing this fix.",
   "packages": {
     "respan-ai": "minor",
+    "respan-tracing": "patch",
     "respan-instrumentation-openai": "patch",
     "respan-instrumentation-anthropic": "patch",
     "respan-instrumentation-aws-bedrock": "patch",

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/pyproject.toml
@@ -12,7 +12,12 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
 respan-tracing = "^2.3.0"
-anthropic = ">=0.39.0"
+# Optional: the instrumentor lazy-imports anthropic and no-ops when it is absent,
+# so the app brings its own anthropic. Install with the SDK via the `instruments` extra.
+anthropic = { version = ">=0.39.0", optional = true }
+
+[tool.poetry.extras]
+instruments = ["anthropic"]
 
 [tool.poetry.plugins."respan.instrumentations"]
 anthropic = "respan_instrumentation_anthropic:AnthropicInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_instrumentation.py
@@ -239,8 +239,9 @@ class AnthropicInstrumentor:
         try:
             Messages, AsyncMessages = _load_messages_classes()
         except (AttributeError, ImportError) as exc:
-            logger.warning(
-                "Failed to activate Anthropic instrumentation — missing dependency: %s",
+            # Expected when the app doesn't use Anthropic (the SDK is an optional dep).
+            logger.debug(
+                "Anthropic instrumentation inactive — missing dependency: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_instrumentation.py
@@ -238,10 +238,19 @@ class AnthropicInstrumentor:
 
         try:
             Messages, AsyncMessages = _load_messages_classes()
-        except (AttributeError, ImportError) as exc:
-            # Expected when the app doesn't use Anthropic (the SDK is an optional dep).
+        except ImportError as exc:
+            # SDK genuinely absent — expected when the app doesn't use Anthropic
+            # (the anthropic SDK is an optional extra).
             logger.debug(
                 "Anthropic instrumentation inactive — missing dependency: %s",
+                exc,
+            )
+            return
+        except AttributeError as exc:
+            # SDK installed but incompatible (a class moved/renamed) — surface it
+            # so a broken install isn't silently left untraced.
+            logger.warning(
+                "anthropic is installed but incompatible — instrumentation inactive: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/pyproject.toml
@@ -13,8 +13,13 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.1"
-boto3 = ">=1.34.0"
+# Optional: the instrumentor lazy-imports boto3 and no-ops when it is absent, so
+# the app brings its own boto3. Install with the SDK via the `instruments` extra.
+boto3 = { version = ">=1.34.0", optional = true }
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
+
+[tool.poetry.extras]
+instruments = ["boto3"]
 
 [tool.poetry.plugins."respan.instrumentations"]
 aws-bedrock = "respan_instrumentation_aws_bedrock:AWSBedrockInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_instrumentation.py
@@ -194,8 +194,9 @@ class AWSBedrockInstrumentor:
         try:
             base_client = _load_base_client_class()
         except (AttributeError, ImportError) as exc:
-            logger.warning(
-                "Failed to activate AWS Bedrock instrumentation - missing dependency: %s",
+            # Expected when the app doesn't use Bedrock (boto3 is an optional dep).
+            logger.debug(
+                "AWS Bedrock instrumentation inactive - missing dependency: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_instrumentation.py
@@ -193,10 +193,19 @@ class AWSBedrockInstrumentor:
 
         try:
             base_client = _load_base_client_class()
-        except (AttributeError, ImportError) as exc:
-            # Expected when the app doesn't use Bedrock (boto3 is an optional dep).
+        except ImportError as exc:
+            # SDK genuinely absent - expected when the app doesn't use Bedrock
+            # (boto3 is an optional extra).
             logger.debug(
                 "AWS Bedrock instrumentation inactive - missing dependency: %s",
+                exc,
+            )
+            return
+        except AttributeError as exc:
+            # boto3 installed but incompatible (a class moved/renamed) - surface it
+            # so a broken install isn't silently left untraced.
+            logger.warning(
+                "boto3 is installed but incompatible - AWS Bedrock instrumentation inactive: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/pyproject.toml
@@ -13,8 +13,13 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.1"
-google-genai = ">=1.0.0"
+# Optional: the instrumentor lazy-imports google-genai and no-ops when it is
+# absent, so the app brings its own. Install with the SDK via the `instruments` extra.
+google-genai = { version = ">=1.0.0", optional = true }
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
+
+[tool.poetry.extras]
+instruments = ["google-genai"]
 
 [tool.poetry.plugins."respan.instrumentations"]
 google-genai = "respan_instrumentation_google_genai:GoogleGenAIInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_instrumentation.py
@@ -244,8 +244,9 @@ class GoogleGenAIInstrumentor:
         try:
             Models, AsyncModels = _load_models_classes()
         except (AttributeError, ImportError) as exc:
-            logger.warning(
-                "Failed to activate Google Gen AI instrumentation - missing dependency: %s",
+            # Expected when the app doesn't use Google Gen AI (the SDK is an optional dep).
+            logger.debug(
+                "Google Gen AI instrumentation inactive - missing dependency: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_instrumentation.py
@@ -243,10 +243,19 @@ class GoogleGenAIInstrumentor:
 
         try:
             Models, AsyncModels = _load_models_classes()
-        except (AttributeError, ImportError) as exc:
-            # Expected when the app doesn't use Google Gen AI (the SDK is an optional dep).
+        except ImportError as exc:
+            # SDK genuinely absent - expected when the app doesn't use Google Gen AI
+            # (the google-genai SDK is an optional extra).
             logger.debug(
                 "Google Gen AI instrumentation inactive - missing dependency: %s",
+                exc,
+            )
+            return
+        except AttributeError as exc:
+            # SDK installed but incompatible (a class moved/renamed) - surface it
+            # so a broken install isn't silently left untraced.
+            logger.warning(
+                "google-genai is installed but incompatible - instrumentation inactive: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/pyproject.toml
@@ -13,8 +13,13 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.26"
-ollama = ">=0.6.0"
+# Optional: the instrumentor lazy-imports ollama and no-ops when it is absent, so
+# the app brings its own ollama. Install with the SDK via the `instruments` extra.
+ollama = { version = ">=0.6.0", optional = true }
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
+
+[tool.poetry.extras]
+instruments = ["ollama"]
 
 [tool.poetry.plugins."respan.instrumentations"]
 ollama = "respan_instrumentation_ollama:OllamaInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_instrumentation.py
@@ -299,10 +299,19 @@ class OllamaInstrumentor:
 
         try:
             Client, AsyncClient = _load_client_classes()
-        except (AttributeError, ImportError) as exc:
-            # Expected when the app doesn't use Ollama (the SDK is an optional dep).
+        except ImportError as exc:
+            # SDK genuinely absent - expected when the app doesn't use Ollama
+            # (the ollama SDK is an optional extra).
             logger.debug(
                 "Ollama instrumentation inactive - missing dependency: %s",
+                exc,
+            )
+            return
+        except AttributeError as exc:
+            # SDK installed but incompatible (a class moved/renamed) - surface it
+            # so a broken install isn't silently left untraced.
+            logger.warning(
+                "ollama is installed but incompatible - instrumentation inactive: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_instrumentation.py
@@ -300,8 +300,9 @@ class OllamaInstrumentor:
         try:
             Client, AsyncClient = _load_client_classes()
         except (AttributeError, ImportError) as exc:
-            logger.warning(
-                "Failed to activate Ollama instrumentation - missing dependency: %s",
+            # Expected when the app doesn't use Ollama (the SDK is an optional dep).
+            logger.debug(
+                "Ollama instrumentation inactive - missing dependency: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-openai/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/pyproject.toml
@@ -13,7 +13,12 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.3.0"
 respan-sdk = ">=2.6.0"
-openai = ">=1.0.0"
+# Optional: the instrumentor lazy-imports openai and no-ops when it is absent, so
+# the app brings its own openai. Install with the SDK via the `instruments` extra.
+openai = { version = ">=1.0.0", optional = true }
+
+[tool.poetry.extras]
+instruments = ["openai"]
 
 [tool.poetry.plugins."respan.instrumentations"]
 openai = "respan_instrumentation_openai:OpenAIInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
@@ -279,7 +279,8 @@ class OpenAIInstrumentor:
         try:
             import openai  # noqa: F401
         except ImportError as exc:
-            logger.warning("Failed to activate OpenAI instrumentation — openai not installed: %s", exc)
+            # Expected when the app doesn't use OpenAI (the SDK is an optional dep).
+            logger.debug("OpenAI instrumentation inactive — openai not installed: %s", exc)
             return
         try:
             for module_path, class_name, kind, is_async in _TARGETS:

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
@@ -230,18 +230,25 @@ def _load_class(module_path: str, class_name: str) -> type[Any] | None:
     return getattr(module, class_name, None)
 
 
-def _patch(target_class: type[Any] | None, *, kind: str, is_async: bool) -> None:
+def _patch(target_class: type[Any] | None, *, kind: str, is_async: bool) -> bool:
+    """Patch one target class's create method.
+
+    Returns True when the target's API surface is present (patched now or already
+    patched), False when the class or method is missing. The caller treats an
+    all-False result as an installed-but-incompatible openai SDK.
+    """
     if target_class is None:
-        return
+        return False
     original = getattr(target_class, CREATE_METHOD, None)
     if original is None:
-        return
+        return False
     key = (target_class, CREATE_METHOD)
     if key in _original_methods:
-        return
+        return True
     _original_methods[key] = original
     factory = _make_async_wrapper if is_async else _make_sync_wrapper
     setattr(target_class, CREATE_METHOD, factory(original, kind=kind))
+    return True
 
 
 # (module, class, kind, is_async)
@@ -279,12 +286,25 @@ class OpenAIInstrumentor:
         try:
             import openai  # noqa: F401
         except ImportError as exc:
-            # Expected when the app doesn't use OpenAI (the SDK is an optional dep).
+            # SDK genuinely absent — expected when the app doesn't use OpenAI
+            # (the openai SDK is an optional extra).
             logger.debug("OpenAI instrumentation inactive — openai not installed: %s", exc)
             return
         try:
+            patched_any = False
             for module_path, class_name, kind, is_async in _TARGETS:
-                _patch(_load_class(module_path, class_name), kind=kind, is_async=is_async)
+                if _patch(
+                    _load_class(module_path, class_name), kind=kind, is_async=is_async
+                ):
+                    patched_any = True
+            if not patched_any:
+                # openai imports but none of its known API surfaces are present:
+                # installed but incompatible — the silent-failure class this bundling
+                # is meant to fix, so warn instead of leaving it quietly untraced.
+                logger.warning(
+                    "openai is installed but no known API surface could be "
+                    "instrumented — incompatible version? OpenAI instrumentation inactive."
+                )
         except Exception as exc:
             logger.warning("Failed to activate OpenAI instrumentation: %s", exc)
             self.deactivate()

--- a/python-sdks/instrumentations/respan-instrumentation-together/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-together/pyproject.toml
@@ -13,8 +13,13 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = ">=2.17.0"
 respan-sdk = ">=2.6.1"
-together = ">=2.0.0"
+# Optional: the instrumentor lazy-imports together and no-ops when it is absent, so
+# the app brings its own together. Install with the SDK via the `instruments` extra.
+together = { version = ">=2.0.0", optional = true }
 opentelemetry-semantic-conventions-ai = ">=0.5.1"
+
+[tool.poetry.extras]
+instruments = ["together"]
 
 [tool.poetry.plugins."respan.instrumentations"]
 together = "respan_instrumentation_together:TogetherInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_instrumentation.py
@@ -356,8 +356,9 @@ class TogetherInstrumentor:
                 ASYNC_RERANK_RESOURCE_CLASS_NAME,
             )
         except (AttributeError, ImportError) as exc:
-            logger.warning(
-                "Failed to activate Together instrumentation - missing dependency: %s",
+            # Expected when the app doesn't use Together (the SDK is an optional dep).
+            logger.debug(
+                "Together instrumentation inactive - missing dependency: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_instrumentation.py
@@ -355,10 +355,19 @@ class TogetherInstrumentor:
                 TOGETHER_RERANK_MODULE,
                 ASYNC_RERANK_RESOURCE_CLASS_NAME,
             )
-        except (AttributeError, ImportError) as exc:
-            # Expected when the app doesn't use Together (the SDK is an optional dep).
+        except ImportError as exc:
+            # SDK genuinely absent - expected when the app doesn't use Together
+            # (the together SDK is an optional extra).
             logger.debug(
                 "Together instrumentation inactive - missing dependency: %s",
+                exc,
+            )
+            return
+        except AttributeError as exc:
+            # SDK installed but incompatible (a class moved/renamed) - surface it
+            # so a broken install isn't silently left untraced.
+            logger.warning(
+                "together is installed but incompatible - instrumentation inactive: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/pyproject.toml
@@ -13,8 +13,13 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.1"
-google-cloud-aiplatform = ">=1.71.0"
+# Optional: the instrumentor lazy-imports the Vertex SDK and no-ops when it is
+# absent, so the app brings its own. Install with the SDK via the `instruments` extra.
+google-cloud-aiplatform = { version = ">=1.71.0", optional = true }
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
+
+[tool.poetry.extras]
+instruments = ["google-cloud-aiplatform"]
 
 [tool.poetry.plugins."respan.instrumentations"]
 vertexai = "respan_instrumentation_vertexai:VertexAIInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_instrumentation.py
@@ -272,8 +272,9 @@ class VertexAIInstrumentor:
         try:
             GenerativeModel, ChatSession = _load_vertexai_classes()
         except (AttributeError, ImportError) as exc:
-            logger.warning(
-                "Failed to activate Vertex AI instrumentation - missing dependency: %s",
+            # Expected when the app doesn't use Vertex AI (the SDK is an optional dep).
+            logger.debug(
+                "Vertex AI instrumentation inactive - missing dependency: %s",
                 exc,
             )
             return

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_instrumentation.py
@@ -271,10 +271,19 @@ class VertexAIInstrumentor:
 
         try:
             GenerativeModel, ChatSession = _load_vertexai_classes()
-        except (AttributeError, ImportError) as exc:
-            # Expected when the app doesn't use Vertex AI (the SDK is an optional dep).
+        except ImportError as exc:
+            # SDK genuinely absent - expected when the app doesn't use Vertex AI
+            # (the google-cloud-aiplatform SDK is an optional extra).
             logger.debug(
                 "Vertex AI instrumentation inactive - missing dependency: %s",
+                exc,
+            )
+            return
+        except AttributeError as exc:
+            # SDK installed but incompatible (a class moved/renamed) - surface it
+            # so a broken install isn't silently left untraced.
+            logger.warning(
+                "google-cloud-aiplatform is installed but incompatible - Vertex AI instrumentation inactive: %s",
                 exc,
             )
             return

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/instrumentation.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/instrumentation.py
@@ -13,9 +13,15 @@ logger = logging.getLogger(__name__)
 ENTRY_POINT_GROUP = "opentelemetry_instrumentor"
 
 # Map Instruments enum values to entry point names.
-# Only needed when they differ (most match by convention).
+# Only needed when they differ (most match by convention). Traceloop registers
+# the Bedrock and Vertex AI instrumentors under their underlying SDK package
+# names (boto3 / google_cloud_aiplatform), not the provider name — so without
+# these, block_instruments={BEDROCK, VERTEXAI} resolves to names that match no
+# entry point and silently fails to dedup the native plugins' OTEL twins.
 _ENUM_TO_ENTRY_POINT: dict[str, str] = {
     "grpc": "grpc_client",
+    "bedrock": "boto3",
+    "vertexai": "google_cloud_aiplatform",
 }
 
 # Post-init hooks keyed by entry point name.

--- a/python-sdks/respan-tracing/tests/test_instrumentation_registry.py
+++ b/python-sdks/respan-tracing/tests/test_instrumentation_registry.py
@@ -68,6 +68,21 @@ class TestEnumToEntryPoint:
         """GRPC maps to grpc_client entry point."""
         assert _enum_to_entry_point_name(Instruments.GRPC) == "grpc_client"
 
+    def test_bedrock_and_vertexai_map_to_sdk_entry_points(self):
+        """Bedrock/Vertex AI register under their SDK package name in Traceloop,
+        so block_instruments must resolve to boto3 / google_cloud_aiplatform to
+        dedup the native plugins' OTEL twins (respan-ai auto-instrument path)."""
+        assert _enum_to_entry_point_name(Instruments.BEDROCK) == "boto3"
+        assert (
+            _enum_to_entry_point_name(Instruments.VERTEXAI)
+            == "google_cloud_aiplatform"
+        )
+        # Google GenAI already matches by convention — must stay a direct match.
+        assert (
+            _enum_to_entry_point_name(Instruments.GOOGLE_GENERATIVEAI)
+            == "google_generativeai"
+        )
+
     def test_aiohttp_direct_match(self):
         """AIOHTTP_CLIENT maps directly — enum value equals entry point name."""
         assert _enum_to_entry_point_name(Instruments.AIOHTTP_CLIENT) == "aiohttp_client"

--- a/python-sdks/respan/pyproject.toml
+++ b/python-sdks/respan/pyproject.toml
@@ -24,13 +24,18 @@ respan-tracing = ">=2.3.0"
 # Python <3.13 and breaks resolution) are intentionally excluded until they are
 # rewritten native. To add a provider later: add its respan-instrumentation-*
 # package here; discovery + activation are automatic.
-respan-instrumentation-openai = ">=1.2.0,<2.0.0"       # OpenAI + Azure OpenAI
-respan-instrumentation-anthropic = ">=1.0.1,<2.0.0"
-respan-instrumentation-aws-bedrock = ">=0.1.0,<1.0.0"
-respan-instrumentation-vertexai = ">=0.1.0,<1.0.0"     # Gemini via Vertex AI
-respan-instrumentation-google-genai = ">=0.1.0,<1.0.0" # Gemini via the Google GenAI SDK
-respan-instrumentation-together = ">=0.1.0,<1.0.0"
-respan-instrumentation-ollama = ">=0.1.0,<1.0.0"
+#
+# Floors are the first releases in which each instrumentor marks its provider SDK
+# optional (the patch bumps in this PR's release intent). The prior versions
+# hard-require the SDK, so a lower floor would let a resolver drag in
+# openai/boto3/google-cloud-aiplatform/etc. — the exact bloat this bundling avoids.
+respan-instrumentation-openai = ">=1.2.1,<2.0.0"       # OpenAI + Azure OpenAI
+respan-instrumentation-anthropic = ">=1.0.2,<2.0.0"
+respan-instrumentation-aws-bedrock = ">=0.1.1,<1.0.0"
+respan-instrumentation-vertexai = ">=0.1.1,<1.0.0"     # Gemini via Vertex AI
+respan-instrumentation-google-genai = ">=0.1.1,<1.0.0" # Gemini via the Google GenAI SDK
+respan-instrumentation-together = ">=0.1.1,<1.0.0"
+respan-instrumentation-ollama = ">=0.1.1,<1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"

--- a/python-sdks/respan/pyproject.toml
+++ b/python-sdks/respan/pyproject.toml
@@ -11,7 +11,11 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
-respan-tracing = ">=2.3.0"
+# Floor is the release that resolves BEDROCK/VERTEXAI block_instruments to
+# Traceloop's real entry-point names (boto3 / google_cloud_aiplatform). Below
+# it, auto mode can't dedup those two providers' OTEL twins and Bedrock/Vertex
+# calls get traced twice (native plugin + OTEL instrumentor).
+respan-tracing = ">=2.17.1"
 
 # Native (Traceloop-free) instrumentors for the direct LLM SDKs, bundled so a
 # bare `Respan()` auto-traces them with no extra packages. They are discovered

--- a/python-sdks/respan/pyproject.toml
+++ b/python-sdks/respan/pyproject.toml
@@ -27,7 +27,8 @@ respan-tracing = ">=2.3.0"
 respan-instrumentation-openai = ">=1.2.0,<2.0.0"       # OpenAI + Azure OpenAI
 respan-instrumentation-anthropic = ">=1.0.1,<2.0.0"
 respan-instrumentation-aws-bedrock = ">=0.1.0,<1.0.0"
-respan-instrumentation-vertexai = ">=0.1.0,<1.0.0"
+respan-instrumentation-vertexai = ">=0.1.0,<1.0.0"     # Gemini via Vertex AI
+respan-instrumentation-google-genai = ">=0.1.0,<1.0.0" # Gemini via the Google GenAI SDK
 respan-instrumentation-together = ">=0.1.0,<1.0.0"
 respan-instrumentation-ollama = ">=0.1.0,<1.0.0"
 

--- a/python-sdks/respan/pyproject.toml
+++ b/python-sdks/respan/pyproject.toml
@@ -13,6 +13,24 @@ packages = [
 python = ">=3.9,<4.0"
 respan-tracing = ">=2.3.0"
 
+# Native (Traceloop-free) instrumentors for the direct LLM SDKs, bundled so a
+# bare `Respan()` auto-traces them with no extra packages. They are discovered
+# at startup via the `respan.instrumentations` entry-point group and emit proper
+# llm.request.type / tokens / cost (unlike the Traceloop opentelemetry-* ones,
+# which mislabel calls as generic tasks with $0 cost).
+#
+# NOTE: only the providers whose instrumentor is native today are bundled. cohere
+# (still wraps Traceloop) and mistral/groq (wrap openinference, which caps at
+# Python <3.13 and breaks resolution) are intentionally excluded until they are
+# rewritten native. To add a provider later: add its respan-instrumentation-*
+# package here; discovery + activation are automatic.
+respan-instrumentation-openai = ">=1.2.0,<2.0.0"       # OpenAI + Azure OpenAI
+respan-instrumentation-anthropic = ">=1.0.1,<2.0.0"
+respan-instrumentation-aws-bedrock = ">=0.1.0,<1.0.0"
+respan-instrumentation-vertexai = ">=0.1.0,<1.0.0"
+respan-instrumentation-together = ">=0.1.0,<1.0.0"
+respan-instrumentation-ollama = ">=0.1.0,<1.0.0"
+
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"
 python-dotenv = "^1.0.0"

--- a/python-sdks/respan/pyproject.toml
+++ b/python-sdks/respan/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.11,<3.14"
 respan-tracing = ">=2.3.0"
 
 # Native (Traceloop-free) instrumentors for the direct LLM SDKs, bundled so a

--- a/python-sdks/respan/src/respan/_core.py
+++ b/python-sdks/respan/src/respan/_core.py
@@ -1,6 +1,7 @@
 """Respan — unified entry point for tracing and instrumentation plugins."""
 
 import importlib.metadata
+import importlib.util
 import json
 import logging
 import os
@@ -46,6 +47,34 @@ _BUNDLED_NATIVE_INSTRUMENTATIONS: Dict[str, tuple] = {
     "together": (Instruments.TOGETHER,),
     "ollama": (Instruments.OLLAMA,),
 }
+
+# Top-level provider SDK package for each bundled native. Used only to detect the
+# "provider SDK is installed but its native instrumentor never activated" case and
+# warn about it — the safety net for the allowlist/dedup logic above, so a
+# bundling gap or a failed load doesn't leave an installed SDK silently untraced.
+# Probed with find_spec (not import), so checking a provider the app doesn't use
+# has no side effects.
+_PROVIDER_SDK_MODULES: Dict[str, tuple] = {
+    "openai": ("openai",),
+    "anthropic": ("anthropic",),
+    "aws-bedrock": ("botocore",),  # boto3's client layer
+    "vertexai": ("vertexai",),
+    "google-genai": ("google.genai",),
+    "together": ("together",),
+    "ollama": ("ollama",),
+}
+
+
+def _provider_sdk_installed(modules: tuple) -> bool:
+    """True if any of ``modules`` is importable (installed), without importing it."""
+    for name in modules:
+        try:
+            if importlib.util.find_spec(name) is not None:
+                return True
+        except (ImportError, ModuleNotFoundError, ValueError):
+            # Parent package absent, name isn't a package, etc. — treat as absent.
+            continue
+    return False
 
 
 def _discover_native_instrumentations() -> List[tuple]:
@@ -198,23 +227,48 @@ class Respan:
         #     respan-instrumentation-* plugins discovered above so a bare
         #     Respan() traces the direct LLM SDKs out of the box.  Their OTEL
         #     counterparts were blocked above, so each provider is traced once.
-        for _ep_name, inst in native_instrumentations:
+        activated_native_names = set()
+        for ep_name, inst in native_instrumentations:
             name = getattr(inst, "name", type(inst).__name__)
-            self._activate(name, inst)
+            if self._activate(name, inst):
+                activated_native_names.add(ep_name)
+
+        # 3a-safety. Warn when a bundled provider's SDK is installed but its native
+        #     instrumentor never activated (bundling gap, missing entry point, or a
+        #     load failure).  Without this, an installed SDK that isn't covered by a
+        #     native plugin — and whose OTEL twin may have been blocked above — would
+        #     produce no LLM spans with no signal.  (A plugin that ran but found its
+        #     SDK absent or incompatible already logs for itself, so it is not
+        #     re-flagged here.)
+        if instrumentations is None:
+            for ep_name, sdk_modules in _PROVIDER_SDK_MODULES.items():
+                if ep_name in activated_native_names:
+                    continue
+                if _provider_sdk_installed(sdk_modules):
+                    logger.warning(
+                        "%s SDK is installed but its Respan instrumentation did not "
+                        "activate; its LLM calls will not be traced. Reinstall "
+                        "respan-instrumentation-%s, or pass the instrumentor via "
+                        "Respan(instrumentations=[...]).",
+                        ep_name,
+                        ep_name,
+                    )
 
         # 3b. Explicitly-passed instrumentations.
         for inst in instrumentations or []:
             name = getattr(inst, "name", type(inst).__name__)
             self._activate(name, inst)
 
-    def _activate(self, name: str, inst: object) -> None:
-        """Activate a single instrumentor."""
+    def _activate(self, name: str, inst: object) -> bool:
+        """Activate a single instrumentor. Returns False if activation raised."""
         try:
             inst.activate()  # type: ignore[union-attr]
             self._instrumentations[name] = inst
             logger.info("Activated instrumentation: %s", name)
+            return True
         except Exception as exc:
             logger.warning("Failed to activate instrumentation %s: %s", name, exc)
+            return False
 
     @staticmethod
     @contextmanager

--- a/python-sdks/respan/src/respan/_core.py
+++ b/python-sdks/respan/src/respan/_core.py
@@ -1,5 +1,6 @@
 """Respan — unified entry point for tracing and instrumentation plugins."""
 
+import importlib.metadata
 import json
 import logging
 import os
@@ -19,6 +20,39 @@ from respan_tracing.utils.span_factory import (
 from ._types import Instrumentation
 
 logger = logging.getLogger(__name__)
+
+# Entry-point group that native Respan instrumentation plugins register under.
+_NATIVE_INSTRUMENTATION_GROUP = "respan.instrumentations"
+
+
+def _discover_native_instrumentations() -> list:
+    """Instantiate all installed native ``respan.instrumentations`` plugins.
+
+    These ship as ``respan-instrumentation-*`` dependencies of ``respan-ai`` and
+    each hard-requires its provider SDK, so the SDK is normally present. A plugin
+    whose SDK can't be imported is skipped quietly (DEBUG) rather than erroring,
+    so a bare ``Respan()`` never spams about providers the app doesn't use.
+    """
+    plugins: list = []
+    try:
+        entry_points = importlib.metadata.entry_points(
+            group=_NATIVE_INSTRUMENTATION_GROUP
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Failed to discover native instrumentations: %s", exc)
+        return plugins
+
+    for ep in entry_points:
+        try:
+            plugins.append(ep.load()())
+        except (ImportError, ModuleNotFoundError) as exc:
+            # Target SDK not importable — expected when that SDK isn't installed.
+            logger.debug(
+                "Skipping %s instrumentation (SDK not available): %s", ep.name, exc
+            )
+        except Exception as exc:
+            logger.warning("Failed to load %s instrumentation: %s", ep.name, exc)
+    return plugins
 
 
 class Respan:
@@ -114,6 +148,16 @@ class Respan:
 
         # 3. Activate instrumentations
         self._instrumentations: Dict[str, object] = {}
+
+        # 3a. Auto mode (no explicit plugins): activate the native
+        #     respan-instrumentation-* plugins bundled with respan-ai so a bare
+        #     Respan() traces the direct LLM SDKs out of the box.
+        if instrumentations is None:
+            for inst in _discover_native_instrumentations():
+                name = getattr(inst, "name", type(inst).__name__)
+                self._activate(name, inst)
+
+        # 3b. Explicitly-passed instrumentations.
         for inst in instrumentations or []:
             name = getattr(inst, "name", type(inst).__name__)
             self._activate(name, inst)

--- a/python-sdks/respan/src/respan/_core.py
+++ b/python-sdks/respan/src/respan/_core.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 
 from respan_tracing import RespanTelemetry
+from respan_tracing.instruments import Instruments
 from respan_tracing.utils.span_factory import (
     _PROPAGATED_ATTRIBUTES,
     build_readable_span,
@@ -24,16 +25,42 @@ logger = logging.getLogger(__name__)
 # Entry-point group that native Respan instrumentation plugins register under.
 _NATIVE_INSTRUMENTATION_GROUP = "respan.instrumentations"
 
+# Only the instrumentations bundled as ``respan-ai`` dependencies auto-activate
+# on a bare ``Respan()``.  Every other plugin registered under
+# ``respan.instrumentations`` (litellm, langchain, crewai, cohere, mistralai,
+# groq, ...) must be passed explicitly via ``Respan(instrumentations=[...])`` —
+# without this allowlist a bare ``Respan()`` would silently activate whatever
+# happens to be installed.
+#
+# Each entry maps its entry-point name to the Traceloop OTEL ``Instruments`` it
+# supersedes, so auto mode can block those in the ``RespanTelemetry`` pipeline
+# and never wrap a provider twice (native plugin + OTEL instrumentor = two spans
+# and doubled token/cost).  To add a provider later: add its
+# ``respan-instrumentation-*`` dependency in ``pyproject.toml`` and one row here.
+_BUNDLED_NATIVE_INSTRUMENTATIONS: Dict[str, tuple] = {
+    "openai": (Instruments.OPENAI,),  # covers OpenAI + Azure OpenAI
+    "anthropic": (Instruments.ANTHROPIC,),
+    "aws-bedrock": (Instruments.BEDROCK,),
+    "vertexai": (Instruments.VERTEXAI,),
+    "google-genai": (Instruments.GOOGLE_GENERATIVEAI,),
+    "together": (Instruments.TOGETHER,),
+    "ollama": (Instruments.OLLAMA,),
+}
 
-def _discover_native_instrumentations() -> list:
-    """Instantiate all installed native ``respan.instrumentations`` plugins.
 
-    These ship as ``respan-instrumentation-*`` dependencies of ``respan-ai`` and
-    each hard-requires its provider SDK, so the SDK is normally present. A plugin
-    whose SDK can't be imported is skipped quietly (DEBUG) rather than erroring,
-    so a bare ``Respan()`` never spams about providers the app doesn't use.
+def _discover_native_instrumentations() -> List[tuple]:
+    """Instantiate the bundled native ``respan.instrumentations`` plugins.
+
+    Only plugins in :data:`_BUNDLED_NATIVE_INSTRUMENTATIONS` are considered; any
+    other plugin registered under the group must be activated explicitly via
+    ``Respan(instrumentations=[...])``.  Provider SDKs are optional extras, so a
+    bundled plugin whose SDK can't be imported is skipped quietly (DEBUG) rather
+    than erroring — a bare ``Respan()`` never spams about providers the app
+    doesn't use.
+
+    Returns a list of ``(entry_point_name, instrumentor_instance)`` tuples.
     """
-    plugins: list = []
+    plugins: List[tuple] = []
     try:
         entry_points = importlib.metadata.entry_points(
             group=_NATIVE_INSTRUMENTATION_GROUP
@@ -43,8 +70,11 @@ def _discover_native_instrumentations() -> list:
         return plugins
 
     for ep in entry_points:
+        if ep.name not in _BUNDLED_NATIVE_INSTRUMENTATIONS:
+            # Not bundled — only auto-activates when passed explicitly.
+            continue
         try:
-            plugins.append(ep.load()())
+            plugins.append((ep.name, ep.load()()))
         except (ImportError, ModuleNotFoundError) as exc:
             # Target SDK not importable — expected when that SDK isn't installed.
             logger.debug(
@@ -132,12 +162,27 @@ class Respan:
         if is_auto_instrument is None:
             is_auto_instrument = instrumentations is None
 
+        # In auto mode, discover the bundled native plugins *before* building
+        # RespanTelemetry so we can tell its OTEL (Traceloop) pipeline to skip
+        # the providers those natives already cover.  Otherwise a provider that
+        # has both an installed native plugin and an OTEL instrumentor gets
+        # wrapped twice — two spans and doubled token/cost per LLM call.
+        # Instantiating a plugin only constructs it; patching happens later in
+        # _activate(), after the tracer provider exists.
+        native_instrumentations = (
+            _discover_native_instrumentations() if instrumentations is None else []
+        )
+        blocked = set(telemetry_kwargs.pop("block_instruments", None) or set())
+        for ep_name, _inst in native_instrumentations:
+            blocked.update(_BUNDLED_NATIVE_INSTRUMENTATIONS[ep_name])
+
         # 1. OTEL TracerProvider + optional auto-instrumentation
         self.telemetry = RespanTelemetry(
             app_name=app_name,
             api_key=api_key,
             base_url=base_url,
             is_auto_instrument=is_auto_instrument,
+            block_instruments=blocked or None,
             **telemetry_kwargs,
         )
 
@@ -149,13 +194,13 @@ class Respan:
         # 3. Activate instrumentations
         self._instrumentations: Dict[str, object] = {}
 
-        # 3a. Auto mode (no explicit plugins): activate the native
-        #     respan-instrumentation-* plugins bundled with respan-ai so a bare
-        #     Respan() traces the direct LLM SDKs out of the box.
-        if instrumentations is None:
-            for inst in _discover_native_instrumentations():
-                name = getattr(inst, "name", type(inst).__name__)
-                self._activate(name, inst)
+        # 3a. Auto mode (no explicit plugins): activate the bundled native
+        #     respan-instrumentation-* plugins discovered above so a bare
+        #     Respan() traces the direct LLM SDKs out of the box.  Their OTEL
+        #     counterparts were blocked above, so each provider is traced once.
+        for _ep_name, inst in native_instrumentations:
+            name = getattr(inst, "name", type(inst).__name__)
+            self._activate(name, inst)
 
         # 3b. Explicitly-passed instrumentations.
         for inst in instrumentations or []:


### PR DESCRIPTION
 ## Summary

  **What this does:** `respan-ai` now bundles the seven native (Traceloop-free) `respan-instrumentation-*` plugins for the direct LLM SDKs (OpenAI/Azure, Anthropic, AWS Bedrock, Vertex AI, Google GenAI, Together, Ollama) and auto-activates them on a bare `Respan()`, so those SDKs are traced with correct `llm.request.type` / tokens / cost out of the box, with no extra packages.

  **Provider SDKs stay optional.** Each native package marks its provider SDK as an optional extra, so `pip install respan-ai` pulls only the instrumentors, not boto3 / google-cloud-aiplatform / google-genai / openai / together / ollama. An instrumentor whose SDK is absent stays dormant. Discovery is entry-point based (the `respan.instrumentations` group), so adding a provider later is a one-line dependency plus one allowlist entry.

  **Only the bundled seven auto-activate.** Discovery is gated by an explicit allowlist (`_BUNDLED_NATIVE_INSTRUMENTATIONS` in `_core.py`). Everything else in the group (litellm, langchain, crewai, cohere, mistralai, groq, and so on) is ignored by auto mode and must be passed explicitly via `Respan(instrumentations=[...])`.

  **No double instrumentation.** In auto mode the native plugins are discovered before `RespanTelemetry` is built, and each covered provider's OTEL (Traceloop) instrument is added to `block_instruments`, so exactly one instrumentor per provider. A user-supplied `block_instruments` is merged, not dropped.

  **Broken installs are no longer silent.** The `activate()` SDK-load handlers now split the log level: a genuinely-absent SDK (ImportError) stays at DEBUG, while an installed-but-incompatible SDK (AttributeError from a moved or renamed class) logs at WARNING. openai had no combined catch but the same silent path (openai imports, target classes gone, patch no-ops); it now warns when openai is importable but no known API surface could be instrumented.

  **Uninstrumented-SDK safety net.** After activating the natives, if a bundled provider's SDK is importable but no native instrumentor activated for it (bundling gap, missing entry point, load failure), `Respan()` logs a WARNING naming the provider. Probed with `find_spec` (no import side effects). This is the net for the two cases above.

  **Dependency floors.** The bundled instrumentor floors are the first releases in which each marks its provider SDK optional (the patch bumps in this PR's release intent: 1.2.1 / 1.0.2 / 0.1.1). Lower floors would let a resolver pull the pre-optional wheels that still hard-require the SDK.

  **Python floor.** `respan-ai` moves to `python = ">=3.11,<3.14"` to match the bundled packages, which also makes pip fail loudly on 3.9/3.10 instead of backsliding to an unrelated older release.

  **CI.** Adds a `respan-ai auto-instrument smoke check` to `ci.yml`: installs the native instrumentors from local source with deps, then installs respan-ai with `--no-deps` (its raised floors point at not-yet-published versions, so a normal resolve against the local source would fail), asserts the seven natives are discoverable and no provider SDK leaked in, then installs openai and asserts that instrumentor produces a span.

  **User/developer impact:** a bare `pip install respan-ai` plus `Respan()` now auto-traces the seven documented direct LLM SDKs with no provider-SDK bloat. Previously a bare `Respan()` with the OpenAI SDK produced no LLM spans (only threading) while setup tracing still reported success, a silent failure.

  ## Release Intent

  Bumps eight release-managed packages: `respan-ai` (minor) and the seven native instrumentors (patch). Intent: `.release-intents/20260629-respan-ai-bundle-native-autoinstrument.json`.

  ## Validation

  - [x] Added a `.release-intents/*.json` covering respan-ai and the seven bundled instrumentors.
  - [x] Local checks: `_core.py` and all seven instrumentor modules byte-compile; the respan-ai `pyproject.toml` parses and floors resolve.
  - [x] The CI smoke check asserts the natives are bundled, no provider SDK leaks, and openai traces once installed.

  ## Notes for reviewers

  Scope is the seven natives whose instrumentor is native today. cohere (still wraps Traceloop) and mistral/groq (openinference deps cap at Python <3.13) are intentionally excluded. Non-bundled instrumentors are untouched. The skill doc correction is tracked in the companion docs PR (#288).