### PR TITLE
feat(py): add Qdrant instrumentation

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -533,6 +533,12 @@
       "name": "respan-instrumentation-pinecone",
       "path": "python-sdks/instrumentations/respan-instrumentation-pinecone",
       "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-qdrant",
+      "path": "python-sdks/instrumentations/respan-instrumentation-qdrant",
+      "registry": "pypi"
     }
   ]
 }

--- a/.release-intents/20260717-respan-instrumentation-qdrant.json
+++ b/.release-intents/20260717-respan-instrumentation-qdrant.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add Qdrant instrumentation",
+  "packages": {
+    "respan-instrumentation-qdrant": "new"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/README.md
@@ -1,0 +1,56 @@
+# respan-instrumentation-qdrant
+
+Respan instrumentation for synchronous and asynchronous
+[`qdrant-client`](https://github.com/qdrant/qdrant-client) operations. It emits
+canonical Respan task spans for collection management, point writes, payload
+updates, retrieval, filtering, vector queries, facets, snapshots, and cluster
+administration.
+
+## Install
+
+```bash
+pip install respan-ai respan-instrumentation-qdrant qdrant-client
+```
+
+## Quickstart
+
+```python
+from qdrant_client import QdrantClient, models
+from respan import Respan, workflow
+from respan_instrumentation_qdrant import QdrantInstrumentor
+
+respan = Respan(instrumentations=[QdrantInstrumentor()])
+
+
+@workflow(name="qdrant_local_query_workflow")
+def run_query():
+    client = QdrantClient(":memory:")
+    client.create_collection(
+        "docs",
+        vectors_config=models.VectorParams(
+            size=3,
+            distance=models.Distance.COSINE,
+        ),
+    )
+    client.upsert(
+        "docs",
+        points=[models.PointStruct(id=1, vector=[0.1, 0.2, 0.3])],
+    )
+    return client.query_points(
+        "docs",
+        query=[0.1, 0.2, 0.3],
+        limit=1,
+    )
+
+
+print(run_query())
+respan.shutdown()
+```
+
+`QdrantInstrumentor(capture_content=False)` keeps operation names, status, and
+database attributes while omitting request and response bodies. Activation and
+deactivation are idempotent, and `instrument()` / `uninstrument()` aliases are
+also available.
+
+See `respan-example-projects/python/tracing/qdrant` for collection, point,
+query, async, and deterministic error examples.

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.poetry]
+name = "respan-instrumentation-qdrant"
+version = "0.1.0"
+description = "Respan instrumentation plugin for Qdrant"
+authors = ["Respan <team@respan.ai>"]
+license = "Apache 2.0"
+readme = "README.md"
+packages = [
+    { include = "respan_instrumentation_qdrant", from = "./src" },
+]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<3.14"
+respan-tracing = "^2.17.0"
+respan-sdk = ">=2.6.1"
+qdrant-client = ">=1.9.0,<2.0.0"
+opentelemetry-semantic-conventions-ai = ">=0.4.1"
+wrapt = ">=1.16.0"
+
+[tool.poetry.plugins."respan.instrumentations"]
+qdrant = "respan_instrumentation_qdrant:QdrantInstrumentor"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/__init__.py
@@ -1,0 +1,5 @@
+"""Respan instrumentation for Qdrant."""
+
+from respan_instrumentation_qdrant._instrumentation import QdrantInstrumentor
+
+__all__ = ["QdrantInstrumentor"]

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_constants.py
@@ -1,0 +1,78 @@
+"""Qdrant SDK-specific instrumentation constants."""
+
+QDRANT_INSTRUMENTATION_NAME = "qdrant"
+
+# Public operations that issue work against Qdrant. Local model-selection and
+# introspection helpers are intentionally excluded because they do not perform
+# vector-store work.
+QDRANT_OPERATIONS = (
+    "add",
+    "batch_update_points",
+    "clear_payload",
+    "cluster_collection_update",
+    "cluster_status",
+    "cluster_telemetry",
+    "collection_cluster_info",
+    "collection_exists",
+    "count",
+    "create_collection",
+    "create_full_snapshot",
+    "create_payload_index",
+    "create_shard_key",
+    "create_shard_snapshot",
+    "create_snapshot",
+    "create_vector_name",
+    "delete",
+    "delete_collection",
+    "delete_full_snapshot",
+    "delete_payload",
+    "delete_payload_index",
+    "delete_shard_key",
+    "delete_shard_snapshot",
+    "delete_snapshot",
+    "delete_vector_name",
+    "delete_vectors",
+    "facet",
+    "get_aliases",
+    "get_collection",
+    "get_collection_aliases",
+    "get_collections",
+    "get_optimizations",
+    "info",
+    "list_full_snapshots",
+    "list_shard_keys",
+    "list_shard_snapshots",
+    "list_snapshots",
+    "overwrite_payload",
+    "query",
+    "query_batch",
+    "query_batch_points",
+    "query_points",
+    "query_points_groups",
+    "recover_current_peer",
+    "recover_shard_snapshot",
+    "recover_snapshot",
+    "recreate_collection",
+    "remove_peer",
+    "retrieve",
+    "scroll",
+    "search_matrix_offsets",
+    "search_matrix_pairs",
+    "set_payload",
+    "update_collection",
+    "update_collection_aliases",
+    "update_vectors",
+    "upload_collection",
+    "upload_points",
+    "upsert",
+)
+
+MAX_ATTRIBUTE_CHARS = 16_000
+MAX_PREVIEW_ITEMS = 64
+SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "authorization",
+    "password",
+    "secret",
+    "token",
+)

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_instrumentation.py
@@ -1,0 +1,372 @@
+"""Native Qdrant client instrumentation for Respan."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from contextvars import ContextVar
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from numbers import Real
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import SpanKind, Status, StatusCode
+from respan_instrumentation_qdrant._constants import (
+    MAX_ATTRIBUTE_CHARS,
+    MAX_PREVIEW_ITEMS,
+    QDRANT_INSTRUMENTATION_NAME,
+    QDRANT_OPERATIONS,
+    SENSITIVE_KEY_PARTS,
+)
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.llm_logging import LOG_TYPE_TASK
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_tracing.core.tracer import RespanTracer
+from wrapt import wrap_function_wrapper
+
+logger = logging.getLogger(__name__)
+
+
+_VECTOR_KEY_PARTS = ("embedding", "vector")
+
+
+def _is_numeric_vector(value: Any) -> bool:
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes, bytearray))
+        and bool(value)
+        and all(isinstance(item, Real) and not isinstance(item, bool) for item in value)
+    )
+
+
+def _is_vector_key(value: str) -> bool:
+    normalized = value.lower()
+    return any(part in normalized for part in _VECTOR_KEY_PARTS)
+
+
+def _jsonable(
+    value: Any,
+    *,
+    depth: int = 0,
+    vector_context: bool = False,
+    preserved_vector: list[bool] | None = None,
+) -> Any:
+    preserved_vector = preserved_vector if preserved_vector is not None else [False]
+    if depth > 7 and not (vector_context or _is_numeric_vector(value)):
+        return repr(value)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return {"type": "bytes", "length": len(value)}
+    if isinstance(value, Enum):
+        return _jsonable(
+            value.value,
+            depth=depth + 1,
+            vector_context=vector_context,
+            preserved_vector=preserved_vector,
+        )
+    if is_dataclass(value) and not isinstance(value, type):
+        return _jsonable(
+            asdict(value),
+            depth=depth + 1,
+            vector_context=vector_context,
+            preserved_vector=preserved_vector,
+        )
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        omitted = 0
+        regular_items = 0
+        for key, item in value.items():
+            key_text = str(key)
+            item_is_vector = vector_context or _is_vector_key(key_text)
+            if not item_is_vector and regular_items >= MAX_PREVIEW_ITEMS:
+                omitted += 1
+                continue
+            regular_items += int(not item_is_vector)
+            result[key_text] = (
+                "<redacted>"
+                if any(part in key_text.lower() for part in SENSITIVE_KEY_PARTS)
+                else _jsonable(
+                    item,
+                    depth=depth + 1,
+                    vector_context=item_is_vector,
+                    preserved_vector=preserved_vector,
+                )
+            )
+        if omitted:
+            result["__truncated__"] = omitted
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        preserve_all = vector_context or _is_numeric_vector(value)
+        if preserve_all:
+            preserved_vector[0] = True
+        source = value if preserve_all else value[:MAX_PREVIEW_ITEMS]
+        items = [
+            _jsonable(
+                item,
+                depth=depth + 1,
+                vector_context=vector_context,
+                preserved_vector=preserved_vector,
+            )
+            for item in source
+        ]
+        if preserve_all:
+            return items
+        if len(value) > MAX_PREVIEW_ITEMS:
+            return {"count": len(value), "items": items, "truncated": True}
+        return items
+    for method_name in ("model_dump", "to_dict", "dict", "tolist"):
+        method = getattr(value, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            return _jsonable(
+                method(),
+                depth=depth + 1,
+                vector_context=vector_context,
+                preserved_vector=preserved_vector,
+            )
+        except Exception:
+            continue
+    return repr(value)
+
+
+def _json_dumps(value: Any) -> str:
+    preserved_vector = [False]
+    text = json.dumps(
+        _jsonable(value, preserved_vector=preserved_vector),
+        default=str,
+        sort_keys=True,
+    )
+    if preserved_vector[0] or len(text) <= MAX_ATTRIBUTE_CHARS:
+        return text
+    return json.dumps(
+        {"preview": text[:MAX_ATTRIBUTE_CHARS], "truncated": True},
+        sort_keys=True,
+    )
+
+
+def _call_input(
+    operation: str,
+    wrapped: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        bound = inspect.signature(wrapped).bind_partial(*args, **kwargs)
+        arguments = {
+            key: value for key, value in bound.arguments.items() if key != "self"
+        }
+    except Exception:
+        arguments = {"args": list(args), "kwargs": kwargs}
+    return {"operation": operation, **arguments}
+
+
+class QdrantInstrumentor:
+    """Trace synchronous and asynchronous Qdrant operations as task spans."""
+
+    name = QDRANT_INSTRUMENTATION_NAME
+    _patches_applied = False
+    _activation_count = 0
+    _patched_targets: list[tuple[type, str]] = []
+    _active_call: ContextVar[bool] = ContextVar(
+        "respan_qdrant_active_call",
+        default=False,
+    )
+
+    def __init__(self, *, capture_content: bool = True) -> None:
+        self._capture_content = capture_content
+        self._is_instrumented = False
+
+    @staticmethod
+    def _tracing_enabled() -> bool:
+        tracer = getattr(RespanTracer, "_instance", None)
+        return tracer is None or bool(getattr(tracer, "is_enabled", True))
+
+    def _set_start_attributes(
+        self,
+        span: Any,
+        operation: str,
+        wrapped: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> None:
+        entity_name = f"qdrant.{operation}"
+        span.set_attribute(RESPAN_LOG_TYPE, LOG_TYPE_TASK)
+        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
+        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_name)
+        span.set_attribute(OTelSpanAttributes.DB_SYSTEM, "qdrant")
+        span.set_attribute(OTelSpanAttributes.DB_OPERATION, operation)
+        if self._capture_content:
+            span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_INPUT,
+                _json_dumps(_call_input(operation, wrapped, args, kwargs)),
+            )
+
+    def _set_error(self, span: Any, exc: Exception) -> None:
+        span.record_exception(exc)
+        span.set_status(Status(StatusCode.ERROR, str(exc)))
+        span.set_attribute("status_code", 500)
+        span.set_attribute(ERROR_MESSAGE_ATTR, str(exc))
+        if self._capture_content:
+            span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                _json_dumps({"error": type(exc).__name__, "message": str(exc)}),
+            )
+
+    def _trace_sync(
+        self,
+        operation: str,
+        wrapped: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        active_call = type(self)._active_call
+        if active_call.get():
+            return wrapped(*args, **kwargs)
+        token = active_call.set(True)
+        try:
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                f"qdrant.{operation}",
+                kind=SpanKind.CLIENT,
+            ) as span:
+                self._set_start_attributes(span, operation, wrapped, args, kwargs)
+                try:
+                    result = wrapped(*args, **kwargs)
+                except Exception as exc:
+                    self._set_error(span, exc)
+                    raise
+                span.set_status(Status(StatusCode.OK))
+                if self._capture_content:
+                    span.set_attribute(
+                        SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                        _json_dumps(result),
+                    )
+                return result
+        finally:
+            active_call.reset(token)
+
+    async def _trace_async(
+        self,
+        operation: str,
+        wrapped: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        active_call = type(self)._active_call
+        if active_call.get():
+            return await wrapped(*args, **kwargs)
+        token = active_call.set(True)
+        try:
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                f"qdrant.{operation}",
+                kind=SpanKind.CLIENT,
+            ) as span:
+                self._set_start_attributes(span, operation, wrapped, args, kwargs)
+                try:
+                    result = await wrapped(*args, **kwargs)
+                except Exception as exc:
+                    self._set_error(span, exc)
+                    raise
+                span.set_status(Status(StatusCode.OK))
+                if self._capture_content:
+                    span.set_attribute(
+                        SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                        _json_dumps(result),
+                    )
+                return result
+        finally:
+            active_call.reset(token)
+
+    def activate(self) -> None:
+        """Patch supported Qdrant client methods."""
+        cls = type(self)
+        if self._is_instrumented or not self._tracing_enabled():
+            return
+        if cls._patches_applied:
+            cls._activation_count += 1
+            self._is_instrumented = True
+            return
+
+        try:
+            module = importlib.import_module("qdrant_client")
+        except ImportError as exc:
+            logger.warning("Qdrant instrumentation dependency is unavailable: %s", exc)
+            return
+
+        patched_targets: list[tuple[type, str]] = []
+        for class_name in ("QdrantClient", "AsyncQdrantClient"):
+            target_class = getattr(module, class_name, None)
+            if target_class is None:
+                continue
+            for operation in QDRANT_OPERATIONS:
+                original = getattr(target_class, operation, None)
+                if not callable(original):
+                    continue
+                is_async = inspect.iscoroutinefunction(original)
+
+                def traced(
+                    wrapped: Any,
+                    _instance: Any,
+                    args: tuple[Any, ...],
+                    kwargs: dict[str, Any],
+                    *,
+                    _operation: str = operation,
+                    _is_async: bool = is_async,
+                ) -> Any:
+                    if _is_async:
+                        return self._trace_async(_operation, wrapped, args, kwargs)
+                    return self._trace_sync(_operation, wrapped, args, kwargs)
+
+                wrap_function_wrapper(
+                    "qdrant_client",
+                    f"{class_name}.{operation}",
+                    traced,
+                )
+                patched_targets.append((target_class, operation))
+
+        self._is_instrumented = bool(patched_targets)
+        cls._patches_applied = self._is_instrumented
+        cls._activation_count = int(self._is_instrumented)
+        cls._patched_targets = patched_targets
+        if not self._is_instrumented:
+            logger.warning("Qdrant instrumentation found no supported client methods")
+
+    def deactivate(self) -> None:
+        """Remove Qdrant patches after the last active instrumentor stops."""
+        if not self._is_instrumented:
+            return
+        self._is_instrumented = False
+        cls = type(self)
+        cls._activation_count = max(cls._activation_count - 1, 0)
+        if cls._activation_count:
+            return
+        for target_class, operation in reversed(cls._patched_targets):
+            try:
+                unwrap(target_class, operation)
+            except Exception:
+                logger.debug(
+                    "Failed to unwrap Qdrant %s.%s",
+                    target_class.__name__,
+                    operation,
+                    exc_info=True,
+                )
+        cls._patched_targets = []
+        cls._patches_applied = False
+
+    def instrument(self) -> None:
+        """OpenTelemetry-style alias for :meth:`activate`."""
+        self.activate()
+
+    def uninstrument(self) -> None:
+        """OpenTelemetry-style alias for :meth:`deactivate`."""
+        self.deactivate()

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/tests/test_instrumentation.py
@@ -1,0 +1,261 @@
+import json
+import sys
+from contextlib import contextmanager
+from types import ModuleType
+
+import pytest
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import StatusCode
+
+from respan_instrumentation_qdrant import QdrantInstrumentor
+from respan_instrumentation_qdrant import _instrumentation
+from respan_instrumentation_qdrant._constants import (
+    MAX_ATTRIBUTE_CHARS,
+    MAX_PREVIEW_ITEMS,
+)
+from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_TYPE,
+    RESPAN_SPAN_HANDOFFS,
+    RESPAN_SPAN_TOOL_CALLS,
+    RESPAN_SPAN_TOOLS,
+)
+
+
+class _FakeSpan:
+    def __init__(self, name):
+        self.name = name
+        self.attributes = {}
+        self.status = None
+        self.exceptions = []
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def record_exception(self, exc):
+        self.exceptions.append(exc)
+
+    def set_status(self, status):
+        self.status = status
+
+
+class _FakeTracer:
+    def __init__(self):
+        self.spans = []
+
+    @contextmanager
+    def start_as_current_span(self, name, **_kwargs):
+        span = _FakeSpan(name)
+        self.spans.append(span)
+        yield span
+
+
+def _install_fake_qdrant(monkeypatch):
+    module = ModuleType("qdrant_client")
+
+    class QdrantClient:
+        def create_collection(self, collection_name, vectors_config=None):
+            return {"collection_name": collection_name, "created": True}
+
+        def upsert(self, collection_name, points, api_key=None):
+            return {"collection_name": collection_name, "points": points}
+
+        def query_points(self, collection_name, query, limit=10):
+            if collection_name == "missing":
+                raise RuntimeError("collection does not exist")
+            return {"points": [{"id": 1, "score": 0.99}], "query": query}
+
+    class AsyncQdrantClient:
+        async def upsert(self, collection_name, points):
+            return {"collection_name": collection_name, "count": len(points)}
+
+        async def query_points(self, collection_name, query, limit=10):
+            return {"points": [{"id": 2, "score": 0.9}], "query": query}
+
+    module.QdrantClient = QdrantClient
+    module.AsyncQdrantClient = AsyncQdrantClient
+    monkeypatch.setitem(sys.modules, "qdrant_client", module)
+    return QdrantClient, AsyncQdrantClient
+
+
+@pytest.fixture(autouse=True)
+def reset_instrumentor():
+    QdrantInstrumentor._patches_applied = False
+    QdrantInstrumentor._activation_count = 0
+    QdrantInstrumentor._patched_targets = []
+    yield
+    for target, method in reversed(QdrantInstrumentor._patched_targets):
+        _instrumentation.unwrap(target, method)
+    QdrantInstrumentor._patches_applied = False
+    QdrantInstrumentor._activation_count = 0
+    QdrantInstrumentor._patched_targets = []
+
+
+def _assert_contract(span):
+    attrs = span.attributes
+    assert attrs[RESPAN_LOG_TYPE] == "task"
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME]
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH]
+    for banned_alias in (
+        "tools",
+        "tool_calls",
+        "model",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_request_tokens",
+        "span_tools",
+        "has_tool_calls",
+        RESPAN_SPAN_TOOLS,
+        RESPAN_SPAN_TOOL_CALLS,
+        RESPAN_SPAN_HANDOFFS,
+    ):
+        assert banned_alias not in attrs
+
+
+def test_package_exports_qdrant_instrumentor():
+    assert QdrantInstrumentor is _instrumentation.QdrantInstrumentor
+    assert QdrantInstrumentor.name == "qdrant"
+
+
+def test_sync_operations_emit_canonical_task_spans(monkeypatch):
+    QdrantClient, _ = _install_fake_qdrant(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    instrumentor = QdrantInstrumentor()
+    instrumentor.instrument()
+
+    client = QdrantClient()
+    client.create_collection("docs", vectors_config={"size": 3})
+    client.upsert(
+        "docs",
+        [{"id": 1, "vector": [0.1, 0.2, 0.3]}],
+        api_key="do-not-export",
+    )
+    result = client.query_points("docs", [0.1, 0.2, 0.3], limit=1)
+
+    assert result["points"][0]["id"] == 1
+    assert [span.name for span in tracer.spans] == [
+        "qdrant.create_collection",
+        "qdrant.upsert",
+        "qdrant.query_points",
+    ]
+    for span in tracer.spans:
+        _assert_contract(span)
+        assert SpanAttributes.TRACELOOP_ENTITY_INPUT in span.attributes
+        assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT in span.attributes
+        assert span.status.status_code is StatusCode.OK
+    assert (
+        "<redacted>"
+        in tracer.spans[1].attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+    )
+    instrumentor.uninstrument()
+
+
+@pytest.mark.asyncio
+async def test_async_operations_are_awaited_and_traced(monkeypatch):
+    _, AsyncQdrantClient = _install_fake_qdrant(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    instrumentor = QdrantInstrumentor()
+    instrumentor.activate()
+
+    result = await AsyncQdrantClient().upsert(
+        "docs",
+        [{"id": 2, "vector": [0.3, 0.2, 0.1]}],
+    )
+
+    assert result["count"] == 1
+    assert [span.name for span in tracer.spans] == ["qdrant.upsert"]
+    _assert_contract(tracer.spans[0])
+    instrumentor.deactivate()
+
+
+def test_errors_are_recorded_and_reraised(monkeypatch):
+    QdrantClient, _ = _install_fake_qdrant(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    instrumentor = QdrantInstrumentor()
+    instrumentor.activate()
+
+    with pytest.raises(RuntimeError, match="collection does not exist"):
+        QdrantClient().query_points("missing", [0.0, 0.0, 0.0])
+
+    span = tracer.spans[-1]
+    assert span.status.status_code is StatusCode.ERROR
+    assert span.exceptions
+    assert span.attributes["status_code"] == 500
+    assert span.attributes["error.message"] == "collection does not exist"
+    assert (
+        "collection does not exist"
+        in span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    )
+    instrumentor.deactivate()
+
+
+def test_capture_content_false_omits_inputs_and_outputs(monkeypatch):
+    QdrantClient, _ = _install_fake_qdrant(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    instrumentor = QdrantInstrumentor(capture_content=False)
+    instrumentor.activate()
+
+    QdrantClient().query_points("docs", [0.1, 0.2, 0.3])
+
+    attrs = tracer.spans[0].attributes
+    assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in attrs
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in attrs
+    _assert_contract(tracer.spans[0])
+    instrumentor.deactivate()
+
+
+def test_full_vectors_survive_canonical_input_and_output(monkeypatch):
+    QdrantClient, _ = _install_fake_qdrant(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    instrumentor = QdrantInstrumentor()
+    instrumentor.activate()
+    vector = [0.125] * (MAX_ATTRIBUTE_CHARS + 17)
+    tags = [f"tag-{index}" for index in range(MAX_PREVIEW_ITEMS + 17)]
+
+    QdrantClient().upsert(
+        "docs",
+        [{"id": 1, "vector": vector, "payload": {"tags": tags}}],
+    )
+
+    span = tracer.spans[-1]
+    entity_input = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
+    entity_output = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    assert entity_input["points"][0]["vector"] == vector
+    assert entity_output["points"][0]["vector"] == vector
+    assert len(entity_input["points"][0]["vector"]) == len(vector)
+    assert (
+        len(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
+        > MAX_ATTRIBUTE_CHARS
+    )
+    assert (
+        len(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+        > MAX_ATTRIBUTE_CHARS
+    )
+    assert entity_input["points"][0]["payload"]["tags"]["truncated"] is True
+    instrumentor.deactivate()
+
+
+def test_lifecycle_is_idempotent_and_reference_counted(monkeypatch):
+    QdrantClient, _ = _install_fake_qdrant(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    first = QdrantInstrumentor()
+    second = QdrantInstrumentor()
+
+    first.activate()
+    first.activate()
+    second.activate()
+    QdrantClient().query_points("docs", [0.1, 0.2, 0.3])
+    assert len(tracer.spans) == 1
+
+    first.deactivate()
+    QdrantClient().query_points("docs", [0.1, 0.2, 0.3])
+    assert len(tracer.spans) == 2
+
+    second.deactivate()
+    QdrantClient().query_points("docs", [0.1, 0.2, 0.3])
+    assert len(tracer.spans) == 2


### PR DESCRIPTION
## Summary

- Add the `respan-instrumentation-qdrant` Python package.
- Trace synchronous and asynchronous Qdrant collection, point, payload, and query operations as canonical task spans.
- Preserve full vectors when content capture is enabled, with privacy controls, structured errors, lifecycle cleanup, tests, and release metadata.

## Why

Qdrant users need first-party Respan tracing without relying on a separate vendor wrapper. This package provides reproducible vector-database inputs and outputs while retaining bounded previews for unrelated payload data.

## Validation

- 7 package tests passed.
- Ruff check and format checks passed.
- Wheel and source distribution built successfully.
- Release inventory and release intent validation passed.
- Release plan contains only `respan-instrumentation-qdrant`; missing intents are empty.
- Rebased onto current `upstream/main` with the release inventory conflict resolved.
