### PR TITLE
fix(py): correct instrumentation semantic span names

### DIFF
--- a/.release-intents/20260716-python-instrumentation-span-name-audit.json
+++ b/.release-intents/20260716-python-instrumentation-span-name-audit.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Fix Writer semantic tool span names and Haystack tracing compatibility",
+  "packages": {
+    "respan-instrumentation-haystack": "patch",
+    "respan-instrumentation-writer": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_instrumentation.py
@@ -336,8 +336,15 @@ def _suppress_haystack_native_span_export(span: Any) -> None:
     if attributes is None:
         return
 
-    for attribute_name in HAYSTACK_NATIVE_PROCESSING_ATTRIBUTES:
-        attributes.pop(attribute_name, None)
+    # ReadableSpan stores ended-span attributes in an immutable
+    # BoundedAttributes instance on newer OpenTelemetry releases. Replace the
+    # private snapshot instead of mutating it so native Haystack spans remain
+    # unprocessable without raising during processor shutdown.
+    span._attributes = {
+        name: value
+        for name, value in attributes.items()
+        if name not in HAYSTACK_NATIVE_PROCESSING_ATTRIBUTES
+    }
 
 
 def _parse_json_attr(value: Any) -> Any:

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/tests/test_instrumentation.py
@@ -5,6 +5,7 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
+from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.semconv_ai import SpanAttributes
 from respan_instrumentation_haystack import HaystackInstrumentor
 from respan_instrumentation_haystack import _instrumentation
@@ -310,6 +311,33 @@ def test_haystack_parent_span_processor_suppresses_native_span_export():
             RESPAN_LOG_TYPE: "span",
             "haystack.component.name": "prompt_builder",
         },
+    )
+
+    processor.on_start(native_component)
+    processor.on_end(native_component)
+
+    assert native_component.attributes == {
+        "haystack.component.name": "prompt_builder",
+    }
+    assert is_processable_span(native_component) is False
+
+
+def test_haystack_parent_span_processor_suppresses_immutable_native_attributes():
+    processor = _HaystackParentSpanProcessor()
+    native_component = _FakeSpan(
+        HAYSTACK_COMPONENT_RUN_SPAN_NAME,
+        "3000000000000004",
+    )
+    native_component._attributes = BoundedAttributes(
+        maxlen=128,
+        attributes={
+            SpanAttributes.TRACELOOP_ENTITY_NAME: HAYSTACK_COMPONENT_RUN_SPAN_NAME,
+            SpanAttributes.TRACELOOP_ENTITY_PATH: "haystack-example.Pipeline.run",
+            SpanAttributes.TRACELOOP_WORKFLOW_NAME: "haystack-example",
+            RESPAN_LOG_TYPE: "span",
+            "haystack.component.name": "prompt_builder",
+        },
+        immutable=True,
     )
 
     processor.on_start(native_component)

--- a/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_translator.py
@@ -54,7 +54,11 @@ from respan_instrumentation_writer._constants import (
     WRITER_VISION_SPAN_NAME,
 )
 from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_TEXT, LOG_TYPE_TOOL
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_sdk.constants.span_attributes import (
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    RESPAN_INTERNAL_SPAN_NAME_KIND,
+    RESPAN_LOG_TYPE,
+)
 
 _WRITER_SENTINEL_CLASS_NAMES = {"Omit", "NotGiven"}
 _REQUEST_CONTROL_KEYS = {
@@ -643,6 +647,8 @@ def build_tool_attrs(
         TLSpanAttributes.TRACELOOP_ENTITY_INPUT: safe_json(
             _public_request_kwargs(request_kwargs)
         ),
+        RESPAN_INTERNAL_SPAN_NAME_KIND: LOG_TYPE_TOOL,
+        RESPAN_INTERNAL_SPAN_NAME_DETAIL: tool_name.rsplit(".", 1)[-1],
         RESPAN_LOG_TYPE: LOG_TYPE_TOOL,
     }
     workflow_name = context_api.get_value(TLSpanAttributes.TRACELOOP_ENTITY_NAME)

--- a/python-sdks/instrumentations/respan-instrumentation-writer/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-writer/tests/test_instrumentation.py
@@ -27,8 +27,13 @@ from respan_instrumentation_writer._translator import (
     build_vision_attrs,
 )
 from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_TEXT, LOG_TYPE_TOOL
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_sdk.constants.span_attributes import (
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    RESPAN_INTERNAL_SPAN_NAME_KIND,
+    RESPAN_LOG_TYPE,
+)
 from respan_tracing.core.tracer import RespanTracer
+from respan_tracing.exporters.respan import _export_span_name
 
 
 OFF_CONTRACT_ALIASES = {
@@ -397,7 +402,9 @@ def test_other_writer_text_operations_map_to_canonical_attrs() -> None:
     assert translation_attrs[TLSpanAttributes.LLM_REQUEST_MODEL] == "palmyra-translate"
 
 
-def test_direct_writer_tools_emit_tool_spans_without_llm_tool_attrs() -> None:
+def test_direct_writer_tools_emit_tool_spans_without_llm_tool_attrs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     web_attrs = build_tool_attrs(
         tool_name=WRITER_WEB_SEARCH_TOOL_NAME,
         request_kwargs={"query": "Respan tracing", "include_answer": True},
@@ -409,10 +416,22 @@ def test_direct_writer_tools_emit_tool_spans_without_llm_tool_attrs() -> None:
         response=SimpleNamespace(content="PDF output"),
     )
 
-    for attrs in (web_attrs, pdf_attrs):
+    for attrs, legacy_name, semantic_detail in (
+        (web_attrs, WRITER_WEB_SEARCH_TOOL_NAME, "web_search"),
+        (pdf_attrs, WRITER_PARSE_PDF_TOOL_NAME, "parse_pdf"),
+    ):
         assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_TOOL
+        assert attrs[RESPAN_INTERNAL_SPAN_NAME_KIND] == LOG_TYPE_TOOL
+        assert attrs[RESPAN_INTERNAL_SPAN_NAME_DETAIL] == semantic_detail
         assert attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT]
         assert attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]
         assert "gen_ai.tool.name" not in attrs
         assert "gen_ai.tool.call.arguments" not in attrs
         assert not OFF_CONTRACT_ALIASES.intersection(attrs)
+
+        span = SimpleNamespace(name=legacy_name, attributes=attrs)
+        assert _export_span_name(span) == f"tool.{semantic_detail}"
+
+        monkeypatch.setenv("RESPAN_SPAN_NAME_STYLE", "legacy")
+        assert _export_span_name(span) == legacy_name
+        monkeypatch.delenv("RESPAN_SPAN_NAME_STYLE")


### PR DESCRIPTION
## Summary

- fix(py): correct instrumentation semantic span names

## Release Intent

If this PR changes any release-managed package, add one `.release-intents/*.json` file.

Rules:

- use one intent file per PR
- use one of `none`, `new`, `patch`, `minor`, or `major`
- do not hand-edit final package versions just to satisfy CI
- prefer `YYYYMMDD-short-description.json` naming
- use [.release-intents/20260409-example.json](../.release-intents/20260409-example.json) as the starting shape

## Validation

- [ ] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [ ] I ran the relevant local checks for the packages I touched
