### PR TITLE
fix(py): align semantic span naming with shared JS contract

### DIFF
--- a/.release-intents/20260714-py-semantic-span-name-fixes.json
+++ b/.release-intents/20260714-py-semantic-span-name-fixes.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Align Python semantic span naming with the shared contract: RESPAN_SPAN_NAME_STYLE=legacy opt-out, internal name-hint attributes, handoff from/to names, suffix sanitization, and no operation-name suffixes on model-less LLM spans",
+  "packages": {
+    "respan-sdk": "minor",
+    "respan-tracing": "minor"
+  }
+}

--- a/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/constants/span_attributes.py
@@ -146,6 +146,15 @@ RESPAN_SPAN_TOOL_CALLS = "respan.span.tool_calls"
 RESPAN_SPAN_HANDOFFS = "respan.span.handoffs"
 
 # ---------------------------------------------------------------------------
+# Internal exporter hints (shared contract with the JS SDK)
+# Instrumentations may set these to steer semantic span naming; the exporter
+# strips them before export — they must never appear in exported attributes.
+# ---------------------------------------------------------------------------
+RESPAN_INTERNAL_SPAN_NAME_KIND = "respan.internal.span_name.kind"
+RESPAN_INTERNAL_SPAN_NAME_DETAIL = "respan.internal.span_name.detail"
+RESPAN_INTERNAL_DROP_SPAN = "respan.internal.drop_span"
+
+# ---------------------------------------------------------------------------
 # LLM attributes (removed from opentelemetry-semantic-conventions-ai 0.5.0)
 # Defined locally for backward compatibility with the Respan pipeline.
 # ---------------------------------------------------------------------------

--- a/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
@@ -2,6 +2,8 @@ import base64
 import hashlib
 import importlib.metadata
 import json
+import os
+import re
 from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Dict, Optional, Sequence, List, Any
@@ -80,9 +82,14 @@ from respan_sdk.constants.span_attributes import (
     GEN_AI_TOOL_NAME,
     LLM_REQUEST_MODEL,
     LLM_REQUEST_TYPE,
+    RESPAN_INTERNAL_DROP_SPAN,
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    RESPAN_INTERNAL_SPAN_NAME_KIND,
     RESPAN_LOG_TYPE,
+    RESPAN_METADATA_FROM_AGENT,
     RESPAN_METADATA_GUARDRAIL_NAME,
     RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION,
+    RESPAN_METADATA_TO_AGENT,
     RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
 )
@@ -340,6 +347,10 @@ _STRIPPED_ATTRIBUTES = frozenset({
     "logfire.json_schema",
     RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
+    # Internal naming hints — exporter-only, never part of the export contract.
+    RESPAN_INTERNAL_SPAN_NAME_KIND,
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    RESPAN_INTERNAL_DROP_SPAN,
 })
 
 _LLM_SPAN_NAME_PREFIX = "llm"
@@ -419,6 +430,40 @@ _CHAT_NAME_MARKERS = ("chat", "response", "responses")
 _GENERATION_NAME_MARKERS = ("generate", "generation", "completion")
 _EMBEDDING_NAME_MARKERS = ("embedding", "embeddings", "embed")
 
+# Operation/structural tokens that must not survive as a semantic-name suffix
+# (e.g. "handoff.task" or "llm.doGenerate" — the suffix carries no identity).
+_GENERIC_SPAN_NAME_DETAILS = frozenset(
+    set(_SPAN_NAME_PREFIX_ALIASES)
+    | {"completions", "dogenerate", "dostream", "doembed"}
+)
+
+_SPAN_NAME_STYLE_ENV_VAR = "RESPAN_SPAN_NAME_STYLE"
+_SPAN_NAME_STYLE_LEGACY = "legacy"
+_SPAN_NAME_STYLE_SEMANTIC = "semantic"
+
+_SPAN_NAME_ARROW_RE = re.compile(r"\s*(?:→|->)\s*")
+_SPAN_NAME_INVALID_CHARS_RE = re.compile(r"[^\w.-]+")
+_SPAN_NAME_EDGE_PUNCT_RE = re.compile(r"^[_\-.]+|[_\-.]+$")
+
+
+def _resolve_span_name_style() -> str:
+    """Resolve the export span-name style.
+
+    Semantic renaming is the default (matching released behavior);
+    RESPAN_SPAN_NAME_STYLE=legacy preserves original instrumentation names.
+    """
+    value = (os.environ.get(_SPAN_NAME_STYLE_ENV_VAR) or "").strip().lower()
+    if value == _SPAN_NAME_STYLE_LEGACY:
+        return _SPAN_NAME_STYLE_LEGACY
+    return _SPAN_NAME_STYLE_SEMANTIC
+
+
+def _sanitize_span_name_part(value: str) -> str:
+    """Mirror the JS SDK sanitizer: arrows/whitespace/punctuation → underscores."""
+    sanitized = _SPAN_NAME_ARROW_RE.sub("_", value.strip())
+    sanitized = _SPAN_NAME_INVALID_CHARS_RE.sub("_", sanitized)
+    return _SPAN_NAME_EDGE_PUNCT_RE.sub("", sanitized)
+
 
 def _clean_span_name_part(value: Any) -> Optional[str]:
     if value is None:
@@ -443,16 +488,13 @@ def _normalize_existing_semantic_span_name(name: str) -> Optional[str]:
     lower_name = name.lower()
     for candidate, prefix in _SPAN_NAME_PREFIX_ALIASES.items():
         display_prefix = _display_span_name_prefix(prefix)
-        for candidate_name in (candidate, candidate.upper()):
-            candidate_lower = candidate_name.lower()
-            if lower_name == candidate_lower:
+        if lower_name == candidate:
+            return display_prefix
+        if lower_name.startswith(f"{candidate}."):
+            if prefix not in _SUFFIXED_SPAN_NAME_PREFIXES:
                 return display_prefix
-            dotted_prefix = f"{candidate_lower}."
-            if lower_name.startswith(dotted_prefix):
-                if prefix not in _SUFFIXED_SPAN_NAME_PREFIXES:
-                    return display_prefix
-                detail = name[len(candidate_name) + 1 :].strip()
-                return f"{display_prefix}.{detail}" if detail else display_prefix
+            detail = _sanitize_span_name_part(name[len(candidate) + 1 :])
+            return f"{display_prefix}.{detail}" if detail else display_prefix
     return None
 
 
@@ -481,7 +523,25 @@ def _strip_token_from_span_name(name: str, tokens: Sequence[str]) -> Optional[st
     return None
 
 
+def _resolve_hinted_span_name_prefix(hinted_kind: str) -> Optional[str]:
+    """Map an instrumentation-provided kind hint to a semantic prefix."""
+    normalized = hinted_kind.lower()
+    prefix = (
+        _LOG_TYPE_TO_SPAN_NAME_PREFIX.get(normalized)
+        or _SPAN_NAME_PREFIX_ALIASES.get(normalized)
+    )
+    if prefix:
+        return prefix
+    return _sanitize_span_name_part(normalized) or None
+
+
 def _infer_span_name_prefix(name: str, attrs: Mapping[str, Any]) -> Optional[str]:
+    hinted_kind = _clean_span_name_part(attrs.get(RESPAN_INTERNAL_SPAN_NAME_KIND))
+    if hinted_kind:
+        prefix = _resolve_hinted_span_name_prefix(hinted_kind)
+        if prefix:
+            return prefix
+
     log_type = _clean_span_name_part(attrs.get(RESPAN_LOG_TYPE))
     if log_type:
         prefix = _LOG_TYPE_TO_SPAN_NAME_PREFIX.get(log_type.lower())
@@ -555,6 +615,16 @@ def _span_name_detail(prefix: str, name: str, attrs: Mapping[str, Any]) -> Optio
     if prefix == _LLM_SPAN_NAME_PREFIX:
         return _first_present_attr(attrs, _LLM_DETAIL_ATTRS)
 
+    hinted_detail = _clean_span_name_part(attrs.get(RESPAN_INTERNAL_SPAN_NAME_DETAIL))
+    if hinted_detail:
+        return hinted_detail
+
+    if prefix == LOG_TYPE_HANDOFF:
+        from_agent = _clean_span_name_part(attrs.get(RESPAN_METADATA_FROM_AGENT))
+        to_agent = _clean_span_name_part(attrs.get(RESPAN_METADATA_TO_AGENT))
+        if from_agent and to_agent:
+            return f"{from_agent}_to_{to_agent}"
+
     attr_detail = _first_present_attr(
         attrs,
         _ENTITY_DETAIL_ATTRS_BY_PREFIX.get(prefix, ()),
@@ -566,7 +636,7 @@ def _span_name_detail(prefix: str, name: str, attrs: Mapping[str, Any]) -> Optio
         name,
         _detail_tokens_for_prefix(prefix),
     )
-    if stripped_detail:
+    if stripped_detail and stripped_detail.lower() not in _GENERIC_SPAN_NAME_DETAILS:
         return stripped_detail
 
     if prefix == LOG_TYPE_EMBEDDING:
@@ -574,23 +644,43 @@ def _span_name_detail(prefix: str, name: str, attrs: Mapping[str, Any]) -> Optio
         if llm_detail:
             return llm_detail
 
-    return _clean_span_name_part(name)
+    fallback = _clean_span_name_part(name)
+    if fallback and fallback.lower() in _GENERIC_SPAN_NAME_DETAILS:
+        return None
+    return fallback
 
 
 def _export_span_name(span: ReadableSpan) -> str:
+    if _resolve_span_name_style() == _SPAN_NAME_STYLE_LEGACY:
+        return getattr(span, "name", "")
+
     original_name = _clean_span_name_part(getattr(span, "name", None))
     if not original_name:
         return getattr(span, "name", "")
 
     attrs = span.attributes or {}
-    existing_semantic_name = _normalize_existing_semantic_span_name(original_name)
-    if existing_semantic_name:
-        is_llm_name = (
-            existing_semantic_name == _LLM_SPAN_NAME_PREFIX
-            or existing_semantic_name.startswith(f"{_LLM_SPAN_NAME_PREFIX}.")
-        )
-        if not is_llm_name or not _first_present_attr(attrs, _LLM_DETAIL_ATTRS):
-            return existing_semantic_name
+    has_name_hints = (
+        _clean_span_name_part(attrs.get(RESPAN_INTERNAL_SPAN_NAME_KIND)) is not None
+        or _clean_span_name_part(attrs.get(RESPAN_INTERNAL_SPAN_NAME_DETAIL)) is not None
+    )
+
+    # Names that already look semantic pass through — unless an instrumentation
+    # hint overrides them, or the suffix is a structural token ("handoff.task",
+    # "llm.doGenerate") that must be recomputed from attributes.
+    if not has_name_hints:
+        existing_semantic_name = _normalize_existing_semantic_span_name(original_name)
+        if existing_semantic_name:
+            prefix_part, _, detail_part = existing_semantic_name.partition(".")
+            has_generic_detail = (
+                bool(detail_part) and detail_part.lower() in _GENERIC_SPAN_NAME_DETAILS
+            )
+            if prefix_part == _LLM_SPAN_NAME_PREFIX:
+                if not _first_present_attr(attrs, _LLM_DETAIL_ATTRS):
+                    if has_generic_detail:
+                        return _LLM_SPAN_NAME_PREFIX
+                    return existing_semantic_name
+            elif not has_generic_detail:
+                return existing_semantic_name
 
     prefix = _infer_span_name_prefix(original_name, attrs)
     if not prefix:
@@ -601,12 +691,10 @@ def _export_span_name(span: ReadableSpan) -> str:
         return display_prefix
 
     detail = _span_name_detail(prefix, original_name, attrs)
-    if not detail:
+    if detail:
+        detail = _sanitize_span_name_part(detail)
+    if not detail or detail.lower() == display_prefix:
         return display_prefix
-
-    existing_detail_semantic_name = _normalize_existing_semantic_span_name(detail)
-    if existing_detail_semantic_name:
-        return existing_detail_semantic_name
 
     return f"{display_prefix}.{detail}"
 

--- a/python-sdks/respan-tracing/tests/test_respan_exporter.py
+++ b/python-sdks/respan-tracing/tests/test_respan_exporter.py
@@ -20,8 +20,13 @@ from respan_sdk.constants.span_attributes import (
     GEN_AI_SYSTEM,
     LLM_REQUEST_MODEL,
     LLM_REQUEST_TYPE,
+    RESPAN_INTERNAL_DROP_SPAN,
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    RESPAN_INTERNAL_SPAN_NAME_KIND,
     RESPAN_LOG_TYPE,
+    RESPAN_METADATA_FROM_AGENT,
     RESPAN_METADATA_INTERNAL_TRACING_SDK_VERSION,
+    RESPAN_METADATA_TO_AGENT,
     RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
 )
@@ -237,6 +242,173 @@ def test_span_to_otlp_json_prefixes_llm_span_names():
         "llm.claude-3-5-sonnet",
         "llm.gpt-4.1",
         "llm.gpt-5.5",
+    ]
+
+
+def test_span_to_otlp_json_legacy_style_preserves_names(monkeypatch):
+    monkeypatch.setenv("RESPAN_SPAN_NAME_STYLE", "legacy")
+
+    spans = [
+        _make_span(
+            name="chat gpt-4o",
+            span_id=2301,
+            attributes={
+                RESPAN_LOG_TYPE: "chat",
+                LLM_REQUEST_MODEL: "gpt-4o",
+            },
+        ),
+        _make_span(
+            name="triage-service.agent",
+            span_id=2302,
+            attributes={
+                SpanAttributes.TRACELOOP_SPAN_KIND: "agent",
+                SpanAttributes.TRACELOOP_ENTITY_NAME: "triage-service",
+            },
+        ),
+    ]
+
+    assert [_span_to_otlp_json(span)["name"] for span in spans] == [
+        "chat gpt-4o",
+        "triage-service.agent",
+    ]
+
+
+def test_span_to_otlp_json_strips_internal_hints_in_both_styles(monkeypatch):
+    attributes = {
+        RESPAN_LOG_TYPE: "chat",
+        LLM_REQUEST_MODEL: "gpt-4o",
+        RESPAN_INTERNAL_SPAN_NAME_KIND: "llm",
+        RESPAN_INTERNAL_SPAN_NAME_DETAIL: "gpt-4o",
+        RESPAN_INTERNAL_DROP_SPAN: True,
+    }
+
+    for style in ("semantic", "legacy"):
+        monkeypatch.setenv("RESPAN_SPAN_NAME_STYLE", style)
+        span = _make_span(name="openai.chat", span_id=2311, attributes=dict(attributes))
+        exported_keys = {
+            attr[OTLP_ATTR_KEY]
+            for attr in _span_to_otlp_json(span)[OTLP_ATTRIBUTES_KEY]
+        }
+        assert RESPAN_INTERNAL_SPAN_NAME_KIND not in exported_keys
+        assert RESPAN_INTERNAL_SPAN_NAME_DETAIL not in exported_keys
+        assert RESPAN_INTERNAL_DROP_SPAN not in exported_keys
+
+
+def test_span_to_otlp_json_honors_internal_name_hints():
+    spans = [
+        _make_span(
+            name="ai.generateText.doGenerate",
+            span_id=2321,
+            attributes={
+                RESPAN_INTERNAL_SPAN_NAME_KIND: "generate",
+                RESPAN_INTERNAL_SPAN_NAME_DETAIL: "doGenerate",
+                RESPAN_LOG_TYPE: "text",
+                LLM_REQUEST_MODEL: "gpt-4o-mini",
+            },
+        ),
+        _make_span(
+            name="ai.toolCall",
+            span_id=2322,
+            attributes={
+                RESPAN_INTERNAL_SPAN_NAME_KIND: "tool",
+                RESPAN_INTERNAL_SPAN_NAME_DETAIL: "lookup_weather",
+            },
+        ),
+        # Hints override a name that already looks semantic.
+        _make_span(
+            name="handoff.task",
+            span_id=2323,
+            attributes={
+                RESPAN_INTERNAL_SPAN_NAME_KIND: "handoff",
+                RESPAN_INTERNAL_SPAN_NAME_DETAIL: "triage-service_to_bank-service",
+                RESPAN_LOG_TYPE: "handoff",
+            },
+        ),
+    ]
+
+    assert [_span_to_otlp_json(span)["name"] for span in spans] == [
+        "llm.gpt-4o-mini",
+        "tool.lookup_weather",
+        "handoff.triage-service_to_bank-service",
+    ]
+
+
+def test_span_to_otlp_json_builds_handoff_names_from_agent_metadata():
+    spans = [
+        _make_span(
+            name="handoff.task",
+            span_id=2331,
+            attributes={
+                RESPAN_LOG_TYPE: "handoff",
+                SpanAttributes.TRACELOOP_ENTITY_NAME: "handoff",
+                RESPAN_METADATA_FROM_AGENT: "Triage Agent",
+                RESPAN_METADATA_TO_AGENT: "Bank Agent",
+            },
+        ),
+        # No from/to metadata: structural "task" suffix must not survive.
+        _make_span(
+            name="handoff.task",
+            span_id=2332,
+            attributes={
+                RESPAN_LOG_TYPE: "handoff",
+                SpanAttributes.TRACELOOP_ENTITY_NAME: "handoff",
+            },
+        ),
+    ]
+
+    assert [_span_to_otlp_json(span)["name"] for span in spans] == [
+        "handoff.Triage_Agent_to_Bank_Agent",
+        "handoff",
+    ]
+
+
+def test_span_to_otlp_json_drops_operation_suffixes_without_model():
+    spans = [
+        _make_span(
+            name="llm.doGenerate",
+            span_id=2341,
+            attributes={RESPAN_LOG_TYPE: "text"},
+        ),
+        _make_span(
+            name="chat.completions",
+            span_id=2342,
+            attributes={RESPAN_LOG_TYPE: "chat"},
+        ),
+        # A model-looking suffix without model attrs is kept.
+        _make_span(name="llm.gpt-4o", span_id=2343),
+    ]
+
+    assert [_span_to_otlp_json(span)["name"] for span in spans] == [
+        "llm",
+        "llm",
+        "llm.gpt-4o",
+    ]
+
+
+def test_span_to_otlp_json_sanitizes_name_details():
+    spans = [
+        _make_span(
+            name="agent run",
+            span_id=2351,
+            attributes={
+                SpanAttributes.TRACELOOP_SPAN_KIND: "agent",
+                SpanAttributes.TRACELOOP_ENTITY_NAME: "Triage Agent (v2)",
+            },
+        ),
+        _make_span(
+            name="handoff.task",
+            span_id=2352,
+            attributes={
+                RESPAN_LOG_TYPE: "handoff",
+                RESPAN_METADATA_FROM_AGENT: "Triage → Bank",
+                RESPAN_METADATA_TO_AGENT: "Bank",
+            },
+        ),
+    ]
+
+    assert [_span_to_otlp_json(span)["name"] for span in spans] == [
+        "agent.Triage_Agent_v2",
+        "handoff.Triage_Bank_to_Bank",
     ]
 
 


### PR DESCRIPTION
## Summary

Follow-up to #279 (Python semantic span names), applying the same contract fixes raised in the review of #287 (JS counterpart):

- **`RESPAN_SPAN_NAME_STYLE=legacy` opt-out** — Python renamed unconditionally with no escape hatch. Semantic stays the default (it already shipped in respan-tracing 2.17.3), but users can now opt back into original instrumentation names. Note: JS (#287) defaults to `legacy` while Python defaults to `semantic` — the defaults should probably be reconciled once #287 lands.
- **Internal name-hint attributes** — adds `respan.internal.span_name.kind`/`.detail` and `respan.internal.drop_span` constants to `respan-sdk` (same strings as the JS SDK). The exporter honors kind/detail as highest-priority naming hints and strips all three before export in both styles, per the shared contract.
- **Handoff names** — `handoff.task` (structural emitter name) now exports as `handoff.<from>_to_<to>` built from `respan.metadata.from_agent`/`to_agent`, matching the JS contract format.
- **No operation-name suffixes** — model-less LLM spans like `llm.doGenerate` / `chat.completions` now export as bare `llm` instead of leaking SDK operation names; structural suffixes (`handoff.task`) are recomputed from attributes.
- **Sanitization parity** — name parts get the same whitespace/arrow/punctuation cleanup as the JS transformer (`Triage → Bank` → `Triage_Bank`).
- Also removes a latent bug where a tool whose entity name collided with a log-type token (e.g. a tool named `chat`) was renamed to `llm`.

## Release Intent

- [x] `.release-intents/20260714-py-semantic-span-name-fixes.json` — `respan-sdk` minor, `respan-tracing` minor

## Validation

- [x] `respan-tracing` exporter tests: 20 passed (14 existing + 6 new covering legacy style, hint honor/strip, handoff naming, suffix leaks, sanitization)
- [x] Full `respan-tracing` suite: 214 passed; the 19 failures + 3 collection errors are identical on clean main (env-dependent, pre-existing)
- [x] `respan-sdk` suite: same pass/fail set as clean main

🤖 Generated with [Claude Code](https://claude.com/claude-code)