### PR TITLE
feat(js): add Eve instrumentation

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -557,6 +557,12 @@
       "name": "respan-instrumentation-temporal",
       "path": "python-sdks/instrumentations/respan-instrumentation-temporal",
       "registry": "pypi"
+    },
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/instrumentation-eve",
+      "path": "javascript-sdks/instrumentations/respan-instrumentation-eve",
+      "registry": "npm"
     }
   ]
 }

--- a/.release-intents/20260721-eve-instrumentation.json
+++ b/.release-intents/20260721-eve-instrumentation.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add Eve instrumentation",
+  "packages": {
+    "@respan/instrumentation-eve": "new"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/LICENSE
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/README.md
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/README.md
@@ -1,0 +1,148 @@
+# @respan/instrumentation-eve
+
+Respan instrumentation for [Eve](https://eve.dev), Vercel's agent framework.
+It maps Eve turns and sessions into the canonical Respan span contract and
+translates Eve's nested AI SDK 7 model and tool spans. The optional
+`withEveLineage` helper groups delegated sessions under their root session and
+records their immediate parent lineage.
+
+The AI SDK translator is included in this package. It does not depend on
+`@respan/instrumentation-vercel`, and it does not register another
+`@ai-sdk/otel` integration. Eve owns that registration.
+
+## Install
+
+```bash
+npm install @respan/respan @respan/instrumentation-eve eve@0.26.1 ai@7.0.26
+```
+
+Eve 0.26 requires Node.js 24 or newer and AI SDK 7. The initial supported
+ranges are `eve >=0.26.0 <0.27.0` and `ai >=7.0.26 <8.0.0`.
+
+## Configure Eve
+
+Create `agent/instrumentation.ts`. Initialize Respan at module scope and await
+it before exporting Eve's instrumentation definition:
+
+```ts
+import { Respan } from "@respan/respan";
+import {
+  EveInstrumentor,
+  withEveLineage,
+} from "@respan/instrumentation-eve";
+import { defineInstrumentation } from "eve/instrumentation";
+
+const respan = new Respan({
+  apiKey: process.env.RESPAN_API_KEY,
+  instrumentations: [new EveInstrumentor()],
+});
+
+await respan.initialize();
+
+export default withEveLineage(
+  defineInstrumentation({
+    recordInputs: false,
+    recordOutputs: false,
+  }),
+);
+```
+
+Do not start Respan from Eve's synchronous `setup` callback. Awaiting
+initialization at module scope ensures the translator is installed before Eve
+creates its first turn span.
+
+Eve detects `agent/instrumentation.ts` and enables its vendored AI SDK
+OpenTelemetry integration. No separate `@vercel/otel` or
+`@ai-sdk/otel` registration is needed.
+
+Do not activate `VercelAIInstrumentor` alongside `EveInstrumentor`; this
+package already handles Eve-translated AI SDK spans.
+
+This configuration disables model input and output recording because conversations
+can contain sensitive data. Set either option to `true` only after deciding
+that exporting that content matches your privacy and retention requirements.
+
+All user-authored non-`eve.*` values returned from `step.started` as
+`runtimeContext` are exported under `respan.metadata.eve.runtime_context`, even
+when `recordInputs` and `recordOutputs` are `false`; do not put secrets in that
+runtime context.
+
+## Delegated session lineage
+
+Eve exposes parent lineage to `events["step.started"]`, but does not put that
+lineage on its raw OpenTelemetry spans. `withEveLineage` composes that event
+hook, mirrors the root lineage onto the active `ai.eve.turn`, and returns it as
+runtime context for the nested AI SDK spans.
+
+If you already have a `step.started` hook, keep it inside
+`defineInstrumentation`; the helper calls it once and preserves its runtime
+context:
+
+```ts
+export default withEveLineage(
+  defineInstrumentation({
+    events: {
+      "step.started"(input) {
+        return {
+          runtimeContext: {
+            "app.tenant_id":
+              input.session.auth.current?.attributes.tenantId ?? "",
+          },
+        };
+      },
+    },
+    recordInputs: false,
+    recordOutputs: false,
+  }),
+);
+```
+
+Eve reserves authored `eve.*` runtime-context keys and discards them. The
+helper therefore uses the private `__respan_eve` namespace; it owns and
+overwrites that one key while preserving every other authored context key. The
+private bridge attributes are consumed and stripped before export.
+
+With the helper enabled, the current Eve session remains the Respan session and
+thread identifier, while the root session becomes the trace-group identifier.
+For delegated sessions, `respan.metadata.eve.parent` contains the immediate
+parent session id, tool call id, and turn id/sequence. These are workflow
+lineage values, not OpenTelemetry span ids, so they are not written to
+`respan.entity.log_parent_id`.
+
+Eve 0.26 starts the delegated child session in a fresh OpenTelemetry trace.
+When the helper's exact parent-session and parent-turn lineage matches one
+caller, semantic export moves the complete child agent subtree into the caller
+trace. The later caller-side `invoke_agent` usage event contains no unique
+content and duplicates the child model usage, so it is suppressed only after
+that exact correlation succeeds. If lineage is missing or ambiguous, the
+translator leaves the original traces and usage event intact rather than
+assigning them to the wrong caller.
+
+Without `withEveLineage`, each Eve session falls back to its own session id as
+the trace-group identifier.
+
+## What is captured
+
+- Each `ai.eve.turn` span as an agent execution
+- Eve's instrumentation `functionId` as the workflow name on every nested span
+- Current Eve session IDs as Respan session and thread identifiers
+- Root-session trace grouping and immediate parent metadata when
+  `withEveLineage` is enabled
+- Eve version, environment, turn, step, and channel data in JSON metadata
+- Delegated child agent, task, and model spans nested under the caller trace
+- AI SDK model input/output, provider, model, streaming state, and token usage
+- Tool execution input/output
+- Embedding spans, model details, and token usage; input and vectors only when
+  AI SDK telemetry emits those supplemental attributes
+
+In semantic span-name mode, Eve's AI SDK `invoke_agent <model>` transport
+wrappers are omitted. Their task, model, and tool children are reparented to
+the real Eve turn, so the visible tree does not contain a second agent for
+every model step. Legacy mode preserves Eve's original emitted tree.
+
+Eve's `$eve.*` Workflow run tags are not OpenTelemetry attributes and are
+therefore outside this span processor's input.
+
+## License
+
+Apache-2.0

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@respan/instrumentation-eve",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Respan instrumentation plugin for the Eve agent framework",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "author": "Respan <team@respan.ai>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/instrumentations/respan-instrumentation-eve"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "tsc -p tsconfig.json && node --test tests/*.test.mjs",
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.29.0",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@respan/respan-sdk": "^1.1.7",
+    "@traceloop/ai-semantic-conventions": "^0.13.0"
+  },
+  "peerDependencies": {
+    "ai": ">=7.0.26 <8.0.0",
+    "eve": ">=0.26.0 <0.27.0"
+  },
+  "peerDependenciesMeta": {
+    "ai": {
+      "optional": false
+    },
+    "eve": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.29",
+    "ai": "^7.0.26",
+    "eve": "^0.26.1",
+    "typescript": "^5.7.3",
+    "zod": "^4.4.3"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_processor.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_processor.ts
@@ -1,0 +1,976 @@
+/**
+ * Translate Eve and its nested AI SDK spans to the Respan span contract.
+ *
+ * Eve emits an `ai.eve.turn` parent plus AI SDK model, tool, and agent spans.
+ * This processor adds Eve lifecycle semantics and applies a local copy of the
+ * AI SDK attribute translation used by Respan's Vercel integration.
+ *
+ * Two-phase enrichment:
+ * - onStart(): Sets RESPAN_LOG_TYPE so the span passes CompositeProcessor filtering
+ * - onEnd():   Full attribute translation (model, messages, tokens, metadata, etc.)
+ */
+
+import type { Context } from "@opentelemetry/api";
+import type { ReadableSpan, Span, SpanProcessor } from "@opentelemetry/sdk-trace-base";
+import {
+  ATTR_GEN_AI_AGENT_ID,
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_TOOL_NAME,
+  ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT,
+} from "@opentelemetry/semantic-conventions/incubating";
+import { RespanLogType, RespanSpanAttributes } from "@respan/respan-sdk";
+import { SpanAttributes as TraceloopSpanAttributes } from "@traceloop/ai-semantic-conventions";
+import {
+  VERCEL_PARENT_SPANS,
+  VERCEL_SPAN_CONFIG,
+  VERCEL_STRUCTURAL_LLM_PARENT_SPANS,
+} from "./constants/index.js";
+import {
+  EVE_SCOPE_NAME,
+  EVE_SESSION_ID,
+  EVE_TURN_ID,
+  EVE_TURN_SEQUENCE,
+  EVE_TURN_SPAN_NAME,
+} from "./constants/eve.js";
+import {
+  EVE_RESPAN_LINEAGE_PARENT_SESSION_ID_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_PARENT_TURN_ID_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_PARENT_TURN_SEQUENCE_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_ROOT_SESSION_ID_ATTRIBUTE,
+  EVE_RESPAN_INTERNAL_EXPORT_TRACE_ID_ATTRIBUTE,
+} from "./constants/lineage.js";
+import {
+  formatCompletionOutput,
+  formatPromptInput,
+  formatToolInput,
+  formatToolOutput,
+  parseToolChoice,
+  parseToolsValue,
+} from "./_translator/messages.js";
+import {
+  AI_AGENT_ID,
+  AI_MODEL_ID,
+  AI_PREFIX,
+  AI_SETTINGS_CONTEXT_PREFIX,
+  AI_TELEMETRY_METADATA_PREFIX,
+  AI_TELEMETRY_FUNCTION_ID,
+  AI_TOOL_CALL_NAME,
+  formatEmbeddingInput,
+  formatEmbeddingOutput,
+  instrumentationScopeName,
+  isModernVercelAISpanName,
+  isVercelAISpan,
+  isVercelAIScope,
+  setMetadata,
+  resolveLogType,
+  safeJsonStr,
+  setDefault,
+} from "./_translator/shared.js";
+import {
+  enrichEveAttributes,
+  resolveEveAgentName,
+} from "./_translator/eve.js";
+import { enrichMetadata, enrichModel, enrichPerformanceMetrics, enrichSystem, enrichTokens, stripRedundantAttrs } from "./_translator/span-enrichment.js";
+
+interface PendingDelegatedUsageLineage {
+  readonly recordedAt: number;
+  readonly usageKey: string;
+  readonly rootSessionId: string;
+  readonly parentSessionId: string;
+  readonly parentTurnId?: string;
+  readonly parentTurnSequence?: number;
+  readonly workflowName?: string;
+  readonly targetTraceId?: string;
+  readonly targetParentSpanId?: string;
+}
+
+interface RetainedWorkflowName {
+  readonly recordedAt: number;
+  readonly workflowName: string;
+}
+
+interface SessionTraceRoot {
+  readonly recordedAt: number;
+  readonly sessionId: string;
+  readonly turnId?: string;
+  readonly turnSequence?: number;
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly workflowName?: string;
+}
+
+interface DelegatedTraceCorrelation {
+  readonly recordedAt: number;
+  readonly targetTraceId: string;
+  readonly targetParentSpanId: string;
+  readonly workflowName?: string;
+}
+
+const MAX_PENDING_DELEGATED_USAGE_LINEAGES = 128;
+const PENDING_DELEGATED_USAGE_LINEAGE_TTL_MS = 5 * 60 * 1000;
+const MAX_RETAINED_TRACE_CONTEXTS = 128;
+const RETAINED_TRACE_CONTEXT_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * SpanProcessor that translates Eve and AI SDK attributes into Respan fields.
+ *
+ * Phase 1 (onStart): Sets RESPAN_LOG_TYPE so CompositeProcessor lets the span through.
+ * Phase 2 (onEnd):   Full attribute enrichment — model, messages, tokens, metadata,
+ *                     tools, performance metrics, environment, etc.
+ */
+export class EveSpanProcessor implements SpanProcessor {
+  private _ownerCount: number;
+  private readonly _inFlightSpans = new WeakSet<object>();
+  /** Open structural wrapper spans: spanId → its own parentSpanId. */
+  private readonly _openStructuralSpans = new Map<string, string | undefined>();
+  /** Active Eve/AI SDK span IDs mapped to their inherited workflow name. */
+  private readonly _openWorkflowNames = new Map<string, string>();
+  /** Workflow names retained across Eve workflow-step context resumptions. */
+  private readonly _openTraceWorkflowNames =
+    new Map<string, RetainedWorkflowName>();
+  /** Completed Eve turns addressable by exact session + turn lineage. */
+  private readonly _sessionTraceRoots = new Map<string, SessionTraceRoot>();
+  /** Eve child OTel trace ID → caller trace root selected by authored lineage. */
+  private readonly _delegatedTraceCorrelations =
+    new Map<string, DelegatedTraceCorrelation>();
+  /**
+   * Eve 0.26 emits caller-side subagent usage after a workflow boundary, with
+   * no active trace or session attributes. Completed delegated model roots do
+   * carry the authored lineage bridge, so retain a small, short-lived queue
+   * and use the exact token-usage tuple to recover that caller session. When
+   * concurrent matches disagree about lineage, leave the usage span ungrouped
+   * rather than guessing.
+   */
+  private readonly _pendingDelegatedUsageLineages: PendingDelegatedUsageLineage[] = [];
+
+  constructor({ initiallyActive = true }: { initiallyActive?: boolean } = {}) {
+    this._ownerCount = initiallyActive ? 1 : 0;
+  }
+
+  acquire(): void {
+    this._ownerCount += 1;
+  }
+
+  release(): void {
+    this._ownerCount = Math.max(0, this._ownerCount - 1);
+  }
+
+  onStart(span: Span, _parentContext: Context): void {
+    if (this._ownerCount === 0) {
+      return;
+    }
+
+    const writableSpan = span as any;
+    const name: string = writableSpan.name ?? "";
+    const scopeName = instrumentationScopeName(writableSpan);
+    if (
+      name !== EVE_TURN_SPAN_NAME &&
+      scopeName !== EVE_SCOPE_NAME &&
+      !name.startsWith(AI_PREFIX) &&
+      !isModernVercelAISpanName(name) &&
+      !isVercelAIScope(scopeName)
+    ) {
+      return;
+    }
+
+    this._applyPendingDelegatedUsageLineage(writableSpan, scopeName);
+
+    this._inFlightSpans.add(span as object);
+
+    const spanContext =
+      typeof writableSpan.spanContext === "function"
+        ? writableSpan.spanContext()
+        : undefined;
+    const spanId: string | undefined = spanContext?.spanId;
+    const traceId: string | undefined = spanContext?.traceId;
+    const parentSpanId: string | undefined =
+      writableSpan.parentSpanId ?? writableSpan.parentSpanContext?.spanId;
+
+    if (name === EVE_TURN_SPAN_NAME) {
+      this._rememberSessionTraceRoot(
+        writableSpan.attributes,
+        traceId,
+        spanId,
+      );
+    }
+    this._applyDelegatedTraceCorrelation(
+      writableSpan.attributes,
+      name,
+      traceId,
+      spanId,
+      (key, value) => writableSpan.setAttribute(key, value),
+    );
+    this._applyWorkflowName(writableSpan, spanId, traceId, parentSpanId);
+
+    if (name === EVE_TURN_SPAN_NAME) {
+      writableSpan.setAttribute(
+        RespanSpanAttributes.RESPAN_LOG_TYPE,
+        RespanLogType.AGENT,
+      );
+      // Eve creates the turn beneath a framework server span that Respan does
+      // not export. Promote normal turns to exported roots so the platform can
+      // select the workflow name. Delegated turns replace this sentinel with
+      // their caller root during onEnd correlation.
+      writableSpan.setAttribute(
+        RespanSpanAttributes.RESPAN_INTERNAL_EXPORT_PARENT,
+        "",
+      );
+      return;
+    }
+
+    // If the parent chain starts inside an open structural wrapper, stamp the
+    // export-time parent (the wrapper's own parent) so the exporter can drop
+    // the wrapper per-span, immune to export-batch boundaries. "" marks a
+    // wrapper that was itself a root span — the child is promoted to root.
+    if (parentSpanId && this._openStructuralSpans.has(parentSpanId)) {
+      let exportParent: string | undefined = parentSpanId;
+      const seen = new Set<string>();
+      while (
+        exportParent &&
+        this._openStructuralSpans.has(exportParent) &&
+        !seen.has(exportParent)
+      ) {
+        seen.add(exportParent);
+        exportParent = this._openStructuralSpans.get(exportParent);
+      }
+      writableSpan.setAttribute(
+        RespanSpanAttributes.RESPAN_INTERNAL_EXPORT_PARENT,
+        exportParent ?? ""
+      );
+    }
+
+    if (
+      VERCEL_STRUCTURAL_LLM_PARENT_SPANS.has(name) ||
+      isEveModelAgentWrapper(name, scopeName, writableSpan.attributes)
+    ) {
+      // Structural wrapper: the .doGenerate/.doStream child carries the real
+      // model/input/output. Eve's gen_ai invoke_agent span is likewise an AI
+      // SDK transport wrapper around the real step + model spans, not another
+      // framework agent. Semantic export drops these wrappers and reparents
+      // their children; legacy export still preserves the emitted tree.
+      writableSpan.setAttribute(RespanSpanAttributes.RESPAN_INTERNAL_DROP_SPAN, true);
+      if (spanId) {
+        this._openStructuralSpans.set(spanId, parentSpanId);
+      }
+    }
+
+    const config = VERCEL_SPAN_CONFIG[name];
+    if (config) {
+      writableSpan.setAttribute(RespanSpanAttributes.RESPAN_LOG_TYPE, config.logType);
+      return;
+    }
+
+    const parentLogType = VERCEL_PARENT_SPANS[name];
+    if (parentLogType !== undefined) {
+      writableSpan.setAttribute(RespanSpanAttributes.RESPAN_LOG_TYPE, parentLogType);
+      return;
+    }
+
+    writableSpan.setAttribute(RespanSpanAttributes.RESPAN_LOG_TYPE, RespanLogType.TASK);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    const endedSpanId = span.spanContext?.().spanId;
+    if (endedSpanId) {
+      this._openStructuralSpans.delete(endedSpanId);
+      this._openWorkflowNames.delete(endedSpanId);
+    }
+
+    const startedWhileActive = this._inFlightSpans.delete(span as object);
+    if (this._ownerCount === 0 && !startedWhileActive) {
+      return;
+    }
+
+    const attrs = (span as any).attributes as Record<string, any> | undefined;
+    const isEveTurn = span.name === EVE_TURN_SPAN_NAME;
+    const scopeName = instrumentationScopeName(span);
+    if (
+      !attrs ||
+      (!isEveTurn &&
+        scopeName !== EVE_SCOPE_NAME &&
+        !isVercelAISpan(span))
+    ) {
+      return;
+    }
+
+    const endedTraceId = span.spanContext?.().traceId;
+    if (isEveTurn) {
+      this._rememberSessionTraceRoot(attrs, endedTraceId, endedSpanId);
+    }
+    this._applyDelegatedTraceCorrelation(
+      attrs,
+      span.name,
+      endedTraceId,
+      endedSpanId,
+      (key, value) => {
+        attrs[key] = value;
+      },
+    );
+    this._rememberDelegatedUsageLineage(attrs, scopeName, endedTraceId);
+
+    const name = span.name;
+    const config = VERCEL_SPAN_CONFIG[name];
+    const parentLogType = VERCEL_PARENT_SPANS[name];
+    const logType = isEveTurn
+      ? RespanLogType.AGENT
+      : resolveLogType(name, attrs);
+
+    // Embedding spans (span-contract.md): input = embedded text, output = the
+    // embedding vector(s) — captured, not dropped (debuggable RAG data; size is
+    // handled by storage tiering, not by deleting it here). Vercel's synthetic
+    // ai.usage.tokens is intentionally NOT surfaced as a token count; it's
+    // stripped. Extract up front, before any early-return or metadata move, so
+    // both the parent (ai.embed) and child (ai.embed.doEmbed) spans are covered.
+    if (
+      logType === RespanLogType.EMBEDDING ||
+      config?.logType === RespanLogType.EMBEDDING ||
+      parentLogType === RespanLogType.EMBEDDING
+    ) {
+      const embInput = formatEmbeddingInput(attrs);
+      if (embInput) setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_INPUT, embInput);
+      const embOutput = formatEmbeddingOutput(attrs);
+      if (embOutput) setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_OUTPUT, embOutput);
+      enrichTokens(attrs);
+    }
+
+    const entityName =
+      isEveTurn
+        ? resolveEveAgentName(attrs)
+        : logType === RespanLogType.AGENT
+        ? attrs[ATTR_GEN_AI_AGENT_NAME] ??
+          attrs[ATTR_GEN_AI_AGENT_ID] ??
+          attrs["ai.agent.name"] ??
+          attrs[AI_AGENT_ID] ??
+          attrs[AI_TELEMETRY_METADATA_PREFIX + "agent_name"] ??
+          name
+        : name;
+
+    enrichEveAttributes(attrs, { name, scopeName });
+    enrichMetadata(attrs);
+    delete attrs[TraceloopSpanAttributes.TRACELOOP_SPAN_KIND];
+
+    attrs[RespanSpanAttributes.RESPAN_LOG_TYPE] = logType;
+    setDefault(
+      attrs,
+      TraceloopSpanAttributes.TRACELOOP_ENTITY_NAME,
+      String(entityName),
+    );
+    setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_PATH, "");
+
+    if (isEveTurn) {
+      setDefault(
+        attrs,
+        RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_KIND,
+        "agent",
+      );
+      setDefault(
+        attrs,
+        RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+        String(entityName),
+      );
+    }
+
+    if (config) {
+      // Do NOT set traceloop.span.kind for auto-emitted AI SDK spans.
+      // In the Respan composite processor `traceloop.span.kind` is reserved
+      // for user-decorated spans (withWorkflow / withTask / withAgent) and
+      // setting it on auto spans (a) flattens the parent/child tree and
+      // (b) causes LLM detail spans (doGenerate / doStream) to be classified
+      // as "task" instead of LLM in the backend. The respan.entity.log_type
+      // attribute (set above) carries the correct type for ingestion.
+      // Matches the patterns in respan-instrumentation-openinference (see
+      // _processor.ts:500) and respan-instrumentation-openai-agents
+      // (see _otel_emitter.ts:398).
+
+      if (config.isLLM) {
+        setDefault(attrs, TraceloopSpanAttributes.LLM_REQUEST_TYPE, RespanLogType.CHAT);
+
+        enrichSystem(attrs);
+        enrichModel(attrs, attrs[AI_MODEL_ID]);
+
+        const input = formatPromptInput(attrs);
+        if (input) {
+          setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_INPUT, input);
+        }
+
+        const output = formatCompletionOutput(attrs);
+        if (output) {
+          setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_OUTPUT, output);
+        }
+
+        enrichTokens(attrs);
+
+        const toolsValue = parseToolsValue(attrs);
+        if (toolsValue) {
+          attrs[TraceloopSpanAttributes.LLM_REQUEST_FUNCTIONS] = safeJsonStr(toolsValue);
+        }
+
+        const toolChoice = parseToolChoice(attrs);
+        if (toolChoice) {
+          setMetadata(attrs, "tool_choice", toolChoice);
+        }
+
+        enrichPerformanceMetrics(attrs, name);
+      }
+
+      if (config.logType === RespanLogType.EMBEDDING || logType === RespanLogType.EMBEDDING) {
+        // input/output/tokens are mapped in the up-front embedding block.
+        setDefault(attrs, TraceloopSpanAttributes.LLM_REQUEST_TYPE, RespanLogType.EMBEDDING);
+        enrichSystem(attrs);
+        enrichModel(attrs, attrs[AI_MODEL_ID]);
+      }
+
+      if (config.logType === RespanLogType.TOOL || logType === RespanLogType.TOOL) {
+        setToolSpanNameHint(attrs, name);
+
+        const toolInput = formatToolInput(attrs);
+        if (toolInput) {
+          setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_INPUT, toolInput);
+        }
+
+        const toolOutput = formatToolOutput(attrs);
+        if (toolOutput) {
+          setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_OUTPUT, toolOutput);
+        }
+      }
+
+    } else {
+      if (logType === RespanLogType.TEXT) {
+        enrichSystem(attrs);
+        enrichModel(attrs, attrs[AI_MODEL_ID]);
+
+        enrichTokens(attrs);
+
+        setDefault(attrs, TraceloopSpanAttributes.LLM_REQUEST_TYPE, RespanLogType.CHAT);
+
+        const input = formatPromptInput(attrs);
+        if (input) {
+          setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_INPUT, input);
+        }
+
+        const output = formatCompletionOutput(attrs);
+        if (output) {
+          setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_OUTPUT, output);
+        }
+
+        const toolsValue = parseToolsValue(attrs);
+        if (toolsValue) {
+          attrs[TraceloopSpanAttributes.LLM_REQUEST_FUNCTIONS] = safeJsonStr(toolsValue);
+        }
+
+        const toolChoice = parseToolChoice(attrs);
+        if (toolChoice) {
+          setMetadata(attrs, "tool_choice", toolChoice);
+        }
+
+        enrichPerformanceMetrics(attrs, name);
+      }
+
+      if (logType === RespanLogType.EMBEDDING) {
+        // input/output/tokens are mapped in the up-front embedding block.
+        setDefault(attrs, TraceloopSpanAttributes.LLM_REQUEST_TYPE, RespanLogType.EMBEDDING);
+        enrichSystem(attrs);
+        enrichModel(attrs, attrs[AI_MODEL_ID]);
+      }
+
+      if (logType === RespanLogType.TOOL) {
+        setToolSpanNameHint(attrs, name);
+
+        const toolInput = formatToolInput(attrs);
+        if (toolInput) {
+          setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_INPUT, toolInput);
+        }
+
+        const toolOutput = formatToolOutput(attrs);
+        if (toolOutput) {
+          setDefault(attrs, TraceloopSpanAttributes.TRACELOOP_ENTITY_OUTPUT, toolOutput);
+        }
+      }
+    }
+
+    stripRedundantAttrs(attrs, logType);
+
+  }
+
+  private _applyWorkflowName(
+    span: any,
+    spanId: string | undefined,
+    traceId: string | undefined,
+    parentSpanId: string | undefined,
+  ): void {
+    const attrs = span.attributes as Record<string, any> | undefined;
+    if (!attrs) {
+      return;
+    }
+
+    this._pruneRetainedTraceContexts();
+    const retainedWorkflow =
+      traceId === undefined
+        ? undefined
+        : this._openTraceWorkflowNames.get(traceId)?.workflowName;
+    const workflowName =
+      nonEmptyString(
+        attrs[TraceloopSpanAttributes.TRACELOOP_WORKFLOW_NAME],
+      ) ??
+      nonEmptyString(attrs[AI_TELEMETRY_FUNCTION_ID]) ??
+      (parentSpanId === undefined
+        ? undefined
+        : this._openWorkflowNames.get(parentSpanId)) ??
+      retainedWorkflow;
+    if (workflowName === undefined) {
+      return;
+    }
+
+    span.setAttribute(
+      TraceloopSpanAttributes.TRACELOOP_WORKFLOW_NAME,
+      workflowName,
+    );
+    if (spanId !== undefined) {
+      this._openWorkflowNames.set(spanId, workflowName);
+    }
+    if (traceId !== undefined) {
+      this._openTraceWorkflowNames.delete(traceId);
+      this._openTraceWorkflowNames.set(traceId, {
+        recordedAt: Date.now(),
+        workflowName,
+      });
+      trimOldest(this._openTraceWorkflowNames, MAX_RETAINED_TRACE_CONTEXTS);
+    }
+  }
+
+  private _applyPendingDelegatedUsageLineage(
+    span: any,
+    scopeName: string | undefined,
+  ): void {
+    const attrs = span.attributes as Record<string, any> | undefined;
+    if (
+      !attrs ||
+      scopeName !== EVE_SCOPE_NAME ||
+      attrs[ATTR_GEN_AI_OPERATION_NAME] !==
+        GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT ||
+      attrs[EVE_SESSION_ID] !== undefined ||
+      attrs[AI_SETTINGS_CONTEXT_PREFIX + EVE_SESSION_ID] !== undefined ||
+      attrs[RespanSpanAttributes.RESPAN_SESSION_ID] !== undefined
+    ) {
+      return;
+    }
+
+    const usageKey = delegatedUsageKey(attrs);
+    if (usageKey === undefined) {
+      return;
+    }
+
+    this._prunePendingDelegatedUsageLineages();
+    const matches = this._pendingDelegatedUsageLineages
+      .map((lineage, index) => ({ lineage, index }))
+      .filter(({ lineage }) => lineage.usageKey === usageKey);
+    if (matches.length === 0) {
+      return;
+    }
+
+    const lineageSignatures = new Set(
+      matches.map(({ lineage }) =>
+        JSON.stringify([
+          lineage.rootSessionId,
+          lineage.parentSessionId,
+          lineage.parentTurnId,
+          lineage.parentTurnSequence,
+          lineage.workflowName,
+          lineage.targetTraceId,
+          lineage.targetParentSpanId,
+        ]),
+      ),
+    );
+    if (lineageSignatures.size !== 1) {
+      return;
+    }
+
+    const match = matches[0];
+    if (match === undefined) {
+      return;
+    }
+    const [lineage] = this._pendingDelegatedUsageLineages.splice(match.index, 1);
+    if (lineage === undefined) {
+      return;
+    }
+
+    span.setAttribute(EVE_SESSION_ID, lineage.parentSessionId);
+    span.setAttribute(
+      EVE_RESPAN_LINEAGE_ROOT_SESSION_ID_ATTRIBUTE,
+      lineage.rootSessionId,
+    );
+    if (lineage.parentTurnId !== undefined) {
+      span.setAttribute(EVE_TURN_ID, lineage.parentTurnId);
+    }
+    if (lineage.parentTurnSequence !== undefined) {
+      span.setAttribute(EVE_TURN_SEQUENCE, lineage.parentTurnSequence);
+    }
+    if (lineage.workflowName !== undefined) {
+      span.setAttribute(
+        TraceloopSpanAttributes.TRACELOOP_WORKFLOW_NAME,
+        lineage.workflowName,
+      );
+    }
+    if (
+      lineage.targetTraceId !== undefined &&
+      lineage.targetParentSpanId !== undefined
+    ) {
+      span.setAttribute(
+        EVE_RESPAN_INTERNAL_EXPORT_TRACE_ID_ATTRIBUTE,
+        lineage.targetTraceId,
+      );
+      span.setAttribute(
+        RespanSpanAttributes.RESPAN_INTERNAL_EXPORT_PARENT,
+        lineage.targetParentSpanId,
+      );
+      // The real child Eve agent subtree carries the delegated model content
+      // and tokens. This late Eve usage event duplicates that call and has no
+      // content of its own, so suppress it only when exact correlation exists.
+      span.setAttribute(
+        RespanSpanAttributes.RESPAN_INTERNAL_DROP_SPAN,
+        true,
+      );
+    }
+  }
+
+  private _rememberDelegatedUsageLineage(
+    attrs: Record<string, any>,
+    scopeName: string | undefined,
+    sourceTraceId: string | undefined,
+  ): void {
+    if (
+      scopeName === EVE_SCOPE_NAME ||
+      attrs[ATTR_GEN_AI_OPERATION_NAME] !==
+        GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT
+    ) {
+      return;
+    }
+
+    const usageKey = delegatedUsageKey(attrs);
+    const rootSessionId = nonEmptyString(
+      attrs[EVE_RESPAN_LINEAGE_ROOT_SESSION_ID_ATTRIBUTE],
+    );
+    const parentSessionId = nonEmptyString(
+      attrs[EVE_RESPAN_LINEAGE_PARENT_SESSION_ID_ATTRIBUTE],
+    );
+    if (
+      usageKey === undefined ||
+      rootSessionId === undefined ||
+      parentSessionId === undefined
+    ) {
+      return;
+    }
+
+    this._prunePendingDelegatedUsageLineages();
+    const correlation =
+      sourceTraceId === undefined
+        ? undefined
+        : this._delegatedTraceCorrelations.get(sourceTraceId);
+    this._pendingDelegatedUsageLineages.push({
+      recordedAt: Date.now(),
+      usageKey,
+      rootSessionId,
+      parentSessionId,
+      parentTurnId: nonEmptyString(
+        attrs[EVE_RESPAN_LINEAGE_PARENT_TURN_ID_ATTRIBUTE],
+      ),
+      parentTurnSequence: finiteNumber(
+        attrs[EVE_RESPAN_LINEAGE_PARENT_TURN_SEQUENCE_ATTRIBUTE],
+      ),
+      workflowName: nonEmptyString(
+        attrs[TraceloopSpanAttributes.TRACELOOP_WORKFLOW_NAME],
+      ),
+      targetTraceId: correlation?.targetTraceId,
+      targetParentSpanId: correlation?.targetParentSpanId,
+    });
+    if (
+      this._pendingDelegatedUsageLineages.length >
+      MAX_PENDING_DELEGATED_USAGE_LINEAGES
+    ) {
+      this._pendingDelegatedUsageLineages.shift();
+    }
+  }
+
+  private _prunePendingDelegatedUsageLineages(): void {
+    const oldestAllowed = Date.now() - PENDING_DELEGATED_USAGE_LINEAGE_TTL_MS;
+    while (
+      this._pendingDelegatedUsageLineages[0]?.recordedAt !== undefined &&
+      this._pendingDelegatedUsageLineages[0].recordedAt < oldestAllowed
+    ) {
+      this._pendingDelegatedUsageLineages.shift();
+    }
+  }
+
+  private _rememberSessionTraceRoot(
+    attrs: Record<string, any> | undefined,
+    traceId: string | undefined,
+    spanId: string | undefined,
+  ): void {
+    if (!attrs || traceId === undefined || spanId === undefined) {
+      return;
+    }
+
+    const sessionId =
+      nonEmptyString(attrs[EVE_SESSION_ID]) ??
+      nonEmptyString(attrs[AI_SETTINGS_CONTEXT_PREFIX + EVE_SESSION_ID]) ??
+      nonEmptyString(attrs[RespanSpanAttributes.RESPAN_SESSION_ID]);
+    if (sessionId === undefined) {
+      return;
+    }
+
+    const turnId =
+      nonEmptyString(attrs[EVE_TURN_ID]) ??
+      nonEmptyString(attrs[AI_SETTINGS_CONTEXT_PREFIX + EVE_TURN_ID]);
+    const turnSequence =
+      finiteNumber(attrs[EVE_TURN_SEQUENCE]) ??
+      finiteNumber(attrs[AI_SETTINGS_CONTEXT_PREFIX + EVE_TURN_SEQUENCE]);
+    const root: SessionTraceRoot = {
+      recordedAt: Date.now(),
+      sessionId,
+      turnId,
+      turnSequence,
+      traceId,
+      spanId,
+      workflowName:
+        nonEmptyString(
+          attrs[TraceloopSpanAttributes.TRACELOOP_WORKFLOW_NAME],
+        ) ?? nonEmptyString(attrs[AI_TELEMETRY_FUNCTION_ID]),
+    };
+
+    this._pruneRetainedTraceContexts();
+    const key = sessionTraceRootKey(sessionId, turnId, turnSequence);
+    this._sessionTraceRoots.delete(key);
+    this._sessionTraceRoots.set(key, root);
+    trimOldest(this._sessionTraceRoots, MAX_RETAINED_TRACE_CONTEXTS);
+  }
+
+  private _applyDelegatedTraceCorrelation(
+    attrs: Record<string, any> | undefined,
+    spanName: string,
+    sourceTraceId: string | undefined,
+    sourceSpanId: string | undefined,
+    setAttribute: (key: string, value: string) => void,
+  ): void {
+    if (!attrs || sourceTraceId === undefined) {
+      return;
+    }
+
+    this._pruneRetainedTraceContexts();
+    let correlation = this._delegatedTraceCorrelations.get(sourceTraceId);
+    if (correlation === undefined) {
+      const parentSessionId = nonEmptyString(
+        attrs[EVE_RESPAN_LINEAGE_PARENT_SESSION_ID_ATTRIBUTE],
+      );
+      const parentTurnId = nonEmptyString(
+        attrs[EVE_RESPAN_LINEAGE_PARENT_TURN_ID_ATTRIBUTE],
+      );
+      const parentTurnSequence = finiteNumber(
+        attrs[EVE_RESPAN_LINEAGE_PARENT_TURN_SEQUENCE_ATTRIBUTE],
+      );
+      if (parentSessionId === undefined) {
+        return;
+      }
+
+      // Eve 0.26 includes the parent sequence on delegated runtime context but
+      // omits it from the caller ai.eve.turn root. Session + turn ID is still
+      // an exact turn identity, so use that form only when the fully qualified
+      // key is unavailable.
+      const target =
+        this._sessionTraceRoots.get(
+          sessionTraceRootKey(
+            parentSessionId,
+            parentTurnId,
+            parentTurnSequence,
+          ),
+        ) ??
+        this._sessionTraceRoots.get(
+          sessionTraceRootKey(parentSessionId, parentTurnId, undefined),
+        );
+      if (target === undefined || target.traceId === sourceTraceId) {
+        return;
+      }
+
+      correlation = {
+        recordedAt: Date.now(),
+        targetTraceId: target.traceId,
+        targetParentSpanId: target.spanId,
+        workflowName: target.workflowName,
+      };
+      this._delegatedTraceCorrelations.delete(sourceTraceId);
+      this._delegatedTraceCorrelations.set(sourceTraceId, correlation);
+      trimOldest(
+        this._delegatedTraceCorrelations,
+        MAX_RETAINED_TRACE_CONTEXTS,
+      );
+    }
+
+    setAttribute(
+      EVE_RESPAN_INTERNAL_EXPORT_TRACE_ID_ATTRIBUTE,
+      correlation.targetTraceId,
+    );
+    if (spanName === EVE_TURN_SPAN_NAME && sourceSpanId !== undefined) {
+      setAttribute(
+        RespanSpanAttributes.RESPAN_INTERNAL_EXPORT_PARENT,
+        correlation.targetParentSpanId,
+      );
+    }
+    if (
+      correlation.workflowName !== undefined &&
+      nonEmptyString(
+        attrs[TraceloopSpanAttributes.TRACELOOP_WORKFLOW_NAME],
+      ) === undefined
+    ) {
+      setAttribute(
+        TraceloopSpanAttributes.TRACELOOP_WORKFLOW_NAME,
+        correlation.workflowName,
+      );
+    }
+  }
+
+  private _pruneRetainedTraceContexts(): void {
+    const oldestAllowed = Date.now() - RETAINED_TRACE_CONTEXT_TTL_MS;
+    pruneRecordedMap(this._openTraceWorkflowNames, oldestAllowed);
+    pruneRecordedMap(this._sessionTraceRoots, oldestAllowed);
+    pruneRecordedMap(this._delegatedTraceCorrelations, oldestAllowed);
+  }
+
+  /** Return an export-only clone for an exactly correlated delegated trace. */
+  prepareForExport(span: ReadableSpan): ReadableSpan {
+    const attrs = span.attributes as Record<string, any>;
+    const rawTraceId = attrs[EVE_RESPAN_INTERNAL_EXPORT_TRACE_ID_ATTRIBUTE];
+    if (rawTraceId === undefined) {
+      return span;
+    }
+
+    const attributes = { ...attrs };
+    delete attributes[EVE_RESPAN_INTERNAL_EXPORT_TRACE_ID_ATTRIBUTE];
+    const clone = Object.create(Object.getPrototypeOf(span));
+    Object.assign(clone, span);
+    Object.defineProperty(clone, "attributes", {
+      configurable: true,
+      enumerable: true,
+      value: attributes,
+    });
+
+    const traceId = String(rawTraceId).trim().toLowerCase();
+    if (/^[0-9a-f]{32}$/.test(traceId)) {
+      const originalSpanContext = span.spanContext();
+      Object.defineProperty(clone, "spanContext", {
+        configurable: true,
+        enumerable: true,
+        value: () => ({ ...originalSpanContext, traceId }),
+      });
+    }
+    return clone as ReadableSpan;
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  shutdown(): Promise<void> {
+    this._ownerCount = 0;
+    this._openStructuralSpans.clear();
+    this._openWorkflowNames.clear();
+    this._openTraceWorkflowNames.clear();
+    this._sessionTraceRoots.clear();
+    this._delegatedTraceCorrelations.clear();
+    this._pendingDelegatedUsageLineages.length = 0;
+    return Promise.resolve();
+  }
+}
+
+function isEveModelAgentWrapper(
+  name: string,
+  scopeName: string | undefined,
+  attrs: Record<string, any> | undefined,
+): boolean {
+  return (
+    attrs !== undefined &&
+    scopeName !== EVE_SCOPE_NAME &&
+    name.startsWith("invoke_agent ") &&
+    attrs[ATTR_GEN_AI_OPERATION_NAME] ===
+      GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT &&
+    (attrs[EVE_SESSION_ID] !== undefined ||
+      attrs[AI_SETTINGS_CONTEXT_PREFIX + EVE_SESSION_ID] !== undefined)
+  );
+}
+
+function sessionTraceRootKey(
+  sessionId: string,
+  turnId: string | undefined,
+  turnSequence: number | undefined,
+): string {
+  return JSON.stringify([sessionId, turnId ?? null, turnSequence ?? null]);
+}
+
+function trimOldest<T>(map: Map<string, T>, maximum: number): void {
+  while (map.size > maximum) {
+    const oldestKey = map.keys().next().value;
+    if (oldestKey === undefined) {
+      return;
+    }
+    map.delete(oldestKey);
+  }
+}
+
+function pruneRecordedMap<T extends { readonly recordedAt: number }>(
+  map: Map<string, T>,
+  oldestAllowed: number,
+): void {
+  for (const [key, value] of map) {
+    if (value.recordedAt >= oldestAllowed) {
+      continue;
+    }
+    map.delete(key);
+  }
+}
+
+function delegatedUsageKey(attrs: Record<string, any>): string | undefined {
+  const inputTokens = finiteNumber(attrs[ATTR_GEN_AI_USAGE_INPUT_TOKENS]);
+  const outputTokens = finiteNumber(attrs[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]);
+  if (inputTokens === undefined || outputTokens === undefined) {
+    return undefined;
+  }
+
+  return JSON.stringify([
+    inputTokens,
+    outputTokens,
+    finiteNumber(attrs[ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]) ?? 0,
+    finiteNumber(attrs[ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]) ?? 0,
+  ]);
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  return String(value);
+}
+
+/**
+ * Semantic-name hint for tool spans. The exporter derives the "tool" prefix
+ * from the log type, but the detail must be the tool's own name — the entity
+ * name on AI SDK tool spans is the raw span name (e.g. "ai.toolCall").
+ */
+function setToolSpanNameHint(attrs: Record<string, any>, spanName: string): void {
+  setDefault(attrs, RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_KIND, "tool");
+  setDefault(
+    attrs,
+    RespanSpanAttributes.RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    attrs[AI_TOOL_CALL_NAME] ?? attrs[ATTR_GEN_AI_TOOL_NAME] ?? spanName.split(".").at(-1)
+  );
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_translator/eve.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_translator/eve.ts
@@ -1,0 +1,327 @@
+import {
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT,
+} from "@opentelemetry/semantic-conventions/incubating";
+import { RespanSpanAttributes } from "@respan/respan-sdk";
+import {
+  EVE_ATTRIBUTE_PREFIX,
+  EVE_CHANNEL_KIND,
+  EVE_ENVIRONMENT,
+  EVE_RETRY_REASON,
+  EVE_SCOPE_NAME,
+  EVE_SESSION_ID,
+  EVE_STEP_INDEX,
+  EVE_TURN_ID,
+  EVE_TURN_SEQUENCE,
+  EVE_VERSION,
+} from "../constants/eve.js";
+import {
+  EVE_RESPAN_BRIDGE_RUNTIME_CONTEXT_KEY,
+  EVE_RESPAN_BRIDGE_RUNTIME_CONTEXT_PREFIX,
+  EVE_RESPAN_LINEAGE_PARENT_CALL_ID_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_PARENT_SESSION_ID_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_PARENT_TURN_ID_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_PARENT_TURN_SEQUENCE_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_ROOT_SESSION_ID_ATTRIBUTE,
+} from "../constants/lineage.js";
+import {
+  AI_AGENT_ID,
+  AI_SETTINGS_CONTEXT_PREFIX,
+  AI_TELEMETRY_FUNCTION_ID,
+  setDefault,
+  setMetadata,
+  type SpanAttributes,
+} from "./shared.js";
+
+export function resolveEveAgentName(
+  attrs: SpanAttributes,
+  fallback = "eve",
+): string {
+  return String(
+    attrs[AI_TELEMETRY_FUNCTION_ID] ??
+      attrs[ATTR_GEN_AI_AGENT_NAME] ??
+      attrs[AI_AGENT_ID] ??
+      fallback,
+  );
+}
+
+export function enrichEveAttributes(
+  attrs: SpanAttributes,
+  span: { readonly name: string; readonly scopeName?: string },
+): void {
+  const sessionId = readEveAttribute(attrs, EVE_SESSION_ID);
+  const rootSessionId = readNonEmptyAttribute(
+    attrs,
+    EVE_RESPAN_LINEAGE_ROOT_SESSION_ID_ATTRIBUTE,
+  );
+  if (sessionId !== undefined && sessionId !== null && sessionId !== "") {
+    const normalizedSessionId = String(sessionId);
+    setDefault(
+      attrs,
+      RespanSpanAttributes.RESPAN_SESSION_ID,
+      normalizedSessionId,
+    );
+    setDefault(
+      attrs,
+      RespanSpanAttributes.RESPAN_THREADS_ID,
+      normalizedSessionId,
+    );
+    setDefault(
+      attrs,
+      RespanSpanAttributes.RESPAN_TRACE_GROUP_ID,
+      rootSessionId ?? normalizedSessionId,
+    );
+  }
+
+  const environment = readEveAttribute(attrs, EVE_ENVIRONMENT);
+  if (environment !== undefined && environment !== null && environment !== "") {
+    setDefault(
+      attrs,
+      RespanSpanAttributes.RESPAN_ENVIRONMENT,
+      String(environment),
+    );
+  }
+
+  const eveMetadata: Record<string, unknown> = {};
+  addMetadataValue(
+    eveMetadata,
+    "version",
+    readEveAttribute(attrs, EVE_VERSION),
+  );
+  addMetadataValue(eveMetadata, "environment", environment);
+  addMetadataValue(
+    eveMetadata,
+    "turn_id",
+    readEveAttribute(attrs, EVE_TURN_ID),
+  );
+  addNumericMetadataValue(
+    eveMetadata,
+    "turn_sequence",
+    readEveAttribute(attrs, EVE_TURN_SEQUENCE),
+  );
+  addNumericMetadataValue(
+    eveMetadata,
+    "step_index",
+    readEveAttribute(attrs, EVE_STEP_INDEX),
+  );
+  addMetadataValue(
+    eveMetadata,
+    "channel_kind",
+    readEveAttribute(attrs, EVE_CHANNEL_KIND),
+  );
+  addMetadataValue(
+    eveMetadata,
+    "retry_reason",
+    readEveAttribute(attrs, EVE_RETRY_REASON),
+  );
+  addMetadataValue(eveMetadata, "root_session_id", rootSessionId);
+
+  const parentMetadata = buildParentMetadata(attrs);
+  if (parentMetadata !== undefined) {
+    eveMetadata.parent = parentMetadata;
+  }
+
+  const runtimeContext = collectAuthoredRuntimeContext(attrs);
+  if (Object.keys(runtimeContext).length > 0) {
+    eveMetadata.runtime_context = runtimeContext;
+  }
+
+  if (
+    span.scopeName === EVE_SCOPE_NAME &&
+    span.name.startsWith("invoke_agent ") &&
+    attrs[ATTR_GEN_AI_OPERATION_NAME] ===
+      GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT
+  ) {
+    const usage: Record<string, number> = {};
+    addNumericUsage(
+      usage,
+      "input_tokens",
+      attrs[ATTR_GEN_AI_USAGE_INPUT_TOKENS],
+    );
+    addNumericUsage(
+      usage,
+      "output_tokens",
+      attrs[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS],
+    );
+    addNumericUsage(
+      usage,
+      "cache_read_input_tokens",
+      attrs[ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS],
+    );
+    addNumericUsage(
+      usage,
+      "cache_creation_input_tokens",
+      attrs[ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS],
+    );
+
+    const subagent: Record<string, unknown> = {
+      name: resolveEveAgentName(attrs),
+    };
+    if (Object.keys(usage).length > 0) {
+      subagent.usage = usage;
+    }
+    eveMetadata.subagent = subagent;
+  }
+
+  if (Object.keys(eveMetadata).length > 0) {
+    setMetadata(attrs, "eve", eveMetadata);
+  }
+}
+
+function readEveAttribute(
+  attrs: SpanAttributes,
+  key: string,
+): unknown {
+  return attrs[key] ?? attrs[AI_SETTINGS_CONTEXT_PREFIX + key];
+}
+
+/**
+ * Preserve user-authored `step.started` context before the generic `ai.*`
+ * cleanup runs. Eve reserves every `eve.*` runtime-context key for framework
+ * fields, so those stay exclusively owned by the explicit mappings above.
+ *
+ * AI SDK flattens nested context objects into dotted attribute names. Keeping
+ * the suffix as-is avoids guessing whether a dot came from an authored key or
+ * from that flattening step (both are valid in Eve authored context).
+ */
+function collectAuthoredRuntimeContext(
+  attrs: SpanAttributes,
+): Record<string, unknown> {
+  const runtimeContext: Record<string, unknown> = {};
+
+  for (const [attributeKey, value] of Object.entries(attrs)) {
+    if (!attributeKey.startsWith(AI_SETTINGS_CONTEXT_PREFIX)) {
+      continue;
+    }
+
+    const contextKey = attributeKey.slice(AI_SETTINGS_CONTEXT_PREFIX.length);
+    if (
+      contextKey === "" ||
+      contextKey.startsWith(EVE_ATTRIBUTE_PREFIX) ||
+      contextKey === EVE_RESPAN_BRIDGE_RUNTIME_CONTEXT_KEY ||
+      contextKey.startsWith(EVE_RESPAN_BRIDGE_RUNTIME_CONTEXT_PREFIX)
+    ) {
+      continue;
+    }
+
+    const jsonValue = toJsonSafeValue(value);
+    if (jsonValue !== undefined) {
+      runtimeContext[contextKey] = jsonValue;
+    }
+  }
+
+  return runtimeContext;
+}
+
+function buildParentMetadata(
+  attrs: SpanAttributes,
+): Record<string, unknown> | undefined {
+  const parent: Record<string, unknown> = {};
+  addMetadataValue(
+    parent,
+    "session_id",
+    readNonEmptyAttribute(
+      attrs,
+      EVE_RESPAN_LINEAGE_PARENT_SESSION_ID_ATTRIBUTE,
+    ),
+  );
+  addMetadataValue(
+    parent,
+    "call_id",
+    readNonEmptyAttribute(attrs, EVE_RESPAN_LINEAGE_PARENT_CALL_ID_ATTRIBUTE),
+  );
+
+  const turn: Record<string, unknown> = {};
+  addMetadataValue(
+    turn,
+    "id",
+    readNonEmptyAttribute(attrs, EVE_RESPAN_LINEAGE_PARENT_TURN_ID_ATTRIBUTE),
+  );
+  addNumericMetadataValue(
+    turn,
+    "sequence",
+    attrs[EVE_RESPAN_LINEAGE_PARENT_TURN_SEQUENCE_ATTRIBUTE],
+  );
+  if (Object.keys(turn).length > 0) {
+    parent.turn = turn;
+  }
+
+  return Object.keys(parent).length > 0 ? parent : undefined;
+}
+
+function readNonEmptyAttribute(
+  attrs: SpanAttributes,
+  key: string,
+): string | undefined {
+  const value = attrs[key];
+  return value === undefined || value === null || value === ""
+    ? undefined
+    : String(value);
+}
+
+function toJsonSafeValue(value: unknown): unknown | undefined {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value !== "object") {
+    return undefined;
+  }
+
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? undefined : JSON.parse(serialized);
+  } catch {
+    // Authored instrumentation must never be able to break span export.
+    return undefined;
+  }
+}
+
+function addMetadataValue(
+  metadata: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  if (value !== undefined && value !== null && value !== "") {
+    metadata[key] = String(value);
+  }
+}
+
+function addNumericMetadataValue(
+  metadata: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  if (value === undefined || value === null || value === "") {
+    return;
+  }
+  const parsed = Number(value);
+  metadata[key] = Number.isFinite(parsed) ? parsed : String(value);
+}
+
+function addNumericUsage(
+  usage: Record<string, number>,
+  key: string,
+  value: unknown,
+): void {
+  if (value === undefined || value === null || value === "") {
+    return;
+  }
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    usage[key] = parsed;
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_translator/messages.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_translator/messages.ts
@@ -1,0 +1,694 @@
+import {
+  ATTR_GEN_AI_INPUT_MESSAGES,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
+  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+  ATTR_GEN_AI_TOOL_CALL_ID,
+  ATTR_GEN_AI_TOOL_CALL_RESULT,
+  ATTR_GEN_AI_TOOL_DEFINITIONS,
+  ATTR_GEN_AI_TOOL_NAME,
+} from "@opentelemetry/semantic-conventions/incubating";
+import { SpanAttributes as TraceloopSpanAttributes } from "@traceloop/ai-semantic-conventions";
+import {
+  AI_PROMPT,
+  AI_PROMPT_MESSAGES,
+  AI_PROMPT_TOOLS,
+  AI_PROMPT_TOOL_CHOICE,
+  AI_RESPONSE_OBJECT,
+  AI_RESPONSE_TEXT,
+  AI_RESPONSE_TOOL_CALLS,
+  AI_TOOL_CALL,
+  AI_TOOL_CALLS,
+  AI_TOOL_CALL_ARGS,
+  AI_TOOL_CALL_ID,
+  AI_TOOL_CALL_NAME,
+  AI_TOOL_CALL_PREFIX,
+  AI_TOOL_CALL_RESULT,
+  isRecord,
+  parseJsonish,
+  safeJsonParse,
+  safeJsonStr,
+  type SpanAttributes,
+} from "./shared.js";
+
+type MessagePayload = Record<string, any>;
+
+function normalizeToolCallShape(call: unknown): Record<string, any> | undefined {
+  if (!isRecord(call)) {
+    return undefined;
+  }
+
+  const callFunction = isRecord(call.function) ? call.function : undefined;
+  const rawName =
+    callFunction?.name ??
+    call.name ??
+    call.toolName ??
+    call.tool_name;
+  const rawArguments =
+    callFunction?.arguments ??
+    callFunction?.args ??
+    call.args ??
+    call.arguments ??
+    call.input;
+  const rawId = call.id ?? call.toolCallId ?? call.tool_call_id;
+
+  const normalized: Record<string, any> = { type: "function" };
+  if (rawId !== undefined) {
+    normalized.id = String(rawId);
+  }
+
+  const functionPayload: Record<string, any> = {};
+  if (rawName !== undefined) {
+    functionPayload.name = String(rawName);
+  }
+  if (rawArguments !== undefined) {
+    functionPayload.arguments =
+      typeof rawArguments === "string"
+        ? rawArguments
+        : safeJsonStr(rawArguments);
+  }
+  if (Object.keys(functionPayload).length > 0) {
+    normalized.function = functionPayload;
+  }
+
+  return normalized;
+}
+
+function normalizeSemConvToolResult(block: MessagePayload): MessagePayload {
+  const result = block.response ?? block.result ?? block.content ?? "";
+  const message: MessagePayload = {
+    role: "tool",
+    content: typeof result === "string" ? result : safeJsonStr(result),
+  };
+
+  const toolCallId = block.id ?? block.toolCallId ?? block.tool_call_id;
+  if (toolCallId !== undefined && toolCallId !== null) {
+    message.tool_call_id = String(toolCallId);
+  }
+
+  const toolName = block.name ?? block.toolName ?? block.tool_name;
+  if (toolName !== undefined && toolName !== null) {
+    message.name = String(toolName);
+  }
+
+  return message;
+}
+
+function normalizeToolCallList(value: unknown): Record<string, any>[] | undefined {
+  const parsed = safeJsonParse(value);
+  const rawCalls = Array.isArray(parsed) ? parsed : parsed !== undefined ? [parsed] : [];
+  const normalized = rawCalls
+    .map((call) => normalizeToolCallShape(call))
+    .filter((call): call is Record<string, any> => Boolean(call));
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function parseToolCalls(attrs: SpanAttributes): Record<string, any>[] | undefined {
+  for (const key of [AI_RESPONSE_TOOL_CALLS, AI_TOOL_CALL, AI_TOOL_CALLS]) {
+    if (!attrs[key]) {
+      continue;
+    }
+
+    const normalized = normalizeToolCallList(attrs[key]);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  if (attrs[AI_TOOL_CALL_ID] || attrs[AI_TOOL_CALL_NAME] || attrs[AI_TOOL_CALL_ARGS]) {
+    const toolCall: Record<string, any> = { type: "function" };
+    for (const [key, value] of Object.entries(attrs)) {
+      if (key.startsWith(AI_TOOL_CALL_PREFIX)) {
+        toolCall[key.replace(AI_TOOL_CALL_PREFIX, "")] = value;
+      }
+    }
+    return normalizeToolCallList(toolCall);
+  }
+
+  if (attrs[ATTR_GEN_AI_TOOL_CALL_ID] || attrs[ATTR_GEN_AI_TOOL_NAME] || attrs[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]) {
+    return normalizeToolCallList({
+      id: attrs[ATTR_GEN_AI_TOOL_CALL_ID],
+      name: attrs[ATTR_GEN_AI_TOOL_NAME],
+      arguments: attrs[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS],
+    });
+  }
+
+  return undefined;
+}
+
+function parseToolDefinition(tool: unknown): unknown {
+  const parsedTool = typeof tool === "string" ? safeJsonParse(tool) : tool;
+  if (!isRecord(parsedTool) || parsedTool.type !== "function") {
+    return parsedTool;
+  }
+
+  if (isRecord(parsedTool.function)) {
+    if (parsedTool.inputSchema && !parsedTool.function.parameters) {
+      const { inputSchema, ...rest } = parsedTool;
+      return {
+        ...rest,
+        function: { ...parsedTool.function, parameters: inputSchema },
+      };
+    }
+
+    return parsedTool;
+  }
+
+  const { name, description, parameters, inputSchema, ...rest } = parsedTool;
+  const resolvedParameters = parameters ?? inputSchema;
+  return {
+    ...rest,
+    type: "function",
+    function: {
+      name,
+      ...(description ? { description } : {}),
+      ...(resolvedParameters ? { parameters: resolvedParameters } : {}),
+    },
+  };
+}
+
+export function parseToolsValue(attrs: SpanAttributes): unknown[] | undefined {
+  try {
+    const tools = attrs[ATTR_GEN_AI_TOOL_DEFINITIONS] ?? attrs[AI_PROMPT_TOOLS];
+    if (!tools) {
+      return undefined;
+    }
+
+    const parsedToolsValue = safeJsonParse(tools);
+    const rawTools = Array.isArray(parsedToolsValue) ? parsedToolsValue : [parsedToolsValue];
+    const parsedTools = rawTools
+      .map((tool) => parseToolDefinition(tool))
+      .filter(Boolean);
+
+    return parsedTools.length > 0 ? parsedTools : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+
+export function parseToolChoice(attrs: SpanAttributes): string | undefined {
+  try {
+    const toolChoice = attrs[AI_PROMPT_TOOL_CHOICE];
+    if (!toolChoice) {
+      return undefined;
+    }
+
+    const parsed = typeof toolChoice === "string" ? JSON.parse(toolChoice) : toolChoice;
+    if (parsed.function?.name) {
+      return safeJsonStr({
+        type: String(parsed.type),
+        function: { name: String(parsed.function.name) },
+      });
+    }
+    if (parsed.toolName) {
+      return safeJsonStr({
+        type: String(parsed.type),
+        function: { name: String(parsed.toolName) },
+      });
+    }
+
+    return safeJsonStr({ type: String(parsed.type) });
+  } catch {
+    return undefined;
+  }
+}
+
+function isMessageLike(value: unknown): value is MessagePayload {
+  if (!isRecord(value) || typeof value.role !== "string") {
+    return false;
+  }
+
+  return (
+    "content" in value ||
+    "tool_calls" in value ||
+    "toolCalls" in value ||
+    "tool_call_id" in value ||
+    "toolCallId" in value
+  );
+}
+
+function isMessageArray(value: unknown): value is MessagePayload[] {
+  return Array.isArray(value) && value.length > 0 && value.every((item) => isMessageLike(item));
+}
+
+function unwrapKnownResponseWrapper(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return value.response ?? value.object ?? value.output ?? value.result ?? value;
+}
+
+function extractMessagePayload(value: unknown): unknown {
+  const parsed = safeJsonParse(value);
+
+  if (typeof parsed === "string") {
+    const nested = safeJsonParse(parsed);
+    return nested === parsed ? undefined : extractMessagePayload(nested);
+  }
+
+  if (isMessageLike(parsed) || isMessageArray(parsed)) {
+    return parsed;
+  }
+
+  if (Array.isArray(parsed)) {
+    for (const item of parsed) {
+      const nested = extractMessagePayload(item);
+      if (nested !== undefined) {
+        return nested;
+      }
+    }
+    return undefined;
+  }
+
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  const unwrapped = unwrapKnownResponseWrapper(parsed);
+  if (unwrapped !== parsed) {
+    const nested = extractMessagePayload(unwrapped);
+    if (nested !== undefined) {
+      return nested;
+    }
+  }
+
+  for (const key of ["message", "messages", "text", "content", "value"]) {
+    if (!(key in parsed)) {
+      continue;
+    }
+
+    const nested = extractMessagePayload(parsed[key]);
+    if (nested !== undefined) {
+      return nested;
+    }
+  }
+
+  return undefined;
+}
+
+function collapseNestedMessageWrapper(value: unknown): unknown {
+  if (!isMessageLike(value)) {
+    return value;
+  }
+
+  const hasTopLevelMessageFields =
+    "tool_calls" in value ||
+    "toolCalls" in value ||
+    "tool_call_id" in value ||
+    "toolCallId" in value ||
+    "name" in value;
+  if (hasTopLevelMessageFields) {
+    return value;
+  }
+
+  const nested = extractMessagePayload(value.content);
+  return nested ?? value;
+}
+
+function isContentBlockType(block: unknown, type: string): block is MessagePayload {
+  return isRecord(block) && block.type === type;
+}
+
+function normalizeToolResultMessage(block: MessagePayload): MessagePayload {
+  const result = block.result ?? block.content ?? block.output ?? "";
+  const message: MessagePayload = {
+    role: "tool",
+    content: typeof result === "string" ? result : safeJsonStr(result),
+  };
+
+  const toolCallId = block.toolCallId ?? block.tool_call_id ?? block.id;
+  if (toolCallId !== undefined) {
+    message.tool_call_id = String(toolCallId);
+  }
+
+  const toolName = block.toolName ?? block.tool_name ?? block.name;
+  if (toolName !== undefined) {
+    message.name = String(toolName);
+  }
+
+  return message;
+}
+
+function normalizeMessageForBackend(message: unknown): MessagePayload[] {
+  if (!isRecord(message)) {
+    return [];
+  }
+
+  if (Array.isArray(message.parts)) {
+    const textParts: string[] = [];
+    const toolCalls: Record<string, any>[] = [];
+    const toolResults: MessagePayload[] = [];
+    const unknownParts: unknown[] = [];
+
+    for (const part of message.parts) {
+      if (!isRecord(part)) {
+        unknownParts.push(part);
+        continue;
+      }
+
+      if (part.type === "text" || part.type === "reasoning") {
+        const content = part.content ?? part.text;
+        if (content !== undefined && content !== null) {
+          textParts.push(String(content));
+        }
+        continue;
+      }
+
+      if (part.type === "tool_call") {
+        const normalized = normalizeToolCallShape({
+          id: part.id,
+          name: part.name,
+          arguments: part.arguments,
+        });
+        if (normalized) {
+          toolCalls.push(normalized);
+        }
+        continue;
+      }
+
+      if (part.type === "tool_call_response") {
+        toolResults.push(normalizeSemConvToolResult(part));
+        continue;
+      }
+
+      unknownParts.push(part);
+    }
+
+    if (message.role === "tool" && toolResults.length > 0) {
+      return toolResults;
+    }
+
+    const normalized: MessagePayload = {
+      role: typeof message.role === "string" ? message.role : "assistant",
+      content: textParts.join("\n"),
+    };
+    if (!normalized.content && unknownParts.length > 0) {
+      normalized.content = safeJsonStr(unknownParts);
+    }
+    if (toolCalls.length > 0) {
+      normalized.tool_calls = toolCalls;
+    }
+
+    const normalizedMessages = [normalized];
+    if (toolResults.length > 0) {
+      normalizedMessages.push(...toolResults);
+    }
+    return normalizedMessages;
+  }
+
+  const normalizedToolCalls =
+    normalizeToolCallList(message.tool_calls) ??
+    normalizeToolCallList(message.toolCalls);
+
+  if (!Array.isArray(message.content)) {
+    const normalized = { ...message };
+    if (normalizedToolCalls) {
+      normalized.tool_calls = normalizedToolCalls;
+    }
+    delete normalized.toolCalls;
+
+    if (normalized.role === "tool") {
+      if (normalized.toolCallId !== undefined && normalized.tool_call_id === undefined) {
+        normalized.tool_call_id = String(normalized.toolCallId);
+      }
+      delete normalized.toolCallId;
+      if (normalized.content !== undefined && typeof normalized.content !== "string") {
+        normalized.content = safeJsonStr(normalized.content);
+      }
+    }
+
+    return [normalized];
+  }
+
+  const textParts: string[] = [];
+  const toolCallBlocks = message.content.filter((block) => isContentBlockType(block, "tool-call"));
+  const toolResultBlocks = message.content.filter((block) => isContentBlockType(block, "tool-result"));
+  const unknownBlocks = message.content.filter((block) => {
+    if (typeof block === "string") {
+      return false;
+    }
+    if (!isRecord(block)) {
+      return true;
+    }
+    return !["text", "output_text", "tool-call", "tool-result"].includes(String(block.type ?? ""));
+  });
+
+  for (const block of message.content) {
+    if (typeof block === "string") {
+      textParts.push(block);
+      continue;
+    }
+    if (!isRecord(block)) {
+      continue;
+    }
+    if ((block.type === "text" || block.type === "output_text") && typeof block.text === "string") {
+      textParts.push(block.text);
+    }
+  }
+
+  const textContent = textParts.join("\n");
+
+  if (message.role === "assistant" && (toolCallBlocks.length > 0 || normalizedToolCalls)) {
+    const normalizedMessage: MessagePayload = {
+      ...message,
+      content: textContent,
+    };
+    const toolCalls = normalizeToolCallList(toolCallBlocks) ?? normalizedToolCalls;
+    if (toolCalls) {
+      normalizedMessage.tool_calls = toolCalls;
+    }
+    delete normalizedMessage.toolCalls;
+    return [normalizedMessage];
+  }
+
+  if (message.role === "tool" && toolResultBlocks.length > 0) {
+    return toolResultBlocks.map((block) => normalizeToolResultMessage(block));
+  }
+
+  if (unknownBlocks.length === 0) {
+    return [{ ...message, content: textContent }];
+  }
+
+  return [{ ...message, content: message.content }];
+}
+
+function normalizeMessageCollection(value: unknown): MessagePayload[] | undefined {
+  const parsed = safeJsonParse(value);
+  if (parsed === undefined || parsed === null) {
+    return undefined;
+  }
+
+  if (Array.isArray(parsed)) {
+    const normalized = parsed.flatMap((message) => normalizeMessageForBackend(message));
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  if (isRecord(parsed)) {
+    const normalized = normalizeMessageForBackend(parsed);
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  return undefined;
+}
+
+function collapseSingleMessagePayload(messages: MessagePayload[]): unknown {
+  return messages.length === 1 ? messages[0] : messages;
+}
+
+function buildToolResultMessage(attrs: SpanAttributes): MessagePayload | undefined {
+  if (!attrs[AI_TOOL_CALL_RESULT]) {
+    return undefined;
+  }
+
+  return {
+    role: "tool",
+    tool_call_id: String(attrs[AI_TOOL_CALL_ID] || ""),
+    content: String(attrs[AI_TOOL_CALL_RESULT] || ""),
+  };
+}
+
+function hasToolResultMessage(payload: unknown, toolResult: MessagePayload): boolean {
+  const messages = Array.isArray(payload) ? payload : [payload];
+  return messages.some((message) => {
+    if (!isRecord(message) || message.role !== "tool") {
+      return false;
+    }
+
+    if (toolResult.tool_call_id) {
+      return message.tool_call_id === toolResult.tool_call_id || message.toolCallId === toolResult.tool_call_id;
+    }
+
+    return message.content === toolResult.content;
+  });
+}
+
+function appendToolResultMessage(payload: unknown, attrs: SpanAttributes): unknown {
+  const toolResult = buildToolResultMessage(attrs);
+  if (!toolResult || hasToolResultMessage(payload, toolResult)) {
+    return payload;
+  }
+
+  return Array.isArray(payload) ? [...payload, toolResult] : [payload, toolResult];
+}
+
+function selectPrimaryAssistantMessage(value: unknown): MessagePayload | undefined {
+  if (isMessageLike(value)) {
+    return value.role === "assistant" ? value : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (isMessageLike(item) && item.role === "assistant") {
+        return item;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function enrichCompletionAttrs(attrs: SpanAttributes, payload: unknown): void {
+  const message = selectPrimaryAssistantMessage(payload);
+  const responseToolCalls = message
+    ? normalizeToolCallList(message.tool_calls) ||
+      normalizeToolCallList(message.toolCalls) ||
+      parseToolCalls(attrs)
+    : parseToolCalls(attrs);
+
+  if (message) {
+    attrs[`${TraceloopSpanAttributes.LLM_COMPLETIONS}.0.role`] = "assistant";
+    attrs[`${TraceloopSpanAttributes.LLM_COMPLETIONS}.0.content`] =
+      typeof message.content === "string"
+        ? message.content
+        : message.content !== undefined
+          ? safeJsonStr(message.content)
+          : "";
+  }
+
+  if (responseToolCalls && responseToolCalls.length > 0) {
+    attrs[`${TraceloopSpanAttributes.LLM_COMPLETIONS}.0.tool_calls`] = safeJsonStr(responseToolCalls);
+  }
+}
+
+function parsePromptInputValue(attrs: SpanAttributes): Record<string, any>[] | undefined {
+  const genAiMessages = normalizeMessageCollection(attrs[ATTR_GEN_AI_INPUT_MESSAGES]);
+  if (genAiMessages && genAiMessages.length > 0) {
+    return genAiMessages;
+  }
+
+  const normalizedMessages = normalizeMessageCollection(attrs[AI_PROMPT_MESSAGES]);
+  if (normalizedMessages && normalizedMessages.length > 0) {
+    return normalizedMessages;
+  }
+
+  const prompt = attrs[AI_PROMPT];
+  if (prompt) {
+    return [{ role: "user", content: String(prompt) }];
+  }
+
+  return undefined;
+}
+
+function enrichPromptAttrs(attrs: SpanAttributes, messages: MessagePayload[]): void {
+  messages.forEach((message, index) => {
+    const prefix = `${TraceloopSpanAttributes.LLM_PROMPTS}.${index}`;
+    if (message.role !== undefined) {
+      attrs[`${prefix}.role`] = String(message.role);
+    }
+    if (message.content !== undefined) {
+      attrs[`${prefix}.content`] =
+        typeof message.content === "string"
+          ? message.content
+          : safeJsonStr(message.content);
+    }
+
+    const toolCalls =
+      normalizeToolCallList(message.tool_calls) ??
+      normalizeToolCallList(message.toolCalls);
+    if (toolCalls && toolCalls.length > 0) {
+      attrs[`${prefix}.tool_calls`] = safeJsonStr(toolCalls);
+    }
+  });
+}
+
+export function formatPromptInput(attrs: SpanAttributes): string | undefined {
+  const messages = parsePromptInputValue(attrs);
+  if (!messages) {
+    return undefined;
+  }
+
+  enrichPromptAttrs(attrs, messages);
+  return safeJsonStr(messages);
+}
+
+export function formatCompletionOutput(attrs: SpanAttributes): string | undefined {
+  const genAiOutputMessages = normalizeMessageCollection(attrs[ATTR_GEN_AI_OUTPUT_MESSAGES]);
+  if (genAiOutputMessages && genAiOutputMessages.length > 0) {
+    const outputPayload = appendToolResultMessage(collapseSingleMessagePayload(genAiOutputMessages), attrs);
+    enrichCompletionAttrs(attrs, outputPayload);
+    return safeJsonStr(outputPayload);
+  }
+
+  // `ai.response.text` may itself be a JSON-encoded chat message. Normalize that
+  // shape first so assistant messages and tool calls are preserved for the backend.
+  const existingPayload = extractMessagePayload(attrs[AI_RESPONSE_TEXT]);
+  if (existingPayload !== undefined) {
+    const normalizedMessages = normalizeMessageCollection(collapseNestedMessageWrapper(existingPayload));
+    const normalizedPayload = normalizedMessages
+      ? collapseSingleMessagePayload(normalizedMessages)
+      : collapseNestedMessageWrapper(existingPayload);
+    const outputPayload = appendToolResultMessage(normalizedPayload, attrs);
+    enrichCompletionAttrs(attrs, outputPayload);
+    return safeJsonStr(outputPayload);
+  }
+
+  let content = "";
+
+  if (attrs[AI_RESPONSE_OBJECT]) {
+    const parsed = unwrapKnownResponseWrapper(safeJsonParse(attrs[AI_RESPONSE_OBJECT]));
+    content = safeJsonStr(parsed);
+  } else {
+    content = String(attrs[AI_RESPONSE_TEXT] ?? "");
+  }
+
+  const toolCalls = parseToolCalls(attrs);
+  if (!content && (!toolCalls || toolCalls.length === 0)) {
+    return undefined;
+  }
+
+  const message: Record<string, any> = { role: "assistant", content };
+  if (toolCalls && toolCalls.length > 0) {
+    message.tool_calls = toolCalls;
+  }
+
+  const normalizedPayload = appendToolResultMessage(message, attrs);
+  enrichCompletionAttrs(attrs, normalizedPayload);
+  return safeJsonStr(normalizedPayload);
+}
+
+export function formatToolInput(attrs: SpanAttributes): string | undefined {
+  const name = attrs[ATTR_GEN_AI_TOOL_NAME] ?? attrs[AI_TOOL_CALL_NAME];
+  const args = attrs[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] ?? attrs[AI_TOOL_CALL_ARGS];
+  const id = attrs[ATTR_GEN_AI_TOOL_CALL_ID] ?? attrs[AI_TOOL_CALL_ID];
+  if (!name && !args && !id) {
+    return undefined;
+  }
+
+  const input: Record<string, any> = {};
+  if (name) {
+    input.name = name;
+  }
+  if (args) {
+    input.arguments = parseJsonish(args);
+  }
+  return safeJsonStr(input);
+}
+
+export function formatToolOutput(attrs: SpanAttributes): string | undefined {
+  const result = attrs[ATTR_GEN_AI_TOOL_CALL_RESULT] ?? attrs[AI_TOOL_CALL_RESULT];
+  if (result === undefined) {
+    return undefined;
+  }
+  return safeJsonStr(typeof result === "string" ? safeJsonParse(result) : result);
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_translator/shared.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_translator/shared.ts
@@ -1,0 +1,297 @@
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+  ATTR_GEN_AI_TOOL_CALL_ID,
+  ATTR_GEN_AI_TOOL_CALL_RESULT,
+  ATTR_GEN_AI_TOOL_NAME,
+  GEN_AI_OPERATION_NAME_VALUE_CHAT,
+  GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS,
+  GEN_AI_OPERATION_NAME_VALUE_EXECUTE_TOOL,
+  GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT,
+} from "@opentelemetry/semantic-conventions/incubating";
+import { RespanLogType, RespanSpanAttributes } from "@respan/respan-sdk";
+import { VERCEL_PARENT_SPANS, VERCEL_SPAN_CONFIG } from "../constants/index.js";
+
+export type SpanAttributes = Record<string, any>;
+
+export const AI_PREFIX = "ai.";
+export const AI_SDK = "ai.sdk";
+export const AI_OPERATION_ID = "ai.operationId";
+export const AI_MODEL_ID = "ai.model.id";
+export const AI_MODEL_PROVIDER = "ai.model.provider";
+export const AI_EMBEDDING = "ai.embedding";
+export const AI_EMBEDDINGS = "ai.embeddings";
+export const AI_VALUE = "ai.value";
+export const AI_VALUES = "ai.values";
+export const AI_AGENT_ID = "ai.agent.id";
+export const AI_WORKFLOW_ID = "ai.workflow.id";
+export const AI_TRANSCRIPT = "ai.transcript";
+export const AI_SPEECH = "ai.speech";
+export const AI_TELEMETRY_METADATA_PREFIX = "ai.telemetry.metadata.";
+export const AI_TELEMETRY_FUNCTION_ID = "ai.telemetry.functionId";
+export const AI_SETTINGS_CONTEXT_PREFIX = "ai.settings.context.";
+export const AI_PROMPT = "ai.prompt";
+export const AI_PROMPT_MESSAGES = "ai.prompt.messages";
+export const AI_PROMPT_TOOLS = "ai.prompt.tools";
+export const AI_PROMPT_TOOL_CHOICE = "ai.prompt.toolChoice";
+export const AI_RESPONSE_OBJECT = "ai.response.object";
+export const AI_RESPONSE_TEXT = "ai.response.text";
+export const AI_RESPONSE_TOOL_CALLS = "ai.response.toolCalls";
+export const AI_RESPONSE_MS_TO_FINISH = "ai.response.msToFinish";
+export const AI_USAGE_PROMPT_TOKENS = "ai.usage.promptTokens";
+export const AI_USAGE_COMPLETION_TOKENS = "ai.usage.completionTokens";
+export const AI_USAGE_INPUT_TOKENS = "ai.usage.inputTokens";
+export const AI_USAGE_OUTPUT_TOKENS = "ai.usage.outputTokens";
+export const AI_USAGE_TOTAL_TOKENS = "ai.usage.totalTokens";
+export const AI_USAGE_CACHED_INPUT_TOKENS = "ai.usage.cachedInputTokens";
+export const GEN_AI_USAGE_COST = "gen_ai.usage.cost";
+export const GEN_AI_USAGE_TTFT = "gen_ai.usage.ttft";
+export const GEN_AI_USAGE_GENERATION_TIME = "gen_ai.usage.generation_time";
+export const GEN_AI_USAGE_WARNINGS = "gen_ai.usage.warnings";
+export const GEN_AI_USAGE_TYPE = "gen_ai.usage.type";
+export const AI_TOOL_CALL = "ai.toolCall";
+export const AI_TOOL_CALLS = "ai.toolCalls";
+export const AI_TOOL_CALL_PREFIX = "ai.toolCall.";
+export const AI_TOOL_CALL_ID = "ai.toolCall.id";
+export const AI_TOOL_CALL_NAME = "ai.toolCall.name";
+export const AI_TOOL_CALL_ARGS = "ai.toolCall.args";
+export const AI_TOOL_CALL_RESULT = "ai.toolCall.result";
+
+const VERCEL_AI_SCOPE_NAMES = new Set(["ai", "gen_ai", "@ai-sdk/otel"]);
+const MODERN_OPERATION_LOG_TYPES: Record<string, string> = {
+  [GEN_AI_OPERATION_NAME_VALUE_CHAT]: RespanLogType.TEXT,
+  [GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT]: RespanLogType.AGENT,
+  [GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS]: RespanLogType.EMBEDDING,
+  [GEN_AI_OPERATION_NAME_VALUE_EXECUTE_TOOL]: RespanLogType.TOOL,
+  agent_step: RespanLogType.TASK,
+  rerank: RespanLogType.TASK,
+};
+
+export function setMetadata(
+  attrs: SpanAttributes,
+  key: string,
+  value: unknown,
+): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  const attribute = RespanSpanAttributes.RESPAN_METADATA;
+  const existing = safeJsonParse(attrs[attribute]);
+  const metadata = isRecord(existing) ? { ...existing } : {};
+  if (metadata[key] === undefined) {
+    metadata[key] = value;
+  }
+  attrs[attribute] = safeJsonStr(metadata);
+
+  // Keep the canonical JSON bucket above and also follow the JavaScript
+  // tracing SDK's live wire format. The current ingest path promotes
+  // respan.metadata.<key> attributes into the request-log metadata object.
+  const flattenedAttribute = `${attribute}.${key}`;
+  if (attrs[flattenedAttribute] === undefined) {
+    attrs[flattenedAttribute] = safeJsonStr(value);
+  }
+}
+
+export function setDefault(attrs: SpanAttributes, key: string, value: any): void {
+  if (attrs[key] === undefined && value !== undefined && value !== null) {
+    attrs[key] = value;
+  }
+}
+
+export function safeJsonStr(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Map a Vercel embedding span's value(s) + vector(s) onto the universal
+ * input/output. Input = the embedded text; output = the embedding vector(s).
+ * We capture the full vector (it's debuggable data for RAG — similarity,
+ * drift, degenerate-vector detection); size is handled by storage tiering at
+ * ingest, not by dropping data here.
+ */
+export function formatEmbeddingInput(attrs: SpanAttributes): string | undefined {
+  const value = attrs[AI_VALUE] ?? attrs[AI_VALUES];
+  if (value === undefined || value === null) return undefined;
+  return safeJsonStr(normalizeEmbeddingValue(value));
+}
+
+export function formatEmbeddingOutput(attrs: SpanAttributes): string | undefined {
+  const raw = attrs[AI_EMBEDDING] ?? attrs[AI_EMBEDDINGS];
+  if (raw === undefined || raw === null) return undefined;
+  return safeJsonStr(normalizeEmbeddingValue(raw));
+}
+
+export function safeJsonParse(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+export function parseJsonish(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const parsed = safeJsonParse(value);
+  return parsed === value ? value : parsed;
+}
+
+function normalizeEmbeddingValue(value: unknown): unknown {
+  const parsed = parseJsonish(value);
+  if (!Array.isArray(parsed)) {
+    return parsed;
+  }
+
+  return parsed.map((item) => parseJsonish(item));
+}
+
+export function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function instrumentationScopeName(span: Partial<ReadableSpan> | any): string | undefined {
+  return span.instrumentationScope?.name ?? span.instrumentationLibrary?.name;
+}
+
+export function isVercelAIScope(scopeName: unknown): boolean {
+  if (typeof scopeName !== "string") {
+    return false;
+  }
+  return VERCEL_AI_SCOPE_NAMES.has(scopeName) || scopeName.includes("ai-sdk");
+}
+
+export function modernOperationName(name: string, attrs: SpanAttributes = {}): string | undefined {
+  const fromAttrs = attrs[ATTR_GEN_AI_OPERATION_NAME];
+  if (fromAttrs !== undefined && fromAttrs !== null) {
+    return String(fromAttrs);
+  }
+
+  const [firstToken] = name.trim().split(/\s+/, 1);
+  if (firstToken && MODERN_OPERATION_LOG_TYPES[firstToken] !== undefined) {
+    return firstToken;
+  }
+
+  return undefined;
+}
+
+export function isModernVercelAISpanName(name: string): boolean {
+  return modernOperationName(name) !== undefined;
+}
+
+export function isVercelAISpan(span: ReadableSpan): boolean {
+  if (isVercelAIScope(instrumentationScopeName(span))) {
+    return true;
+  }
+  if (span.attributes[AI_SDK] !== undefined) {
+    return true;
+  }
+  if (span.attributes[ATTR_GEN_AI_OPERATION_NAME] !== undefined) {
+    return true;
+  }
+  return span.name.startsWith(AI_PREFIX) || isModernVercelAISpanName(span.name);
+}
+
+export function resolveLogType(name: string, attrs: SpanAttributes): string {
+  const config = VERCEL_SPAN_CONFIG[name];
+  if (config) {
+    return config.logType;
+  }
+
+  const parentType = VERCEL_PARENT_SPANS[name];
+  if (parentType) {
+    return parentType;
+  }
+
+  const operationId = attrs[AI_OPERATION_ID]?.toString();
+  if (operationId) {
+    const operationConfig = VERCEL_SPAN_CONFIG[operationId];
+    if (operationConfig) {
+      return operationConfig.logType;
+    }
+
+    const operationParentType = VERCEL_PARENT_SPANS[operationId];
+    if (operationParentType) {
+      return operationParentType;
+    }
+  }
+
+  const operationName = modernOperationName(name, attrs);
+  if (operationName && MODERN_OPERATION_LOG_TYPES[operationName]) {
+    return MODERN_OPERATION_LOG_TYPES[operationName];
+  }
+
+  if (
+    attrs[AI_EMBEDDING] || attrs[AI_EMBEDDINGS] ||
+    name.includes("embed") || operationId?.includes("embed")
+  ) {
+    return RespanLogType.EMBEDDING;
+  }
+
+  if (
+    attrs[AI_TOOL_CALL_ID] || attrs[AI_TOOL_CALL_NAME] ||
+    attrs[AI_TOOL_CALL_ARGS] || attrs[AI_TOOL_CALL_RESULT] ||
+    attrs[ATTR_GEN_AI_TOOL_CALL_ID] || attrs[ATTR_GEN_AI_TOOL_NAME] ||
+    attrs[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] || attrs[ATTR_GEN_AI_TOOL_CALL_RESULT] ||
+    attrs[AI_RESPONSE_TOOL_CALLS] ||
+    name.includes("tool") || operationId?.includes("tool")
+  ) {
+    return RespanLogType.TOOL;
+  }
+
+  if (
+    attrs[AI_AGENT_ID] ||
+    name.includes("agent") || operationId?.includes("agent")
+  ) {
+    return RespanLogType.AGENT;
+  }
+
+  if (
+    attrs[AI_WORKFLOW_ID] ||
+    name.includes("workflow") || operationId?.includes("workflow")
+  ) {
+    return RespanLogType.WORKFLOW;
+  }
+
+  if (
+    attrs[AI_TRANSCRIPT] ||
+    name.includes("transcript") || operationId?.includes("transcript")
+  ) {
+    return RespanLogType.TEXT;
+  }
+
+  if (
+    attrs[AI_SPEECH] ||
+    name.includes("speech") || operationId?.includes("speech")
+  ) {
+    return RespanLogType.TEXT;
+  }
+
+  if (name.includes("doGenerate") || name.includes("doStream")) {
+    return RespanLogType.TEXT;
+  }
+
+  return RespanLogType.TASK;
+}
+
+export function normalizeModel(modelId: string): string {
+  const model = modelId.toLowerCase();
+
+  if (model.includes("gemini-2.0-flash-001")) return "gemini/gemini-2.0-flash";
+  if (model.includes("gemini-2.0-pro")) return "gemini/gemini-2.0-pro-exp-02-05";
+  if (model.includes("claude-3-5-sonnet")) return "claude-3-5-sonnet-20241022";
+  if (model.includes("deepseek")) return `deepseek/${model}`;
+  if (model.includes("o3-mini")) return "o3-mini";
+
+  return model;
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_translator/span-enrichment.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/_translator/span-enrichment.ts
@@ -1,0 +1,328 @@
+import {
+  ATTR_GEN_AI_INPUT_MESSAGES,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
+  ATTR_GEN_AI_PROVIDER_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
+  ATTR_GEN_AI_RESPONSE_ID,
+  ATTR_GEN_AI_SYSTEM,
+  ATTR_GEN_AI_TOOL_DEFINITIONS,
+  ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+} from "@opentelemetry/semantic-conventions/incubating";
+import { RespanLogType, RespanSpanAttributes } from "@respan/respan-sdk";
+import { SpanAttributes as TraceloopSpanAttributes } from "@traceloop/ai-semantic-conventions";
+import {
+  AI_RESPONSE_MS_TO_FINISH,
+  AI_PREFIX,
+  AI_MODEL_PROVIDER,
+  AI_TELEMETRY_METADATA_PREFIX,
+  AI_USAGE_CACHED_INPUT_TOKENS,
+  AI_USAGE_COMPLETION_TOKENS,
+  AI_USAGE_INPUT_TOKENS,
+  AI_USAGE_OUTPUT_TOKENS,
+  AI_USAGE_PROMPT_TOKENS,
+  AI_USAGE_TOTAL_TOKENS,
+  GEN_AI_USAGE_COST,
+  GEN_AI_USAGE_GENERATION_TIME,
+  GEN_AI_USAGE_TTFT,
+  GEN_AI_USAGE_TYPE,
+  GEN_AI_USAGE_WARNINGS,
+  setMetadata,
+  normalizeModel,
+  setDefault,
+  type SpanAttributes,
+} from "./shared.js";
+import { EVE_ATTRIBUTE_PREFIX } from "../constants/eve.js";
+
+const LLM_USAGE_CACHE_READ_INPUT_TOKENS = "llm.usage.cache_read_input_tokens";
+const LLM_IS_STREAMING = "llm.is_streaming";
+
+export function enrichMetadata(attrs: SpanAttributes): void {
+  for (const [key, value] of Object.entries(attrs)) {
+    const respanMetadataPrefix = RespanSpanAttributes.RESPAN_METADATA + ".";
+    if (key.startsWith(respanMetadataPrefix)) {
+      const cleanKey = key.slice(respanMetadataPrefix.length);
+      if (cleanKey === "agent_name") {
+        delete attrs[key];
+      } else {
+        setMetadata(attrs, cleanKey, value);
+      }
+      continue;
+    }
+
+    if (!key.startsWith(AI_TELEMETRY_METADATA_PREFIX)) {
+      continue;
+    }
+
+    const cleanKey = key.slice(AI_TELEMETRY_METADATA_PREFIX.length);
+    switch (cleanKey) {
+      case "customer_identifier":
+        setDefault(attrs, RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_ID, String(value));
+        break;
+      case "customer_email":
+        setDefault(attrs, RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_EMAIL, String(value));
+        break;
+      case "customer_name":
+        setDefault(attrs, RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_NAME, String(value));
+        break;
+      case "session_identifier":
+        setDefault(attrs, RespanSpanAttributes.RESPAN_SESSION_ID, String(value));
+        break;
+      case "thread_identifier":
+        setDefault(attrs, RespanSpanAttributes.RESPAN_THREADS_ID, String(value));
+        break;
+      case "trace_group_identifier":
+        setDefault(attrs, RespanSpanAttributes.RESPAN_TRACE_GROUP_ID, String(value));
+        break;
+      case "customer_params": {
+        // customer_params is a JSON-stringified object (Vercel telemetry
+        // metadata values must be flat scalars, so users serialize the object).
+        // Documented shape uses `email` / `name` (matching the Customer columns
+        // in the UI); accept the legacy `customer_email` / `customer_name`
+        // aliases too so older integrations keep working.
+        try {
+          const parsed = typeof value === "string" ? JSON.parse(value) : value;
+          if (parsed?.customer_identifier) setDefault(attrs, RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_ID, parsed.customer_identifier);
+          const email = parsed?.email ?? parsed?.customer_email;
+          if (email) setDefault(attrs, RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_EMAIL, email);
+          const name = parsed?.name ?? parsed?.customer_name;
+          if (name) setDefault(attrs, RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_NAME, name);
+        } catch {
+          // Ignore malformed customer_params metadata.
+        }
+        break;
+      }
+      case "prompt_unit_price":
+        setMetadata(attrs, "prompt_unit_price", String(value));
+        break;
+      case "completion_unit_price":
+        setMetadata(attrs, "completion_unit_price", String(value));
+        break;
+      case "userId":
+        setDefault(attrs, RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_ID, String(value));
+        setMetadata(attrs, cleanKey, String(value ?? ""));
+        break;
+      case "agent_name":
+        // Agent display names are carried by traceloop.entity.name.
+        break;
+      default:
+        setMetadata(attrs, cleanKey, String(value ?? ""));
+        break;
+    }
+  }
+}
+
+export function enrichModel(attrs: SpanAttributes, modelId: unknown): void {
+  if (!modelId) {
+    return;
+  }
+
+  const model = normalizeModel(String(modelId));
+  setDefault(attrs, ATTR_GEN_AI_REQUEST_MODEL, model);
+}
+
+function normalizeSystem(system: unknown): string | undefined {
+  if (!system) {
+    return undefined;
+  }
+
+  const value = String(system).trim().toLowerCase();
+  if (!value) {
+    return undefined;
+  }
+
+  if (value.includes("openai")) return "openai";
+  if (value.includes("anthropic")) return "anthropic";
+  if (value.includes("google") || value.includes("gemini")) return "google";
+  if (value.includes("bedrock")) return "bedrock";
+  if (value.includes("azure")) return "azure";
+  if (value.includes("mistral")) return "mistral";
+  if (value.includes("cohere")) return "cohere";
+  if (value.includes("groq")) return "groq";
+  if (value.includes("xai")) return "xai";
+  if (value.includes("deepseek")) return "deepseek";
+
+  return value.split(/[.:/]/, 1)[0] || value;
+}
+
+export function enrichSystem(attrs: SpanAttributes): void {
+  const system = normalizeSystem(attrs[ATTR_GEN_AI_SYSTEM] ?? attrs[ATTR_GEN_AI_PROVIDER_NAME] ?? attrs[AI_MODEL_PROVIDER]);
+  if (system) {
+    setDefault(attrs, ATTR_GEN_AI_SYSTEM, system);
+  }
+}
+
+function numberAttr(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+}
+
+export function enrichTokens(attrs: SpanAttributes): void {
+  const inputTokens =
+    attrs[ATTR_GEN_AI_USAGE_INPUT_TOKENS] ??
+    attrs[TraceloopSpanAttributes.LLM_USAGE_PROMPT_TOKENS] ??
+    attrs[AI_USAGE_INPUT_TOKENS] ??
+    attrs[AI_USAGE_PROMPT_TOKENS];
+  const outputTokens =
+    attrs[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] ??
+    attrs[TraceloopSpanAttributes.LLM_USAGE_COMPLETION_TOKENS] ??
+    attrs[AI_USAGE_OUTPUT_TOKENS] ??
+    attrs[AI_USAGE_COMPLETION_TOKENS];
+  const totalTokens = attrs[TraceloopSpanAttributes.LLM_USAGE_TOTAL_TOKENS] ?? attrs[AI_USAGE_TOTAL_TOKENS];
+  const cacheReadInputTokens =
+    attrs[ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] ??
+    attrs[LLM_USAGE_CACHE_READ_INPUT_TOKENS] ??
+    attrs[AI_USAGE_CACHED_INPUT_TOKENS];
+
+  const promptTokens = numberAttr(inputTokens);
+  const completionTokens = numberAttr(outputTokens);
+
+  if (promptTokens !== undefined) {
+    setDefault(attrs, ATTR_GEN_AI_USAGE_INPUT_TOKENS, promptTokens);
+    setDefault(attrs, TraceloopSpanAttributes.LLM_USAGE_PROMPT_TOKENS, promptTokens);
+  }
+  if (completionTokens !== undefined) {
+    setDefault(attrs, ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, completionTokens);
+    setDefault(attrs, TraceloopSpanAttributes.LLM_USAGE_COMPLETION_TOKENS, completionTokens);
+  }
+
+  const resolvedTotalTokens = numberAttr(totalTokens) ?? (
+    promptTokens !== undefined && completionTokens !== undefined
+      ? promptTokens + completionTokens
+      : undefined
+  );
+  if (resolvedTotalTokens !== undefined) {
+    setDefault(attrs, TraceloopSpanAttributes.LLM_USAGE_TOTAL_TOKENS, resolvedTotalTokens);
+  }
+
+  const resolvedCacheReadInputTokens = numberAttr(cacheReadInputTokens);
+  if (resolvedCacheReadInputTokens !== undefined) {
+    setDefault(attrs, LLM_USAGE_CACHE_READ_INPUT_TOKENS, resolvedCacheReadInputTokens);
+  }
+}
+
+export function enrichPerformanceMetrics(attrs: SpanAttributes, spanName: string): void {
+  // Streaming is a first-class promoted attribute (llm.is_streaming), not metadata.
+  setDefault(attrs, LLM_IS_STREAMING, spanName.toLowerCase().includes("stream"));
+
+  const msToFinish = attrs[AI_RESPONSE_MS_TO_FINISH];
+  if (msToFinish !== undefined) {
+    setMetadata(attrs, "time_to_first_token", String(Number(msToFinish) / 1000));
+  }
+
+  const cost = attrs[GEN_AI_USAGE_COST];
+  if (cost !== undefined) {
+    setMetadata(attrs, "cost", String(cost));
+  }
+
+  const ttft = attrs[GEN_AI_USAGE_TTFT];
+  if (ttft !== undefined) {
+    setMetadata(attrs, "ttft", String(ttft));
+  }
+
+  const generationTime = attrs[GEN_AI_USAGE_GENERATION_TIME];
+  if (generationTime !== undefined) {
+    setMetadata(attrs, "generation_time", String(generationTime));
+  }
+
+  const warnings = attrs[GEN_AI_USAGE_WARNINGS];
+  if (warnings !== undefined) {
+    setMetadata(attrs, "warnings", String(warnings));
+  }
+
+  const responseType = attrs[GEN_AI_USAGE_TYPE];
+  if (responseType !== undefined) {
+    setMetadata(attrs, "type", String(responseType));
+  }
+}
+
+const NON_CONTRACT_ATTRS_TO_STRIP = [
+  "operation.name",
+  ATTR_GEN_AI_INPUT_MESSAGES,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
+  ATTR_GEN_AI_PROVIDER_NAME,
+  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
+  ATTR_GEN_AI_RESPONSE_ID,
+  ATTR_GEN_AI_TOOL_DEFINITIONS,
+  ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+  GEN_AI_USAGE_COST,
+  GEN_AI_USAGE_TTFT,
+  GEN_AI_USAGE_GENERATION_TIME,
+  GEN_AI_USAGE_WARNINGS,
+  GEN_AI_USAGE_TYPE,
+  "service.name",
+  "telemetry.sdk.language",
+  "telemetry.sdk.name",
+  "telemetry.sdk.version",
+  "process.pid",
+  "process.executable.name",
+  "process.executable.path",
+  "process.command_args",
+  "process.runtime.version",
+  "process.runtime.name",
+  "process.runtime.description",
+  "process.command",
+  "process.owner",
+  "host.name",
+  "host.arch",
+  "host.id",
+  "otel.scope.name",
+  "otel.scope.version",
+  "next.span_name",
+  "next.span_type",
+  "http.url",
+  "http.method",
+  "net.peer.name",
+];
+
+const OFF_CONTRACT_ALIAS_ATTRS_TO_STRIP = [
+  "tools",
+  "tool_calls",
+  "model",
+  "prompt_tokens",
+  "completion_tokens",
+  "total_request_tokens",
+  "span_tools",
+  "has_tool_calls",
+  "parallel_tool_calls",
+  RespanSpanAttributes.RESPAN_SPAN_TOOLS,
+  RespanSpanAttributes.RESPAN_SPAN_TOOL_CALLS,
+  RespanSpanAttributes.RESPAN_SPAN_HANDOFFS,
+];
+
+export function stripRedundantAttrs(
+  attrs: SpanAttributes,
+  logType: string,
+): void {
+  for (const key of NON_CONTRACT_ATTRS_TO_STRIP) {
+    delete attrs[key];
+  }
+
+  for (const key of OFF_CONTRACT_ALIAS_ATTRS_TO_STRIP) {
+    delete attrs[key];
+  }
+
+  const carriesLLMFields =
+    logType === RespanLogType.TEXT ||
+    logType === RespanLogType.EMBEDDING;
+
+  for (const key of Object.keys(attrs)) {
+    if (
+      key.startsWith(AI_PREFIX) ||
+      key.startsWith(EVE_ATTRIBUTE_PREFIX) ||
+      key.startsWith("gen_ai.tool.") ||
+      (!carriesLLMFields &&
+        (key.startsWith("gen_ai.") || key.startsWith("llm.")))
+    ) {
+      delete attrs[key];
+    }
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/constants/eve.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/constants/eve.ts
@@ -1,0 +1,16 @@
+/**
+ * Eve-owned raw OpenTelemetry span names and attributes.
+ *
+ * These are translator-local inputs, not part of the public Respan contract.
+ */
+export const EVE_TURN_SPAN_NAME = "ai.eve.turn";
+export const EVE_SCOPE_NAME = "eve";
+export const EVE_ATTRIBUTE_PREFIX = "eve.";
+export const EVE_VERSION = "eve.version";
+export const EVE_ENVIRONMENT = "eve.environment";
+export const EVE_SESSION_ID = "eve.session.id";
+export const EVE_TURN_ID = "eve.turn.id";
+export const EVE_TURN_SEQUENCE = "eve.turn.sequence";
+export const EVE_STEP_INDEX = "eve.step.index";
+export const EVE_CHANNEL_KIND = "eve.channel.kind";
+export const EVE_RETRY_REASON = "eve.retry.reason";

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/constants/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/constants/index.ts
@@ -1,0 +1,6 @@
+export {
+  VERCEL_SPAN_CONFIG,
+  VERCEL_PARENT_SPANS,
+  VERCEL_STRUCTURAL_LLM_PARENT_SPANS,
+  type VercelSpanConfig,
+} from "./logs.js";

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/constants/lineage.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/constants/lineage.ts
@@ -1,0 +1,26 @@
+/**
+ * Private bridge between Eve's authored runtime context and this translator.
+ *
+ * Eve reserves `eve.*` for framework-owned values. The helper therefore uses
+ * a package-private namespace that AI SDK 7 flattens under
+ * `ai.settings.context.*`. These keys are consumed and stripped before export;
+ * they are not additions to the public Respan span contract.
+ */
+export const EVE_RESPAN_BRIDGE_RUNTIME_CONTEXT_KEY = "__respan_eve";
+export const EVE_RESPAN_BRIDGE_RUNTIME_CONTEXT_PREFIX =
+  EVE_RESPAN_BRIDGE_RUNTIME_CONTEXT_KEY + ".";
+
+export const EVE_RESPAN_LINEAGE_ROOT_SESSION_ID_ATTRIBUTE =
+  "ai.settings.context.__respan_eve.lineage.rootSessionId";
+export const EVE_RESPAN_LINEAGE_PARENT_SESSION_ID_ATTRIBUTE =
+  "ai.settings.context.__respan_eve.lineage.sessionId";
+export const EVE_RESPAN_LINEAGE_PARENT_CALL_ID_ATTRIBUTE =
+  "ai.settings.context.__respan_eve.lineage.callId";
+export const EVE_RESPAN_LINEAGE_PARENT_TURN_ID_ATTRIBUTE =
+  "ai.settings.context.__respan_eve.lineage.turn.id";
+export const EVE_RESPAN_LINEAGE_PARENT_TURN_SEQUENCE_ATTRIBUTE =
+  "ai.settings.context.__respan_eve.lineage.turn.sequence";
+
+// Package-private handoff consumed by EveProcessorWrapper before Respan export.
+export const EVE_RESPAN_INTERNAL_EXPORT_TRACE_ID_ATTRIBUTE =
+  "respan.instrumentation.eve.export_trace_id";

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/constants/logs.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/constants/logs.ts
@@ -1,0 +1,76 @@
+/**
+ * Mappings from Vercel AI SDK span names to Respan/Traceloop conventions.
+ *
+ * The Vercel AI SDK emits OTEL spans with names like "ai.generateText.doGenerate".
+ * These mappings tell the translator which traceloop.span.kind, respan log type,
+ * and whether to apply full LLM attribute enrichment.
+ */
+
+import { RespanLogType } from "@respan/respan-sdk";
+
+export interface VercelSpanConfig {
+  /** Traceloop span kind (workflow, agent, task, tool) */
+  kind: string;
+  /** Respan log type for backend categorization */
+  logType: string;
+  /** Whether this span represents an LLM call (triggers prompt/completion enrichment) */
+  isLLM: boolean;
+}
+
+// ── Detailed spans (leaf nodes with actual LLM/embedding/tool data) ─────────
+
+export const VERCEL_SPAN_CONFIG: Record<string, VercelSpanConfig> = {
+  // LLM generation (detailed spans carry response data)
+  "ai.generateText.doGenerate": { kind: RespanLogType.TASK, logType: RespanLogType.TEXT, isLLM: true },
+  "ai.streamText.doStream":     { kind: RespanLogType.TASK, logType: RespanLogType.TEXT, isLLM: true },
+  "ai.generateObject.doGenerate": { kind: RespanLogType.TASK, logType: RespanLogType.TEXT, isLLM: true },
+  "ai.streamObject.doStream":   { kind: RespanLogType.TASK, logType: RespanLogType.TEXT, isLLM: true },
+
+  // Embeddings
+  "ai.embed.doEmbed":     { kind: RespanLogType.TASK, logType: RespanLogType.EMBEDDING, isLLM: false },
+  "ai.embedMany.doEmbed": { kind: RespanLogType.TASK, logType: RespanLogType.EMBEDDING, isLLM: false },
+
+  // Tool calls
+  "ai.toolCall": { kind: RespanLogType.TOOL, logType: RespanLogType.TOOL, isLLM: false },
+
+  // Agent / workflow
+  "ai.agent":      { kind: RespanLogType.AGENT,    logType: RespanLogType.AGENT,    isLLM: false },
+  "ai.agent.run":  { kind: RespanLogType.AGENT,    logType: RespanLogType.AGENT,    isLLM: false },
+  "ai.agent.step": { kind: RespanLogType.TASK,     logType: RespanLogType.TASK,     isLLM: false },
+  "ai.workflow":   { kind: RespanLogType.WORKFLOW,  logType: RespanLogType.WORKFLOW, isLLM: false },
+
+  // Function / handoff
+  "ai.function": { kind: RespanLogType.TOOL, logType: RespanLogType.TOOL, isLLM: false },
+  "ai.handoff":  { kind: RespanLogType.TASK, logType: RespanLogType.TASK, isLLM: false },
+
+  // Media
+  "ai.transcript": { kind: RespanLogType.TASK, logType: RespanLogType.TEXT, isLLM: false },
+  "ai.speech":     { kind: RespanLogType.TASK, logType: RespanLogType.TEXT, isLLM: false },
+
+  // Other
+  "ai.response":          { kind: RespanLogType.TASK, logType: RespanLogType.TEXT,     isLLM: true },
+  "ai.stream.firstChunk": { kind: RespanLogType.TASK, logType: RespanLogType.TEXT,     isLLM: false },
+};
+
+// ── Parent wrapper spans (structural only, no LLM data) ─────────────────────
+
+export const VERCEL_PARENT_SPANS: Record<string, string> = {
+  "ai.generateText":   RespanLogType.TASK,
+  "ai.streamText":     RespanLogType.TASK,
+  "ai.generateObject": RespanLogType.TASK,
+  "ai.streamObject":   RespanLogType.TASK,
+  "ai.embed":          RespanLogType.TASK,
+  "ai.embedMany":      RespanLogType.TASK,
+};
+
+// Classic-telemetry LLM wrappers whose detailed `.doGenerate`/`.doStream`
+// child carries the actual model/input/output. Marked with the internal
+// drop attribute so the semantic export style removes them (children are
+// reparented); legacy style still exports them. Modern AI SDK 7 telemetry
+// emits flat spans, so no modern names belong here.
+export const VERCEL_STRUCTURAL_LLM_PARENT_SPANS = new Set([
+  "ai.generateText",
+  "ai.streamText",
+  "ai.generateObject",
+  "ai.streamObject",
+]);

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/index.ts
@@ -1,0 +1,207 @@
+/**
+ * Respan instrumentation plugin for the Eve agent framework.
+ *
+ * Eve enables its vendored AI SDK OpenTelemetry integration whenever
+ * `agent/instrumentation.ts` is present. This plugin installs a package-local
+ * processor wrapper ahead of the active Respan processor so Eve turn, model,
+ * and tool spans are translated before Respan filters and exports them.
+ */
+
+import { trace } from "@opentelemetry/api";
+import type { Context } from "@opentelemetry/api";
+import type {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { EveSpanProcessor } from "./_processor.js";
+
+export { withEveLineage } from "./lineage.js";
+
+type ProcessorProperty = "activeSpanProcessor" | "_activeSpanProcessor";
+
+interface ProcessorPatchState {
+  originalProcessor: SpanProcessor;
+  processorProperty: ProcessorProperty;
+  provider: Record<string, unknown>;
+  wrapper: EveProcessorWrapper;
+}
+
+const WRAPPED_PROCESSOR = Symbol.for(
+  "respan.instrumentation.eve.wrappedProcessor",
+);
+
+class EveProcessorWrapper implements SpanProcessor {
+  readonly [WRAPPED_PROCESSOR] = true;
+
+  constructor(
+    private readonly _delegate: SpanProcessor,
+    private readonly _translator: EveSpanProcessor,
+  ) {}
+
+  onStart(span: Span, parentContext: Context): void {
+    this._translator.onStart(span, parentContext);
+    this._delegate.onStart(span, parentContext);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    this._translator.onEnd(span);
+    this._delegate.onEnd(this._translator.prepareForExport(span));
+  }
+
+  shutdown(): Promise<void> {
+    return this._delegate.shutdown();
+  }
+
+  forceFlush(): Promise<void> {
+    return this._delegate.forceFlush();
+  }
+}
+
+export class EveInstrumentor {
+  public readonly name = "eve";
+
+  private static _patchCount = 0;
+  private static _patchState: ProcessorPatchState | null = null;
+  private static readonly _processor = new EveSpanProcessor({
+    initiallyActive: false,
+  });
+
+  private _active = false;
+
+  activate(): void {
+    if (this._active) {
+      return;
+    }
+
+    EveInstrumentor._processor.acquire();
+    try {
+      this._installProcessor();
+      this._active = true;
+    } catch (error) {
+      EveInstrumentor._processor.release();
+      throw error;
+    }
+  }
+
+  deactivate(): void {
+    if (!this._active) {
+      return;
+    }
+
+    this._restoreProcessor();
+    EveInstrumentor._processor.release();
+    this._active = false;
+  }
+
+  isActive(): boolean {
+    return this._active;
+  }
+
+  private _installProcessor(): void {
+    const provider = resolveWritableTracerProvider();
+    const { activeProcessor, processorProperty } =
+      resolveActiveSpanProcessor(provider);
+
+    if (
+      (activeProcessor as unknown as Record<symbol, unknown>)[WRAPPED_PROCESSOR]
+    ) {
+      EveInstrumentor._patchCount += 1;
+      return;
+    }
+
+    const wrapper = new EveProcessorWrapper(
+      activeProcessor,
+      EveInstrumentor._processor,
+    );
+    setActiveSpanProcessor(provider, processorProperty, wrapper);
+    EveInstrumentor._patchState = {
+      originalProcessor: activeProcessor,
+      processorProperty,
+      provider,
+      wrapper,
+    };
+    EveInstrumentor._patchCount = 1;
+  }
+
+  private _restoreProcessor(): void {
+    if (EveInstrumentor._patchCount === 0) {
+      return;
+    }
+
+    EveInstrumentor._patchCount -= 1;
+    if (EveInstrumentor._patchCount > 0) {
+      return;
+    }
+
+    const patchState = EveInstrumentor._patchState;
+    if (!patchState) {
+      return;
+    }
+
+    if (patchState.provider[patchState.processorProperty] === patchState.wrapper) {
+      setActiveSpanProcessor(
+        patchState.provider,
+        patchState.processorProperty,
+        patchState.originalProcessor,
+      );
+    }
+    EveInstrumentor._patchState = null;
+  }
+}
+
+function resolveWritableTracerProvider(): Record<string, unknown> {
+  const provider = trace.getTracerProvider() as unknown as Record<string, unknown>;
+  const delegated = provider?._delegate as Record<string, unknown> | undefined;
+  return delegated ?? provider;
+}
+
+function resolveActiveSpanProcessor(provider: Record<string, unknown>): {
+  activeProcessor: SpanProcessor;
+  processorProperty: ProcessorProperty;
+} {
+  for (const property of [
+    "activeSpanProcessor",
+    "_activeSpanProcessor",
+  ] as const) {
+    const candidate = provider[property];
+    if (isSpanProcessor(candidate)) {
+      return { activeProcessor: candidate, processorProperty: property };
+    }
+  }
+  throw new Error(
+    "EveInstrumentor requires an active OpenTelemetry SpanProcessor. Initialize Respan before activating this instrumentor.",
+  );
+}
+
+function setActiveSpanProcessor(
+  provider: Record<string, unknown>,
+  property: ProcessorProperty,
+  processor: SpanProcessor,
+): void {
+  try {
+    provider[property] = processor;
+    if (provider[property] === processor) {
+      return;
+    }
+  } catch {
+    // Fall through to defineProperty.
+  }
+
+  Object.defineProperty(provider, property, {
+    configurable: true,
+    value: processor,
+    writable: true,
+  });
+}
+
+function isSpanProcessor(value: unknown): value is SpanProcessor {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      typeof (value as SpanProcessor).onStart === "function" &&
+      typeof (value as SpanProcessor).onEnd === "function",
+  );
+}
+
+export { EveSpanProcessor };

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/src/lineage.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/src/lineage.ts
@@ -1,0 +1,153 @@
+import { trace, type Attributes } from "@opentelemetry/api";
+import type { InstrumentationDefinition } from "eve/instrumentation";
+import {
+  EVE_RESPAN_BRIDGE_RUNTIME_CONTEXT_KEY,
+  EVE_RESPAN_LINEAGE_PARENT_CALL_ID_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_PARENT_SESSION_ID_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_PARENT_TURN_ID_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_PARENT_TURN_SEQUENCE_ATTRIBUTE,
+  EVE_RESPAN_LINEAGE_ROOT_SESSION_ID_ATTRIBUTE,
+} from "./constants/lineage.js";
+
+type StepStartedHandler = (...args: never[]) => unknown;
+
+interface EveInstrumentationDefinitionLike {
+  readonly events?: {
+    readonly "step.started"?: StepStartedHandler;
+  };
+}
+
+interface EveStepStartedInputLike {
+  readonly session: {
+    readonly id: string;
+    readonly parent?: {
+      readonly callId: string;
+      readonly rootSessionId: string;
+      readonly sessionId: string;
+      readonly turn: {
+        readonly id: string;
+        readonly sequence: number;
+      };
+    };
+  };
+}
+
+interface EveLineage {
+  readonly callId?: string;
+  readonly rootSessionId: string;
+  readonly sessionId?: string;
+  readonly turn?: {
+    readonly id: string;
+    readonly sequence: number;
+  };
+}
+
+/**
+ * Adds Respan delegation lineage to an Eve instrumentation definition.
+ *
+ * Wrap the result of Eve's `defineInstrumentation(...)`. Any authored
+ * `events["step.started"]` callback is invoked once and its runtime context is
+ * preserved. The private `__respan_eve` key is helper-owned and wins over an
+ * authored value with the same name.
+ */
+export function withEveLineage<T extends InstrumentationDefinition>(
+  definition: T,
+): T {
+  const typedDefinition = definition as T & EveInstrumentationDefinitionLike;
+  const authoredStepStarted = typedDefinition.events?.["step.started"] as
+    | ((input: EveStepStartedInputLike) => unknown)
+    | undefined;
+
+  const stepStarted = (input: EveStepStartedInputLike): unknown => {
+    const authoredResult = authoredStepStarted?.(input);
+
+    // Preserve Eve's own warning-only validation for forced async or malformed
+    // callback results instead of silently converting them into valid output.
+    if (
+      authoredResult !== undefined &&
+      (!isRecord(authoredResult) || !isRecord(authoredResult.runtimeContext))
+    ) {
+      return authoredResult;
+    }
+
+    const lineage = buildLineage(input);
+    const authoredRuntimeContext =
+      authoredResult === undefined
+        ? {}
+        : (authoredResult.runtimeContext as Record<string, unknown>);
+
+    stampActiveTurn(lineage);
+
+    return {
+      runtimeContext: {
+        ...authoredRuntimeContext,
+        [EVE_RESPAN_BRIDGE_RUNTIME_CONTEXT_KEY]: { lineage },
+      },
+    };
+  };
+
+  return {
+    ...definition,
+    events: {
+      ...typedDefinition.events,
+      "step.started": stepStarted,
+    },
+  } as T;
+}
+
+function buildLineage(input: EveStepStartedInputLike): EveLineage {
+  const parent = input.session.parent;
+  if (parent === undefined) {
+    return { rootSessionId: input.session.id };
+  }
+
+  return {
+    callId: parent.callId,
+    rootSessionId: parent.rootSessionId,
+    sessionId: parent.sessionId,
+    turn: {
+      id: parent.turn.id,
+      sequence: parent.turn.sequence,
+    },
+  };
+}
+
+/**
+ * Eve invokes the authored callback inside the active `ai.eve.turn` context on
+ * the first step. Mirroring the flattened bridge attributes here lets the turn
+ * root and the AI SDK children receive identical grouping without maintaining
+ * cross-span state in the translator. Continuation steps expose a non-recording
+ * remote parent, so this is intentionally best-effort.
+ */
+function stampActiveTurn(lineage: EveLineage): void {
+  try {
+    const activeSpan = trace.getActiveSpan();
+    if (activeSpan === undefined || !activeSpan.isRecording()) {
+      return;
+    }
+
+    const attributes: Attributes = {
+      [EVE_RESPAN_LINEAGE_ROOT_SESSION_ID_ATTRIBUTE]:
+        lineage.rootSessionId,
+    };
+    if (lineage.sessionId !== undefined) {
+      attributes[EVE_RESPAN_LINEAGE_PARENT_SESSION_ID_ATTRIBUTE] =
+        lineage.sessionId;
+    }
+    if (lineage.callId !== undefined) {
+      attributes[EVE_RESPAN_LINEAGE_PARENT_CALL_ID_ATTRIBUTE] = lineage.callId;
+    }
+    if (lineage.turn !== undefined) {
+      attributes[EVE_RESPAN_LINEAGE_PARENT_TURN_ID_ATTRIBUTE] = lineage.turn.id;
+      attributes[EVE_RESPAN_LINEAGE_PARENT_TURN_SEQUENCE_ATTRIBUTE] =
+        lineage.turn.sequence;
+    }
+    activeSpan.setAttributes(attributes);
+  } catch {
+    // Observability enrichment must never interrupt an Eve turn.
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/tests/instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/tests/instrumentor.test.mjs
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { trace } from "@opentelemetry/api";
+import { EveInstrumentor } from "../dist/index.js";
+
+function makeTurn(sessionId, suffix) {
+  const attributes = {
+    "ai.telemetry.functionId": "support-agent",
+    "eve.environment": "test",
+    "eve.session.id": sessionId,
+    "eve.version": "0.26.1",
+  };
+  return {
+    name: "ai.eve.turn",
+    instrumentationScope: { name: "eve" },
+    attributes,
+    spanContext() {
+      return {
+        traceId: suffix.padStart(32, "0"),
+        spanId: suffix.padStart(16, "0"),
+        traceFlags: 1,
+      };
+    },
+    setAttribute(key, value) {
+      attributes[key] = value;
+    },
+  };
+}
+
+function assertCanonicalTurn(span, sessionId) {
+  assert.equal(span.attributes["respan.entity.log_type"], "agent");
+  assert.equal(span.attributes["traceloop.entity.name"], "support-agent");
+  assert.equal(
+    span.attributes["respan.threads.thread_identifier"],
+    sessionId,
+  );
+  assert.equal(span.attributes["traceloop.workflow.name"], "support-agent");
+  assert.equal(span.attributes["eve.session.id"], undefined);
+}
+
+test("wraps the active processor with shared ownership and drain-safe deactivation", () => {
+  const delegatedSpans = [];
+  const originalProcessor = {
+    onStart() {},
+    onEnd(span) {
+      delegatedSpans.push(span);
+    },
+    shutdown() {
+      return Promise.resolve();
+    },
+    forceFlush() {
+      return Promise.resolve();
+    },
+  };
+  const provider = { activeSpanProcessor: originalProcessor };
+  const originalGetTracerProvider = trace.getTracerProvider.bind(trace);
+
+  Object.defineProperty(trace, "getTracerProvider", {
+    configurable: true,
+    writable: true,
+    value: () => provider,
+  });
+
+  const first = new EveInstrumentor();
+  const second = new EveInstrumentor();
+
+  try {
+    first.activate();
+    second.activate();
+
+    const wrapper = provider.activeSpanProcessor;
+    assert.notEqual(wrapper, originalProcessor);
+    assert.equal(first.isActive(), true);
+    assert.equal(second.isActive(), true);
+
+    const both = makeTurn("session-both", "1");
+    wrapper.onStart(both, undefined);
+    wrapper.onEnd(both);
+    assertCanonicalTurn(delegatedSpans[0], "session-both");
+
+    first.deactivate();
+    assert.equal(provider.activeSpanProcessor, wrapper);
+
+    const secondOwner = makeTurn("session-second-owner", "2");
+    wrapper.onStart(secondOwner, undefined);
+    wrapper.onEnd(secondOwner);
+    assertCanonicalTurn(delegatedSpans[1], "session-second-owner");
+
+    const draining = makeTurn("session-draining", "3");
+    wrapper.onStart(draining, undefined);
+    second.deactivate();
+    assert.equal(provider.activeSpanProcessor, originalProcessor);
+    wrapper.onEnd(draining);
+    assertCanonicalTurn(delegatedSpans[2], "session-draining");
+
+    const inactive = makeTurn("session-after-deactivation", "4");
+    originalProcessor.onStart(inactive, undefined);
+    originalProcessor.onEnd(inactive);
+    assert.equal(
+      delegatedSpans[3].attributes["respan.entity.log_type"],
+      undefined,
+    );
+  } finally {
+    first.deactivate();
+    second.deactivate();
+    Object.defineProperty(trace, "getTracerProvider", {
+      configurable: true,
+      writable: true,
+      value: originalGetTracerProvider,
+    });
+  }
+});

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/tests/lineage.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/tests/lineage.test.mjs
@@ -1,0 +1,180 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { trace } from "@opentelemetry/api";
+import { withEveLineage } from "../dist/lineage.js";
+
+function withActiveSpan(activeSpan, run) {
+  const descriptor = Object.getOwnPropertyDescriptor(trace, "getActiveSpan");
+  Object.defineProperty(trace, "getActiveSpan", {
+    configurable: true,
+    value: () => activeSpan,
+  });
+
+  try {
+    return run();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(trace, "getActiveSpan", descriptor);
+    } else {
+      delete trace.getActiveSpan;
+    }
+  }
+}
+
+test("composes an authored step.started hook and stamps delegated lineage", () => {
+  const stamped = {};
+  const activeSpan = {
+    isRecording: () => true,
+    setAttributes(attributes) {
+      Object.assign(stamped, attributes);
+    },
+  };
+  const authoredRuntimeContext = {
+    tenant: "acme",
+    nested: { enabled: true },
+    __respan_eve: { spoofed: true },
+  };
+  const input = {
+    session: {
+      id: "session-child",
+      parent: {
+        callId: "call-parent",
+        rootSessionId: "session-root",
+        sessionId: "session-parent",
+        turn: {
+          id: "turn-parent",
+          sequence: 4,
+        },
+      },
+    },
+  };
+  let seenInput;
+  let calls = 0;
+  const untouchedEvent = () => undefined;
+  const definition = {
+    recordInputs: false,
+    events: {
+      "session.started": untouchedEvent,
+      "step.started"(value) {
+        calls += 1;
+        seenInput = value;
+        return { runtimeContext: authoredRuntimeContext };
+      },
+    },
+  };
+
+  const wrapped = withEveLineage(definition);
+  const result = withActiveSpan(activeSpan, () =>
+    wrapped.events["step.started"](input),
+  );
+
+  assert.notEqual(wrapped, definition);
+  assert.notEqual(wrapped.events, definition.events);
+  assert.equal(wrapped.recordInputs, false);
+  assert.equal(wrapped.events["session.started"], untouchedEvent);
+  assert.equal(calls, 1);
+  assert.equal(seenInput, input);
+  assert.deepEqual(result, {
+    runtimeContext: {
+      tenant: "acme",
+      nested: { enabled: true },
+      __respan_eve: {
+        lineage: {
+          callId: "call-parent",
+          rootSessionId: "session-root",
+          sessionId: "session-parent",
+          turn: {
+            id: "turn-parent",
+            sequence: 4,
+          },
+        },
+      },
+    },
+  });
+  assert.deepEqual(authoredRuntimeContext, {
+    tenant: "acme",
+    nested: { enabled: true },
+    __respan_eve: { spoofed: true },
+  });
+  assert.deepEqual(stamped, {
+    "ai.settings.context.__respan_eve.lineage.rootSessionId":
+      "session-root",
+    "ai.settings.context.__respan_eve.lineage.sessionId":
+      "session-parent",
+    "ai.settings.context.__respan_eve.lineage.callId": "call-parent",
+    "ai.settings.context.__respan_eve.lineage.turn.id": "turn-parent",
+    "ai.settings.context.__respan_eve.lineage.turn.sequence": 4,
+  });
+});
+
+test("uses the current session as the root when Eve has no parent lineage", () => {
+  const wrapped = withEveLineage({});
+  const result = withActiveSpan(undefined, () =>
+    wrapped.events["step.started"]({
+      session: {
+        id: "session-root",
+      },
+    }),
+  );
+
+  assert.deepEqual(result, {
+    runtimeContext: {
+      __respan_eve: {
+        lineage: {
+          rootSessionId: "session-root",
+        },
+      },
+    },
+  });
+});
+
+test("keeps active-turn stamping best-effort", () => {
+  const wrapped = withEveLineage({});
+  const result = withActiveSpan(
+    {
+      isRecording: () => true,
+      setAttributes() {
+        throw new Error("custom span rejected attributes");
+      },
+    },
+    () =>
+      wrapped.events["step.started"]({
+        session: {
+          id: "session-root",
+        },
+      }),
+  );
+
+  assert.deepEqual(result, {
+    runtimeContext: {
+      __respan_eve: {
+        lineage: {
+          rootSessionId: "session-root",
+        },
+      },
+    },
+  });
+});
+
+test("preserves Eve validation for a forced async authored hook", async () => {
+  const promise = Promise.resolve({
+    runtimeContext: {
+      tenant: "acme",
+    },
+  });
+  const wrapped = withEveLineage({
+    events: {
+      "step.started": () => promise,
+    },
+  });
+
+  const result = wrapped.events["step.started"]({
+    session: {
+      id: "session-root",
+    },
+  });
+
+  assert.equal(result, promise);
+  await promise;
+});

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/tests/processor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/tests/processor.test.mjs
@@ -1,0 +1,992 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { EveSpanProcessor } from "../dist/_processor.js";
+
+function translate(name, attributes, options = {}) {
+  return translateSpan(name, attributes, options).attributes;
+}
+
+function translateSpan(name, attributes, options = {}) {
+  const translated = { ...attributes };
+  const instrumentationScope = {
+    name: options.scope ?? "gen_ai",
+  };
+  const span = {
+    name,
+    instrumentationScope,
+    attributes: translated,
+    status: options.status,
+    events: options.events,
+    spanContext() {
+      return {
+        spanId: options.spanId ?? "0123456789abcdef",
+        traceId:
+          options.traceId ?? "11111111111111111111111111111111",
+      };
+    },
+  };
+  const writableSpan = {
+    name,
+    instrumentationScope,
+    attributes: translated,
+    parentSpanId: options.parentSpanId,
+    spanContext: span.spanContext,
+    setAttribute(key, value) {
+      translated[key] = value;
+    },
+  };
+
+  const translator = options.translator ?? new EveSpanProcessor();
+  translator.onStart(writableSpan, undefined);
+  translator.onEnd(span);
+  return { span, attributes: translated };
+}
+
+function assertRawVendorAttrsStripped(attrs) {
+  const rawKeys = Object.keys(attrs).filter(
+    (key) => key.startsWith("ai.") || key.startsWith("eve."),
+  );
+  assert.deepEqual(rawKeys, []);
+}
+
+function assertNoOffContractAliases(attrs) {
+  for (const key of [
+    "tools",
+    "tool_calls",
+    "model",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_request_tokens",
+    "span_tools",
+    "has_tool_calls",
+    "parallel_tool_calls",
+    "respan.span.tools",
+    "respan.span.tool_calls",
+    "respan.span.handoffs",
+  ]) {
+    assert.equal(attrs[key], undefined, `${key} should be stripped`);
+  }
+}
+
+test("maps the ai.eve.turn root to an agent and promotes raw Eve context", () => {
+  const attrs = translate(
+    "ai.eve.turn",
+    {
+      "ai.telemetry.functionId": "support-agent",
+      "eve.version": "0.26.1",
+      "eve.environment": "production",
+      "eve.session.id": "session-root",
+      "eve.turn.id": "turn-root",
+    },
+    { scope: "eve" },
+  );
+
+  assert.equal(attrs["respan.entity.log_type"], "agent");
+  assert.equal(attrs["traceloop.entity.name"], "support-agent");
+  assert.equal(attrs["traceloop.entity.path"], "");
+  assert.equal(attrs["respan.sessions.session_identifier"], "session-root");
+  assert.equal(attrs["respan.threads.thread_identifier"], "session-root");
+  assert.equal(attrs["respan.trace.trace_group_identifier"], "session-root");
+  assert.equal(attrs["respan.environment"], "production");
+  assert.equal(attrs["traceloop.workflow.name"], "support-agent");
+  assert.equal(attrs["respan.internal.export_parent_span_id"], "");
+  assert.equal(attrs["respan.internal.span_name.kind"], "agent");
+  assert.equal(attrs["respan.internal.span_name.detail"], "support-agent");
+  assert.deepEqual(JSON.parse(attrs["respan.metadata"]), {
+    eve: {
+      version: "0.26.1",
+      environment: "production",
+      turn_id: "turn-root",
+    },
+  });
+  assert.deepEqual(JSON.parse(attrs["respan.metadata.eve"]), {
+    version: "0.26.1",
+    environment: "production",
+    turn_id: "turn-root",
+  });
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("extracts exact AI SDK 7 runtimeContext keys on a gen_ai chat span", () => {
+  const attrs = translate("chat openai/gpt-4.1", {
+    "gen_ai.operation.name": "chat",
+    "gen_ai.provider.name": "openai",
+    "gen_ai.request.model": "gpt-4.1",
+    "gen_ai.input.messages": JSON.stringify([
+      { role: "user", parts: [{ type: "text", content: "hello" }] },
+    ]),
+    "gen_ai.output.messages": JSON.stringify([
+      { role: "assistant", parts: [{ type: "text", content: "hi" }] },
+    ]),
+    "gen_ai.usage.input_tokens": 7,
+    "gen_ai.usage.output_tokens": 2,
+    "ai.settings.context.eve.version": "0.26.1",
+    "ai.settings.context.eve.environment": "development",
+    "ai.settings.context.eve.session.id": "session-1",
+    "ai.settings.context.eve.turn.id": "turn-1",
+    "ai.settings.context.eve.turn.sequence": "3",
+    "ai.settings.context.eve.step.index": "1",
+    "ai.settings.context.eve.channel.kind": "channel:support",
+    "ai.settings.context.eve.retry.reason": "provider-retry",
+  });
+
+  assert.equal(attrs["respan.entity.log_type"], "text");
+  assert.equal(attrs["gen_ai.system"], "openai");
+  assert.equal(attrs["gen_ai.request.model"], "gpt-4.1");
+  assert.equal(attrs["llm.request.type"], "chat");
+  assert.equal(attrs["gen_ai.prompt.0.role"], "user");
+  assert.equal(attrs["gen_ai.prompt.0.content"], "hello");
+  assert.equal(attrs["gen_ai.completion.0.role"], "assistant");
+  assert.equal(attrs["gen_ai.completion.0.content"], "hi");
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 7);
+  assert.equal(attrs["gen_ai.usage.output_tokens"], 2);
+  assert.equal(attrs["respan.sessions.session_identifier"], "session-1");
+  assert.equal(attrs["respan.threads.thread_identifier"], "session-1");
+  assert.equal(attrs["respan.trace.trace_group_identifier"], "session-1");
+  assert.equal(attrs["respan.environment"], "development");
+  assert.deepEqual(JSON.parse(attrs["respan.metadata"]), {
+    eve: {
+      version: "0.26.1",
+      environment: "development",
+      turn_id: "turn-1",
+      turn_sequence: 3,
+      step_index: 1,
+      channel_kind: "channel:support",
+      retry_reason: "provider-retry",
+    },
+  });
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("maps legacy AI SDK token aliases into canonical usage totals", () => {
+  const attrs = translate("ai.generateText.doGenerate", {
+    "ai.model.id": "gpt-4o-mini",
+    "ai.model.provider": "openai.chat",
+    "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hello" }]),
+    "ai.response.text": "world",
+    "ai.usage.promptTokens": "9",
+    "ai.usage.completionTokens": "4",
+    "ai.usage.totalTokens": "13",
+    "ai.usage.cachedInputTokens": "2",
+  });
+
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 9);
+  assert.equal(attrs["gen_ai.usage.output_tokens"], 4);
+  assert.equal(attrs["gen_ai.usage.prompt_tokens"], 9);
+  assert.equal(attrs["gen_ai.usage.completion_tokens"], 4);
+  assert.equal(attrs["llm.usage.total_tokens"], 13);
+  assert.equal(attrs["llm.usage.cache_read_input_tokens"], 2);
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("maps legacy embedding input, vector, and model while stripping raw aliases", () => {
+  const attrs = translate("ai.embed.doEmbed", {
+    "ai.model.id": "text-embedding-3-small",
+    "ai.model.provider": "openai.embedding",
+    "ai.value": "embed this",
+    "ai.embedding": [0.1, 0.2, 0.3],
+    "ai.usage.tokens": 1,
+    "gen_ai.usage.input_tokens": 3,
+    model: "off-contract-model",
+    prompt_tokens: 1,
+    "respan.span.tools": JSON.stringify([{ name: "off-contract-tool" }]),
+  });
+
+  assert.equal(attrs["respan.entity.log_type"], "embedding");
+  assert.equal(attrs["llm.request.type"], "embedding");
+  assert.equal(attrs["gen_ai.system"], "openai");
+  assert.equal(attrs["gen_ai.request.model"], "text-embedding-3-small");
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 3);
+  assert.equal(attrs["gen_ai.usage.prompt_tokens"], 3);
+  assert.equal(attrs["traceloop.entity.input"], "embed this");
+  assert.equal(attrs["traceloop.entity.output"], JSON.stringify([0.1, 0.2, 0.3]));
+  assert.equal(attrs["ai.usage.tokens"], undefined);
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("preserves authored step.started runtime context in canonical metadata", () => {
+  const cyclic = {};
+  cyclic.self = cyclic;
+
+  const attrs = translate("chat openai/gpt-4.1", {
+    "gen_ai.operation.name": "chat",
+    "gen_ai.provider.name": "openai",
+    "gen_ai.request.model": "gpt-4.1",
+    "ai.settings.context.eve.version": "0.26.1",
+    "ai.settings.context.eve.user_override": "must-not-leak",
+    "ai.settings.context.tenant": "acme",
+    "ai.settings.context.attempt": 2,
+    "ai.settings.context.enabled": true,
+    "ai.settings.context.nullable": null,
+    "ai.settings.context.roles": ["admin", "support"],
+    "ai.settings.context.profile.tier": "enterprise",
+    "ai.settings.context.snapshot": {
+      flags: [true, false],
+      nested: { count: 3 },
+    },
+    "ai.settings.context.unsafe": cyclic,
+    "ai.settings.context.missing": undefined,
+    "ai.response.text": "AI SDK internal field",
+  });
+
+  assert.deepEqual(JSON.parse(attrs["respan.metadata"]), {
+    eve: {
+      version: "0.26.1",
+      runtime_context: {
+        tenant: "acme",
+        attempt: 2,
+        enabled: true,
+        nullable: null,
+        roles: ["admin", "support"],
+        "profile.tier": "enterprise",
+        snapshot: {
+          flags: [true, false],
+          nested: { count: 3 },
+        },
+      },
+    },
+  });
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("preserves a pre-populated root trace group on Eve child spans", () => {
+  const attrs = translate("step 1", {
+    "gen_ai.operation.name": "agent_step",
+    "ai.settings.context.eve.session.id": "session-child",
+    "respan.trace.trace_group_identifier": "session-root",
+  });
+
+  assert.equal(attrs["respan.entity.log_type"], "task");
+  assert.equal(attrs["respan.sessions.session_identifier"], "session-child");
+  assert.equal(attrs["respan.threads.thread_identifier"], "session-child");
+  assert.equal(attrs["respan.trace.trace_group_identifier"], "session-root");
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("drop-marks structural wrappers and reparents children until wrapper end", () => {
+  const translator = new EveSpanProcessor();
+
+  function makeSpan(name, spanId, parentSpanContext) {
+    const attributes = {};
+    return {
+      name,
+      instrumentationScope: { name: "ai" },
+      attributes,
+      parentSpanContext,
+      spanContext() {
+        return { spanId };
+      },
+      setAttribute(key, value) {
+        attributes[key] = value;
+      },
+    };
+  }
+
+  const wrapper = makeSpan("ai.generateText", "wrapper-span", {
+    spanId: "upstream-parent",
+  });
+  translator.onStart(wrapper, undefined);
+  assert.equal(wrapper.attributes["respan.internal.drop_span"], true);
+  assert.equal(wrapper.attributes["respan.entity.log_type"], "task");
+
+  const child = makeSpan(
+    "ai.generateText.doGenerate",
+    "child-span",
+    { spanId: "wrapper-span" },
+  );
+  translator.onStart(child, undefined);
+  assert.equal(
+    child.attributes["respan.internal.export_parent_span_id"],
+    "upstream-parent",
+  );
+
+  const outside = makeSpan("ai.toolCall", "outside-span", {
+    spanId: "upstream-parent",
+  });
+  translator.onStart(outside, undefined);
+  assert.equal(
+    outside.attributes["respan.internal.export_parent_span_id"],
+    undefined,
+  );
+
+  translator.onEnd(wrapper);
+  assert.equal(wrapper.attributes["respan.internal.drop_span"], true);
+  assert.equal(wrapper.attributes["respan.entity.log_type"], "task");
+
+  const lateChild = makeSpan(
+    "ai.generateText.doGenerate",
+    "late-child-span",
+    { spanId: "wrapper-span" },
+  );
+  translator.onStart(lateChild, undefined);
+  assert.equal(
+    lateChild.attributes["respan.internal.export_parent_span_id"],
+    undefined,
+  );
+});
+
+test("uses an empty export-parent sentinel for children of root wrappers", () => {
+  const translator = new EveSpanProcessor();
+
+  function makeSpan(name, spanId, parentSpanContext) {
+    const attributes = {};
+    return {
+      name,
+      instrumentationScope: { name: "ai" },
+      attributes,
+      parentSpanContext,
+      spanContext() {
+        return { spanId };
+      },
+      setAttribute(key, value) {
+        attributes[key] = value;
+      },
+    };
+  }
+
+  const wrapper = makeSpan("ai.streamText", "root-wrapper", undefined);
+  translator.onStart(wrapper, undefined);
+
+  const child = makeSpan(
+    "ai.streamText.doStream",
+    "root-child",
+    { spanId: "root-wrapper" },
+  );
+  translator.onStart(child, undefined);
+  assert.equal(child.attributes["respan.internal.export_parent_span_id"], "");
+
+  translator.onEnd(wrapper);
+});
+
+test("admits Eve-scope invoke_agent spans and keeps subagent usage in metadata", () => {
+  const attrs = translate(
+    "invoke_agent researcher",
+    {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "researcher",
+      "gen_ai.usage.input_tokens": 12,
+      "gen_ai.usage.output_tokens": 5,
+      "gen_ai.usage.cache_read.input_tokens": 3,
+      "gen_ai.usage.cache_creation.input_tokens": 2,
+      "ai.settings.context.eve.session.id": "session-1",
+    },
+    { scope: "eve" },
+  );
+
+  assert.equal(attrs["respan.entity.log_type"], "agent");
+  assert.equal(attrs["traceloop.entity.name"], "researcher");
+  assert.deepEqual(JSON.parse(attrs["respan.metadata"]), {
+    eve: {
+      subagent: {
+        name: "researcher",
+        usage: {
+          input_tokens: 12,
+          output_tokens: 5,
+          cache_read_input_tokens: 3,
+          cache_creation_input_tokens: 2,
+        },
+      },
+    },
+  });
+  assert.equal(
+    Object.keys(attrs).some((key) => key.startsWith("gen_ai.")),
+    false,
+  );
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("reattaches detached Eve subagent usage to its caller session", () => {
+  const translator = new EveSpanProcessor();
+
+  translateSpan(
+    "invoke_agent eve-deterministic-researcher",
+    {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "eve-deterministic-researcher",
+      "gen_ai.usage.input_tokens": 19,
+      "gen_ai.usage.output_tokens": 6,
+      "gen_ai.usage.cache_read.input_tokens": 0,
+      "gen_ai.usage.cache_creation.input_tokens": 0,
+      "ai.telemetry.functionId": "eve-typescript-run",
+      "ai.settings.context.eve.session.id": "session-child",
+      "ai.settings.context.__respan_eve.lineage.rootSessionId":
+        "session-root",
+      "ai.settings.context.__respan_eve.lineage.sessionId":
+        "session-parent",
+      "ai.settings.context.__respan_eve.lineage.callId": "call-parent",
+      "ai.settings.context.__respan_eve.lineage.turn.id": "turn-parent",
+      "ai.settings.context.__respan_eve.lineage.turn.sequence": 4,
+    },
+    { translator },
+  );
+
+  const attrs = translate(
+    "invoke_agent researcher",
+    {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "researcher",
+      "gen_ai.usage.input_tokens": 19,
+      "gen_ai.usage.output_tokens": 6,
+      "gen_ai.usage.cache_read.input_tokens": 0,
+      "gen_ai.usage.cache_creation.input_tokens": 0,
+    },
+    { scope: "eve", translator },
+  );
+
+  assert.equal(attrs["respan.sessions.session_identifier"], "session-parent");
+  assert.equal(attrs["respan.threads.thread_identifier"], "session-parent");
+  assert.equal(attrs["respan.trace.trace_group_identifier"], "session-root");
+  assert.equal(attrs["traceloop.workflow.name"], "eve-typescript-run");
+  assert.deepEqual(JSON.parse(attrs["respan.metadata"]), {
+    eve: {
+      turn_id: "turn-parent",
+      turn_sequence: 4,
+      root_session_id: "session-root",
+      subagent: {
+        name: "researcher",
+        usage: {
+          input_tokens: 19,
+          output_tokens: 6,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    },
+  });
+  assert.deepEqual(JSON.parse(attrs["respan.metadata.eve"]), {
+    turn_id: "turn-parent",
+    turn_sequence: 4,
+    root_session_id: "session-root",
+    subagent: {
+      name: "researcher",
+      usage: {
+        input_tokens: 19,
+        output_tokens: 6,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    },
+  });
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("inherits the Eve workflow name through nested AI SDK spans", () => {
+  const translator = new EveSpanProcessor();
+  const rootAttributes = {
+    "ai.telemetry.functionId": "eve-typescript-run",
+  };
+  const root = {
+    name: "ai.eve.turn",
+    instrumentationScope: { name: "eve" },
+    attributes: rootAttributes,
+    spanContext() {
+      return { spanId: "workflow-root", traceId: "workflow-trace" };
+    },
+    setAttribute(key, value) {
+      rootAttributes[key] = value;
+    },
+  };
+  translator.onStart(root, undefined);
+
+  const childAttributes = {
+    "gen_ai.operation.name": "agent_step",
+  };
+  const child = {
+    name: "step 1",
+    instrumentationScope: { name: "gen_ai" },
+    attributes: childAttributes,
+    parentSpanId: "workflow-root",
+    spanContext() {
+      return { spanId: "workflow-child", traceId: "workflow-trace" };
+    },
+    setAttribute(key, value) {
+      childAttributes[key] = value;
+    },
+  };
+  translator.onStart(child, undefined);
+
+  assert.equal(
+    childAttributes["traceloop.workflow.name"],
+    "eve-typescript-run",
+  );
+
+  // Eve may close its first turn segment before resuming the same workflow
+  // trace for a later model/tool step.
+  translator.onEnd(child);
+  translator.onEnd(root);
+
+  const resumedAttributes = {
+    "gen_ai.operation.name": "agent_step",
+  };
+  const resumed = {
+    name: "step 2",
+    instrumentationScope: { name: "gen_ai" },
+    attributes: resumedAttributes,
+    spanContext() {
+      return { spanId: "workflow-resumed", traceId: "workflow-trace" };
+    },
+    setAttribute(key, value) {
+      resumedAttributes[key] = value;
+    },
+  };
+  translator.onStart(resumed, undefined);
+
+  assert.equal(
+    resumedAttributes["traceloop.workflow.name"],
+    "eve-typescript-run",
+  );
+
+  translator.onEnd(resumed);
+});
+
+test("drops AI SDK invoke_agent wrappers inside an Eve turn", () => {
+  const translator = new EveSpanProcessor();
+
+  function makeSpan(name, attributes, spanId, parentSpanId) {
+    return {
+      name,
+      instrumentationScope: { name: "gen_ai" },
+      attributes,
+      parentSpanId,
+      spanContext() {
+        return {
+          spanId,
+          traceId: "22222222222222222222222222222222",
+        };
+      },
+      setAttribute(key, value) {
+        attributes[key] = value;
+      },
+    };
+  }
+
+  const wrapper = makeSpan(
+    "invoke_agent eve-deterministic-root",
+    {
+      "gen_ai.operation.name": "invoke_agent",
+      "ai.telemetry.functionId": "eve-typescript-run",
+      "ai.settings.context.eve.session.id": "session-tool",
+    },
+    "model-wrapper",
+    "eve-turn-root",
+  );
+  translator.onStart(wrapper, undefined);
+
+  assert.equal(wrapper.attributes["respan.internal.drop_span"], true);
+
+  const task = makeSpan(
+    "step 1",
+    {
+      "gen_ai.operation.name": "agent_step",
+      "ai.settings.context.eve.session.id": "session-tool",
+    },
+    "model-task",
+    "model-wrapper",
+  );
+  translator.onStart(task, undefined);
+
+  assert.equal(
+    task.attributes["respan.internal.export_parent_span_id"],
+    "eve-turn-root",
+  );
+  assert.equal(
+    task.attributes["traceloop.workflow.name"],
+    "eve-typescript-run",
+  );
+});
+
+test("merges an exact delegated child trace and suppresses late usage duplication", () => {
+  const translator = new EveSpanProcessor();
+  const parentTraceId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const childTraceId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+  function makeSpan(
+    name,
+    scope,
+    attributes,
+    spanId,
+    traceId,
+    parentSpanId,
+  ) {
+    return {
+      name,
+      instrumentationScope: { name: scope },
+      attributes,
+      parentSpanId,
+      spanContext() {
+        return { spanId, traceId };
+      },
+      setAttribute(key, value) {
+        attributes[key] = value;
+      },
+    };
+  }
+
+  const parent = makeSpan(
+    "ai.eve.turn",
+    "eve",
+    {
+      "ai.telemetry.functionId": "eve-typescript-run",
+      "eve.session.id": "session-parent",
+      "eve.turn.id": "turn-parent",
+    },
+    "parent-turn-root",
+    parentTraceId,
+  );
+  translator.onStart(parent, undefined);
+  translator.onEnd(parent);
+
+  const lineage = {
+    "ai.settings.context.__respan_eve.lineage.rootSessionId":
+      "session-parent",
+    "ai.settings.context.__respan_eve.lineage.sessionId":
+      "session-parent",
+    "ai.settings.context.__respan_eve.lineage.turn.id": "turn-parent",
+    "ai.settings.context.__respan_eve.lineage.turn.sequence": 0,
+  };
+  const childRoot = makeSpan(
+    "ai.eve.turn",
+    "eve",
+    {
+      "ai.telemetry.functionId": "eve-typescript-run",
+      "eve.session.id": "session-child",
+      "eve.turn.id": "turn-child",
+      "eve.turn.sequence": 0,
+    },
+    "child-turn-root",
+    childTraceId,
+  );
+  translator.onStart(childRoot, undefined);
+
+  const childWrapper = makeSpan(
+    "invoke_agent eve-deterministic-researcher",
+    "gen_ai",
+    {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "eve-deterministic-researcher",
+      "gen_ai.usage.input_tokens": 19,
+      "gen_ai.usage.output_tokens": 6,
+      "ai.telemetry.functionId": "eve-typescript-run",
+      "ai.settings.context.eve.session.id": "session-child",
+      ...lineage,
+    },
+    "child-model-wrapper",
+    childTraceId,
+    "child-turn-root",
+  );
+  translator.onStart(childWrapper, undefined);
+
+  assert.equal(
+    translator.prepareForExport(childWrapper).spanContext().traceId,
+    parentTraceId,
+  );
+  assert.equal(childWrapper.attributes["respan.internal.drop_span"], true);
+  assert.equal(
+    translator.prepareForExport(childWrapper).attributes[
+      "respan.instrumentation.eve.export_trace_id"
+    ],
+    undefined,
+  );
+
+  const childTask = makeSpan(
+    "step 1",
+    "gen_ai",
+    {
+      "gen_ai.operation.name": "agent_step",
+      "ai.settings.context.eve.session.id": "session-child",
+      ...lineage,
+    },
+    "child-task",
+    childTraceId,
+    "child-model-wrapper",
+  );
+  translator.onStart(childTask, undefined);
+
+  assert.equal(
+    translator.prepareForExport(childTask).spanContext().traceId,
+    parentTraceId,
+  );
+  assert.equal(
+    childTask.attributes["respan.internal.export_parent_span_id"],
+    "child-turn-root",
+  );
+  assert.equal(
+    childTask.attributes["traceloop.workflow.name"],
+    "eve-typescript-run",
+  );
+
+  translator.onEnd(childTask);
+  translator.onEnd(childWrapper);
+  Object.assign(childRoot.attributes, lineage);
+  translator.onEnd(childRoot);
+
+  assert.equal(
+    translator.prepareForExport(childRoot).spanContext().traceId,
+    parentTraceId,
+  );
+  assert.equal(
+    childRoot.attributes["respan.internal.export_parent_span_id"],
+    "parent-turn-root",
+  );
+
+  const lateUsage = makeSpan(
+    "invoke_agent researcher",
+    "eve",
+    {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "researcher",
+      "gen_ai.usage.input_tokens": 19,
+      "gen_ai.usage.output_tokens": 6,
+    },
+    "late-usage",
+    "cccccccccccccccccccccccccccccccc",
+  );
+  translator.onStart(lateUsage, undefined);
+
+  assert.equal(
+    translator.prepareForExport(lateUsage).spanContext().traceId,
+    parentTraceId,
+  );
+  assert.equal(
+    lateUsage.attributes["respan.internal.export_parent_span_id"],
+    "parent-turn-root",
+  );
+  assert.equal(lateUsage.attributes["respan.internal.drop_span"], true);
+});
+
+test("does not guess detached subagent lineage across ambiguous callers", () => {
+  const translator = new EveSpanProcessor();
+
+  for (const suffix of ["a", "b"]) {
+    translateSpan(
+      `invoke_agent child-${suffix}`,
+      {
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": `child-${suffix}`,
+        "gen_ai.usage.input_tokens": 12,
+        "gen_ai.usage.output_tokens": 5,
+        "ai.settings.context.eve.session.id": `session-child-${suffix}`,
+        "ai.settings.context.__respan_eve.lineage.rootSessionId":
+          `session-root-${suffix}`,
+        "ai.settings.context.__respan_eve.lineage.sessionId":
+          `session-parent-${suffix}`,
+      },
+      { translator },
+    );
+  }
+
+  const attrs = translate(
+    "invoke_agent researcher",
+    {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "researcher",
+      "gen_ai.usage.input_tokens": 12,
+      "gen_ai.usage.output_tokens": 5,
+    },
+    { scope: "eve", translator },
+  );
+
+  assert.equal(attrs["respan.sessions.session_identifier"], undefined);
+  assert.equal(attrs["respan.threads.thread_identifier"], undefined);
+  assert.equal(attrs["respan.trace.trace_group_identifier"], undefined);
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("does not mislabel a gen_ai invoke_agent model root as an Eve subagent", () => {
+  const attrs = translate("invoke_agent openai/gpt-4.1", {
+    "gen_ai.operation.name": "invoke_agent",
+    "gen_ai.agent.name": "support-agent",
+    "gen_ai.usage.input_tokens": 12,
+    "ai.settings.context.eve.session.id": "session-1",
+    "ai.settings.context.eve.turn.id": "turn-1",
+  });
+
+  assert.equal(attrs["respan.entity.log_type"], "agent");
+  assert.equal(attrs["traceloop.entity.name"], "support-agent");
+  assert.deepEqual(JSON.parse(attrs["respan.metadata"]), {
+    eve: {
+      turn_id: "turn-1",
+    },
+  });
+  assert.equal(
+    Object.keys(attrs).some((key) => key.startsWith("gen_ai.")),
+    false,
+  );
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("maps AI SDK 7 execute_tool children with canonical tool input and output", () => {
+  const attrs = translate("execute_tool search", {
+    "gen_ai.operation.name": "execute_tool",
+    "gen_ai.tool.name": "search",
+    "gen_ai.tool.call.id": "call-1",
+    "gen_ai.tool.call.arguments": JSON.stringify({ query: "eve" }),
+    "gen_ai.tool.call.result": JSON.stringify({ hits: 2 }),
+    "ai.settings.context.eve.session.id": "session-1",
+  });
+
+  assert.equal(attrs["respan.entity.log_type"], "tool");
+  assert.equal(
+    attrs["traceloop.entity.input"],
+    JSON.stringify({ name: "search", arguments: { query: "eve" } }),
+  );
+  assert.equal(
+    attrs["traceloop.entity.output"],
+    JSON.stringify({ hits: 2 }),
+  );
+  assert.equal(attrs["respan.internal.span_name.kind"], "tool");
+  assert.equal(attrs["respan.internal.span_name.detail"], "search");
+  assert.equal(
+    Object.keys(attrs).some((key) => key.startsWith("gen_ai.tool.")),
+    false,
+  );
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("preserves an errored span status and events unchanged", () => {
+  const status = { code: 2, message: "tool failed" };
+  const events = [
+    {
+      name: "exception",
+      attributes: {
+        "exception.type": "Error",
+        "exception.message": "tool failed",
+      },
+    },
+  ];
+  const { span } = translateSpan(
+    "execute_tool search",
+    {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": "search",
+      "gen_ai.tool.call.arguments": JSON.stringify({ query: "eve" }),
+    },
+    { status, events },
+  );
+
+  assert.equal(span.status, status);
+  assert.equal(span.events, events);
+  assert.deepEqual(span.status, { code: 2, message: "tool failed" });
+  assert.deepEqual(span.events, events);
+});
+
+test("leaves unrelated OpenTelemetry spans untouched", () => {
+  const attrs = translate(
+    "http.request",
+    { "http.request.method": "GET" },
+    { scope: "@opentelemetry/instrumentation-http" },
+  );
+
+  assert.deepEqual(attrs, { "http.request.method": "GET" });
+});
+
+test("maps delegated session lineage without treating session IDs as span parents", () => {
+  const attrs = translate("chat openai/gpt-4.1", {
+    "gen_ai.operation.name": "chat",
+    "gen_ai.provider.name": "openai",
+    "gen_ai.request.model": "gpt-4.1",
+    "ai.settings.context.eve.session.id": "session-child",
+    "ai.settings.context.eve.turn.id": "turn-child",
+    "ai.settings.context.__respan_eve.lineage.rootSessionId":
+      "session-root",
+    "ai.settings.context.__respan_eve.lineage.sessionId":
+      "session-parent",
+    "ai.settings.context.__respan_eve.lineage.callId": "call-parent",
+    "ai.settings.context.__respan_eve.lineage.turn.id": "turn-parent",
+    "ai.settings.context.__respan_eve.lineage.turn.sequence": 4,
+    "ai.settings.context.tenant": "acme",
+  });
+
+  assert.equal(
+    attrs["respan.sessions.session_identifier"],
+    "session-child",
+  );
+  assert.equal(
+    attrs["respan.threads.thread_identifier"],
+    "session-child",
+  );
+  assert.equal(
+    attrs["respan.trace.trace_group_identifier"],
+    "session-root",
+  );
+  assert.equal(attrs["respan.entity.log_parent_id"], undefined);
+  assert.equal(attrs["respan.entity.log_root_id"], undefined);
+  assert.deepEqual(JSON.parse(attrs["respan.metadata"]), {
+    eve: {
+      turn_id: "turn-child",
+      root_session_id: "session-root",
+      parent: {
+        session_id: "session-parent",
+        call_id: "call-parent",
+        turn: {
+          id: "turn-parent",
+          sequence: 4,
+        },
+      },
+      runtime_context: {
+        tenant: "acme",
+      },
+    },
+  });
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});
+
+test("maps lineage mirrored directly onto an ai.eve.turn root", () => {
+  const attrs = translate(
+    "ai.eve.turn",
+    {
+      "ai.telemetry.functionId": "research-agent",
+      "eve.session.id": "session-child",
+      "ai.settings.context.__respan_eve.lineage.rootSessionId":
+        "session-root",
+      "ai.settings.context.__respan_eve.lineage.sessionId":
+        "session-parent",
+      "ai.settings.context.__respan_eve.lineage.callId": "call-parent",
+      "ai.settings.context.__respan_eve.lineage.turn.id": "turn-parent",
+      "ai.settings.context.__respan_eve.lineage.turn.sequence": 4,
+    },
+    { scope: "eve" },
+  );
+
+  assert.equal(attrs["respan.entity.log_type"], "agent");
+  assert.equal(
+    attrs["respan.sessions.session_identifier"],
+    "session-child",
+  );
+  assert.equal(
+    attrs["respan.threads.thread_identifier"],
+    "session-child",
+  );
+  assert.equal(
+    attrs["respan.trace.trace_group_identifier"],
+    "session-root",
+  );
+  assert.deepEqual(JSON.parse(attrs["respan.metadata"]), {
+    eve: {
+      root_session_id: "session-root",
+      parent: {
+        session_id: "session-parent",
+        call_id: "call-parent",
+        turn: {
+          id: "turn-parent",
+          sequence: 4,
+        },
+      },
+    },
+  });
+  assertRawVendorAttrsStripped(attrs);
+  assertNoOffContractAliases(attrs);
+});

--- a/javascript-sdks/instrumentations/respan-instrumentation-eve/tsconfig.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-eve/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es2022",
+    "outDir": "./dist",
+    "declaration": true,
+    "lib": ["DOM", "DOM.Iterable", "es2022"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "sourceMap": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/javascript-sdks/package.json
+++ b/javascript-sdks/package.json
@@ -33,6 +33,7 @@
     "respan-sdk",
     "respan-tracing",
     "instrumentations/respan-instrumentation-openrouter",
-    "instrumentations/respan-instrumentation-together-ai"
+    "instrumentations/respan-instrumentation-together-ai",
+    "instrumentations/respan-instrumentation-eve"
   ]
 }


### PR DESCRIPTION
## Summary

- add the standalone @respan/instrumentation-eve JavaScript package
- translate Eve turns plus nested AI SDK 7 model, tool, embedding, and usage spans with a package-local copy of the translator
- preserve Eve delegated-session lineage and correlate the child subtree through the Eve-owned processor wrapper
- register only the new workspace package, release inventory entry, and Eve-only release intent

## Why

Eve owns and enables its AI SDK OpenTelemetry integration. A dedicated instrumentation avoids depending on or activating @respan/instrumentation-vercel, prevents duplicate AI SDK translation, and keeps Eve-specific session and subagent semantics inside the Eve package.

## Scope and impact

This is an opt-in new package. It does not modify @respan/instrumentation-vercel, @respan/tracing, @respan/respan-sdk, the @respan/respan facade, lockfiles, backend code, or existing instrumentation behavior.

## Verification

- package test suite: 25 passing
- npm pack --dry-run
- release inventory validation passed
- release intent validation, plan, and missing checks passed; plan contains only @respan/instrumentation-eve
- isolated Eve 0.26.1 example set typechecked and built against unchanged upstream runtime packages
- live three-case batch verified through Respan MCP as exactly 3 traces with 3, 6, and 8 spans and zero errors
- workflow eve_typescript_independent-pr-20260721T1950 is present on every span
- all chat spans have non-empty input/output; tool.get_weather has structured input/output; delegated subagent tree is nested in the third trace

No package was published.
