### PR TITLE
fix(instrumentation/claude-agent-sdk): wire ResultMessage usage/cost

### DIFF
--- a/.release-intents/20260629-claude-agent-sdk-from-import-fix.json
+++ b/.release-intents/20260629-claude-agent-sdk-from-import-fix.json
@@ -1,0 +1,6 @@
+{
+  "summary": "respan-instrumentation-claude-agent-sdk: trace `from claude_agent_sdk import query` by instrumenting the InternalClient.process_query seam (resolved at call time) instead of the bypassable module-level `query` attribute, and drop the now-redundant module wrap so each call yields exactly one span (A6).",
+  "packages": {
+    "respan-instrumentation-claude-agent-sdk": "patch"
+  }
+}

--- a/.release-intents/20260630-claude-agent-sdk-usage-cost.json
+++ b/.release-intents/20260630-claude-agent-sdk-usage-cost.json
@@ -1,0 +1,6 @@
+{
+  "summary": "respan-instrumentation-claude-agent-sdk: wire ResultMessage usage/cost into the canonical span attributes the Respan backend rolls up (A7). The invoke_agent span recorded the model but total_request_tokens/total_cost were 0 because tokens were only set as gen_ai.usage.input_tokens and cost as a bare 'cost' attribute. Now also set gen_ai.usage.prompt_tokens/completion_tokens/total_tokens and respan.metadata.response_cost (from total_cost_usd), matching the LiteLLM/OpenAI instrumentors.",
+  "packages": {
+    "respan-instrumentation-claude-agent-sdk": "patch"
+  }
+}

--- a/.release-intents/20260630-claude-agent-sdk-usage-cost.json
+++ b/.release-intents/20260630-claude-agent-sdk-usage-cost.json
@@ -1,5 +1,5 @@
 {
-  "summary": "respan-instrumentation-claude-agent-sdk: wire ResultMessage usage/cost into the canonical span attributes the Respan backend rolls up (A7). The invoke_agent span recorded the model but total_request_tokens/total_cost were 0 because tokens were only set as gen_ai.usage.input_tokens and cost as a bare 'cost' attribute. Now also set gen_ai.usage.prompt_tokens/completion_tokens/total_tokens and respan.metadata.response_cost (from total_cost_usd), matching the LiteLLM/OpenAI instrumentors.",
+  "summary": "respan-instrumentation-claude-agent-sdk: fix zero usage/cost on the invoke_agent span (A7). Tokens were previously set only as gen_ai.usage.input_tokens (output missing) and cost as a bare 'cost' attribute, so the backend rolled up total_request_tokens=0 and total_cost=0. Now also emit gen_ai.usage.output_tokens so the span processor derives prompt/completion/total (with cache-token normalization and the total-request-tokens rollup), and set cost as respan.metadata.response_cost (from total_cost_usd), matching the LiteLLM/OpenAI instrumentors.",
   "packages": {
     "respan-instrumentation-claude-agent-sdk": "patch"
   }

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/pyproject.toml
@@ -16,6 +16,7 @@ respan-sdk = ">=2.5.0"
 claude-agent-sdk = ">=0.1.58"
 opentelemetry-claude-agent-sdk = ">=0.1.4"
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
+wrapt = ">=1.16.0"
 
 [tool.poetry.plugins."respan.instrumentations"]
 claude-agent-sdk = "respan_instrumentation_claude_agent_sdk:ClaudeAgentSDKInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
@@ -55,7 +55,6 @@ class ClaudeAgentSDKInstrumentor:
         self._processor = None
         self._is_instrumented = False
         self._patched_modules: list[tuple[Any, str, Any]] = []
-        self._query_seam_wrapped = False
 
     @staticmethod
     def _register_processor(
@@ -296,7 +295,7 @@ class ClaudeAgentSDKInstrumentor:
             module, attr_name, original = self._patched_modules.pop()
             setattr(module, attr_name, original)
 
-    def _repoint_standalone_query_to_internal_seam(self) -> None:
+    def _patch_standalone_query_seam(self, *, strip_module_query_wrap: bool) -> None:
         """Make ``from claude_agent_sdk import query`` traceable (issue A6).
 
         Upstream wraps ``claude_agent_sdk.query`` — a *module attribute*. Code that
@@ -308,19 +307,15 @@ class ClaudeAgentSDKInstrumentor:
         ``query`` was imported, without touching the ``ClaudeSDKClient`` path. The
         now-redundant module-level wrap is then dropped so each call yields one span.
 
-        Best-effort: on failure the upstream module-level wrap is left intact, so
-        behaviour is no worse than before.
+        Both patches are recorded in ``self._patched_modules`` so the generic
+        ``_restore_upstream_helpers`` loop undoes them. Best-effort: on failure the
+        upstream module-level wrap is left intact, so behaviour is no worse than before.
         """
-        import wrapt
-        import claude_agent_sdk
-
         try:
-            wrapt.wrap_function_wrapper(
-                "claude_agent_sdk._internal.client",
-                "InternalClient.process_query",
-                self._otel_instrumentor._wrap_query,
-            )
-        except Exception as exc:
+            import wrapt
+            import claude_agent_sdk
+            from claude_agent_sdk._internal.client import InternalClient
+        except ImportError as exc:
             logger.warning(
                 "Claude Agent SDK: could not instrument the internal query seam; "
                 "`from claude_agent_sdk import query` may not be traced: %s",
@@ -328,27 +323,42 @@ class ClaudeAgentSDKInstrumentor:
             )
             return
 
-        self._query_seam_wrapped = True
-
-        # Drop the bypassable module-level `query` wrap now that the seam covers it,
-        # so module-qualified and from-imported calls behave identically (one span).
-        module_query = getattr(claude_agent_sdk, "query", None)
-        if module_query is not None and hasattr(module_query, "__wrapped__"):
-            claude_agent_sdk.query = module_query.__wrapped__
-
-    def _restore_standalone_query_seam(self) -> None:
-        """Undo :meth:`_repoint_standalone_query_to_internal_seam`."""
-        if not self._query_seam_wrapped:
+        # Idempotency: a second activation (or an already-wrapped seam) must not
+        # stack another wrapper, which would emit two spans per standalone query().
+        # getattr (not __dict__) so an inherited process_query is still found.
+        process_query = getattr(InternalClient, "process_query", None)
+        if process_query is None or hasattr(process_query, "__wrapped__"):
             return
-        try:
-            from claude_agent_sdk._internal.client import InternalClient
 
-            process_query = getattr(InternalClient, "process_query", None)
-            if process_query is not None and hasattr(process_query, "__wrapped__"):
-                InternalClient.process_query = process_query.__wrapped__
-        except Exception:
-            pass
-        self._query_seam_wrapped = False
+        # Record the original before wrapping so the restore loop unwraps the seam.
+        self._patched_modules.append((InternalClient, "process_query", process_query))
+        try:
+            wrapt.wrap_function_wrapper(
+                "claude_agent_sdk._internal.client",
+                "InternalClient.process_query",
+                self._otel_instrumentor._wrap_query,
+            )
+        except Exception as exc:
+            self._patched_modules.pop()
+            logger.warning(
+                "Claude Agent SDK: could not instrument the internal query seam; "
+                "`from claude_agent_sdk import query` may not be traced: %s",
+                exc,
+            )
+            return
+
+        # Drop the now-redundant module-level `query` wrap so module-qualified and
+        # from-imported calls behave identically (one span). Only strip a wrap our
+        # own instrument() added — never a user's or another vendor's pre-existing
+        # wrap — and record the pristine original so the restore loop puts it back.
+        if not strip_module_query_wrap:
+            return
+        module_query = getattr(claude_agent_sdk, "query", None)
+        if hasattr(module_query, "__wrapped__"):
+            self._patched_modules.append(
+                (claude_agent_sdk, "query", module_query.__wrapped__)
+            )
+            claude_agent_sdk.query = module_query.__wrapped__
 
     def activate(self) -> None:
         if self._is_instrumented:
@@ -372,6 +382,19 @@ class ClaudeAgentSDKInstrumentor:
         self._register_processor(tracer_provider=tracer_provider, processor=self._processor)
 
         self._otel_instrumentor = upstream_instrumentor_class()
+
+        # Note whether a module-level `query` wrap already exists *before* we
+        # instrument, so the seam patch below only strips a wrap our own
+        # instrument() adds — never a user's or another vendor's pre-existing wrap.
+        try:
+            import claude_agent_sdk as _claude_agent_sdk
+
+            module_query_prewrapped = hasattr(
+                getattr(_claude_agent_sdk, "query", None), "__wrapped__"
+            )
+        except Exception:
+            module_query_prewrapped = False
+
         try:
             self._otel_instrumentor.instrument(
                 tracer_provider=tracer_provider,
@@ -393,7 +416,9 @@ class ClaudeAgentSDKInstrumentor:
 
         # Cover `from claude_agent_sdk import query` (A6) by instrumenting the
         # internal seam instead of the bypassable module-level `query` attribute.
-        self._repoint_standalone_query_to_internal_seam()
+        self._patch_standalone_query_seam(
+            strip_module_query_wrap=not module_query_prewrapped
+        )
 
         self._is_instrumented = True
         logger.info("Claude Agent SDK instrumentation activated")
@@ -408,7 +433,6 @@ class ClaudeAgentSDKInstrumentor:
         finally:
             self._otel_instrumentor = None
             self._restore_upstream_helpers()
-            self._restore_standalone_query_seam()
             if self._processor is not None:
                 self._unregister_processor(
                     tracer_provider=trace.get_tracer_provider(),

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
@@ -14,8 +14,16 @@ from respan_instrumentation_claude_agent_sdk._processor import (  # type: ignore
     ClaudeAgentSDKSpanProcessor,
     _safe_json_loads,
 )
+from respan_sdk.constants.span_attributes import (
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
+    RESPAN_METADATA,
+)
 
 logger = logging.getLogger(__name__)
+
+# Total-tokens key the Respan backend rolls up (respan_sdk exposes prompt/completion only).
+_LLM_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
 
 def _get_span_attr_value(span: Any, key: str) -> Any:
     attributes = getattr(span, "attributes", None)
@@ -129,6 +137,7 @@ class ClaudeAgentSDKInstrumentor:
 
         output_messages_attr = constants_module.GEN_AI_OUTPUT_MESSAGES
         usage_input_tokens_attr = constants_module.GEN_AI_USAGE_INPUT_TOKENS
+        usage_output_tokens_attr = constants_module.GEN_AI_USAGE_OUTPUT_TOKENS
         usage_cache_creation_tokens_attr = (
             constants_module.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
         )
@@ -175,25 +184,38 @@ class ClaudeAgentSDKInstrumentor:
 
             usage = getattr(result_message, "usage", None)
             if isinstance(usage, dict):
-                input_tokens = usage.get("input_tokens", 0) or 0
-                cache_creation_tokens = usage.get("cache_creation_input_tokens", 0) or 0
-                cache_read_tokens = usage.get("cache_read_input_tokens", 0) or 0
+                input_tokens = int(usage.get("input_tokens", 0) or 0)
+                output_tokens = int(usage.get("output_tokens", 0) or 0)
+                cache_creation_tokens = int(
+                    usage.get("cache_creation_input_tokens", 0) or 0
+                )
+                cache_read_tokens = int(usage.get("cache_read_input_tokens", 0) or 0)
 
-                span.set_attribute(usage_input_tokens_attr, int(input_tokens))
+                # Anthropic uses input/output; also emit the prompt/completion/total
+                # names the Respan backend rolls up into total_request_tokens (A7).
+                span.set_attribute(usage_input_tokens_attr, input_tokens)
+                span.set_attribute(usage_output_tokens_attr, output_tokens)
+                span.set_attribute(LLM_USAGE_PROMPT_TOKENS, input_tokens)
+                span.set_attribute(LLM_USAGE_COMPLETION_TOKENS, output_tokens)
+                span.set_attribute(
+                    _LLM_USAGE_TOTAL_TOKENS, input_tokens + output_tokens
+                )
                 if cache_creation_tokens > 0:
                     span.set_attribute(
                         usage_cache_creation_tokens_attr,
-                        int(cache_creation_tokens),
+                        cache_creation_tokens,
                     )
                 if cache_read_tokens > 0:
                     span.set_attribute(
                         usage_cache_read_tokens_attr,
-                        int(cache_read_tokens),
+                        cache_read_tokens,
                     )
 
             total_cost = getattr(result_message, "total_cost_usd", None)
-            if isinstance(total_cost, int | float):
-                span.set_attribute("cost", float(total_cost))
+            if isinstance(total_cost, (int, float)) and not isinstance(total_cost, bool):
+                # The backend reads cost from respan.metadata.response_cost (matches the
+                # LiteLLM/OpenAI instrumentors), not a bare "cost" attribute (A7).
+                span.set_attribute(f"{RESPAN_METADATA}.response_cost", str(total_cost))
 
         def patched_wrap_client_query(
             instrumentor: Any,

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
@@ -14,16 +14,9 @@ from respan_instrumentation_claude_agent_sdk._processor import (  # type: ignore
     ClaudeAgentSDKSpanProcessor,
     _safe_json_loads,
 )
-from respan_sdk.constants.span_attributes import (
-    LLM_USAGE_COMPLETION_TOKENS,
-    LLM_USAGE_PROMPT_TOKENS,
-    RESPAN_METADATA,
-)
+from respan_sdk.constants.span_attributes import RESPAN_METADATA
 
 logger = logging.getLogger(__name__)
-
-# Total-tokens key the Respan backend rolls up (respan_sdk exposes prompt/completion only).
-_LLM_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
 
 def _get_span_attr_value(span: Any, key: str) -> Any:
     attributes = getattr(span, "attributes", None)
@@ -109,6 +102,9 @@ class ClaudeAgentSDKInstrumentor:
         )
 
     def _patch_upstream_helpers(self) -> bool:
+        if self._patched_modules:
+            return True
+
         try:
             query_module = importlib.import_module("claude_agent_sdk._internal.query")
             Query = getattr(query_module, "Query")
@@ -125,6 +121,19 @@ class ClaudeAgentSDKInstrumentor:
                 "opentelemetry.instrumentation.claude_agent_sdk._spans"
             )
             instrumentor_class = _load_upstream_instrumentor_class()
+
+            # Read the upstream constant names inside the guarded block so a version
+            # that renames or drops one degrades to a logged no-op instead of an
+            # uncaught AttributeError out of activate().
+            output_messages_attr = constants_module.GEN_AI_OUTPUT_MESSAGES
+            usage_input_tokens_attr = constants_module.GEN_AI_USAGE_INPUT_TOKENS
+            usage_output_tokens_attr = constants_module.GEN_AI_USAGE_OUTPUT_TOKENS
+            usage_cache_creation_tokens_attr = (
+                constants_module.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+            )
+            usage_cache_read_tokens_attr = (
+                constants_module.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            )
         except (AttributeError, ImportError) as exc:
             logger.warning(
                 "Failed to patch Claude Agent SDK helpers — missing dependency: %s",
@@ -132,18 +141,6 @@ class ClaudeAgentSDKInstrumentor:
             )
             return False
 
-        if self._patched_modules:
-            return True
-
-        output_messages_attr = constants_module.GEN_AI_OUTPUT_MESSAGES
-        usage_input_tokens_attr = constants_module.GEN_AI_USAGE_INPUT_TOKENS
-        usage_output_tokens_attr = constants_module.GEN_AI_USAGE_OUTPUT_TOKENS
-        usage_cache_creation_tokens_attr = (
-            constants_module.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        )
-        usage_cache_read_tokens_attr = (
-            constants_module.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
-        )
         serialize_value = getattr(spans_module, "_to_serializable", lambda value: value)
 
         original_set_response_content = spans_module.set_response_content
@@ -191,15 +188,14 @@ class ClaudeAgentSDKInstrumentor:
                 )
                 cache_read_tokens = int(usage.get("cache_read_input_tokens", 0) or 0)
 
-                # Anthropic uses input/output; also emit the prompt/completion/total
-                # names the Respan backend rolls up into total_request_tokens (A7).
+                # Emit the raw Anthropic input/output token counts. The span
+                # processor (ClaudeAgentSDKSpanProcessor) derives prompt/completion/
+                # total from these — with cache-token normalization and the override
+                # attr that rolls up into total_request_tokens — so writing those here
+                # would only pre-empt it. output_tokens was previously missing, which
+                # starved that roll-up and left total_request_tokens at 0 (A7).
                 span.set_attribute(usage_input_tokens_attr, input_tokens)
                 span.set_attribute(usage_output_tokens_attr, output_tokens)
-                span.set_attribute(LLM_USAGE_PROMPT_TOKENS, input_tokens)
-                span.set_attribute(LLM_USAGE_COMPLETION_TOKENS, output_tokens)
-                span.set_attribute(
-                    _LLM_USAGE_TOTAL_TOKENS, input_tokens + output_tokens
-                )
                 if cache_creation_tokens > 0:
                     span.set_attribute(
                         usage_cache_creation_tokens_attr,

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
@@ -55,6 +55,7 @@ class ClaudeAgentSDKInstrumentor:
         self._processor = None
         self._is_instrumented = False
         self._patched_modules: list[tuple[Any, str, Any]] = []
+        self._query_seam_wrapped = False
 
     @staticmethod
     def _register_processor(
@@ -295,6 +296,60 @@ class ClaudeAgentSDKInstrumentor:
             module, attr_name, original = self._patched_modules.pop()
             setattr(module, attr_name, original)
 
+    def _repoint_standalone_query_to_internal_seam(self) -> None:
+        """Make ``from claude_agent_sdk import query`` traceable (issue A6).
+
+        Upstream wraps ``claude_agent_sdk.query`` — a *module attribute*. Code that
+        does ``from claude_agent_sdk import query`` binds the original function before
+        instrumentation runs, so a bare ``query(...)`` is never traced. The standalone
+        ``query()`` always delegates to ``InternalClient.process_query`` — a method
+        resolved at call time and used *only* by the standalone path — so wrapping that
+        seam (with upstream's own span logic) captures the call regardless of how
+        ``query`` was imported, without touching the ``ClaudeSDKClient`` path. The
+        now-redundant module-level wrap is then dropped so each call yields one span.
+
+        Best-effort: on failure the upstream module-level wrap is left intact, so
+        behaviour is no worse than before.
+        """
+        import wrapt
+        import claude_agent_sdk
+
+        try:
+            wrapt.wrap_function_wrapper(
+                "claude_agent_sdk._internal.client",
+                "InternalClient.process_query",
+                self._otel_instrumentor._wrap_query,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Claude Agent SDK: could not instrument the internal query seam; "
+                "`from claude_agent_sdk import query` may not be traced: %s",
+                exc,
+            )
+            return
+
+        self._query_seam_wrapped = True
+
+        # Drop the bypassable module-level `query` wrap now that the seam covers it,
+        # so module-qualified and from-imported calls behave identically (one span).
+        module_query = getattr(claude_agent_sdk, "query", None)
+        if module_query is not None and hasattr(module_query, "__wrapped__"):
+            claude_agent_sdk.query = module_query.__wrapped__
+
+    def _restore_standalone_query_seam(self) -> None:
+        """Undo :meth:`_repoint_standalone_query_to_internal_seam`."""
+        if not self._query_seam_wrapped:
+            return
+        try:
+            from claude_agent_sdk._internal.client import InternalClient
+
+            process_query = getattr(InternalClient, "process_query", None)
+            if process_query is not None and hasattr(process_query, "__wrapped__"):
+                InternalClient.process_query = process_query.__wrapped__
+        except Exception:
+            pass
+        self._query_seam_wrapped = False
+
     def activate(self) -> None:
         if self._is_instrumented:
             return
@@ -336,6 +391,10 @@ class ClaudeAgentSDKInstrumentor:
             )
             return
 
+        # Cover `from claude_agent_sdk import query` (A6) by instrumenting the
+        # internal seam instead of the bypassable module-level `query` attribute.
+        self._repoint_standalone_query_to_internal_seam()
+
         self._is_instrumented = True
         logger.info("Claude Agent SDK instrumentation activated")
 
@@ -349,6 +408,7 @@ class ClaudeAgentSDKInstrumentor:
         finally:
             self._otel_instrumentor = None
             self._restore_upstream_helpers()
+            self._restore_standalone_query_seam()
             if self._processor is not None:
                 self._unregister_processor(
                     tracer_provider=trace.get_tracer_provider(),

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_instrumentation.py
@@ -63,6 +63,10 @@ def _install_fake_claude_agent_sdk_modules(
     usage_cache_read_tokens_attr = "gen_ai.usage.cache_read_input_tokens"
 
     class FakeClaudeAgentSdkInstrumentor:
+        # Mirrors upstream's BaseInstrumentor singleton: instrument() applies the
+        # module-level `query` wrap once and a second call is a no-op.
+        _module_query_wrapped = False
+
         def __init__(self):
             self.instrument_kwargs = None
             self.uninstrument_calls = 0
@@ -71,9 +75,26 @@ def _install_fake_claude_agent_sdk_modules(
             self.instrument_kwargs = kwargs
             if instrument_error is not None:
                 raise instrument_error
+            if FakeClaudeAgentSdkInstrumentor._module_query_wrapped:
+                return
+            import wrapt
+
+            wrapt.wrap_function_wrapper("claude_agent_sdk", "query", self._wrap_query)
+            FakeClaudeAgentSdkInstrumentor._module_query_wrapped = True
 
         def uninstrument(self):
             self.uninstrument_calls += 1
+            if not FakeClaudeAgentSdkInstrumentor._module_query_wrapped:
+                return
+            FakeClaudeAgentSdkInstrumentor._module_query_wrapped = False
+            import claude_agent_sdk
+
+            module_query = getattr(claude_agent_sdk, "query", None)
+            if hasattr(module_query, "__wrapped__"):
+                claude_agent_sdk.query = module_query.__wrapped__
+
+        def _wrap_query(self, wrapped, instance, args, kwargs):
+            return wrapped(*args, **kwargs)
 
         def _wrap_client_query(self, wrapped, instance, args, kwargs):
             instance._otel_invocation_ctx = kwargs.get("otel_invocation_ctx")
@@ -160,6 +181,15 @@ def _install_fake_claude_agent_sdk_modules(
 
     claude_sdk_module = ModuleType("claude_agent_sdk")
     claude_sdk_module.__path__ = []
+
+    # Standalone `query()` module attribute — what upstream wraps and what
+    # `from claude_agent_sdk import query` binds. The A6 seam covers it via
+    # InternalClient.process_query below.
+    def _standalone_query(*args, **kwargs):
+        return "standalone-query-result"
+
+    claude_sdk_module.query = _standalone_query
+
     internal_module = ModuleType("claude_agent_sdk._internal")
     internal_module.__path__ = []
     query_module = ModuleType("claude_agent_sdk._internal.query")
@@ -172,6 +202,16 @@ def _install_fake_claude_agent_sdk_modules(
             return context_module.get_invocation_context()
 
     query_module.Query = FakeQuery
+
+    # Internal seam that the standalone query() delegates to (A6). Wrapping this
+    # is how respan traces `from claude_agent_sdk import query`.
+    client_module = ModuleType("claude_agent_sdk._internal.client")
+
+    class FakeInternalClient:
+        def process_query(self, *args, **kwargs):
+            return "process-query-result"
+
+    client_module.InternalClient = FakeInternalClient
 
     monkeypatch.setitem(
         sys.modules,
@@ -205,6 +245,11 @@ def _install_fake_claude_agent_sdk_modules(
         "claude_agent_sdk._internal.query",
         query_module,
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "claude_agent_sdk._internal.client",
+        client_module,
+    )
 
     return SimpleNamespace(
         instrumentor_class=FakeClaudeAgentSdkInstrumentor,
@@ -214,6 +259,9 @@ def _install_fake_claude_agent_sdk_modules(
         instrumentor_module=instrumentor_module,
         original_set_response_content=_original_set_response_content,
         original_set_result_attributes=_original_set_result_attributes,
+        claude_sdk_module=claude_sdk_module,
+        standalone_query=_standalone_query,
+        internal_client=FakeInternalClient,
     )
 
 
@@ -378,6 +426,54 @@ def test_activate_patches_helpers_and_restores_originals(monkeypatch):
     assert fake.spans_module.set_result_attributes is fake.original_set_result_attributes
     restored_ctx = asyncio.run(fake_query._handle_control_request({"request": {}}))
     assert restored_ctx is None
+
+
+def test_activate_traces_standalone_query_via_internal_seam(monkeypatch):
+    """A6: the from-import query() path is instrumented at InternalClient.process_query."""
+    tracer_provider = _make_fake_tracer_provider()
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: tracer_provider)
+    fake = _install_fake_claude_agent_sdk_modules(monkeypatch)
+
+    instrumentor = ClaudeAgentSDKInstrumentor()
+    instrumentor.activate()
+
+    # The internal seam is wrapped, so `from claude_agent_sdk import query` traces...
+    assert hasattr(fake.internal_client.process_query, "__wrapped__")
+    # ...and the bypassable module-level `query` wrap is dropped, so module-qualified
+    # and from-imported calls both hit exactly the seam (one span, no double-count).
+    assert fake.claude_sdk_module.query is fake.standalone_query
+    assert not hasattr(fake.claude_sdk_module.query, "__wrapped__")
+
+
+def test_double_activation_does_not_stack_the_query_seam(monkeypatch):
+    """A second instrumentor must not wrap the seam twice (would emit two spans)."""
+    tracer_provider = _make_fake_tracer_provider()
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: tracer_provider)
+    fake = _install_fake_claude_agent_sdk_modules(monkeypatch)
+
+    ClaudeAgentSDKInstrumentor().activate()
+    ClaudeAgentSDKInstrumentor().activate()
+
+    wrapped = fake.internal_client.process_query
+    assert hasattr(wrapped, "__wrapped__")
+    # Exactly one wrapper layer: __wrapped__ is the pristine original, not a second wrapper.
+    assert not hasattr(wrapped.__wrapped__, "__wrapped__")
+
+
+def test_deactivate_restores_the_query_seam_and_module_query(monkeypatch):
+    tracer_provider = _make_fake_tracer_provider()
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: tracer_provider)
+    fake = _install_fake_claude_agent_sdk_modules(monkeypatch)
+
+    original_process_query = fake.internal_client.process_query
+
+    instrumentor = ClaudeAgentSDKInstrumentor()
+    instrumentor.activate()
+    instrumentor.deactivate()
+
+    assert fake.internal_client.process_query is original_process_query
+    assert not hasattr(fake.internal_client.process_query, "__wrapped__")
+    assert fake.claude_sdk_module.query is fake.standalone_query
 
 
 def test_activate_logs_warning_when_dependency_missing(monkeypatch, caplog):

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_instrumentation.py
@@ -145,6 +145,7 @@ def _install_fake_claude_agent_sdk_modules(
     )
     constants_module.GEN_AI_OUTPUT_MESSAGES = output_messages_attr
     constants_module.GEN_AI_USAGE_INPUT_TOKENS = usage_input_tokens_attr
+    constants_module.GEN_AI_USAGE_OUTPUT_TOKENS = usage_output_tokens_attr
     constants_module.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = (
         usage_cache_creation_tokens_attr
     )
@@ -416,7 +417,14 @@ def test_activate_patches_helpers_and_restores_originals(monkeypatch):
         },
     ]
     assert span.attributes["gen_ai.usage.input_tokens"] == 4
-    assert span.attributes["cost"] == 0.04241955
+    assert span.attributes["gen_ai.usage.output_tokens"] == 121
+    # Cost is emitted as respan.metadata.response_cost (string), matching the
+    # LiteLLM/OpenAI instrumentors, not a bare "cost" attribute (A7).
+    assert span.attributes["respan.metadata.response_cost"] == "0.04241955"
+    assert "cost" not in span.attributes
+    # The helper writes only raw input/output; the span processor owns
+    # prompt/completion/total, so the helper must not pre-empt them here.
+    assert "gen_ai.usage.total_tokens" not in span.attributes
 
     instrumentor.deactivate()
 


### PR DESCRIPTION
## Summary

- **Code change:** In `respan-instrumentation-claude-agent-sdk`, the `patched_set_result_attributes` hook now emits `gen_ai.usage.output_tokens` (previously missing) alongside the existing `gen_ai.usage.input_tokens`, and sets cost as normalization and the override attribute that rolls up into `total_request_tokens`. Writing them in the helper would only pre-empt that.
- **User impact:** Fixes A7. The `invoke_agent` span recorded the model but showed `total_request_tokens: 0` and `total_cost: 0`, because output tokens were missing (starving the processor's completion/total roll-up) and cost used a key the backend does not read. With output tokens supplied and cost under the correct key, the backend now rolls up real tokens and cost.

## Release Intent

This PR changes one release-managed package. Intent: `.release-intents/20260630-claude-agent-sdk-usage-cost.json` (`respan-instrumentation-claude-agent-sdk`: patch). Stacked on #286.

## Validation

- [x] Added the `.release-intents/*.json`; `release_intents.py` validate passes.
- [x] Package unit tests pass (28) in a Python 3.13 venv; the fake `_constants` now defines `GEN_AI_USAGE_OUTPUT_TOKENS`, and the activate test asserts `respan.metadata.response_cost` (string) plus `output_tokens`, and that bare `cost` / `total_tokens` are not set.
- [x] Confirmed the pinned upstream floor (0.1.4) exports `GEN_AI_USAGE_OUTPUT_TOKENS`; constant reads moved inside the guarded try regardless.
- Note: `total_request_tokens` / `total_cost` are backend rollups, so final dashboard confirmation should run the claude-agent-sdk e2e.