### PR TITLE
feat(py): enhance LlamaIndex Core and Workflows tracing

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -392,12 +392,6 @@
     },
     {
       "ecosystem": "python",
-      "name": "respan-instrumentation-llama-index",
-      "path": "python-sdks/instrumentations/respan-instrumentation-llama-index",
-      "registry": "pypi"
-    },
-    {
-      "ecosystem": "python",
       "name": "respan-instrumentation-instructor",
       "path": "python-sdks/instrumentations/respan-instrumentation-instructor",
       "registry": "pypi"
@@ -532,6 +526,12 @@
       "ecosystem": "python",
       "name": "respan-instrumentation-pinecone",
       "path": "python-sdks/instrumentations/respan-instrumentation-pinecone",
+      "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-llama-index",
+      "path": "python-sdks/instrumentations/respan-instrumentation-llama-index",
       "registry": "pypi"
     }
   ]

--- a/.release-intents/20260717-respan-instrumentation-llama-index.json
+++ b/.release-intents/20260717-respan-instrumentation-llama-index.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Enhance LlamaIndex Core and Workflows tracing",
+  "packages": {
+    "respan-instrumentation-llama-index": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-llama-index/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-llama-index/README.md
@@ -1,6 +1,6 @@
 # respan-instrumentation-llama-index
 
-Respan instrumentation plugin for LlamaIndex. It registers native LlamaIndex
+Respan instrumentation plugin for LlamaIndex Core and standalone Workflows. It registers native LlamaIndex
 instrumentation handlers and emits Respan-compatible OpenTelemetry spans through
 the Respan tracing pipeline.
 
@@ -73,5 +73,4 @@ After running the script, traces appear on your [Respan dashboard](https://platf
 ## Further Reading
 
 See the [python/tracing/llama-index](https://github.com/respanai/respan-example-projects/tree/main/python/tracing/llama-index)
-examples for runnable scripts covering hello world, gateway routing, workflow
-spans, Respan parameters, and tool use.
+examples for runnable scripts covering Core LLM, embedding, retrieval, and agent APIs, plus standalone Workflows success and failure paths.

--- a/python-sdks/instrumentations/respan-instrumentation-llama-index/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-llama-index/pyproject.toml
@@ -13,8 +13,9 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.1"
-llama-index-core = ">=0.10.20"
-llama-index-instrumentation = ">=0.4.0"
+llama-index-core = ">=0.14.23,<1.0"
+llama-index-workflows = ">=2.14.0,<3"
+llama-index-instrumentation = ">=0.4.3"
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
 
 [tool.poetry.plugins."respan.instrumentations"]

--- a/python-sdks/instrumentations/respan-instrumentation-llama-index/src/respan_instrumentation_llama_index/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-llama-index/src/respan_instrumentation_llama_index/_constants.py
@@ -7,7 +7,7 @@ COMPLETION_EVENT_KEY = "completion"
 EMBEDDING_EVENT_KEY = "embedding"
 
 LLAMA_INDEX_INSTRUMENTATION_NAME = "llama-index"
-LLAMA_INDEX_ROOT_MODULE = "llama_index.core.instrumentation"
+LLAMA_INDEX_ROOT_MODULE = "llama_index_instrumentation"
 
 LLAMA_INDEX_CHAT_SPAN_NAME = "llama_index.chat"
 LLAMA_INDEX_COMPLETION_SPAN_NAME = "llama_index.completion"
@@ -15,21 +15,16 @@ LLAMA_INDEX_EMBEDDING_SPAN_NAME = "llama_index.embedding"
 LLAMA_INDEX_TOOL_SPAN_PREFIX = "llama_index.tool."
 LLAMA_INDEX_DEFAULT_TOOL_NAME = "llama_index_tool"
 
-LLAMA_INDEX_SPAN_ID_ATTR = "llama_index.span_id"
-LLAMA_INDEX_PARENT_SPAN_ID_ATTR = "llama_index.parent_span_id"
-LLAMA_INDEX_SYNTHETIC_PARENT_ATTR = "llama_index.synthetic_parent"
-LLAMA_INDEX_TAGS_ATTR = "llama_index.tags"
+LLAMA_INDEX_RUN_ID_TAG = "llamaindex.run_id"
+LLAMA_INDEX_START_EVENT_TAG = "llamaindex.start_event"
+LLAMA_INDEX_STEP_INPUT_EVENT_TAG = "llamaindex.step.input_event"
+LLAMA_INDEX_STEP_INPUT_SUMMARY_TAG = "llamaindex.step.input_summary"
 
 MESSAGE_ROLE_ASSISTANT = "assistant"
 MESSAGE_ROLE_SYSTEM = "system"
 MESSAGE_ROLE_USER = "user"
 
-# Not available in the installed Traceloop GenAI semantic-convention package.
+# Not available in the supported Traceloop GenAI semantic-convention package.
 LLAMA_INDEX_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
 LLAMA_INDEX_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
-LLM_EMBEDDINGS_0 = "llm.embeddings.0"
-
-# Backend override keys used by Respan ingestion for provider-reported usage.
-RESPAN_OVERRIDE_PROMPT_TOKENS_ATTR = "prompt_tokens"
-RESPAN_OVERRIDE_COMPLETION_TOKENS_ATTR = "completion_tokens"
-RESPAN_OVERRIDE_TOTAL_REQUEST_TOKENS_ATTR = "total_request_tokens"
+STATUS_CODE_ATTR = "status_code"

--- a/python-sdks/instrumentations/respan-instrumentation-llama-index/src/respan_instrumentation_llama_index/_handlers.py
+++ b/python-sdks/instrumentations/respan-instrumentation-llama-index/src/respan_instrumentation_llama_index/_handlers.py
@@ -7,14 +7,16 @@ import logging
 import re
 from typing import Any
 
-from llama_index.core.instrumentation.event_handlers import BaseEventHandler
-from llama_index.core.instrumentation.span.base import BaseSpan
-from llama_index.core.instrumentation.span_handlers import BaseSpanHandler
+from llama_index_instrumentation.dispatcher import active_instrument_tags
+from llama_index_instrumentation.event_handlers import BaseEventHandler
+from llama_index_instrumentation.span import BaseSpan
+from llama_index_instrumentation.span_handlers import BaseSpanHandler
 from opentelemetry import context
 from opentelemetry import trace
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
 from opentelemetry.trace import Status, StatusCode
 from pydantic import ConfigDict, PrivateAttr
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
 from respan_sdk.constants.llm_logging import (
     LOG_TYPE_AGENT,
     LOG_TYPE_CHAT,
@@ -42,17 +44,14 @@ from respan_instrumentation_llama_index._constants import (
     LLAMA_INDEX_EMBEDDING_SPAN_NAME,
     LLAMA_INDEX_USAGE_INPUT_TOKENS,
     LLAMA_INDEX_USAGE_OUTPUT_TOKENS,
-    LLAMA_INDEX_PARENT_SPAN_ID_ATTR,
-    LLAMA_INDEX_SPAN_ID_ATTR,
-    LLAMA_INDEX_SYNTHETIC_PARENT_ATTR,
-    LLAMA_INDEX_TAGS_ATTR,
+    LLAMA_INDEX_RUN_ID_TAG,
+    LLAMA_INDEX_START_EVENT_TAG,
+    LLAMA_INDEX_STEP_INPUT_EVENT_TAG,
+    LLAMA_INDEX_STEP_INPUT_SUMMARY_TAG,
     LLAMA_INDEX_TOOL_SPAN_PREFIX,
-    LLM_EMBEDDINGS_0,
     MESSAGE_ROLE_ASSISTANT,
     MESSAGE_ROLE_USER,
-    RESPAN_OVERRIDE_COMPLETION_TOKENS_ATTR,
-    RESPAN_OVERRIDE_PROMPT_TOKENS_ATTR,
-    RESPAN_OVERRIDE_TOTAL_REQUEST_TOKENS_ATTR,
+    STATUS_CODE_ATTR,
 )
 from respan_instrumentation_llama_index._serialization import (
     chat_messages_to_dicts,
@@ -115,6 +114,7 @@ class RespanLlamaIndexSpanHandler(BaseSpanHandler[RespanLlamaIndexSpan]):
         tags: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> RespanLlamaIndexSpan:
+        tags = tags or active_instrument_tags.get()
         entity_name = _span_entity_name(span_id=id_)
         log_type = _span_log_type(
             entity_name=entity_name,
@@ -126,17 +126,9 @@ class RespanLlamaIndexSpanHandler(BaseSpanHandler[RespanLlamaIndexSpan]):
             log_type=log_type,
             entity_path=entity_name,
         )
-        attributes[LLAMA_INDEX_SPAN_ID_ATTR] = id_
-        if parent_span_id:
-            attributes[LLAMA_INDEX_PARENT_SPAN_ID_ATTR] = parent_span_id
-        if tags:
-            attributes[LLAMA_INDEX_TAGS_ATTR] = safe_json(tags)
         if self.capture_content:
             attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safe_json(
-                {
-                    "args": to_jsonable(bound_args.args),
-                    "kwargs": to_jsonable(bound_args.kwargs),
-                }
+                _span_input_payload(bound_args=bound_args, tags=tags)
             )
 
         otel_span, context_token, span_context = _start_otel_span(
@@ -184,9 +176,6 @@ class RespanLlamaIndexSpanHandler(BaseSpanHandler[RespanLlamaIndexSpan]):
             ),
             entity_path=entity_name,
         )
-        attributes[LLAMA_INDEX_SPAN_ID_ATTR] = parent_span_id
-        attributes[LLAMA_INDEX_SYNTHETIC_PARENT_ATTR] = True
-
         parent_context = context.get_current()
         otel_span = _start_detached_otel_span(
             span_name=entity_name,
@@ -236,13 +225,20 @@ class RespanLlamaIndexSpanHandler(BaseSpanHandler[RespanLlamaIndexSpan]):
         if active_span is None:
             return None
         if err is not None:
-            active_span.otel_span.record_exception(err)
+            error_message = str(err) if self.capture_content else type(err).__name__
+            if self.capture_content and isinstance(err, Exception):
+                active_span.otel_span.record_exception(err)
             active_span.otel_span.set_status(
-                Status(status_code=StatusCode.ERROR, description=str(err))
+                Status(status_code=StatusCode.ERROR, description=error_message)
             )
+            active_span.otel_span.set_attribute(ERROR_MESSAGE_ATTR, error_message)
+            active_span.otel_span.set_attribute(STATUS_CODE_ATTR, 500)
+            error_output = {"status": "error", "error": type(err).__name__}
+            if self.capture_content:
+                error_output["message"] = error_message
             active_span.otel_span.set_attribute(
                 SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                safe_json({"error": str(err)}),
+                safe_json(error_output),
             )
         _end_otel_span(active_span=active_span)
         with self.lock:
@@ -294,14 +290,14 @@ class RespanLlamaIndexEventHandler(BaseEventHandler):
             request_type=LLMRequestTypeValues.CHAT.value,
             model_dict=model_dict,
         )
-        for message_index, message in enumerate(messages):
-            attributes[f"{SpanAttributes.LLM_PROMPTS}.{message_index}.role"] = (
-                message.get("role", "")
-            )
-            attributes[f"{SpanAttributes.LLM_PROMPTS}.{message_index}.content"] = (
-                _content_attribute(value=message.get("content"))
-            )
         if self.capture_content:
+            for message_index, message in enumerate(messages):
+                attributes[f"{SpanAttributes.LLM_PROMPTS}.{message_index}.role"] = (
+                    message.get("role", "")
+                )
+                attributes[f"{SpanAttributes.LLM_PROMPTS}.{message_index}.content"] = (
+                    _content_attribute(value=message.get("content"))
+                )
             attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safe_json(messages)
         self._push_event_span(
             span_id=getattr(event, "span_id", None),
@@ -320,15 +316,14 @@ class RespanLlamaIndexEventHandler(BaseEventHandler):
         response_message = chat_response_to_message_dict(
             getattr(event, "response", None)
         )
-        attributes = {
-            f"{SpanAttributes.LLM_COMPLETIONS}.0.role": response_message.get(
-                "role", MESSAGE_ROLE_ASSISTANT
-            ),
-            f"{SpanAttributes.LLM_COMPLETIONS}.0.content": _content_attribute(
-                value=response_message.get("content")
-            ),
-        }
+        attributes: dict[str, Any] = {}
         if self.capture_content:
+            attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.role"] = (
+                response_message.get("role", MESSAGE_ROLE_ASSISTANT)
+            )
+            attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] = (
+                _content_attribute(value=response_message.get("content"))
+            )
             attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(
                 response_message
             )
@@ -350,9 +345,9 @@ class RespanLlamaIndexEventHandler(BaseEventHandler):
             request_type=LLMRequestTypeValues.COMPLETION.value,
             model_dict=model_dict,
         )
-        attributes[f"{SpanAttributes.LLM_PROMPTS}.0.role"] = MESSAGE_ROLE_USER
-        attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"] = str(prompt)
         if self.capture_content:
+            attributes[f"{SpanAttributes.LLM_PROMPTS}.0.role"] = MESSAGE_ROLE_USER
+            attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"] = str(prompt)
             attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safe_json(
                 [{"role": MESSAGE_ROLE_USER, "content": prompt}]
             )
@@ -371,11 +366,12 @@ class RespanLlamaIndexEventHandler(BaseEventHandler):
         if active_event_span is None:
             return
         completion_text = completion_response_to_text(getattr(event, "response", None))
-        attributes = {
-            f"{SpanAttributes.LLM_COMPLETIONS}.0.role": MESSAGE_ROLE_ASSISTANT,
-            f"{SpanAttributes.LLM_COMPLETIONS}.0.content": completion_text,
-        }
+        attributes: dict[str, Any] = {}
         if self.capture_content:
+            attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.role"] = (
+                MESSAGE_ROLE_ASSISTANT
+            )
+            attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] = completion_text
             attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(
                 {"role": MESSAGE_ROLE_ASSISTANT, "content": completion_text}
             )
@@ -411,19 +407,15 @@ class RespanLlamaIndexEventHandler(BaseEventHandler):
         if active_event_span is None:
             return
         chunks = getattr(event, "chunks", [])
-        embedding_summary = _embedding_summary(
-            embeddings=getattr(event, "embeddings", []) or []
-        )
-        attributes: dict[str, Any] = {
-            SpanAttributes.TRACELOOP_ENTITY_OUTPUT: safe_json(embedding_summary),
-            LLM_EMBEDDINGS_0: safe_json(embedding_summary),
-        }
-        if chunks:
-            attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"] = _embedding_input(
-                chunks=chunks
-            )
+        embeddings = getattr(event, "embeddings", []) or []
+        attributes: dict[str, Any] = {}
         if self.capture_content:
             attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safe_json(chunks)
+            attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(embeddings)
+            if chunks:
+                attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"] = (
+                    _embedding_input(chunks=chunks)
+                )
         _finish_event_span(
             active_event_span=active_event_span,
             attributes=attributes,
@@ -453,18 +445,36 @@ class RespanLlamaIndexEventHandler(BaseEventHandler):
     def _handle_exception(self, *, event: Any) -> None:
         span_id = getattr(event, "span_id", None)
         exception = getattr(event, "exception", None)
-        for (open_span_id, _), active_event_spans in self._open_event_spans.items():
-            if open_span_id != span_id:
-                continue
-            for active_event_span in active_event_spans:
-                if exception is not None:
+        if exception is None:
+            return
+        error_message = (
+            str(exception) if self.capture_content else type(exception).__name__
+        )
+        error_output = {"status": "error", "error": type(exception).__name__}
+        if self.capture_content:
+            error_output["message"] = error_message
+        matching_keys = [key for key in self._open_event_spans if key[0] == span_id]
+        for key in matching_keys:
+            active_event_spans = self._open_event_spans.pop(key)
+            for active_event_span in reversed(active_event_spans):
+                if self.capture_content and isinstance(exception, Exception):
                     active_event_span.otel_span.record_exception(exception)
-                    active_event_span.otel_span.set_status(
-                        Status(
-                            status_code=StatusCode.ERROR,
-                            description=str(exception),
-                        )
+                active_event_span.otel_span.set_status(
+                    Status(
+                        status_code=StatusCode.ERROR,
+                        description=error_message,
                     )
+                )
+                active_event_span.otel_span.set_attribute(
+                    ERROR_MESSAGE_ATTR, error_message
+                )
+                active_event_span.otel_span.set_attribute(STATUS_CODE_ATTR, 500)
+                _finish_event_span(
+                    active_event_span=active_event_span,
+                    attributes={
+                        SpanAttributes.TRACELOOP_ENTITY_OUTPUT: safe_json(error_output)
+                    },
+                )
 
     def _push_event_span(
         self,
@@ -604,14 +614,11 @@ def _set_usage_attributes(*, attributes: dict[str, Any], response: Any) -> None:
     if prompt_tokens is not None:
         attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = prompt_tokens
         attributes[LLAMA_INDEX_USAGE_INPUT_TOKENS] = prompt_tokens
-        attributes[RESPAN_OVERRIDE_PROMPT_TOKENS_ATTR] = prompt_tokens
     if completion_tokens is not None:
         attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = completion_tokens
         attributes[LLAMA_INDEX_USAGE_OUTPUT_TOKENS] = completion_tokens
-        attributes[RESPAN_OVERRIDE_COMPLETION_TOKENS_ATTR] = completion_tokens
     if total_tokens is not None:
         attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = total_tokens
-        attributes[RESPAN_OVERRIDE_TOTAL_REQUEST_TOKENS_ATTR] = total_tokens
 
 
 def _clean_attributes(*, attributes: dict[str, Any]) -> dict[str, Any]:
@@ -634,27 +641,46 @@ def _content_attribute(*, value: Any) -> str:
 
 
 def _span_output_payload(*, entity_name: str, result: Any) -> Any:
-    if "embedding" in entity_name.lower():
-        return _embedding_summary(embeddings=result)
     return result
 
 
-def _embedding_summary(*, embeddings: Any) -> dict[str, Any]:
-    if _is_number_sequence(embeddings):
-        return {
-            "embedding_count": 1,
-            "embedding_dimensions": len(embeddings),
+def _span_input_payload(
+    *,
+    bound_args: inspect.BoundArguments,
+    tags: dict[str, Any] | None,
+) -> Any:
+    """Prefer public Workflows event summaries over internal runtime state.
+
+    Current llama-index-workflows run spans bind a recursive broker state
+    object. Serializing that object can fail before the root span is created.
+    The SDK emits stable input summaries in instrumentation tags specifically
+    for integrations, so consume those and keep the raw vendor tags off the
+    exported span.
+    """
+
+    tags = tags or {}
+    if LLAMA_INDEX_START_EVENT_TAG in tags:
+        payload: dict[str, Any] = {
+            "event": tags[LLAMA_INDEX_START_EVENT_TAG],
         }
-    if isinstance(embeddings, list):
-        first_embedding = next(
-            (embedding for embedding in embeddings if _is_number_sequence(embedding)),
-            None,
-        )
-        summary: dict[str, Any] = {"embedding_count": len(embeddings)}
-        if first_embedding is not None:
-            summary["embedding_dimensions"] = len(first_embedding)
-        return summary
-    return {"embedding_count": 0}
+        if LLAMA_INDEX_RUN_ID_TAG in tags:
+            payload["run_id"] = tags[LLAMA_INDEX_RUN_ID_TAG]
+        return payload
+    if LLAMA_INDEX_STEP_INPUT_SUMMARY_TAG in tags:
+        payload = {
+            "event": tags[LLAMA_INDEX_STEP_INPUT_SUMMARY_TAG],
+        }
+        if LLAMA_INDEX_STEP_INPUT_EVENT_TAG in tags:
+            payload["event_type"] = tags[LLAMA_INDEX_STEP_INPUT_EVENT_TAG]
+        if LLAMA_INDEX_RUN_ID_TAG in tags:
+            payload["run_id"] = tags[LLAMA_INDEX_RUN_ID_TAG]
+        return payload
+    if LLAMA_INDEX_RUN_ID_TAG in tags:
+        return {"run_id": tags[LLAMA_INDEX_RUN_ID_TAG]}
+    return {
+        "args": to_jsonable(bound_args.args),
+        "kwargs": to_jsonable(bound_args.kwargs),
+    }
 
 
 def _embedding_input(*, chunks: Any) -> str:
@@ -663,19 +689,10 @@ def _embedding_input(*, chunks: Any) -> str:
     return safe_json(chunks)
 
 
-def _is_number_sequence(value: Any) -> bool:
-    return (
-        isinstance(value, list)
-        and bool(value)
-        and all(
-            isinstance(item, (int, float)) and not isinstance(item, bool)
-            for item in value
-        )
-    )
-
-
 def _span_entity_name(*, span_id: str) -> str:
     entity_name = _UUID_SUFFIX_RE.sub(repl="", string=span_id)
+    if ".<locals>." in entity_name:
+        entity_name = entity_name.rsplit(".<locals>.", maxsplit=1)[-1]
     return entity_name or span_id
 
 

--- a/python-sdks/instrumentations/respan-instrumentation-llama-index/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-llama-index/tests/test_instrumentation.py
@@ -1,9 +1,12 @@
-import logging
+import asyncio
 import json
+import logging
 from types import SimpleNamespace
 
 import pytest
 from llama_index.core import instrumentation
+from workflows import Workflow, step
+from workflows.events import Event, StartEvent, StopEvent
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import StatusCode
@@ -30,11 +33,6 @@ from respan_instrumentation_llama_index._handlers import (
     RespanLlamaIndexEventHandler,
     RespanLlamaIndexSpanHandler,
 )
-from respan_instrumentation_llama_index._constants import (
-    RESPAN_OVERRIDE_COMPLETION_TOKENS_ATTR,
-    RESPAN_OVERRIDE_PROMPT_TOKENS_ATTR,
-    RESPAN_OVERRIDE_TOTAL_REQUEST_TOKENS_ATTR,
-)
 from respan_instrumentation_llama_index._serialization import extract_usage
 
 
@@ -50,7 +48,7 @@ def span_exporter():
     exporter = InMemorySpanExporter()
     telemetry = RespanTelemetry(
         app_name="llama-index-test",
-        api_key="test-key",
+        api_key=None,
         is_auto_instrument=False,
         is_batching_enabled=False,
     )
@@ -174,6 +172,31 @@ def test_span_handler_emits_workflow_and_task_spans(span_exporter):
     )
 
 
+def test_span_handler_error_respects_content_capture_setting(span_exporter):
+    handler = RespanLlamaIndexSpanHandler(capture_content=False)
+    bound_args = SimpleNamespace(args=("top-secret input",), kwargs={})
+    span_id = "RetrieverQueryEngine.query-private"
+
+    handler.span_enter(id_=span_id, bound_args=bound_args, parent_id=None)
+    handler.span_drop(
+        id_=span_id,
+        bound_args=bound_args,
+        err=RuntimeError("top-secret failure"),
+    )
+
+    span = span_exporter.get_finished_spans()[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes["status_code"] == 500
+    assert span.attributes["error.message"] == "RuntimeError"
+    assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in span.attributes
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "error": "RuntimeError",
+        "status": "error",
+    }
+    assert "top-secret" not in json.dumps(dict(span.attributes))
+    assert not span.events
+
+
 def test_span_handler_uses_cached_parent_context_after_parent_exits(span_exporter):
     handler = RespanLlamaIndexSpanHandler()
     root_bound_args = SimpleNamespace(args=("question",), kwargs={})
@@ -244,11 +267,60 @@ def test_span_handler_groups_missing_parent_siblings_under_synthetic_parent(
     step_span = spans_by_name["BaseWorkflowAgent.run_agent_step"]
 
     assert synthetic_parent.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_AGENT
-    assert synthetic_parent.attributes["llama_index.synthetic_parent"] is True
+    assert not any(
+        key.startswith("llama_index.") for key in synthetic_parent.attributes
+    )
     assert setup_span.context.trace_id == synthetic_parent.context.trace_id
     assert step_span.context.trace_id == synthetic_parent.context.trace_id
     assert setup_span.parent.span_id == synthetic_parent.context.span_id
     assert step_span.parent.span_id == synthetic_parent.context.span_id
+
+
+def test_standalone_workflows_emit_real_root_and_step_spans(span_exporter):
+    class DraftEvent(Event):
+        text: str
+
+    class DemoWorkflow(Workflow):
+        @step
+        async def draft(self, event: StartEvent) -> DraftEvent:
+            return DraftEvent(text=f"draft:{event.topic}")
+
+        @step
+        async def finish(self, event: DraftEvent) -> StopEvent:
+            return StopEvent(result=event.text.upper())
+
+    async def run_workflow():
+        return await DemoWorkflow().run(topic="respan")
+
+    instrumentor = LlamaIndexInstrumentor()
+    instrumentor.activate()
+    try:
+        result = asyncio.run(run_workflow())
+    finally:
+        instrumentor.deactivate()
+
+    assert result == "DRAFT:RESPAN"
+    spans_by_name = {span.name: span for span in span_exporter.get_finished_spans()}
+    root_span = spans_by_name["DemoWorkflow.run"]
+    draft_span = spans_by_name["DemoWorkflow.draft"]
+    finish_span = spans_by_name["DemoWorkflow.finish"]
+
+    assert root_span.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_WORKFLOW
+    assert (
+        "StartEvent"
+        in json.loads(root_span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])[
+            "event"
+        ]
+    )
+    assert json.loads(root_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "result": "DRAFT:RESPAN"
+    }
+    assert draft_span.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_TASK
+    assert finish_span.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_TASK
+    assert draft_span.parent.span_id == root_span.context.span_id
+    assert finish_span.parent.span_id == root_span.context.span_id
+    for span in (root_span, draft_span, finish_span):
+        assert not any(key.startswith("llama_index.") for key in span.attributes)
 
 
 def test_chat_events_emit_canonical_llm_span(span_exporter):
@@ -506,6 +578,50 @@ def test_chat_events_can_disable_content_capture(span_exporter):
 
     assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in chat_span.attributes
     assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in chat_span.attributes
+    assert not any(
+        key.startswith(f"{SpanAttributes.LLM_PROMPTS}.")
+        or key.startswith(f"{SpanAttributes.LLM_COMPLETIONS}.")
+        for key in chat_span.attributes
+    )
+    assert "hidden" not in json.dumps(dict(chat_span.attributes))
+
+
+def test_completion_events_can_disable_content_capture(span_exporter):
+    handler = RespanLlamaIndexEventHandler(capture_content=False)
+    handler.handle(
+        SimpleNamespace(
+            class_name=lambda: "LLMCompletionStartEvent",
+            span_id="span-private",
+            prompt="completion secret",
+            model_dict={},
+        )
+    )
+    handler.handle(
+        SimpleNamespace(
+            class_name=lambda: "LLMCompletionEndEvent",
+            span_id="span-private",
+            response=SimpleNamespace(
+                text="private response",
+                raw={"usage": {"input_tokens": 2, "output_tokens": 1}},
+            ),
+        )
+    )
+
+    completion_span = next(
+        span
+        for span in span_exporter.get_finished_spans()
+        if span.name == "llama_index.completion"
+    )
+    assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in completion_span.attributes
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in completion_span.attributes
+    assert not any(
+        key.startswith(f"{SpanAttributes.LLM_PROMPTS}.")
+        or key.startswith(f"{SpanAttributes.LLM_COMPLETIONS}.")
+        for key in completion_span.attributes
+    )
+    assert completion_span.attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 3
+    assert "secret" not in json.dumps(dict(completion_span.attributes))
+    assert "private response" not in json.dumps(dict(completion_span.attributes))
 
 
 def test_completion_events_emit_text_span(span_exporter):
@@ -553,13 +669,16 @@ def test_completion_events_emit_text_span(span_exporter):
         attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]
         == "A short completion."
     )
-    assert attributes[RESPAN_OVERRIDE_PROMPT_TOKENS_ATTR] == 4
-    assert attributes[RESPAN_OVERRIDE_COMPLETION_TOKENS_ATTR] == 3
-    assert attributes[RESPAN_OVERRIDE_TOTAL_REQUEST_TOKENS_ATTR] == 7
+    assert attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 4
+    assert attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 3
+    assert attributes["gen_ai.usage.input_tokens"] == 4
+    assert attributes["gen_ai.usage.output_tokens"] == 3
     assert attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 7
+    for alias in ("prompt_tokens", "completion_tokens", "total_request_tokens"):
+        assert alias not in attributes
 
 
-def test_embedding_events_emit_embedding_span_without_vectors(span_exporter):
+def test_embedding_events_capture_full_vectors(span_exporter):
     handler = RespanLlamaIndexEventHandler()
 
     handler.handle(
@@ -593,10 +712,11 @@ def test_embedding_events_emit_embedding_span_without_vectors(span_exporter):
     assert attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"] == (
         '["alpha", "beta"]'
     )
-    assert "embedding_count" in attributes["llm.embeddings.0"]
-    assert "0.1" not in attributes["llm.embeddings.0"]
-    assert "embedding_count" in attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
-    assert "0.1" not in attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    assert json.loads(attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == [
+        [0.1, 0.2],
+        [0.3, 0.4],
+    ]
+    assert "llm.embeddings.0" not in attributes
 
 
 def test_tool_event_emits_tool_span(span_exporter):
@@ -674,6 +794,48 @@ def test_exception_event_marks_open_event_span_error(span_exporter):
     )
 
     assert completion_span.status.status_code == StatusCode.ERROR
+    assert completion_span.attributes["error.message"] == "llama failure"
+    assert completion_span.attributes["status_code"] == 500
+    assert json.loads(
+        completion_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    ) == {
+        "error": "RuntimeError",
+        "message": "llama failure",
+        "status": "error",
+    }
+
+
+def test_exception_event_respects_content_capture_setting(span_exporter):
+    handler = RespanLlamaIndexEventHandler(capture_content=False)
+    handler.handle(
+        SimpleNamespace(
+            class_name=lambda: "LLMCompletionStartEvent",
+            span_id="span-private-error",
+            prompt="top-secret prompt",
+            model_dict={},
+        )
+    )
+    handler.handle(
+        SimpleNamespace(
+            class_name=lambda: "ExceptionEvent",
+            span_id="span-private-error",
+            exception=RuntimeError("top-secret failure"),
+        )
+    )
+
+    completion_span = next(
+        span
+        for span in span_exporter.get_finished_spans()
+        if span.name == "llama_index.completion"
+    )
+    assert completion_span.status.status_code == StatusCode.ERROR
+    assert completion_span.attributes["error.message"] == "RuntimeError"
+    assert json.loads(
+        completion_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    ) == {"error": "RuntimeError", "status": "error"}
+    serialized = json.dumps(dict(completion_span.attributes))
+    assert "top-secret" not in serialized
+    assert not completion_span.events
 
 
 def test_extract_usage_ignores_fractional_token_counts():


### PR DESCRIPTION
## Summary

- Enhance the existing `respan-instrumentation-llama-index` package; no second LlamaIndex package is introduced.
- Add tracing for LlamaIndex Core and standalone Workflows runs, steps, events, and failures.
- Tighten `capture_content=False` behavior for prompts, completions, workflow data, errors, and embedding vectors.
- Emit canonical structured error outputs and update package dependencies, tests, README, and patch release metadata.

## Why

LlamaIndex Core and the standalone Workflows runtime should share one lifecycle-managed instrumentation package and one consistent Respan span contract.

## Validation

- 23 package tests passed with 1 version-gated skip.
- Successful and failing workflow traces were verified with correct parentage and canonical error status.
- Ruff check and format checks passed.
- Wheel and source distribution built successfully.
- Release inventory, intent, plan, and missing checks passed.
- Rebased onto current `upstream/main` with the release inventory conflict resolved.
