### PR TITLE
feat(py): add Weaviate instrumentation

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -533,6 +533,12 @@
       "name": "respan-instrumentation-pinecone",
       "path": "python-sdks/instrumentations/respan-instrumentation-pinecone",
       "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-weaviate",
+      "path": "python-sdks/instrumentations/respan-instrumentation-weaviate",
+      "registry": "pypi"
     }
   ]
 }

--- a/.release-intents/20260717-respan-instrumentation-weaviate.json
+++ b/.release-intents/20260717-respan-instrumentation-weaviate.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add Weaviate instrumentation",
+  "packages": {
+    "respan-instrumentation-weaviate": "new"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/README.md
@@ -1,0 +1,57 @@
+# respan-instrumentation-weaviate
+
+Respan instrumentation for the Weaviate Python client v4. It emits canonical
+task spans for synchronous and asynchronous collection lifecycle, data,
+reference, vector and keyword query, aggregate, config, batch, and tenant
+operations.
+
+## Install
+
+```bash
+pip install respan-ai respan-instrumentation-weaviate "weaviate-client>=4.22.0,<5"
+```
+
+## Quickstart
+
+```python
+import weaviate
+from weaviate.classes.config import Configure
+from respan import Respan, workflow
+from respan_instrumentation_weaviate import WeaviateInstrumentor
+
+respan = Respan(instrumentations=[WeaviateInstrumentor()])
+
+
+@workflow(name="weaviate_vector_query_workflow")
+def run_query():
+    client = weaviate.connect_to_local()
+    collection = client.collections.create(
+        "RespanDocs",
+        vector_config=Configure.Vectors.self_provided(),
+    )
+    collection.data.insert(
+        {"text": "Respan traces vector-store operations."},
+        vector=[0.1, 0.2, 0.3],
+    )
+    result = collection.query.near_vector(
+        near_vector=[0.1, 0.2, 0.3],
+        limit=1,
+    )
+    client.close()
+    return result
+
+
+print(run_query())
+respan.shutdown()
+```
+
+Pass `capture_content=False` to omit operation arguments and results while
+retaining names, status, and database attributes. Activation/deactivation and
+the `instrument()` / `uninstrument()` aliases are idempotent.
+
+The adapter targets `weaviate-client>=4.22.0,<5` and its v4 collection API.
+Generative search calls are left to an LLM-specific integration because they require chat
+semantics rather than vector-store task semantics.
+
+See `respan-example-projects/python/tracing/weaviate` for runnable sync, async,
+batch, aggregate, query, mutation, and deterministic error examples.

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.poetry]
+name = "respan-instrumentation-weaviate"
+version = "0.1.0"
+description = "Respan instrumentation plugin for Weaviate"
+authors = ["Respan <team@respan.ai>"]
+license = "Apache 2.0"
+readme = "README.md"
+packages = [
+    { include = "respan_instrumentation_weaviate", from = "./src" },
+]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<3.14"
+respan-tracing = "^2.17.0"
+respan-sdk = ">=2.6.1"
+weaviate-client = ">=4.22.0,<5"
+opentelemetry-semantic-conventions-ai = ">=0.4.1"
+wrapt = ">=1.16.0"
+
+[tool.poetry.plugins."respan.instrumentations"]
+weaviate = "respan_instrumentation_weaviate:WeaviateInstrumentor"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/src/respan_instrumentation_weaviate/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/src/respan_instrumentation_weaviate/__init__.py
@@ -1,0 +1,5 @@
+"""Respan instrumentation for Weaviate."""
+
+from respan_instrumentation_weaviate._instrumentation import WeaviateInstrumentor
+
+__all__ = ["WeaviateInstrumentor"]

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/src/respan_instrumentation_weaviate/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/src/respan_instrumentation_weaviate/_constants.py
@@ -1,0 +1,189 @@
+"""Weaviate SDK-specific instrumentation constants."""
+
+from typing import NamedTuple
+
+
+class PatchSpec(NamedTuple):
+    module: str
+    class_name: str
+    label: str
+    methods: tuple[str, ...]
+    is_async: bool = False
+
+
+WEAVIATE_INSTRUMENTATION_NAME = "weaviate"
+
+COLLECTION_OPERATIONS = (
+    "create",
+    "create_from_config",
+    "create_from_dict",
+    "delete",
+    "delete_all",
+    "exists",
+    "export_config",
+    "list_all",
+)
+DATA_OPERATIONS = (
+    "delete_by_id",
+    "delete_many",
+    "exists",
+    "ingest",
+    "insert",
+    "insert_many",
+    "reference_add",
+    "reference_add_many",
+    "reference_delete",
+    "reference_replace",
+    "replace",
+    "update",
+)
+QUERY_OPERATIONS = (
+    "bm25",
+    "fetch_object_by_id",
+    "fetch_objects",
+    "fetch_objects_by_ids",
+    "hybrid",
+    "near_image",
+    "near_media",
+    "near_object",
+    "near_text",
+    "near_vector",
+)
+AGGREGATE_OPERATIONS = (
+    "hybrid",
+    "near_image",
+    "near_object",
+    "near_text",
+    "near_vector",
+    "over_all",
+)
+CONFIG_OPERATIONS = (
+    "add_property",
+    "add_reference",
+    "add_vector",
+    "delete_property_index",
+    "get",
+    "get_shards",
+    "update",
+    "update_shards",
+)
+BATCH_OPERATIONS = ("add_object", "add_reference", "flush")
+TENANT_OPERATIONS = (
+    "create",
+    "exists",
+    "get",
+    "get_by_name",
+    "get_by_names",
+    "remove",
+    "update",
+)
+
+WEAVIATE_PATCH_SPECS = (
+    PatchSpec(
+        "weaviate.collections.collections.sync",
+        "_Collections",
+        "collections",
+        COLLECTION_OPERATIONS,
+    ),
+    PatchSpec(
+        "weaviate.collections.collections.async_",
+        "_CollectionsAsync",
+        "collections",
+        COLLECTION_OPERATIONS,
+        True,
+    ),
+    PatchSpec(
+        "weaviate.collections.data.sync",
+        "_DataCollection",
+        "data",
+        DATA_OPERATIONS,
+    ),
+    PatchSpec(
+        "weaviate.collections.data.async_",
+        "_DataCollectionAsync",
+        "data",
+        DATA_OPERATIONS,
+        True,
+    ),
+    PatchSpec(
+        "weaviate.collections.query",
+        "_QueryCollection",
+        "query",
+        QUERY_OPERATIONS,
+    ),
+    PatchSpec(
+        "weaviate.collections.query",
+        "_QueryCollectionAsync",
+        "query",
+        QUERY_OPERATIONS,
+        True,
+    ),
+    PatchSpec(
+        "weaviate.collections.aggregate",
+        "_AggregateCollection",
+        "aggregate",
+        AGGREGATE_OPERATIONS,
+    ),
+    PatchSpec(
+        "weaviate.collections.aggregate",
+        "_AggregateCollectionAsync",
+        "aggregate",
+        AGGREGATE_OPERATIONS,
+        True,
+    ),
+    PatchSpec(
+        "weaviate.collections.config.sync",
+        "_ConfigCollection",
+        "config",
+        CONFIG_OPERATIONS,
+    ),
+    PatchSpec(
+        "weaviate.collections.config.async_",
+        "_ConfigCollectionAsync",
+        "config",
+        CONFIG_OPERATIONS,
+        True,
+    ),
+    PatchSpec(
+        "weaviate.collections.batch.collection",
+        "_BatchCollection",
+        "batch",
+        BATCH_OPERATIONS,
+    ),
+    PatchSpec(
+        "weaviate.collections.batch.collection",
+        "_BatchCollectionSync",
+        "batch",
+        BATCH_OPERATIONS,
+    ),
+    PatchSpec(
+        "weaviate.collections.batch.collection",
+        "_BatchCollectionAsync",
+        "batch",
+        BATCH_OPERATIONS,
+        True,
+    ),
+    PatchSpec(
+        "weaviate.collections.tenants.sync",
+        "_Tenants",
+        "tenants",
+        TENANT_OPERATIONS,
+    ),
+    PatchSpec(
+        "weaviate.collections.tenants.async_",
+        "_TenantsAsync",
+        "tenants",
+        TENANT_OPERATIONS,
+        True,
+    ),
+)
+
+MAX_ATTRIBUTE_CHARS = 16_000
+MAX_PREVIEW_ITEMS = 64
+SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "authorization",
+    "password",
+    "secret",
+    "token",
+)

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/src/respan_instrumentation_weaviate/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/src/respan_instrumentation_weaviate/_instrumentation.py
@@ -1,0 +1,443 @@
+"""Native Weaviate v4 collection instrumentation for Respan."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from contextvars import ContextVar
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from numbers import Real
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import SpanKind, Status, StatusCode
+from respan_instrumentation_weaviate._constants import (
+    MAX_ATTRIBUTE_CHARS,
+    MAX_PREVIEW_ITEMS,
+    SENSITIVE_KEY_PARTS,
+    WEAVIATE_INSTRUMENTATION_NAME,
+    WEAVIATE_PATCH_SPECS,
+    PatchSpec,
+)
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.llm_logging import LOG_TYPE_TASK
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_tracing.core.tracer import RespanTracer
+from wrapt import wrap_function_wrapper
+
+logger = logging.getLogger(__name__)
+
+
+_VECTOR_KEY_PARTS = ("embedding", "vector")
+
+
+def _is_numeric_vector(value: Any) -> bool:
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes, bytearray))
+        and bool(value)
+        and all(isinstance(item, Real) and not isinstance(item, bool) for item in value)
+    )
+
+
+def _is_vector_key(value: str) -> bool:
+    normalized = value.lower()
+    return any(part in normalized for part in _VECTOR_KEY_PARTS)
+
+
+def _jsonable(
+    value: Any,
+    *,
+    depth: int = 0,
+    vector_context: bool = False,
+    preserved_vector: list[bool] | None = None,
+) -> Any:
+    preserved_vector = preserved_vector if preserved_vector is not None else [False]
+    if depth > 7 and not (vector_context or _is_numeric_vector(value)):
+        return repr(value)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return {"type": "bytes", "length": len(value)}
+    if isinstance(value, Enum):
+        return _jsonable(
+            value.value,
+            depth=depth + 1,
+            vector_context=vector_context,
+            preserved_vector=preserved_vector,
+        )
+    if is_dataclass(value) and not isinstance(value, type):
+        return _jsonable(
+            asdict(value),
+            depth=depth + 1,
+            vector_context=vector_context,
+            preserved_vector=preserved_vector,
+        )
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        omitted = 0
+        regular_items = 0
+        for key, item in value.items():
+            key_text = str(key)
+            item_is_vector = vector_context or _is_vector_key(key_text)
+            if not item_is_vector and regular_items >= MAX_PREVIEW_ITEMS:
+                omitted += 1
+                continue
+            regular_items += int(not item_is_vector)
+            result[key_text] = (
+                "<redacted>"
+                if any(part in key_text.lower() for part in SENSITIVE_KEY_PARTS)
+                else _jsonable(
+                    item,
+                    depth=depth + 1,
+                    vector_context=item_is_vector,
+                    preserved_vector=preserved_vector,
+                )
+            )
+        if omitted:
+            result["__truncated__"] = omitted
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        preserve_all = vector_context or _is_numeric_vector(value)
+        if preserve_all:
+            preserved_vector[0] = True
+        source = value if preserve_all else value[:MAX_PREVIEW_ITEMS]
+        items = [
+            _jsonable(
+                item,
+                depth=depth + 1,
+                vector_context=vector_context,
+                preserved_vector=preserved_vector,
+            )
+            for item in source
+        ]
+        if preserve_all:
+            return items
+        if len(value) > MAX_PREVIEW_ITEMS:
+            return {"count": len(value), "items": items, "truncated": True}
+        return items
+    for method_name in ("model_dump", "to_dict", "dict", "to_json", "tolist"):
+        method = getattr(value, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            return _jsonable(
+                method(),
+                depth=depth + 1,
+                vector_context=vector_context,
+                preserved_vector=preserved_vector,
+            )
+        except Exception:
+            continue
+    public_values = getattr(value, "__dict__", None)
+    if isinstance(public_values, dict):
+        return _jsonable(
+            {
+                key: item
+                for key, item in public_values.items()
+                if not key.startswith("_") and not callable(item)
+            },
+            depth=depth + 1,
+            vector_context=vector_context,
+            preserved_vector=preserved_vector,
+        )
+    return repr(value)
+
+
+def _json_dumps(value: Any) -> str:
+    preserved_vector = [False]
+    text = json.dumps(
+        _jsonable(value, preserved_vector=preserved_vector),
+        default=str,
+        sort_keys=True,
+    )
+    if preserved_vector[0] or len(text) <= MAX_ATTRIBUTE_CHARS:
+        return text
+    return json.dumps(
+        {"preview": text[:MAX_ATTRIBUTE_CHARS], "truncated": True},
+        sort_keys=True,
+    )
+
+
+def _instance_identity(instance: Any) -> dict[str, str]:
+    identity: dict[str, str] = {}
+    for source, target in (
+        ("name", "collection_name"),
+        ("_name", "collection_name"),
+        ("tenant", "tenant"),
+        ("_tenant", "tenant"),
+    ):
+        value = getattr(instance, source, None)
+        if value is not None and target not in identity:
+            identity[target] = str(value)
+    return identity
+
+
+def _call_input(
+    label: str,
+    operation: str,
+    instance: Any,
+    wrapped: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        bound = inspect.signature(wrapped).bind_partial(*args, **kwargs)
+        arguments = {
+            key: value for key, value in bound.arguments.items() if key != "self"
+        }
+    except Exception:
+        arguments = {"args": list(args), "kwargs": kwargs}
+    return {
+        "operation": f"{label}.{operation}",
+        **_instance_identity(instance),
+        **arguments,
+    }
+
+
+class WeaviateInstrumentor:
+    """Trace Weaviate v4 sync and async collection operations."""
+
+    name = WEAVIATE_INSTRUMENTATION_NAME
+    _patches_applied = False
+    _activation_count = 0
+    _patched_targets: list[tuple[type, str]] = []
+    _active_call: ContextVar[bool] = ContextVar(
+        "respan_weaviate_active_call",
+        default=False,
+    )
+
+    def __init__(self, *, capture_content: bool = True) -> None:
+        self._capture_content = capture_content
+        self._is_instrumented = False
+
+    @staticmethod
+    def _tracing_enabled() -> bool:
+        tracer = getattr(RespanTracer, "_instance", None)
+        return tracer is None or bool(getattr(tracer, "is_enabled", True))
+
+    def _set_start_attributes(
+        self,
+        span: Any,
+        label: str,
+        operation: str,
+        instance: Any,
+        wrapped: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> None:
+        operation_name = f"{label}.{operation}"
+        entity_name = f"weaviate.{operation_name}"
+        span.set_attribute(RESPAN_LOG_TYPE, LOG_TYPE_TASK)
+        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
+        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_name)
+        span.set_attribute(OTelSpanAttributes.DB_SYSTEM, "weaviate")
+        span.set_attribute(OTelSpanAttributes.DB_OPERATION, operation_name)
+        if self._capture_content:
+            span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_INPUT,
+                _json_dumps(
+                    _call_input(
+                        label,
+                        operation,
+                        instance,
+                        wrapped,
+                        args,
+                        kwargs,
+                    )
+                ),
+            )
+
+    def _set_error(self, span: Any, exc: Exception) -> None:
+        span.record_exception(exc)
+        span.set_status(Status(StatusCode.ERROR, str(exc)))
+        span.set_attribute("status_code", 500)
+        span.set_attribute(ERROR_MESSAGE_ATTR, str(exc))
+        if self._capture_content:
+            span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                _json_dumps({"error": type(exc).__name__, "message": str(exc)}),
+            )
+
+    def _trace_sync(
+        self,
+        label: str,
+        operation: str,
+        wrapped: Any,
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        active_call = type(self)._active_call
+        if active_call.get():
+            return wrapped(*args, **kwargs)
+        token = active_call.set(True)
+        try:
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                f"weaviate.{label}.{operation}",
+                kind=SpanKind.CLIENT,
+            ) as span:
+                self._set_start_attributes(
+                    span, label, operation, instance, wrapped, args, kwargs
+                )
+                try:
+                    result = wrapped(*args, **kwargs)
+                except Exception as exc:
+                    self._set_error(span, exc)
+                    raise
+                span.set_status(Status(StatusCode.OK))
+                if self._capture_content:
+                    span.set_attribute(
+                        SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                        _json_dumps(result),
+                    )
+                return result
+        finally:
+            active_call.reset(token)
+
+    async def _trace_async(
+        self,
+        label: str,
+        operation: str,
+        wrapped: Any,
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        active_call = type(self)._active_call
+        if active_call.get():
+            return await wrapped(*args, **kwargs)
+        token = active_call.set(True)
+        try:
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                f"weaviate.{label}.{operation}",
+                kind=SpanKind.CLIENT,
+            ) as span:
+                self._set_start_attributes(
+                    span, label, operation, instance, wrapped, args, kwargs
+                )
+                try:
+                    result = await wrapped(*args, **kwargs)
+                except Exception as exc:
+                    self._set_error(span, exc)
+                    raise
+                span.set_status(Status(StatusCode.OK))
+                if self._capture_content:
+                    span.set_attribute(
+                        SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                        _json_dumps(result),
+                    )
+                return result
+        finally:
+            active_call.reset(token)
+
+    def _patch_spec(self, spec: PatchSpec) -> list[tuple[type, str]]:
+        try:
+            module = importlib.import_module(spec.module)
+            target_class = getattr(module, spec.class_name)
+        except (ImportError, AttributeError):
+            return []
+
+        patched: list[tuple[type, str]] = []
+        for operation in spec.methods:
+            if not callable(getattr(target_class, operation, None)):
+                continue
+
+            def traced(
+                wrapped: Any,
+                instance: Any,
+                args: tuple[Any, ...],
+                kwargs: dict[str, Any],
+                *,
+                _label: str = spec.label,
+                _operation: str = operation,
+                _is_async: bool = spec.is_async,
+            ) -> Any:
+                if _is_async:
+                    return self._trace_async(
+                        _label,
+                        _operation,
+                        wrapped,
+                        instance,
+                        args,
+                        kwargs,
+                    )
+                return self._trace_sync(
+                    _label,
+                    _operation,
+                    wrapped,
+                    instance,
+                    args,
+                    kwargs,
+                )
+
+            # Use the already imported module object. Importing a dotted private
+            # Weaviate module a second time can re-enter the package's broad
+            # ``weaviate.__init__`` import graph during startup.
+            wrap_function_wrapper(
+                module,
+                f"{spec.class_name}.{operation}",
+                traced,
+            )
+            patched.append((target_class, operation))
+        return patched
+
+    def activate(self) -> None:
+        """Patch supported Weaviate v4 managers."""
+        cls = type(self)
+        if self._is_instrumented or not self._tracing_enabled():
+            return
+        if cls._patches_applied:
+            cls._activation_count += 1
+            self._is_instrumented = True
+            return
+
+        patched_targets: list[tuple[type, str]] = []
+        for spec in WEAVIATE_PATCH_SPECS:
+            patched_targets.extend(self._patch_spec(spec))
+
+        self._is_instrumented = bool(patched_targets)
+        cls._patches_applied = self._is_instrumented
+        cls._activation_count = int(self._is_instrumented)
+        cls._patched_targets = patched_targets
+        if not self._is_instrumented:
+            logger.warning("Weaviate instrumentation found no supported v4 methods")
+
+    def deactivate(self) -> None:
+        """Remove Weaviate patches after the final active instance stops."""
+        if not self._is_instrumented:
+            return
+        self._is_instrumented = False
+        cls = type(self)
+        cls._activation_count = max(cls._activation_count - 1, 0)
+        if cls._activation_count:
+            return
+        for target_class, operation in reversed(cls._patched_targets):
+            try:
+                unwrap(target_class, operation)
+            except Exception:
+                logger.debug(
+                    "Failed to unwrap Weaviate %s.%s",
+                    target_class.__name__,
+                    operation,
+                    exc_info=True,
+                )
+        cls._patched_targets = []
+        cls._patches_applied = False
+
+    def instrument(self) -> None:
+        """OpenTelemetry-style alias for :meth:`activate`."""
+        self.activate()
+
+    def uninstrument(self) -> None:
+        """OpenTelemetry-style alias for :meth:`deactivate`."""
+        self.deactivate()

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/tests/test_instrumentation.py
@@ -1,0 +1,364 @@
+import json
+import sys
+from contextlib import contextmanager
+from types import ModuleType
+
+import pytest
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import StatusCode
+
+from respan_instrumentation_weaviate import WeaviateInstrumentor
+from respan_instrumentation_weaviate import _instrumentation
+from respan_instrumentation_weaviate._constants import (
+    MAX_ATTRIBUTE_CHARS,
+    MAX_PREVIEW_ITEMS,
+    PatchSpec,
+)
+from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_TYPE,
+    RESPAN_SPAN_HANDOFFS,
+    RESPAN_SPAN_TOOL_CALLS,
+    RESPAN_SPAN_TOOLS,
+)
+
+
+class _FakeSpan:
+    def __init__(self, name):
+        self.name = name
+        self.attributes = {}
+        self.status = None
+        self.exceptions = []
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def record_exception(self, exc):
+        self.exceptions.append(exc)
+
+    def set_status(self, status):
+        self.status = status
+
+
+class _FakeTracer:
+    def __init__(self):
+        self.spans = []
+
+    @contextmanager
+    def start_as_current_span(self, name, **_kwargs):
+        span = _FakeSpan(name)
+        self.spans.append(span)
+        yield span
+
+
+def _module(monkeypatch, name, class_name, target_class):
+    module = ModuleType(name)
+    setattr(module, class_name, target_class)
+    monkeypatch.setitem(sys.modules, name, module)
+
+
+def _install_fake_weaviate(monkeypatch):
+    class _Collections:
+        def create(self, name, vector_config=None):
+            return {"name": name, "created": True}
+
+        def exists(self, name):
+            return name != "missing"
+
+        def delete(self, name):
+            if name == "missing":
+                raise RuntimeError("collection missing")
+            return None
+
+    class _DataCollection:
+        name = "Docs"
+        _tenant = None
+
+        def insert(self, properties, uuid=None, vector=None):
+            return uuid or "generated-id"
+
+        def update(self, uuid, properties=None, vector=None):
+            return None
+
+    class _DataCollectionAsync:
+        name = "AsyncDocs"
+        _tenant = "tenant-a"
+
+        async def insert(self, properties, uuid=None, vector=None):
+            return uuid or "async-id"
+
+    class _QueryCollection:
+        name = "Docs"
+
+        def near_vector(self, near_vector, limit=10, **kwargs):
+            return {
+                "objects": [{"uuid": "one", "distance": 0.01, "vector": near_vector}]
+            }
+
+    modules = [
+        (
+            "weaviate.collections.collections.sync",
+            "_Collections",
+            _Collections,
+            "collections",
+            ("create", "exists", "delete"),
+            False,
+        ),
+        (
+            "weaviate.collections.data.sync",
+            "_DataCollection",
+            _DataCollection,
+            "data",
+            ("insert", "update"),
+            False,
+        ),
+        (
+            "weaviate.collections.data.async_",
+            "_DataCollectionAsync",
+            _DataCollectionAsync,
+            "data",
+            ("insert",),
+            True,
+        ),
+        (
+            "weaviate.collections.query",
+            "_QueryCollection",
+            _QueryCollection,
+            "query",
+            ("near_vector",),
+            False,
+        ),
+    ]
+    specs = []
+    for module_name, class_name, target, label, methods, is_async in modules:
+        _module(monkeypatch, module_name, class_name, target)
+        specs.append(PatchSpec(module_name, class_name, label, methods, is_async))
+    monkeypatch.setattr(_instrumentation, "WEAVIATE_PATCH_SPECS", tuple(specs))
+    return _Collections, _DataCollection, _DataCollectionAsync, _QueryCollection
+
+
+@pytest.fixture(autouse=True)
+def reset_instrumentor():
+    WeaviateInstrumentor._patches_applied = False
+    WeaviateInstrumentor._activation_count = 0
+    WeaviateInstrumentor._patched_targets = []
+    yield
+    for target, method in reversed(WeaviateInstrumentor._patched_targets):
+        _instrumentation.unwrap(target, method)
+    WeaviateInstrumentor._patches_applied = False
+    WeaviateInstrumentor._activation_count = 0
+    WeaviateInstrumentor._patched_targets = []
+
+
+def _assert_contract(span):
+    attrs = span.attributes
+    assert attrs[RESPAN_LOG_TYPE] == "task"
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME]
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH]
+    for banned_alias in (
+        "tools",
+        "tool_calls",
+        "model",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_request_tokens",
+        "span_tools",
+        "has_tool_calls",
+        RESPAN_SPAN_TOOLS,
+        RESPAN_SPAN_TOOL_CALLS,
+        RESPAN_SPAN_HANDOFFS,
+    ):
+        assert banned_alias not in attrs
+
+
+def test_package_exports_weaviate_instrumentor():
+    assert WeaviateInstrumentor is _instrumentation.WeaviateInstrumentor
+    assert WeaviateInstrumentor.name == "weaviate"
+
+
+def test_collection_data_and_query_operations_emit_spans(monkeypatch):
+    Collections, Data, _, Query = _install_fake_weaviate(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    instrumentor = WeaviateInstrumentor()
+    instrumentor.activate()
+
+    Collections().create("Docs", vector_config={"vectorizer": "none"})
+    object_id = Data().insert(
+        {"text": "Respan traces Weaviate"},
+        vector=[0.1, 0.2, 0.3],
+    )
+    result = Query().near_vector([0.1, 0.2, 0.3], limit=1)
+
+    assert object_id == "generated-id"
+    assert result["objects"][0]["uuid"] == "one"
+    assert [span.name for span in tracer.spans] == [
+        "weaviate.collections.create",
+        "weaviate.data.insert",
+        "weaviate.query.near_vector",
+    ]
+    for span in tracer.spans:
+        _assert_contract(span)
+        assert SpanAttributes.TRACELOOP_ENTITY_INPUT in span.attributes
+        assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT in span.attributes
+        assert span.status.status_code is StatusCode.OK
+    assert (
+        '"collection_name": "Docs"'
+        in tracer.spans[1].attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+    )
+    instrumentor.deactivate()
+
+
+@pytest.mark.asyncio
+async def test_async_data_operation_is_awaited(monkeypatch):
+    _, _, AsyncData, _ = _install_fake_weaviate(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    instrumentor = WeaviateInstrumentor()
+    instrumentor.instrument()
+
+    result = await AsyncData().insert(
+        {"text": "async"},
+        vector=[0.3, 0.2, 0.1],
+    )
+
+    assert result == "async-id"
+    assert [span.name for span in tracer.spans] == ["weaviate.data.insert"]
+    _assert_contract(tracer.spans[0])
+    instrumentor.uninstrument()
+
+
+def test_error_status_and_content_control(monkeypatch):
+    Collections, _, _, _ = _install_fake_weaviate(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    instrumentor = WeaviateInstrumentor(capture_content=False)
+    instrumentor.activate()
+
+    with pytest.raises(RuntimeError, match="collection missing"):
+        Collections().delete("missing")
+
+    span = tracer.spans[-1]
+    assert span.status.status_code is StatusCode.ERROR
+    assert span.exceptions
+    assert span.attributes["status_code"] == 500
+    assert span.attributes["error.message"] == "collection missing"
+    assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in span.attributes
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in span.attributes
+    _assert_contract(span)
+    instrumentor.deactivate()
+
+
+def test_full_vectors_survive_canonical_input_and_output(monkeypatch):
+    _, _, _, Query = _install_fake_weaviate(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    instrumentor = WeaviateInstrumentor()
+    instrumentor.activate()
+    vector = [0.125] * (MAX_ATTRIBUTE_CHARS + 17)
+    tags = [f"tag-{index}" for index in range(MAX_PREVIEW_ITEMS + 17)]
+
+    Query().near_vector(vector, limit=1, filters={"tags": tags})
+
+    span = tracer.spans[-1]
+    entity_input = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
+    entity_output = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    assert entity_input["near_vector"] == vector
+    assert entity_output["objects"][0]["vector"] == vector
+    assert len(entity_output["objects"][0]["vector"]) == len(vector)
+    assert (
+        len(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
+        > MAX_ATTRIBUTE_CHARS
+    )
+    assert (
+        len(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+        > MAX_ATTRIBUTE_CHARS
+    )
+    assert entity_input["kwargs"]["filters"]["tags"]["truncated"] is True
+    instrumentor.deactivate()
+
+
+def test_lifecycle_is_idempotent_and_reference_counted(monkeypatch):
+    Collections, _, _, _ = _install_fake_weaviate(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    first = WeaviateInstrumentor()
+    second = WeaviateInstrumentor()
+    first.activate()
+    first.activate()
+    second.activate()
+
+    Collections().exists("Docs")
+    assert len(tracer.spans) == 1
+    first.deactivate()
+    Collections().exists("Docs")
+    assert len(tracer.spans) == 2
+    second.deactivate()
+    Collections().exists("Docs")
+    assert len(tracer.spans) == 2
+
+
+def test_real_dynamic_batch_runtime_target_is_patched_and_unwrapped(monkeypatch):
+    from weaviate.collections.batch.collection import _BatchCollection
+
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(
+        _instrumentation,
+        "WEAVIATE_PATCH_SPECS",
+        (
+            PatchSpec(
+                "weaviate.collections.batch.collection",
+                "_BatchCollection",
+                "batch",
+                ("add_object", "flush"),
+            ),
+        ),
+    )
+    original_add_object = _BatchCollection.add_object
+    original_flush = _BatchCollection.flush
+    instrumentor = WeaviateInstrumentor()
+    instrumentor.activate()
+
+    batch = object.__new__(_BatchCollection)
+    batch._BatchCollection__name = "Docs"
+    batch._BatchCollection__tenant = None
+    batch._BatchBase__active_requests = 0
+    batch._BatchBase__batch_objects = []
+    batch._BatchBase__batch_references = []
+    object_ids = iter(("object-1", "object-2", "object-3"))
+    batch._add_object = lambda **_kwargs: next(object_ids)
+
+    assert (
+        batch.add_object(
+            {"text": "first"},
+            vector=[0.1, 0.2, 0.3],
+        )
+        == "object-1"
+    )
+    batch.add_object({"text": "second"}, vector=[0.4, 0.5, 0.6])
+    batch.add_object({"text": "third"}, vector=[0.7, 0.8, 0.9])
+    batch.flush()
+
+    assert [span.name for span in tracer.spans] == [
+        "weaviate.batch.add_object",
+        "weaviate.batch.add_object",
+        "weaviate.batch.add_object",
+        "weaviate.batch.flush",
+    ]
+    for span in tracer.spans:
+        _assert_contract(span)
+        assert span.status.status_code is StatusCode.OK
+        assert SpanAttributes.TRACELOOP_ENTITY_INPUT in span.attributes
+        assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT in span.attributes
+    first_input = json.loads(
+        tracer.spans[0].attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+    )
+    assert first_input["operation"] == "batch.add_object"
+    assert first_input["properties"] == {"text": "first"}
+    assert first_input["vector"] == [0.1, 0.2, 0.3]
+
+    instrumentor.deactivate()
+    assert _BatchCollection.add_object is original_add_object
+    assert _BatchCollection.flush is original_flush
+    batch.flush()
+    assert len(tracer.spans) == 4


### PR DESCRIPTION
## Summary

- Add the `respan-instrumentation-weaviate` Python package for Weaviate v4 clients.
- Trace sync and async collection, data, query, aggregate, configuration, tenant, and batch operations.
- Preserve complete vectors, support content privacy, emit structured failures, and patch the real `_BatchCollection` runtime used by dynamic batches.
- Add focused tests and package-specific release metadata.

## Why

Weaviate users need first-party coverage across the v4 collection API, including dynamic batch writes that are not covered by generic database instrumentation.

## Validation

- 7 package tests passed.
- Real Weaviate 1.30.5 service validation covered sync, async, error, batch, and 513-dimensional vector paths without duplicate spans.
- Ruff check and format checks passed.
- Wheel and source distribution built successfully.
- Release inventory, intent, plan, and missing checks passed.
- Rebased onto current `upstream/main` with the release inventory conflict resolved.
