### PR TITLE
feat(py): add Burr instrumentation

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -587,6 +587,12 @@
       "name": "respan-instrumentation-mirascope",
       "path": "python-sdks/instrumentations/respan-instrumentation-mirascope",
       "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-burr",
+      "path": "python-sdks/instrumentations/respan-instrumentation-burr",
+      "registry": "pypi"
     }
   ]
 }

--- a/.release-intents/20260728-respan-instrumentation-burr.json
+++ b/.release-intents/20260728-respan-instrumentation-burr.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add Burr instrumentation",
+  "packages": {
+    "respan-instrumentation-burr": "new"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-burr/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-burr/README.md
@@ -1,0 +1,55 @@
+# Respan instrumentation for Apache Burr
+
+This package attaches a Burr lifecycle adapter when
+`ApplicationBuilder.build()` is called. It maps Burr's own execution model:
+
+- application execution methods (`run`, `arun`, `iterate`, streaming methods)
+  become workflow spans
+- state-machine actions become task spans with their declared reads, writes,
+  tags, inputs, sequence ID, result, and state transition
+- Burr custom `ActionSpan` instances become nested task spans
+- Burr stream lifecycle callbacks become span events
+- attributes logged through Burr's tracing API are retained in Respan metadata
+
+Burr application IDs are mapped to Respan trace-group identifiers and Burr
+partition keys are mapped to thread identifiers.
+
+Activate Respan before building the application:
+
+```python
+from burr.core import ApplicationBuilder, Result, State, action, default, expr
+from respan import Respan
+from respan_instrumentation_burr import BurrInstrumentor
+
+respan = Respan(
+    api_key="...",
+    instrumentations=[BurrInstrumentor()],
+)
+
+@action(reads=["count"], writes=["count"])
+def increment(state: State) -> State:
+    return state.update(count=state["count"] + 1)
+
+result = Result("count").with_name("result")
+
+app = (
+    ApplicationBuilder()
+    .with_identifiers(app_id="counter-app", partition_key="user-42")
+    .with_actions(increment, result)
+    .with_transitions(("increment", "increment", expr("count < 2")))
+    .with_transitions(("increment", "result", default))
+    .with_entrypoint("increment")
+    .with_state(count=0)
+    .build()
+)
+
+try:
+    _, _, state = app.run(halt_after=["result"])
+    print(state["count"])
+finally:
+    respan.shutdown()
+```
+
+Set `capture_content=False` to retain Burr operation identity and status while
+omitting state, action inputs/results, stream items, and logged attribute
+values.

--- a/python-sdks/instrumentations/respan-instrumentation-burr/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-burr/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "respan-instrumentation-burr"
+version = "0.1.0"
+description = "Respan instrumentation plugin for Apache Burr"
+authors = ["Respan <team@respan.ai>"]
+license = "Apache 2.0"
+readme = "README.md"
+packages = [
+    { include = "respan_instrumentation_burr", from = "./src" },
+]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<3.14"
+apache-burr = ">=0.42.0,<1.0.0"
+opentelemetry-api = ">=1.38.0,<2.0.0"
+opentelemetry-semantic-conventions-ai = ">=0.4.1"
+respan-sdk = ">=2.6.1"
+respan-tracing = "^2.17.0"
+wrapt = ">=1.16.0"
+
+[tool.poetry.plugins."respan.instrumentations"]
+burr = "respan_instrumentation_burr:BurrInstrumentor"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/instrumentations/respan-instrumentation-burr/src/respan_instrumentation_burr/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-burr/src/respan_instrumentation_burr/__init__.py
@@ -1,0 +1,5 @@
+"""Respan instrumentation plugin for Apache Burr."""
+
+from respan_instrumentation_burr._instrumentation import BurrInstrumentor
+
+__all__ = ["BurrInstrumentor"]

--- a/python-sdks/instrumentations/respan-instrumentation-burr/src/respan_instrumentation_burr/_adapter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-burr/src/respan_instrumentation_burr/_adapter.py
@@ -1,0 +1,462 @@
+"""Burr lifecycle adapter that emits canonical Respan spans."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from contextvars import ContextVar
+from typing import Any
+
+from burr.lifecycle.base import (
+    DoLogAttributeHook,
+    PostApplicationExecuteCallHook,
+    PostEndSpanHook,
+    PostEndStreamHook,
+    PostRunStepHook,
+    PostStreamItemHook,
+    PreApplicationExecuteCallHook,
+    PreRunStepHook,
+    PreStartSpanHook,
+    PreStartStreamHook,
+)
+from opentelemetry import context as context_api
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.semconv_ai import SpanAttributes
+
+from respan_instrumentation_burr._constants import BURR_ADAPTER_MARKER
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.llm_logging import LogMethodChoices
+from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_METHOD,
+    RESPAN_LOG_TYPE,
+    RESPAN_METADATA,
+    RESPAN_THREADS_ID,
+    RESPAN_TRACE_GROUP_ID,
+)
+from respan_sdk.utils.serialization import serialize_value
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class _ActiveSpan:
+    scope: str
+    span: Any
+    token: Any
+    metadata: dict[str, Any]
+
+
+_ACTIVE_SPANS: ContextVar[tuple[_ActiveSpan, ...]] = ContextVar(
+    "respan_burr_active_spans",
+    default=(),
+)
+
+
+def _jsonable(value: Any, *, depth: int = 0) -> Any:
+    if depth > 8:
+        return repr(value)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return {"type": "bytes", "length": len(value)}
+    if isinstance(value, Mapping):
+        return {
+            str(key): _jsonable(item, depth=depth + 1) for key, item in value.items()
+        }
+    if isinstance(value, Sequence):
+        return [_jsonable(item, depth=depth + 1) for item in value]
+    serializer = getattr(value, "serialize", None)
+    if callable(serializer):
+        try:
+            return _jsonable(serializer(), depth=depth + 1)
+        except Exception:
+            pass
+    get_all = getattr(value, "get_all", None)
+    if callable(get_all):
+        try:
+            return _jsonable(get_all(), depth=depth + 1)
+        except Exception:
+            pass
+    try:
+        return serialize_value(value=value)
+    except Exception:
+        return repr(value)
+
+
+def _json_string(value: Any) -> str:
+    return json.dumps(_jsonable(value), default=str, ensure_ascii=False)
+
+
+def _method_value(method: Any) -> str:
+    return str(getattr(method, "value", method))
+
+
+def _action_metadata(action: Any) -> dict[str, Any]:
+    metadata = {
+        "name": str(getattr(action, "name", type(action).__name__)),
+        "reads": list(getattr(action, "reads", ()) or ()),
+        "writes": list(getattr(action, "writes", ()) or ()),
+        "tags": list(getattr(action, "tags", ()) or ()),
+        "streaming": bool(getattr(action, "streaming", False)),
+    }
+    inputs = getattr(action, "inputs", None)
+    if inputs:
+        metadata["declared_inputs"] = _jsonable(inputs)
+    return metadata
+
+
+class BurrLifecycleAdapter(
+    PreApplicationExecuteCallHook,
+    PostApplicationExecuteCallHook,
+    PreRunStepHook,
+    PostRunStepHook,
+    PreStartSpanHook,
+    PostEndSpanHook,
+    DoLogAttributeHook,
+    PreStartStreamHook,
+    PostStreamItemHook,
+    PostEndStreamHook,
+):
+    """Map Burr applications, actions, custom spans, and streams to Respan."""
+
+    def __init__(
+        self,
+        *,
+        capture_content: bool = True,
+        tracer: Any | None = None,
+    ) -> None:
+        self.capture_content = capture_content
+        self.tracer = tracer or trace.get_tracer(__name__)
+        self.enabled = True
+        setattr(self, BURR_ADAPTER_MARKER, True)
+
+    def _attributes(
+        self,
+        *,
+        log_type: str,
+        entity_name: str,
+        app_id: str,
+        partition_key: str | None,
+        metadata: dict[str, Any],
+        input_value: Any,
+    ) -> dict[str, Any]:
+        attrs: dict[str, Any] = {
+            RESPAN_LOG_METHOD: LogMethodChoices.TRACING_INTEGRATION.value,
+            RESPAN_LOG_TYPE: log_type,
+            RESPAN_TRACE_GROUP_ID: str(app_id),
+            RESPAN_METADATA: _json_string({"burr": metadata}),
+            SpanAttributes.TRACELOOP_ENTITY_NAME: entity_name,
+            SpanAttributes.TRACELOOP_ENTITY_PATH: entity_name,
+        }
+        if partition_key:
+            attrs[RESPAN_THREADS_ID] = str(partition_key)
+        if self.capture_content:
+            attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _json_string(input_value)
+        return attrs
+
+    def _start(
+        self,
+        *,
+        scope: str,
+        name: str,
+        attributes: dict[str, Any],
+        metadata: dict[str, Any],
+    ) -> None:
+        if not self.enabled:
+            return
+        span = self.tracer.start_span(name, attributes=attributes)
+        token = context_api.attach(trace.set_span_in_context(span))
+        _ACTIVE_SPANS.set(
+            (*_ACTIVE_SPANS.get(), _ActiveSpan(scope, span, token, metadata))
+        )
+
+    def _end(
+        self,
+        *,
+        scope: str,
+        exception: BaseException | None,
+        output_value: Any,
+    ) -> None:
+        stack = list(_ACTIVE_SPANS.get())
+        if not stack:
+            return
+        active = stack[-1]
+        if active.scope != scope:
+            logger.warning(
+                "Burr span lifecycle mismatch: expected %s, found %s",
+                scope,
+                active.scope,
+            )
+            return
+        stack.pop()
+        _ACTIVE_SPANS.set(tuple(stack))
+        context_api.detach(active.token)
+        if exception is None:
+            active.span.set_status(Status(StatusCode.OK))
+            active.span.set_attribute("status_code", 200)
+        else:
+            message = str(exception) or type(exception).__name__
+            active.span.record_exception(exception)
+            active.span.set_status(Status(StatusCode.ERROR, message))
+            active.span.set_attribute("status_code", 500)
+            active.span.set_attribute(ERROR_MESSAGE_ATTR, message)
+        if self.capture_content:
+            active.span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                _json_string(output_value),
+            )
+        active.span.end()
+
+    def _current(self) -> _ActiveSpan | None:
+        stack = _ACTIVE_SPANS.get()
+        return stack[-1] if stack else None
+
+    def pre_run_execute_call(
+        self,
+        *,
+        app_id: str,
+        partition_key: str,
+        state: Any,
+        method: Any,
+        **future_kwargs: Any,
+    ) -> None:
+        del future_kwargs
+        method_name = _method_value(method)
+        metadata = {
+            "scope": "application",
+            "app_id": app_id,
+            "partition_key": partition_key,
+            "method": method_name,
+        }
+        self._start(
+            scope="application",
+            name=f"burr.application.{method_name}",
+            attributes=self._attributes(
+                log_type="workflow",
+                entity_name=f"burr.application.{method_name}",
+                app_id=app_id,
+                partition_key=partition_key,
+                metadata=metadata,
+                input_value={
+                    **metadata,
+                    "state": _jsonable(state),
+                },
+            ),
+            metadata=metadata,
+        )
+
+    def post_run_execute_call(
+        self,
+        *,
+        state: Any,
+        exception: BaseException | None,
+        **future_kwargs: Any,
+    ) -> None:
+        del future_kwargs
+        output = (
+            {"status": "completed", "state": _jsonable(state)}
+            if exception is None
+            else {
+                "status": "error",
+                "error": type(exception).__name__,
+                "message": str(exception),
+                "state": _jsonable(state),
+            }
+        )
+        self._end(scope="application", exception=exception, output_value=output)
+
+    def pre_run_step(
+        self,
+        *,
+        app_id: str,
+        partition_key: str,
+        sequence_id: int,
+        state: Any,
+        action: Any,
+        inputs: dict[str, Any],
+        **future_kwargs: Any,
+    ) -> None:
+        del future_kwargs
+        action_details = _action_metadata(action)
+        metadata = {
+            "scope": "action",
+            "app_id": app_id,
+            "partition_key": partition_key,
+            "sequence_id": sequence_id,
+            "action": action_details,
+        }
+        action_name = action_details["name"]
+        self._start(
+            scope="action",
+            name=f"burr.action.{action_name}",
+            attributes=self._attributes(
+                log_type="task",
+                entity_name=action_name,
+                app_id=app_id,
+                partition_key=partition_key,
+                metadata=metadata,
+                input_value={
+                    **metadata,
+                    "inputs": _jsonable(inputs),
+                    "state": _jsonable(state),
+                },
+            ),
+            metadata=metadata,
+        )
+
+    def post_run_step(
+        self,
+        *,
+        state: Any,
+        result: dict[str, Any] | None,
+        exception: BaseException | None,
+        **future_kwargs: Any,
+    ) -> None:
+        del future_kwargs
+        output = {
+            "status": "completed" if exception is None else "error",
+            "result": _jsonable(result),
+            "state": _jsonable(state),
+        }
+        if exception is not None:
+            output.update(
+                {
+                    "error": type(exception).__name__,
+                    "message": str(exception),
+                }
+            )
+        self._end(scope="action", exception=exception, output_value=output)
+
+    def pre_start_span(
+        self,
+        *,
+        action: str,
+        action_sequence_id: int,
+        span: Any,
+        span_dependencies: list[str],
+        app_id: str,
+        partition_key: str | None,
+        **future_kwargs: Any,
+    ) -> None:
+        del future_kwargs
+        span_name = str(getattr(span, "name", None) or "custom")
+        metadata = {
+            "scope": "custom_span",
+            "app_id": app_id,
+            "partition_key": partition_key,
+            "action": action,
+            "action_sequence_id": action_sequence_id,
+            "span_name": span_name,
+            "span_dependencies": list(span_dependencies),
+        }
+        self._start(
+            scope="custom_span",
+            name=f"burr.span.{span_name}",
+            attributes=self._attributes(
+                log_type="task",
+                entity_name=span_name,
+                app_id=app_id,
+                partition_key=partition_key,
+                metadata=metadata,
+                input_value=metadata,
+            ),
+            metadata=metadata,
+        )
+
+    def post_end_span(self, **future_kwargs: Any) -> None:
+        del future_kwargs
+        self._end(
+            scope="custom_span",
+            exception=None,
+            output_value={"status": "completed"},
+        )
+
+    def do_log_attributes(
+        self,
+        *,
+        attributes: dict[str, Any],
+        tags: dict,
+        **future_kwargs: Any,
+    ) -> None:
+        del future_kwargs
+        active = self._current()
+        if not self.enabled or active is None:
+            return
+        if self.capture_content:
+            active.metadata["logged_attributes"] = _jsonable(attributes)
+        if tags:
+            active.metadata["tags"] = _jsonable(tags)
+        active.span.set_attribute(
+            RESPAN_METADATA,
+            _json_string({"burr": active.metadata}),
+        )
+
+    def pre_start_stream(
+        self,
+        *,
+        action: str,
+        sequence_id: int,
+        app_id: str,
+        partition_key: str | None,
+        **future_kwargs: Any,
+    ) -> None:
+        del future_kwargs
+        active = self._current()
+        if not self.enabled or active is None:
+            return
+        active.span.add_event(
+            "burr.stream.start",
+            {
+                "burr.action": action,
+                "burr.sequence_id": sequence_id,
+                "burr.app_id": app_id,
+                "burr.partition_key": partition_key or "",
+            },
+        )
+
+    def post_stream_item(
+        self,
+        *,
+        item: Any,
+        item_index: int,
+        action: str,
+        sequence_id: int,
+        **future_kwargs: Any,
+    ) -> None:
+        del future_kwargs
+        active = self._current()
+        if not self.enabled or active is None:
+            return
+        attributes = {
+            "burr.action": action,
+            "burr.sequence_id": sequence_id,
+            "burr.item_index": item_index,
+        }
+        if self.capture_content:
+            attributes["burr.item"] = _json_string(item)
+        active.span.add_event("burr.stream.item", attributes)
+
+    def post_end_stream(
+        self,
+        *,
+        action: str,
+        sequence_id: int,
+        **future_kwargs: Any,
+    ) -> None:
+        del future_kwargs
+        active = self._current()
+        if not self.enabled or active is None:
+            return
+        active.span.add_event(
+            "burr.stream.end",
+            {
+                "burr.action": action,
+                "burr.sequence_id": sequence_id,
+            },
+        )

--- a/python-sdks/instrumentations/respan-instrumentation-burr/src/respan_instrumentation_burr/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-burr/src/respan_instrumentation_burr/_constants.py
@@ -1,0 +1,6 @@
+"""Burr integration constants."""
+
+BURR_INSTRUMENTATION_NAME = "burr"
+BURR_APPLICATION_MODULE = "burr.core.application"
+BURR_APPLICATION_BUILD_TARGET = "ApplicationBuilder.build"
+BURR_ADAPTER_MARKER = "_respan_burr_lifecycle_adapter"

--- a/python-sdks/instrumentations/respan-instrumentation-burr/src/respan_instrumentation_burr/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-burr/src/respan_instrumentation_burr/_instrumentation.py
@@ -1,0 +1,119 @@
+"""Lifecycle management for Burr instrumentation."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import threading
+from typing import Any
+
+from opentelemetry.instrumentation.utils import unwrap
+from wrapt import wrap_function_wrapper
+
+from respan_instrumentation_burr._adapter import BurrLifecycleAdapter
+from respan_instrumentation_burr._constants import (
+    BURR_ADAPTER_MARKER,
+    BURR_APPLICATION_BUILD_TARGET,
+    BURR_APPLICATION_MODULE,
+    BURR_INSTRUMENTATION_NAME,
+)
+from respan_tracing.core.tracer import RespanTracer
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.RLock()
+_ACTIVATION_COUNT = 0
+_PATCHED = False
+_ADAPTER: BurrLifecycleAdapter | None = None
+
+
+def _is_respan_tracing_enabled() -> bool:
+    tracer = getattr(RespanTracer, "_instance", None)
+    if tracer is None:
+        return True
+    return bool(getattr(tracer, "is_enabled", True))
+
+
+def _ensure_adapter(builder: Any) -> None:
+    if _ADAPTER is None:
+        return
+    adapters = list(getattr(builder, "lifecycle_adapters", None) or ())
+    if not any(
+        bool(getattr(adapter, BURR_ADAPTER_MARKER, False)) for adapter in adapters
+    ):
+        adapters.append(_ADAPTER)
+        builder.lifecycle_adapters = adapters
+
+
+def _build_wrapper(
+    wrapped: Any,
+    instance: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    _ensure_adapter(instance)
+    return wrapped(*args, **kwargs)
+
+
+class BurrInstrumentor:
+    """Attach a Respan lifecycle adapter to Burr applications at build time."""
+
+    name = BURR_INSTRUMENTATION_NAME
+
+    def __init__(self, *, capture_content: bool = True) -> None:
+        self._capture_content = capture_content
+        self._is_instrumented = False
+
+    def activate(self) -> None:
+        """Patch `ApplicationBuilder.build` to add the Burr lifecycle adapter."""
+        global _ACTIVATION_COUNT, _ADAPTER, _PATCHED
+
+        if self._is_instrumented or not _is_respan_tracing_enabled():
+            return
+        try:
+            importlib.import_module(BURR_APPLICATION_MODULE)
+        except ImportError as exc:
+            logger.warning("Burr instrumentation unavailable: %s", exc)
+            return
+
+        with _LOCK:
+            if _ACTIVATION_COUNT == 0:
+                _ADAPTER = BurrLifecycleAdapter(capture_content=self._capture_content)
+                wrap_function_wrapper(
+                    BURR_APPLICATION_MODULE,
+                    BURR_APPLICATION_BUILD_TARGET,
+                    _build_wrapper,
+                )
+                _PATCHED = True
+            elif _ADAPTER is not None and (
+                _ADAPTER.capture_content != self._capture_content
+            ):
+                logger.warning(
+                    "Burr is already active; the first capture_content setting wins"
+                )
+            _ACTIVATION_COUNT += 1
+            self._is_instrumented = True
+
+    def deactivate(self) -> None:
+        """Restore the Burr builder; built applications retain a disabled hook."""
+        global _ACTIVATION_COUNT, _ADAPTER, _PATCHED
+
+        if not self._is_instrumented:
+            return
+        with _LOCK:
+            self._is_instrumented = False
+            _ACTIVATION_COUNT = max(0, _ACTIVATION_COUNT - 1)
+            if _ACTIVATION_COUNT:
+                return
+            if _ADAPTER is not None:
+                _ADAPTER.enabled = False
+            if _PATCHED:
+                try:
+                    unwrap(
+                        BURR_APPLICATION_MODULE,
+                        BURR_APPLICATION_BUILD_TARGET,
+                    )
+                except Exception:
+                    logger.debug("Failed to unwrap Burr builder", exc_info=True)
+            _PATCHED = False
+            _ADAPTER = None

--- a/python-sdks/instrumentations/respan-instrumentation-burr/tests/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-burr/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Respan Burr instrumentation."""

--- a/python-sdks/instrumentations/respan-instrumentation-burr/tests/test_adapter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-burr/tests/test_adapter.py
@@ -1,0 +1,175 @@
+from types import SimpleNamespace
+
+from respan_instrumentation_burr._adapter import BurrLifecycleAdapter, _ACTIVE_SPANS
+from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_TYPE,
+    RESPAN_THREADS_ID,
+    RESPAN_TRACE_GROUP_ID,
+)
+from opentelemetry.semconv_ai import SpanAttributes
+
+
+class FakeSpan:
+    def __init__(self, name: str, attributes: dict):
+        self.name = name
+        self.attributes = dict(attributes)
+        self.events = []
+        self.exceptions = []
+        self.ended = False
+
+    def get_span_context(self):
+        return SimpleNamespace(is_valid=True, trace_id=1, span_id=2)
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def set_status(self, status):
+        self.status = status
+
+    def record_exception(self, exception):
+        self.exceptions.append(exception)
+
+    def add_event(self, name, attributes):
+        self.events.append((name, attributes))
+
+    def end(self):
+        self.ended = True
+
+
+class FakeTracer:
+    def __init__(self):
+        self.spans = []
+
+    def start_span(self, name, *, attributes):
+        span = FakeSpan(name, attributes)
+        self.spans.append(span)
+        return span
+
+
+class FakeState:
+    def __init__(self, values):
+        self.values = values
+
+    def serialize(self):
+        return dict(self.values)
+
+
+def _action():
+    return SimpleNamespace(
+        name="increment",
+        reads=["count"],
+        writes=["count"],
+        tags=["counter"],
+        streaming=False,
+        inputs=[],
+    )
+
+
+def test_application_and_action_hooks_capture_burr_state_machine_data() -> None:
+    _ACTIVE_SPANS.set(())
+    tracer = FakeTracer()
+    adapter = BurrLifecycleAdapter(tracer=tracer)
+    method = SimpleNamespace(value="run")
+
+    adapter.pre_run_execute_call(
+        app_id="app-123",
+        partition_key="customer-42",
+        state=FakeState({"count": 0}),
+        method=method,
+    )
+    adapter.pre_run_step(
+        app_id="app-123",
+        partition_key="customer-42",
+        sequence_id=1,
+        state=FakeState({"count": 0}),
+        action=_action(),
+        inputs={},
+    )
+    adapter.post_run_step(
+        state=FakeState({"count": 1}),
+        result={"count": 1},
+        exception=None,
+    )
+    adapter.post_run_execute_call(
+        state=FakeState({"count": 1}),
+        exception=None,
+    )
+
+    workflow, task = tracer.spans
+    assert workflow.attributes[RESPAN_LOG_TYPE] == "workflow"
+    assert task.attributes[RESPAN_LOG_TYPE] == "task"
+    assert task.attributes[RESPAN_TRACE_GROUP_ID] == "app-123"
+    assert task.attributes[RESPAN_THREADS_ID] == "customer-42"
+    assert (
+        '"reads": ["count"]' in task.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+    )
+    assert (
+        '"result": {"count": 1}'
+        in task.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    )
+    assert workflow.ended and task.ended
+
+
+def test_action_failure_uses_backend_error_contract() -> None:
+    _ACTIVE_SPANS.set(())
+    tracer = FakeTracer()
+    adapter = BurrLifecycleAdapter(tracer=tracer)
+    adapter.pre_run_step(
+        app_id="app-failure",
+        partition_key=None,
+        sequence_id=7,
+        state=FakeState({"count": 0}),
+        action=_action(),
+        inputs={},
+    )
+    error = RuntimeError("deterministic Burr failure")
+    adapter.post_run_step(
+        state=FakeState({"count": 0}),
+        result=None,
+        exception=error,
+    )
+
+    span = tracer.spans[0]
+    assert span.attributes["status_code"] == 500
+    assert span.attributes["error.message"] == "deterministic Burr failure"
+    assert span.exceptions == [error]
+
+
+def test_custom_span_attributes_and_stream_events_follow_burr_hooks() -> None:
+    _ACTIVE_SPANS.set(())
+    tracer = FakeTracer()
+    adapter = BurrLifecycleAdapter(tracer=tracer)
+    adapter.pre_start_span(
+        action="respond",
+        action_sequence_id=3,
+        span=SimpleNamespace(name="retrieve_context"),
+        span_dependencies=["prompt"],
+        app_id="app-stream",
+        partition_key="thread-1",
+    )
+    adapter.do_log_attributes(
+        attributes={"documents": 2},
+        tags={"phase": "retrieval"},
+    )
+    adapter.pre_start_stream(
+        action="respond",
+        sequence_id=3,
+        app_id="app-stream",
+        partition_key="thread-1",
+    )
+    adapter.post_stream_item(
+        item={"text": "hello"},
+        item_index=0,
+        action="respond",
+        sequence_id=3,
+    )
+    adapter.post_end_stream(action="respond", sequence_id=3)
+    adapter.post_end_span()
+
+    span = tracer.spans[0]
+    assert [event[0] for event in span.events] == [
+        "burr.stream.start",
+        "burr.stream.item",
+        "burr.stream.end",
+    ]
+    assert '"logged_attributes": {"documents": 2}' in span.attributes["respan.metadata"]

--- a/python-sdks/instrumentations/respan-instrumentation-burr/tests/test_lifecycle.py
+++ b/python-sdks/instrumentations/respan-instrumentation-burr/tests/test_lifecycle.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+
+from respan_instrumentation_burr import BurrInstrumentor
+import respan_instrumentation_burr._instrumentation as instrumentation
+
+
+def test_builder_receives_only_one_respan_adapter(monkeypatch) -> None:
+    adapter = SimpleNamespace(
+        capture_content=True,
+        enabled=True,
+        _respan_burr_lifecycle_adapter=True,
+    )
+    monkeypatch.setattr(instrumentation, "_ADAPTER", adapter)
+    builder = SimpleNamespace(lifecycle_adapters=[])
+    instrumentation._ensure_adapter(builder)
+    instrumentation._ensure_adapter(builder)
+    assert builder.lifecycle_adapters == [adapter]
+
+
+def test_activate_and_deactivate_patch_builder(monkeypatch) -> None:
+    wrapped = []
+    unwrapped = []
+    monkeypatch.setattr(
+        instrumentation.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "wrap_function_wrapper",
+        lambda module, target, wrapper: wrapped.append((module, target)),
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "unwrap",
+        lambda module, target: unwrapped.append((module, target)),
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "BurrLifecycleAdapter",
+        lambda capture_content: SimpleNamespace(
+            capture_content=capture_content,
+            enabled=True,
+            _respan_burr_lifecycle_adapter=True,
+        ),
+    )
+    monkeypatch.setattr(instrumentation, "_ACTIVATION_COUNT", 0)
+    monkeypatch.setattr(instrumentation, "_PATCHED", False)
+    monkeypatch.setattr(instrumentation, "_ADAPTER", None)
+
+    first = BurrInstrumentor()
+    second = BurrInstrumentor(capture_content=False)
+    first.activate()
+    second.activate()
+    assert len(wrapped) == 1
+    assert instrumentation._ACTIVATION_COUNT == 2
+
+    first.deactivate()
+    assert unwrapped == []
+    second.deactivate()
+    assert unwrapped == [
+        (
+            instrumentation.BURR_APPLICATION_MODULE,
+            instrumentation.BURR_APPLICATION_BUILD_TARGET,
+        )
+    ]


### PR DESCRIPTION
## What changed

- Add the Apache Burr instrumentation package and plugin entry point.
- Adapt Burr lifecycle events into canonical Respan spans.
- Add focused adapter and lifecycle tests.
- Register the package in the release inventory with a `new` release intent.

## Why

This adds first-party tracing support for Apache Burr applications.

## Validation

- `python3 scripts/release_inventory.py --validate`
- `python3 scripts/release_intents.py validate`
- `poetry build`
- `poetry run pytest -q tests` (5 passed)
