### PR TITLE
feat(py): add AgentOps instrumentation

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -587,6 +587,12 @@
       "name": "respan-instrumentation-mirascope",
       "path": "python-sdks/instrumentations/respan-instrumentation-mirascope",
       "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-agentops",
+      "path": "python-sdks/instrumentations/respan-instrumentation-agentops",
+      "registry": "pypi"
     }
   ]
 }

--- a/.release-intents/20260728-respan-instrumentation-agentops.json
+++ b/.release-intents/20260728-respan-instrumentation-agentops.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add AgentOps instrumentation",
+  "packages": {
+    "respan-instrumentation-agentops": "new"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-agentops/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-agentops/README.md
@@ -1,0 +1,41 @@
+# Respan instrumentation for AgentOps
+
+This package sends spans created by AgentOps' Python decorators through the
+active Respan OpenTelemetry pipeline.
+
+It adapts AgentOps' own span kinds and content:
+
+- `trace` / session and workflow decorators become Respan workflow spans
+- agent decorators become agent spans
+- task and operation decorators become task spans
+- tool and guardrail decorators retain their matching Respan log types
+- AgentOps LLM spans keep their GenAI messages and usage, with AgentOps'
+  request-type and function fields promoted to the canonical Respan contract
+
+The adapter does not initialize the AgentOps exporter. Activate Respan before
+calling AgentOps-decorated code:
+
+```python
+from agentops import task, trace
+from respan import Respan
+from respan_instrumentation_agentops import AgentOpsInstrumentor
+
+respan = Respan(
+    api_key="...",
+    instrumentations=[AgentOpsInstrumentor()],
+)
+
+@task
+def prepare(value: str) -> str:
+    return value.upper()
+
+@trace
+def workflow(value: str) -> str:
+    return prepare(value)
+
+workflow("hello")
+respan.shutdown()
+```
+
+Set `capture_content=False` on `AgentOpsInstrumentor` to omit decorator inputs
+and outputs while retaining operation identity and status.

--- a/python-sdks/instrumentations/respan-instrumentation-agentops/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-agentops/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "respan-instrumentation-agentops"
+version = "0.1.0"
+description = "Respan instrumentation plugin for AgentOps"
+authors = ["Respan <team@respan.ai>"]
+license = "Apache 2.0"
+readme = "README.md"
+packages = [
+    { include = "respan_instrumentation_agentops", from = "./src" },
+]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<3.14"
+agentops = ">=0.4.21,<0.5.0"
+opentelemetry-api = ">=1.38.0,<2.0.0"
+opentelemetry-sdk = ">=1.38.0,<2.0.0"
+opentelemetry-semantic-conventions-ai = ">=0.4.1"
+respan-sdk = ">=2.6.1"
+respan-tracing = "^2.17.0"
+
+[tool.poetry.plugins."respan.instrumentations"]
+agentops = "respan_instrumentation_agentops:AgentOpsInstrumentor"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/instrumentations/respan-instrumentation-agentops/src/respan_instrumentation_agentops/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agentops/src/respan_instrumentation_agentops/__init__.py
@@ -1,0 +1,5 @@
+"""Respan instrumentation plugin for AgentOps."""
+
+from respan_instrumentation_agentops._instrumentation import AgentOpsInstrumentor
+
+__all__ = ["AgentOpsInstrumentor"]

--- a/python-sdks/instrumentations/respan-instrumentation-agentops/src/respan_instrumentation_agentops/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agentops/src/respan_instrumentation_agentops/_constants.py
@@ -1,0 +1,53 @@
+"""AgentOps-owned attribute keys and translation tables."""
+
+from __future__ import annotations
+
+AGENTOPS_INSTRUMENTATION_NAME = "agentops"
+AGENTOPS_SCOPE_PREFIX = "agentops"
+
+AGENTOPS_ENTITY_INPUT = "agentops.entity.input"
+AGENTOPS_ENTITY_OUTPUT = "agentops.entity.output"
+AGENTOPS_SPAN_KIND = "agentops.span.kind"
+AGENTOPS_ENTITY_NAME = "agentops.entity.name"
+AGENTOPS_SESSION_END_STATE = "agentops.session.end_state"
+AGENTOPS_TAGS = "agentops.tags"
+AGENTOPS_DECORATOR_INPUT_TEMPLATE = "agentops.{kind}.input"
+AGENTOPS_DECORATOR_OUTPUT_TEMPLATE = "agentops.{kind}.output"
+
+AGENT_NAME = "agent.name"
+TOOL_NAME = "tool.name"
+OPERATION_NAME = "operation.name"
+OPERATION_VERSION = "operation.version"
+
+AGENTOPS_REQUEST_TYPE = "gen_ai.request.type"
+AGENTOPS_REQUEST_FUNCTIONS = "gen_ai.request.functions"
+AGENTOPS_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
+
+AGENTOPS_KIND_LOG_TYPES = {
+    "session": "workflow",
+    "workflow": "workflow",
+    "agent": "agent",
+    "task": "task",
+    "operation": "task",
+    "chain": "task",
+    "tool": "tool",
+    "guardrail": "guardrail",
+    "http": "task",
+    "llm": "chat",
+    "text": "text",
+}
+
+OFF_CONTRACT_ALIASES = {
+    "tools",
+    "tool_calls",
+    "model",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_request_tokens",
+    "span_tools",
+    "has_tool_calls",
+    "parallel_tool_calls",
+    "respan.span.tools",
+    "respan.span.tool_calls",
+    "respan.span.handoffs",
+}

--- a/python-sdks/instrumentations/respan-instrumentation-agentops/src/respan_instrumentation_agentops/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agentops/src/respan_instrumentation_agentops/_instrumentation.py
@@ -1,0 +1,169 @@
+"""Lifecycle management for AgentOps decorator tracing."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import threading
+from typing import Any
+
+from opentelemetry import trace
+
+from respan_instrumentation_agentops._constants import AGENTOPS_INSTRUMENTATION_NAME
+from respan_instrumentation_agentops._processor import AgentOpsSpanProcessor
+from respan_tracing.core.tracer import RespanTracer
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.RLock()
+_REFCOUNT = 0
+_PROCESSOR: AgentOpsSpanProcessor | None = None
+_PROVIDER: Any = None
+_AGENTOPS_CORE: Any = None
+_AGENTOPS_PROVIDER_PROXY: Any = None
+_OWNED_CORE_INITIALIZATION = False
+_PREVIOUS_CORE_STATE: tuple[Any, ...] | None = None
+
+
+def _is_respan_tracing_enabled() -> bool:
+    tracer = getattr(RespanTracer, "_instance", None)
+    if tracer is None:
+        return True
+    return bool(getattr(tracer, "is_enabled", True))
+
+
+def _active_span_processors(provider: Any) -> tuple[Any, tuple[Any, ...] | None]:
+    active = getattr(provider, "_active_span_processor", None)
+    processors = getattr(active, "_span_processors", None) if active else None
+    return active, processors
+
+
+def _register_first(provider: Any, processor: AgentOpsSpanProcessor) -> None:
+    active, processors = _active_span_processors(provider)
+    if active is not None and processors is not None:
+        remaining = tuple(item for item in processors if item is not processor)
+        active._span_processors = (processor, *remaining)
+    elif hasattr(provider, "add_span_processor"):
+        provider.add_span_processor(processor)
+
+
+def _unregister(provider: Any, processor: AgentOpsSpanProcessor) -> None:
+    active, processors = _active_span_processors(provider)
+    if active is not None and processors is not None:
+        active._span_processors = tuple(
+            item for item in processors if item is not processor
+        )
+
+
+class _ProviderProxy:
+    """Let AgentOps flush Respan spans without owning Respan provider shutdown."""
+
+    def __init__(self, provider: Any) -> None:
+        self._provider = provider
+
+    def force_flush(self, *args: Any, **kwargs: Any) -> Any:
+        force_flush = getattr(self._provider, "force_flush", None)
+        if callable(force_flush):
+            return force_flush(*args, **kwargs)
+        return True
+
+    def shutdown(self, *args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+
+
+def _enable_agentops_core(provider: Any) -> None:
+    global _AGENTOPS_CORE, _AGENTOPS_PROVIDER_PROXY
+    global _OWNED_CORE_INITIALIZATION, _PREVIOUS_CORE_STATE
+
+    core_module = importlib.import_module("agentops.sdk.core")
+    agentops_core = core_module.tracer
+    _AGENTOPS_CORE = agentops_core
+    if bool(getattr(agentops_core, "initialized", False)):
+        return
+
+    _PREVIOUS_CORE_STATE = (
+        getattr(agentops_core, "_initialized", False),
+        getattr(agentops_core, "provider", None),
+        getattr(agentops_core, "_meter_provider", None),
+    )
+    _AGENTOPS_PROVIDER_PROXY = _ProviderProxy(provider)
+    agentops_core.provider = _AGENTOPS_PROVIDER_PROXY
+    agentops_core._meter_provider = None
+    agentops_core._initialized = True
+    _OWNED_CORE_INITIALIZATION = True
+
+
+def _restore_agentops_core() -> None:
+    global _AGENTOPS_CORE, _AGENTOPS_PROVIDER_PROXY
+    global _OWNED_CORE_INITIALIZATION, _PREVIOUS_CORE_STATE
+
+    if (
+        _OWNED_CORE_INITIALIZATION
+        and _AGENTOPS_CORE is not None
+        and _PREVIOUS_CORE_STATE is not None
+        and getattr(_AGENTOPS_CORE, "provider", None) is _AGENTOPS_PROVIDER_PROXY
+    ):
+        initialized, provider, meter_provider = _PREVIOUS_CORE_STATE
+        _AGENTOPS_CORE._initialized = initialized
+        _AGENTOPS_CORE.provider = provider
+        _AGENTOPS_CORE._meter_provider = meter_provider
+    _AGENTOPS_CORE = None
+    _AGENTOPS_PROVIDER_PROXY = None
+    _OWNED_CORE_INITIALIZATION = False
+    _PREVIOUS_CORE_STATE = None
+
+
+class AgentOpsInstrumentor:
+    """Route AgentOps decorators into Respan and normalize their native attrs."""
+
+    name = AGENTOPS_INSTRUMENTATION_NAME
+
+    def __init__(self, *, capture_content: bool = True) -> None:
+        self._capture_content = capture_content
+        self._is_instrumented = False
+
+    def activate(self) -> None:
+        """Activate AgentOps decorator tracing without an AgentOps exporter."""
+        global _PROCESSOR, _PROVIDER, _REFCOUNT
+
+        if self._is_instrumented or not _is_respan_tracing_enabled():
+            return
+        try:
+            importlib.import_module("agentops")
+        except ImportError as exc:
+            logger.warning("AgentOps instrumentation unavailable: %s", exc)
+            return
+
+        with _LOCK:
+            if _REFCOUNT == 0:
+                _PROVIDER = trace.get_tracer_provider()
+                _PROCESSOR = AgentOpsSpanProcessor(
+                    capture_content=self._capture_content
+                )
+                _register_first(_PROVIDER, _PROCESSOR)
+                _enable_agentops_core(_PROVIDER)
+            elif _PROCESSOR is not None and (
+                _PROCESSOR.capture_content != self._capture_content
+            ):
+                logger.warning(
+                    "AgentOps is already active; the first capture_content setting wins"
+                )
+            _REFCOUNT += 1
+            self._is_instrumented = True
+
+    def deactivate(self) -> None:
+        """Remove Respan normalization and restore AgentOps core ownership."""
+        global _PROCESSOR, _PROVIDER, _REFCOUNT
+
+        if not self._is_instrumented:
+            return
+        with _LOCK:
+            self._is_instrumented = False
+            _REFCOUNT = max(0, _REFCOUNT - 1)
+            if _REFCOUNT:
+                return
+            if _PROCESSOR is not None and _PROVIDER is not None:
+                _unregister(_PROVIDER, _PROCESSOR)
+            _restore_agentops_core()
+            _PROCESSOR = None
+            _PROVIDER = None

--- a/python-sdks/instrumentations/respan-instrumentation-agentops/src/respan_instrumentation_agentops/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agentops/src/respan_instrumentation_agentops/_processor.py
@@ -1,0 +1,247 @@
+"""Translate AgentOps decorator spans into the Respan span contract."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.trace import StatusCode
+from opentelemetry.semconv_ai import LLMRequestTypeValues
+from opentelemetry.semconv_ai import SpanAttributes
+
+from respan_instrumentation_agentops._constants import (
+    AGENT_NAME,
+    AGENTOPS_DECORATOR_INPUT_TEMPLATE,
+    AGENTOPS_DECORATOR_OUTPUT_TEMPLATE,
+    AGENTOPS_ENTITY_INPUT,
+    AGENTOPS_ENTITY_NAME,
+    AGENTOPS_ENTITY_OUTPUT,
+    AGENTOPS_INSTRUMENTATION_NAME,
+    AGENTOPS_KIND_LOG_TYPES,
+    AGENTOPS_REQUEST_FUNCTIONS,
+    AGENTOPS_REQUEST_TYPE,
+    AGENTOPS_SCOPE_PREFIX,
+    AGENTOPS_SESSION_END_STATE,
+    AGENTOPS_SPAN_KIND,
+    AGENTOPS_TAGS,
+    AGENTOPS_USAGE_TOTAL_TOKENS,
+    OFF_CONTRACT_ALIASES,
+    OPERATION_NAME,
+    OPERATION_VERSION,
+    TOOL_NAME,
+)
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.llm_logging import LogMethodChoices
+from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_METHOD,
+    RESPAN_LOG_TYPE,
+    RESPAN_METADATA,
+)
+
+
+def _scope_name(span: ReadableSpan) -> str:
+    scope = getattr(span, "instrumentation_scope", None) or getattr(
+        span, "instrumentation_info", None
+    )
+    return str(getattr(scope, "name", "") or "")
+
+
+def _is_agentops_span(span: ReadableSpan, attrs: Mapping[str, Any]) -> bool:
+    scope_name = _scope_name(span)
+    return bool(
+        AGENTOPS_SPAN_KIND in attrs
+        or scope_name == AGENTOPS_SCOPE_PREFIX
+        or scope_name.startswith(f"{AGENTOPS_SCOPE_PREFIX}.")
+    )
+
+
+def _json_string(value: Any) -> str:
+    if isinstance(value, str):
+        try:
+            json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return json.dumps(value, default=str, ensure_ascii=False)
+        return value
+    return json.dumps(value, default=str, ensure_ascii=False)
+
+
+def _metadata_value(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        if isinstance(decoded, Mapping):
+            return dict(decoded)
+    return {}
+
+
+def _content(
+    attrs: Mapping[str, Any],
+    *,
+    kind: str,
+    direction: str,
+) -> Any:
+    key = (
+        AGENTOPS_DECORATOR_INPUT_TEMPLATE
+        if direction == "input"
+        else AGENTOPS_DECORATOR_OUTPUT_TEMPLATE
+    ).format(kind=kind)
+    generic_key = (
+        AGENTOPS_ENTITY_INPUT if direction == "input" else AGENTOPS_ENTITY_OUTPUT
+    )
+    return attrs.get(key, attrs.get(generic_key))
+
+
+def _entity_name(span: ReadableSpan, attrs: Mapping[str, Any], kind: str) -> str:
+    candidates: tuple[Any, ...]
+    if kind == "agent":
+        candidates = (attrs.get(AGENT_NAME), attrs.get(AGENTOPS_ENTITY_NAME))
+    elif kind == "tool":
+        candidates = (attrs.get(TOOL_NAME), attrs.get(AGENTOPS_ENTITY_NAME))
+    else:
+        candidates = (attrs.get(AGENTOPS_ENTITY_NAME), attrs.get(OPERATION_NAME))
+    for candidate in candidates:
+        if candidate:
+            return str(candidate)
+    return str(getattr(span, "name", None) or AGENTOPS_INSTRUMENTATION_NAME)
+
+
+def _set_llm_fields(attrs: dict[str, Any], kind: str) -> None:
+    if kind not in {"llm", "text"}:
+        return
+    request_type = attrs.pop(AGENTOPS_REQUEST_TYPE, None)
+    if request_type is None:
+        request_type = (
+            LLMRequestTypeValues.CHAT.value
+            if kind == "llm"
+            else LLMRequestTypeValues.COMPLETION.value
+        )
+    attrs[SpanAttributes.LLM_REQUEST_TYPE] = str(request_type)
+
+    functions = attrs.pop(AGENTOPS_REQUEST_FUNCTIONS, None)
+    if functions is not None:
+        attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS] = _json_string(functions)
+
+    prompt_tokens = attrs.get(SpanAttributes.LLM_USAGE_PROMPT_TOKENS)
+    completion_tokens = attrs.get(SpanAttributes.LLM_USAGE_COMPLETION_TOKENS)
+    if prompt_tokens is not None:
+        modern_input = getattr(
+            SpanAttributes,
+            "LLM_USAGE_INPUT_TOKENS",
+            "gen_ai.usage.input_tokens",
+        )
+        attrs.setdefault(modern_input, prompt_tokens)
+    if completion_tokens is not None:
+        modern_output = getattr(
+            SpanAttributes,
+            "LLM_USAGE_OUTPUT_TOKENS",
+            "gen_ai.usage.output_tokens",
+        )
+        attrs.setdefault(modern_output, completion_tokens)
+    total_tokens = attrs.pop(AGENTOPS_USAGE_TOTAL_TOKENS, None)
+    if total_tokens is not None:
+        attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = total_tokens
+
+
+def _set_status(span: ReadableSpan, attrs: dict[str, Any]) -> None:
+    status = getattr(span, "status", None)
+    status_code = getattr(status, "status_code", StatusCode.UNSET)
+    description = getattr(status, "description", None)
+    end_state = attrs.get(AGENTOPS_SESSION_END_STATE)
+    normalized_state = str(end_state or "").lower()
+    failed_state = any(
+        marker in normalized_state
+        for marker in ("error", "fail", "indeterminate", "unknown")
+    )
+    if status_code == StatusCode.ERROR or failed_state:
+        message = str(
+            description or f"AgentOps trace ended with {end_state or 'error'}"
+        )
+        attrs["status_code"] = 500
+        attrs[ERROR_MESSAGE_ATTR] = message
+    else:
+        attrs.setdefault("status_code", 200)
+
+
+def _strip_agentops_fields(attrs: dict[str, Any]) -> None:
+    for key in tuple(attrs):
+        if key.startswith("agentops.") or key in {OPERATION_NAME, OPERATION_VERSION}:
+            attrs.pop(key, None)
+
+
+def translate_agentops_span(
+    span: ReadableSpan,
+    *,
+    capture_content: bool,
+) -> bool:
+    """Translate one completed AgentOps span in place."""
+
+    original = getattr(span, "_attributes", None)
+    if original is None:
+        original = getattr(span, "attributes", None)
+    attrs = dict(original or {})
+    if not _is_agentops_span(span, attrs):
+        return False
+
+    kind = str(attrs.get(AGENTOPS_SPAN_KIND) or "task").lower()
+    log_type = AGENTOPS_KIND_LOG_TYPES.get(kind, "task")
+    entity_name = _entity_name(span, attrs, kind)
+    attrs[RESPAN_LOG_METHOD] = LogMethodChoices.TRACING_INTEGRATION.value
+    attrs[RESPAN_LOG_TYPE] = log_type
+    attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] = entity_name
+    attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] = entity_name
+
+    input_value = _content(attrs, kind=kind, direction="input")
+    output_value = _content(attrs, kind=kind, direction="output")
+    if capture_content:
+        if input_value is not None:
+            attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _json_string(input_value)
+        if output_value is not None:
+            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _json_string(output_value)
+    else:
+        attrs.pop(SpanAttributes.TRACELOOP_ENTITY_INPUT, None)
+        attrs.pop(SpanAttributes.TRACELOOP_ENTITY_OUTPUT, None)
+
+    metadata = _metadata_value(attrs.get(RESPAN_METADATA))
+    agentops_metadata: dict[str, Any] = {"kind": kind}
+    if attrs.get(OPERATION_VERSION) is not None:
+        agentops_metadata["operation_version"] = attrs[OPERATION_VERSION]
+    if attrs.get(AGENTOPS_TAGS) is not None:
+        agentops_metadata["tags"] = attrs[AGENTOPS_TAGS]
+    if attrs.get(AGENTOPS_SESSION_END_STATE) is not None:
+        agentops_metadata["end_state"] = str(attrs[AGENTOPS_SESSION_END_STATE])
+    metadata["agentops"] = agentops_metadata
+    attrs[RESPAN_METADATA] = _json_string(metadata)
+
+    _set_llm_fields(attrs, kind)
+    _set_status(span, attrs)
+    for key in OFF_CONTRACT_ALIASES:
+        attrs.pop(key, None)
+    _strip_agentops_fields(attrs)
+    span._attributes = attrs
+    return True
+
+
+class AgentOpsSpanProcessor(SpanProcessor):
+    """Normalize AgentOps-owned spans before downstream Respan exporters."""
+
+    def __init__(self, *, capture_content: bool = True) -> None:
+        self.capture_content = capture_content
+
+    def on_start(self, span: Any, parent_context: Any = None) -> None:
+        del span, parent_context
+
+    def on_end(self, span: ReadableSpan) -> None:
+        translate_agentops_span(span, capture_content=self.capture_content)
+
+    def shutdown(self) -> None:
+        return None
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        del timeout_millis
+        return True

--- a/python-sdks/instrumentations/respan-instrumentation-agentops/tests/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agentops/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Respan AgentOps instrumentation."""

--- a/python-sdks/instrumentations/respan-instrumentation-agentops/tests/test_lifecycle.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agentops/tests/test_lifecycle.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+from respan_instrumentation_agentops import AgentOpsInstrumentor
+
+
+def test_lifecycle_reference_counts_processor_and_core(monkeypatch) -> None:
+    import respan_instrumentation_agentops._instrumentation as lifecycle
+
+    class Active:
+        _span_processors: tuple[object, ...] = ()
+
+    class Provider:
+        _active_span_processor = Active()
+
+        def force_flush(self):
+            return True
+
+    provider = Provider()
+    core = SimpleNamespace(
+        _initialized=False,
+        initialized=False,
+        provider=None,
+        _meter_provider=None,
+    )
+    real_import = lifecycle.importlib.import_module
+
+    def import_module(name: str):
+        if name == "agentops":
+            return SimpleNamespace()
+        if name == "agentops.sdk.core":
+            return SimpleNamespace(tracer=core)
+        return real_import(name)
+
+    monkeypatch.setattr(lifecycle.importlib, "import_module", import_module)
+    monkeypatch.setattr(lifecycle.trace, "get_tracer_provider", lambda: provider)
+    monkeypatch.setattr(lifecycle, "_REFCOUNT", 0)
+    monkeypatch.setattr(lifecycle, "_PROCESSOR", None)
+    monkeypatch.setattr(lifecycle, "_PROVIDER", None)
+    monkeypatch.setattr(lifecycle, "_AGENTOPS_CORE", None)
+    monkeypatch.setattr(lifecycle, "_AGENTOPS_PROVIDER_PROXY", None)
+    monkeypatch.setattr(lifecycle, "_OWNED_CORE_INITIALIZATION", False)
+    monkeypatch.setattr(lifecycle, "_PREVIOUS_CORE_STATE", None)
+
+    first = AgentOpsInstrumentor()
+    second = AgentOpsInstrumentor(capture_content=False)
+    first.activate()
+    second.activate()
+
+    assert lifecycle._REFCOUNT == 2
+    assert core._initialized is True
+    assert len(provider._active_span_processor._span_processors) == 1
+
+    first.deactivate()
+    assert lifecycle._REFCOUNT == 1
+    second.deactivate()
+
+    assert lifecycle._REFCOUNT == 0
+    assert core._initialized is False
+    assert provider._active_span_processor._span_processors == ()

--- a/python-sdks/instrumentations/respan-instrumentation-agentops/tests/test_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agentops/tests/test_processor.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+
+from opentelemetry.trace import Status, StatusCode
+
+from respan_instrumentation_agentops._processor import translate_agentops_span
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE, RESPAN_METADATA
+from opentelemetry.semconv_ai import SpanAttributes
+
+
+class FakeSpan:
+    def __init__(self, name: str, attributes: dict, *, error: str | None = None):
+        self.name = name
+        self._attributes = dict(attributes)
+        self.instrumentation_scope = SimpleNamespace(name="agentops")
+        self.status = (
+            Status(StatusCode.ERROR, error) if error else Status(StatusCode.OK)
+        )
+
+
+def test_agentops_task_maps_native_content_and_strips_vendor_fields() -> None:
+    span = FakeSpan(
+        "prepare.task",
+        {
+            "agentops.span.kind": "task",
+            "operation.name": "prepare",
+            "agentops.task.input": '{"args":["hello"],"kwargs":{}}',
+            "agentops.task.output": '"HELLO"',
+            "agentops.tags": ["example"],
+        },
+    )
+
+    assert translate_agentops_span(span, capture_content=True)
+    attrs = span._attributes
+    assert attrs[RESPAN_LOG_TYPE] == "task"
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] == "prepare"
+    assert (
+        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] == '{"args":["hello"],"kwargs":{}}'
+    )
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == '"HELLO"'
+    assert '"kind": "task"' in attrs[RESPAN_METADATA]
+    assert not any(key.startswith("agentops.") for key in attrs)
+    assert "operation.name" not in attrs
+
+
+def test_agentops_tool_uses_tool_identity_and_error_contract() -> None:
+    span = FakeSpan(
+        "lookup.tool",
+        {
+            "agentops.span.kind": "tool",
+            "operation.name": "lookup",
+            "tool.name": "weather_lookup",
+            "agentops.tool.input": '{"city":"Paris"}',
+        },
+        error="lookup failed",
+    )
+
+    assert translate_agentops_span(span, capture_content=True)
+    attrs = span._attributes
+    assert attrs[RESPAN_LOG_TYPE] == "tool"
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] == "weather_lookup"
+    assert attrs["status_code"] == 500
+    assert attrs["error.message"] == "lookup failed"
+    assert "tool_calls" not in attrs
+    assert "respan.span.tool_calls" not in attrs
+
+
+def test_agentops_llm_promotes_only_fields_agentops_emits() -> None:
+    span = FakeSpan(
+        "chat.llm",
+        {
+            "agentops.span.kind": "llm",
+            "operation.name": "chat",
+            "gen_ai.request.type": "chat",
+            "gen_ai.request.functions": '[{"name":"lookup"}]',
+            SpanAttributes.LLM_USAGE_PROMPT_TOKENS: 8,
+            SpanAttributes.LLM_USAGE_COMPLETION_TOKENS: 3,
+            "gen_ai.usage.total_tokens": 11,
+        },
+    )
+
+    assert translate_agentops_span(span, capture_content=True)
+    attrs = span._attributes
+    assert attrs[RESPAN_LOG_TYPE] == "chat"
+    assert attrs[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
+    assert attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS] == '[{"name":"lookup"}]'
+    assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 11
+    assert "gen_ai.request.type" not in attrs
+    assert "gen_ai.request.functions" not in attrs


### PR DESCRIPTION
## What changed

- Add the AgentOps instrumentation package and plugin entry point.
- Translate AgentOps spans into the canonical Respan span contract.
- Add focused lifecycle and processor tests.
- Register the package in the release inventory with a `new` release intent.

## Why

This makes AgentOps traces available through the active Respan Python instrumentation architecture.

## Validation

- `python3 scripts/release_inventory.py --validate`
- `python3 scripts/release_intents.py validate`
- `poetry build`
- `poetry run pytest -q tests` (4 passed)
