### PR TITLE
docs(skill): scope the Priority-2 "no extra packages" claim

### DIFF
--- a/skills/references/tracing.md
+++ b/skills/references/tracing.md
@@ -58,7 +58,7 @@ If a Priority 1 framework is found, use its instrumentation. Do NOT also add Pri
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 
-These are **auto-instrumented** — just `Respan()` / `new Respan()`, no extra packages needed:
+These are **auto-instrumented** — just `Respan()` / `new Respan()`. The instrumentors ship with the SDK, so no separate install is needed — **except** for a few Python providers noted below the table.
 
 | Library | Python package | JS/TS package | Docs |
 |---------|---------------|---------------|------|
@@ -67,8 +67,11 @@ These are **auto-instrumented** — just `Respan()` / `new Respan()`, no extra p
 | Azure OpenAI | `openai` (azure config) | `openai` | [docs](https://respan.ai/docs/integrations/providers/azure.md) |
 | Google Vertex AI | `google-cloud-aiplatform` | — | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
 | AWS Bedrock | `boto3` | — | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
-| Cohere | `cohere` | — | [docs](https://respan.ai/docs/integrations/providers/cohere.md) |
 | Together AI | `together` | — | [docs](https://respan.ai/docs/integrations/together-ai.md) |
+| Ollama | `ollama` | — | [docs](https://respan.ai/docs/integrations/ollama.md) |
+| Cohere | `cohere` | — | [docs](https://respan.ai/docs/integrations/providers/cohere.md) |
+
+**Python — some providers need an explicit instrumentor:** `respan-ai` bundles native instrumentors for **OpenAI/Azure, Anthropic, Vertex AI, AWS Bedrock, Together, and Ollama** — a bare `Respan()` traces these. **Cohere, Mistral, and Groq are not yet bundled** — install the explicit instrumentor and pass it, e.g. `pip install respan-instrumentation-cohere` then `Respan(instrumentations=[CohereInstrumentor()])`. (The JS/TS SDK auto-instruments all of these natively, no extra package.)
 
 **Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). For Google GenAI (`@google/genai`), see [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md).
 
@@ -165,6 +168,8 @@ pip install respan-ai
 # TypeScript
 npm install @respan/respan
 ```
+
+In Python, also `pip install respan-instrumentation-<provider>` for **Cohere, Mistral, or Groq** (not yet bundled in `respan-ai`) and pass it via `Respan(instrumentations=[...])` — see the Priority-2 note above. All other listed providers, and all of JS/TS, need no extra package.
 
 For agent frameworks (Priority 1) — also install the instrumentor. Check the docs link in the table above for the exact packages.
 

--- a/skills/references/tracing.md
+++ b/skills/references/tracing.md
@@ -64,12 +64,12 @@ These are **auto-instrumented** — just `Respan()` / `new Respan()`. The instru
 |---------|---------------|---------------|------|
 | OpenAI SDK | `openai` | `openai` | [docs](https://respan.ai/docs/integrations/openai-sdk.md) |
 | Anthropic SDK | `anthropic` | `@anthropic-ai/sdk` | [docs](https://respan.ai/docs/integrations/anthropic.md) |
-| Azure OpenAI | `openai` (azure config) | `openai` | [docs](https://respan.ai/docs/integrations/providers/azure.md) |
+| Azure OpenAI | `openai` (azure config) | `openai` | [docs](https://respan.ai/docs/integrations/openai-sdk.md) |
 | Google Vertex AI | `google-cloud-aiplatform` | — | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
 | AWS Bedrock | `boto3` | — | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
 | Together AI | `together` | — | [docs](https://respan.ai/docs/integrations/together-ai.md) |
 | Ollama | `ollama` | — | [docs](https://respan.ai/docs/integrations/ollama.md) |
-| Cohere | `cohere` | — | [docs](https://respan.ai/docs/integrations/providers/cohere.md) |
+| Cohere | `cohere` | — | [docs](https://respan.ai/docs/integrations/cohere.md) |
 
 **Python — some providers need an explicit instrumentor:** `respan-ai` bundles native instrumentors for **OpenAI/Azure, Anthropic, Vertex AI, AWS Bedrock, Together, and Ollama** — a bare `Respan()` traces these. **Cohere, Mistral, and Groq are not yet bundled** — install the explicit instrumentor and pass it, e.g. `pip install respan-instrumentation-cohere` then `Respan(instrumentations=[CohereInstrumentor()])`. (The JS/TS SDK auto-instruments all of these natively, no extra package.)
 

--- a/skills/references/tracing.md
+++ b/skills/references/tracing.md
@@ -58,23 +58,35 @@ If a Priority 1 framework is found, use its instrumentation. Do NOT also add Pri
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 
-These are **auto-instrumented** — just `Respan()` / `new Respan()`. The instrumentors ship with the SDK, so no separate install is needed — **except** for a few Python providers noted below the table.
+These are **auto-instrumented**: just `Respan()` / `new Respan()`, no separate install needed. Rows marked `*` are the exception: in **Python** those providers need an explicit instrumentor (see the note below the table). JS/TS auto-instruments every provider that lists a JS/TS package.
 
 | Library | Python package | JS/TS package | Docs |
 |---------|---------------|---------------|------|
 | OpenAI SDK | `openai` | `openai` | [docs](https://respan.ai/docs/integrations/openai-sdk.md) |
 | Anthropic SDK | `anthropic` | `@anthropic-ai/sdk` | [docs](https://respan.ai/docs/integrations/anthropic.md) |
 | Azure OpenAI | `openai` (azure config) | `openai` | [docs](https://respan.ai/docs/integrations/openai-sdk.md) |
-| Google Vertex AI | `google-cloud-aiplatform` | — | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
-| Google GenAI (Gemini) | `google-genai` | — | [docs](https://respan.ai/docs/integrations/google-genai.md) |
-| AWS Bedrock | `boto3` | — | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
-| Together AI | `together` | — | [docs](https://respan.ai/docs/integrations/together-ai.md) |
-| Ollama | `ollama` | — | [docs](https://respan.ai/docs/integrations/ollama.md) |
-| Cohere | `cohere` | — | [docs](https://respan.ai/docs/integrations/cohere.md) |
+| Google Vertex AI | `google-cloud-aiplatform` | `@google-cloud/vertexai` | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
+| Google GenAI (Gemini) | `google-genai` | n/a (see guide) | [docs](https://respan.ai/docs/integrations/google-genai.md) |
+| AWS Bedrock | `boto3` | `@aws-sdk/client-bedrock-runtime` | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
+| Together AI | `together` | `together-ai` | [docs](https://respan.ai/docs/integrations/together-ai.md) |
+| Ollama | `ollama` | n/a | [docs](https://respan.ai/docs/integrations/ollama.md) |
+| Cohere | `cohere` `*` | `cohere-ai` | [docs](https://respan.ai/docs/integrations/cohere.md) |
+| Mistral | `mistralai` `*` | n/a | [docs](https://respan.ai/docs/integrations/mistral.md) |
+| Groq | `groq` `*` | n/a | [docs](https://respan.ai/docs/integrations/groq.md) |
 
-**Python — some providers need an explicit instrumentor:** `respan-ai` bundles native instrumentors for **OpenAI/Azure, Anthropic, Vertex AI, Google GenAI, AWS Bedrock, Together, and Ollama** — a bare `Respan()` traces these. **Cohere, Mistral, and Groq are not yet bundled** — install the explicit instrumentor and pass it, e.g. `pip install respan-instrumentation-cohere` then `Respan(instrumentations=[CohereInstrumentor()])`. (The JS/TS SDK auto-instruments Cohere/Mistral/Groq natively with no extra package; note the reverse holds for Google GenAI — Python auto-instruments it, but JS/TS `@google/genai` needs the explicit guide below.)
+**`*` Python only, not yet bundled in `respan-ai`.** On a bare `Respan()`, `respan-ai` auto-instruments OpenAI/Azure, Anthropic, Vertex AI, Google GenAI, AWS Bedrock, Together, and Ollama. Cohere, Mistral, and Groq are not bundled yet; in Python install the instrumentor and pass it:
 
-**Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). In **JS/TS**, Google GenAI (`@google/genai`) is not auto-instrumented — see the [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md). (In Python it's auto-instrumented, per the table above.)
+```bash
+pip install respan-instrumentation-cohere   # or respan-instrumentation-mistralai / respan-instrumentation-groq
+```
+```python
+from respan_instrumentation_cohere import CohereInstrumentor  # or MistralAIInstrumentor / GroqInstrumentor
+Respan(instrumentations=[CohereInstrumentor()])
+```
+
+In **JS/TS** these three differ: Cohere auto-instruments natively (`cohere-ai`, no extra package), while Mistral and Groq are not supported in JS/TS at all.
+
+**Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). In **JS/TS**, Google GenAI (`@google/genai`) and Ollama are not auto-instrumented; for Google GenAI see the [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md). (Both are auto-instrumented in Python, per the table.)
 
 **1c. Read the actual code and understand the workflow:**
 
@@ -170,7 +182,7 @@ pip install respan-ai
 npm install @respan/respan
 ```
 
-In Python, also `pip install respan-instrumentation-<provider>` for **Cohere, Mistral, or Groq** (not yet bundled in `respan-ai`) and pass it via `Respan(instrumentations=[...])` — see the Priority-2 note above. All other listed providers, and all of JS/TS, need no extra package.
+In Python, Cohere, Mistral, and Groq additionally need their explicit instrumentor (the `*` rows in the Priority-2 table above). Everything else, and all of JS/TS, needs no extra package.
 
 For agent frameworks (Priority 1) — also install the instrumentor. Check the docs link in the table above for the exact packages.
 

--- a/skills/references/tracing.md
+++ b/skills/references/tracing.md
@@ -175,12 +175,14 @@ Wait for user confirmation before proceeding.
 
 For direct LLM SDKs (Priority 2) — just the core SDK:
 ```bash
-# Python
+# Python (requires Python 3.11 to 3.13)
 pip install respan-ai
 
 # TypeScript
 npm install @respan/respan
 ```
+
+**Python 3.11 to 3.13 required.** On 3.9/3.10 the tracing `respan-ai` (4.x, which needs `respan-tracing >=3.11,<3.14`) is unsatisfiable, so pip silently backslides to an unrelated older `respan-ai` release that has no `Respan()` class: the install succeeds, then `from respan import Respan` fails at runtime with no hint. If that happens, check the Python version first.
 
 In Python, Cohere, Mistral, and Groq additionally need their explicit instrumentor (the `*` rows in the Priority-2 table above). Everything else, and all of JS/TS, needs no extra package.
 

--- a/skills/references/tracing.md
+++ b/skills/references/tracing.md
@@ -66,14 +66,15 @@ These are **auto-instrumented** — just `Respan()` / `new Respan()`. The instru
 | Anthropic SDK | `anthropic` | `@anthropic-ai/sdk` | [docs](https://respan.ai/docs/integrations/anthropic.md) |
 | Azure OpenAI | `openai` (azure config) | `openai` | [docs](https://respan.ai/docs/integrations/openai-sdk.md) |
 | Google Vertex AI | `google-cloud-aiplatform` | — | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
+| Google GenAI (Gemini) | `google-genai` | — | [docs](https://respan.ai/docs/integrations/google-genai.md) |
 | AWS Bedrock | `boto3` | — | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
 | Together AI | `together` | — | [docs](https://respan.ai/docs/integrations/together-ai.md) |
 | Ollama | `ollama` | — | [docs](https://respan.ai/docs/integrations/ollama.md) |
 | Cohere | `cohere` | — | [docs](https://respan.ai/docs/integrations/cohere.md) |
 
-**Python — some providers need an explicit instrumentor:** `respan-ai` bundles native instrumentors for **OpenAI/Azure, Anthropic, Vertex AI, AWS Bedrock, Together, and Ollama** — a bare `Respan()` traces these. **Cohere, Mistral, and Groq are not yet bundled** — install the explicit instrumentor and pass it, e.g. `pip install respan-instrumentation-cohere` then `Respan(instrumentations=[CohereInstrumentor()])`. (The JS/TS SDK auto-instruments all of these natively, no extra package.)
+**Python — some providers need an explicit instrumentor:** `respan-ai` bundles native instrumentors for **OpenAI/Azure, Anthropic, Vertex AI, Google GenAI, AWS Bedrock, Together, and Ollama** — a bare `Respan()` traces these. **Cohere, Mistral, and Groq are not yet bundled** — install the explicit instrumentor and pass it, e.g. `pip install respan-instrumentation-cohere` then `Respan(instrumentations=[CohereInstrumentor()])`. (The JS/TS SDK auto-instruments Cohere/Mistral/Groq natively with no extra package; note the reverse holds for Google GenAI — Python auto-instruments it, but JS/TS `@google/genai` needs the explicit guide below.)
 
-**Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). For Google GenAI (`@google/genai`), see [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md).
+**Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). In **JS/TS**, Google GenAI (`@google/genai`) is not auto-instrumented — see the [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md). (In Python it's auto-instrumented, per the table above.)
 
 **1c. Read the actual code and understand the workflow:**
 

--- a/skills/references/tracing.md
+++ b/skills/references/tracing.md
@@ -58,7 +58,7 @@ If a Priority 1 framework is found, use its instrumentation. Do NOT also add Pri
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 
-These are **auto-instrumented**: just `Respan()` / `new Respan()`, no separate install needed. Rows marked `*` are the exception: in **Python** those providers need an explicit instrumentor (see the note below the table). JS/TS auto-instruments every provider that lists a JS/TS package.
+These are **auto-instrumented** on a bare `Respan()` / `new Respan()`. In **JS/TS**, every provider with a JS/TS package auto-instruments with no separate install. In **Python**, it depends on `respan-ai` bundling the provider's native instrumentor (see the note below the table); rows marked `*` always need an explicit instrumentor.
 
 | Library | Python package | JS/TS package | Docs |
 |---------|---------------|---------------|------|
@@ -74,7 +74,7 @@ These are **auto-instrumented**: just `Respan()` / `new Respan()`, no separate i
 | Mistral | `mistralai` `*` | n/a | [docs](https://respan.ai/docs/integrations/mistral.md) |
 | Groq | `groq` `*` | n/a | [docs](https://respan.ai/docs/integrations/groq.md) |
 
-**`*` Python only, not yet bundled in `respan-ai`.** On a bare `Respan()`, `respan-ai` auto-instruments OpenAI/Azure, Anthropic, Vertex AI, Google GenAI, AWS Bedrock, Together, and Ollama. Cohere, Mistral, and Groq are not bundled yet; in Python install the instrumentor and pass it:
+**`*` Python needs an explicit instrumentor.** On a `respan-ai` release that bundles the native instrumentors, a bare `Respan()` auto-instruments OpenAI/Azure, Anthropic, Vertex AI, Google GenAI, AWS Bedrock, Together, and Ollama. That bundling is **not in the currently released `respan-ai`** (it depends only on `respan-tracing` and bundles none), so until the bundled release ships those need an explicit instrumentor in Python too. Cohere, Mistral, and Groq are not bundled in any release; in Python install the instrumentor and pass it:
 
 ```bash
 pip install respan-instrumentation-cohere   # or respan-instrumentation-mistralai / respan-instrumentation-groq
@@ -86,7 +86,7 @@ Respan(instrumentations=[CohereInstrumentor()])
 
 In **JS/TS** these three differ: Cohere auto-instruments natively (`cohere-ai`, no extra package), while Mistral and Groq are not supported in JS/TS at all.
 
-**Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). In **JS/TS**, Google GenAI (`@google/genai`) and Ollama are not auto-instrumented; for Google GenAI see the [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md). (Both are auto-instrumented in Python, per the table.)
+**Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). In **JS/TS**, Google GenAI (`@google/genai`) and Ollama are not auto-instrumented; for Google GenAI see the [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md). (In Python both are covered by the bundled `respan-ai`, per the note above.)
 
 **1c. Read the actual code and understand the workflow:**
 
@@ -184,7 +184,7 @@ npm install @respan/respan
 
 **Python 3.11 to 3.13 required.** On 3.9/3.10 the tracing `respan-ai` (4.x, which needs `respan-tracing >=3.11,<3.14`) is unsatisfiable, so pip silently backslides to an unrelated older `respan-ai` release that has no `Respan()` class: the install succeeds, then `from respan import Respan` fails at runtime with no hint. If that happens, check the Python version first.
 
-In Python, Cohere, Mistral, and Groq additionally need their explicit instrumentor (the `*` rows in the Priority-2 table above). Everything else, and all of JS/TS, needs no extra package.
+In Python, the `*` providers (Cohere, Mistral, Groq) always need their explicit instrumentor, and the rest need a `respan-ai` that bundles their native instrumentors (see the Priority-2 note above; not the currently released `respan-ai`). In JS/TS, no listed provider needs an extra package.
 
 For agent frameworks (Priority 1) — also install the instrumentor. Check the docs link in the table above for the exact packages.
 


### PR DESCRIPTION
## Summary

- **Change:** Corrected the Priority-2 "Direct LLM SDKs" section of the respan skill (`skills/references/tracing.md`). The blanket "auto-instrumented, no extra packages needed" claim is now scoped, and the table and notes are made accurate per language:
  - Added rows for Ollama, Mistral, and Groq (previously Mistral/Groq were prose-only with no package name).
  - Marked the Python-explicit providers with `*` (Cohere, Mistral, Groq) so the carve-out is visible at the table, not just in a note below it.
  - Filled the JS/TS column where it wrongly showed no support: Vertex AI (`@google-cloud/vertexai`), AWS Bedrock (`@aws-sdk/client-bedrock-runtime`), Together (`together-ai`), Cohere (`cohere-ai`), all present in the JS instrumentation registry.
  - Corrected the JS claim: JS/TS auto-instruments **Cohere only** of the three; **Mistral and Groq are not supported in JS/TS at all** (no entries in `instrumentationTypes.ts`).
  - Stated the Python Cohere/Mistral/Groq carve-out once (the `*` note) and cross-referenced it from the install section instead of repeating it three times.
  - Added a "Python 3.11 to 3.13 required" note at the `pip install respan-ai` line: on 3.9/3.10 the 4.x line is unsatisfiable and pip silently backslides to an unrelated older `respan-ai` with no `Respan()` class.
  - Scoped the Python bundling claim: the seven non-`*` providers auto-instrument on a bare `Respan()` only on a `respan-ai` release that bundles their native instrumentors (added in #285); the wording now calls out that the currently released `respan-ai` bundles none, so they need an explicit instrumentor in Python until that ships. JS/TS auto-instrumentation stays present-tense.
- **Impact:** Fixes B1. The skill now matches actual behavior in both languages. The Python "bundled providers auto-trace" claim depends on the A1 bundling, so this PR is **stacked on #285** and gated on its release. Docs-only; no code or runtime change.

## Release Intent

No release intent. This PR changes only the respan skill docs (`skills/references/tracing.md`), which is not a release-managed package.

## Validation

- [x] Skills-only change; `release_intents.py` missing-intent gate stays empty.
- [x] Verified every JS-column and Cohere/Mistral/Groq claim against the JS registry (`instrumentationTypes.ts`) and the Python instrumentor packages on disk.
- [x] Stacked on #285; base retargeted to `fix/a1-respan-ai-bundle-autoinstrument`.
