### PR TITLE
 docs(skill): correct LangChain/LangGraph/etc. instrumentation in tracing skill

### DIFF
--- a/skills/references/tracing.md
+++ b/skills/references/tracing.md
@@ -44,15 +44,17 @@ Check higher-priority categories first. If a match is found, use that instrument
 | OpenAI Agents SDK | `openai-agents` | `@openai/agents` | `respan-instrumentation-openai-agents` | `@respan/instrumentation-openai-agents` | [docs](https://respan.ai/docs/integrations/openai-agents-sdk.md) |
 | Claude Agent SDK | `claude-agent-sdk` | — | `respan-instrumentation-claude-agent-sdk` | — | [docs](https://respan.ai/docs/integrations/claude-agents-sdk.md) |
 | Pydantic AI | `pydantic-ai` | — | `respan-instrumentation-pydantic-ai` | — | [docs](https://respan.ai/docs/integrations/pydantic-ai.md) |
-| LangChain | `langchain` | `langchain` | via OpenInference | — | [docs](https://respan.ai/docs/integrations/langchain.md) |
-| LangGraph | `langgraph` | — | via OpenInference | — | [docs](https://respan.ai/docs/integrations/langgraph.md) |
+| LangChain | `langchain` | `langchain` | `respan-instrumentation-langchain` (callback) | — | [docs](https://respan.ai/docs/integrations/langchain.md) |
+| LangGraph | `langgraph` | — | `respan-instrumentation-langchain` (callback) | — | [docs](https://respan.ai/docs/integrations/langgraph.md) |
 | CrewAI | `crewai` | — | `respan-instrumentation-crewai` | — | [docs](https://respan.ai/docs/integrations/crewai.md) |
-| LlamaIndex | `llama-index` | — | via OpenInference | — | [docs](https://respan.ai/docs/integrations/llama-index.md) |
+| LlamaIndex | `llama-index` | — | `respan-instrumentation-llama-index` | — | [docs](https://respan.ai/docs/integrations/llama-index.md) |
 | Haystack | `haystack-ai` | — | `respan-instrumentation-haystack` | — | [docs](https://respan.ai/docs/integrations/haystack.md) |
 | Mastra | — | `mastra` | — | via OTEL | [docs](https://respan.ai/docs/integrations/mastra.md) |
-| Google ADK | `google-adk` | — | via OpenInference | — | [docs](https://respan.ai/docs/integrations/google-adk.md) |
+| Google ADK | `google-adk` | — | `respan-instrumentation-google-adk` | — | [docs](https://respan.ai/docs/integrations/google-adk.md) |
 
 If a Priority 1 framework is found, use its instrumentation. Do NOT also add Priority 2 instrumentation for the same provider.
+
+**LangChain / LangGraph use a callback pattern, not `Respan(instrumentations=[...])`.** Set up `RespanTelemetry` and pass `add_respan_callback(config=...)` into the chain/graph invocation: `from respan_tracing import RespanTelemetry` + `from respan_instrumentation_langchain import add_respan_callback`. (The other Priority-1 frameworks use the standard `Respan(instrumentations=[XInstrumentor()])` plugin pattern.)
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 


### PR DESCRIPTION
## Summary

- Change: Corrected the Priority-1 framework table in the respan skill (skills/references/tracing.md). Four frameworks were listed as "via OpenInference" in the Python instrumentation column — they each have a respan-instrumentation-* package: LangChain/LangGraph → respan-instrumentation-langchain, LlamaIndex → respan-instrumentation-llama-index, Google ADK → respan-instrumentation-google-adk. Added a note that LangChain/LangGraph use a callback pattern (RespanTelemetry + add_respan_callback(config=...)), not Respan(instrumentations=[...]).
- Impact: Fixes B2 — the skill no longer points users at a non-existent "OpenInference" install for these frameworks, and the agent now proposes the correct package and (for LangChain/LangGraph) the correct callback setup. Docs-only; no code or runtime change.

## Release Intent

No release intent — this PR changes only the respan skill docs (skills/references/tracing.md), which is not a release-managed package. Verified the missing-intent gate stays empty for this change.

## Validation

- [x] I updated or added a .release-intents/*.json file if this PR changes a release-managed package — N/A (skills-only; no release-managed package changed)
- [x] I ran the relevant local checks for the packages I touched
  - release_intents.py missing --changed-from originhange triggers no release gate)
  - Verified every corrected package name + pattern against the actual packages and the live langchain.md / langgraph.md docs (add_respan_callback, LlamaIndexInstrumentor, GoogleADKInstrumentor); confirmed no via OpenInference references remain in the skill 