### PR TITLE
fix(vertexai, google-genai): fold Gemini thinking tokens into the output token count

### DIFF
--- a/.release-intents/20260729-gemini-thinking-tokens.json
+++ b/.release-intents/20260729-gemini-thinking-tokens.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Fold Gemini thinking tokens into the output token count in the Vertex AI and google-genai instrumentations. Gemini reports thoughtsTokenCount separately from candidatesTokenCount but bills it at the output rate, so a thinking-enabled span reported prompt + completion that no longer reconciled against the total the API returned, and the thinking tokens landed on no attribute at all. Matches the google-adk instrumentation, which already folds them in.",
+  "packages": {
+    "respan-instrumentation-vertexai": "patch",
+    "respan-instrumentation-google-genai": "patch",
+    "@respan/instrumentation-vertexai": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/_constants.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/_constants.ts
@@ -49,6 +49,8 @@ export const PROMPT_TOKEN_COUNT_KEY = "promptTokenCount";
 export const PROMPT_TOKEN_COUNT_SNAKE_KEY = "prompt_token_count";
 export const CANDIDATES_TOKEN_COUNT_KEY = "candidatesTokenCount";
 export const CANDIDATES_TOKEN_COUNT_SNAKE_KEY = "candidates_token_count";
+export const THOUGHTS_TOKEN_COUNT_KEY = "thoughtsTokenCount";
+export const THOUGHTS_TOKEN_COUNT_SNAKE_KEY = "thoughts_token_count";
 export const TOTAL_TOKEN_COUNT_KEY = "totalTokenCount";
 export const TOTAL_TOKEN_COUNT_SNAKE_KEY = "total_token_count";
 

--- a/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/_translator.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/_translator.ts
@@ -4,6 +4,8 @@ import {
   CANDIDATES_KEY,
   CANDIDATES_TOKEN_COUNT_KEY,
   CANDIDATES_TOKEN_COUNT_SNAKE_KEY,
+  THOUGHTS_TOKEN_COUNT_KEY,
+  THOUGHTS_TOKEN_COUNT_SNAKE_KEY,
   CONTENT_KEY,
   FUNCTION_CALL_KEY,
   FUNCTION_CALL_SNAKE_KEY,
@@ -352,11 +354,20 @@ export function extractUsage(responseOrChunks: unknown): Record<string, number> 
     CANDIDATES_TOKEN_COUNT_KEY,
     CANDIDATES_TOKEN_COUNT_SNAKE_KEY,
   );
+  const thoughtsTokens = getField(
+    usage,
+    THOUGHTS_TOKEN_COUNT_KEY,
+    THOUGHTS_TOKEN_COUNT_SNAKE_KEY,
+  );
   const totalTokens = getField(usage, TOTAL_TOKEN_COUNT_KEY, TOTAL_TOKEN_COUNT_SNAKE_KEY);
 
   if (typeof promptTokens === "number") result[PROMPT_TOKEN_COUNT_KEY] = promptTokens;
   if (typeof completionTokens === "number") {
-    result[CANDIDATES_TOKEN_COUNT_KEY] = completionTokens;
+    // Gemini reports thinking tokens separately from candidatesTokenCount and bills
+    // them at the output rate, so they belong in the output count. This matches the
+    // google-adk instrumentation, which already folds them in.
+    result[CANDIDATES_TOKEN_COUNT_KEY] =
+      completionTokens + (typeof thoughtsTokens === "number" ? thoughtsTokens : 0);
   }
   if (typeof totalTokens === "number") result[TOTAL_TOKEN_COUNT_KEY] = totalTokens;
   return result;

--- a/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/index.ts
@@ -407,6 +407,7 @@ export { buildGenerateContentAttrs } from "./_otel_emitter.js";
 export {
   extractToolCalls,
   extractTools,
+  extractUsage,
   formatInput,
   formatOutput,
   normalizeInputMessages,

--- a/javascript-sdks/instrumentations/respan-instrumentation-vertexai/tests/vertexai_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vertexai/tests/vertexai_instrumentor.test.mjs
@@ -10,6 +10,7 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import {
   VertexAIInstrumentor,
   buildGenerateContentAttrs,
+  extractUsage,
   requestPayloadFromCall,
 } from "../dist/index.js";
 
@@ -315,4 +316,62 @@ test("records failed generation as an error span", async () => {
   assert.equal(capturedSpans[0].attributes["gen_ai.request.model"], "gemini-2.0-flash");
 
   instrumentor.deactivate();
+});
+
+// Gemini reports thinking tokens separately but bills them at the output rate. Left out
+// of the completion count the span contradicts itself: prompt + completion stops
+// reconciling against the total the API returned, and the thinking tokens land on no
+// attribute at all, so anything costing off the span under-reports output.
+test("thinking tokens fold into the output count", () => {
+  const result = extractUsage({
+    usageMetadata: {
+      promptTokenCount: 100,
+      candidatesTokenCount: 50,
+      thoughtsTokenCount: 800,
+      totalTokenCount: 950,
+    },
+  });
+
+  assert.equal(result.promptTokenCount, 100);
+  assert.equal(result.candidatesTokenCount, 850);
+  assert.equal(result.totalTokenCount, 950);
+  assert.equal(
+    result.promptTokenCount + result.candidatesTokenCount,
+    result.totalTokenCount,
+  );
+});
+
+test("thinking tokens fold in when the payload uses snake_case", () => {
+  const result = extractUsage({
+    usage_metadata: {
+      prompt_token_count: 100,
+      candidates_token_count: 50,
+      thoughts_token_count: 800,
+      total_token_count: 950,
+    },
+  });
+
+  assert.equal(result.candidatesTokenCount, 850);
+});
+
+// Control: no thoughts field at all, which is every non-thinking model. This is why the
+// defect went unnoticed, since the existing fixtures all look like this.
+test("usage is unchanged when the model does not think", () => {
+  const result = extractUsage({ usageMetadata: makeUsage(100, 50) });
+
+  assert.equal(result.candidatesTokenCount, 50);
+  assert.equal(result.totalTokenCount, 150);
+});
+
+test("zero thinking tokens leave the output count alone", () => {
+  const result = extractUsage({
+    usageMetadata: {
+      promptTokenCount: 100,
+      candidatesTokenCount: 50,
+      thoughtsTokenCount: 0,
+      totalTokenCount: 150,
+    },
+  });
+
+  assert.equal(result.candidatesTokenCount, 50);
 });

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_constants.py
@@ -42,6 +42,7 @@ USAGE_METADATA_KEY = "usage_metadata"
 
 AUTOMATIC_FUNCTION_CALLING_HISTORY_KEY = "automatic_function_calling_history"
 CANDIDATES_TOKEN_COUNT_KEY = "candidates_token_count"
+THOUGHTS_TOKEN_COUNT_KEY = "thoughts_token_count"
 PROMPT_TOKEN_COUNT_KEY = "prompt_token_count"
 TOTAL_TOKEN_COUNT_KEY = "total_token_count"
 

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_translator.py
@@ -12,6 +12,7 @@ from respan_instrumentation_google_genai._constants import (
     BUILTIN_TOOL_FIELDS,
     CANDIDATES_KEY,
     CANDIDATES_TOKEN_COUNT_KEY,
+    THOUGHTS_TOKEN_COUNT_KEY,
     CONFIG_KEY,
     CONTENT_KEY,
     CONTENTS_KEY,
@@ -297,11 +298,17 @@ def extract_usage(response_or_chunks: Any) -> dict[str, int]:
     result: dict[str, int] = {}
     prompt_tokens = _field(usage, PROMPT_TOKEN_COUNT_KEY)
     completion_tokens = _field(usage, CANDIDATES_TOKEN_COUNT_KEY)
+    thoughts_tokens = _field(usage, THOUGHTS_TOKEN_COUNT_KEY)
     total_tokens = _field(usage, TOTAL_TOKEN_COUNT_KEY)
     if isinstance(prompt_tokens, int):
         result[PROMPT_TOKEN_COUNT_KEY] = prompt_tokens
     if isinstance(completion_tokens, int):
-        result[CANDIDATES_TOKEN_COUNT_KEY] = completion_tokens
+        # Gemini reports thinking tokens separately from candidatesTokenCount and
+        # bills them at the output rate, so they belong in the output count. This
+        # matches the google-adk instrumentation, which already folds them in.
+        result[CANDIDATES_TOKEN_COUNT_KEY] = completion_tokens + (
+            thoughts_tokens if isinstance(thoughts_tokens, int) else 0
+        )
     if isinstance(total_tokens, int):
         result[TOTAL_TOKEN_COUNT_KEY] = total_tokens
     return result

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/tests/test_instrumentation.py
@@ -13,12 +13,16 @@ from opentelemetry.semconv_ai import SpanAttributes
 from respan_instrumentation_google_genai import GoogleGenAIInstrumentor
 from respan_instrumentation_google_genai import _instrumentation
 from respan_instrumentation_google_genai._constants import (
+    CANDIDATES_TOKEN_COUNT_KEY,
+    PROMPT_TOKEN_COUNT_KEY,
+    TOTAL_TOKEN_COUNT_KEY,
     ASYNC_MODELS_CLASS_NAME,
     GENERATE_CONTENT_METHOD_NAME,
     GENERATE_CONTENT_STREAM_METHOD_NAME,
     GOOGLE_GENAI_MODELS_MODULE,
     MODELS_CLASS_NAME,
 )
+from respan_instrumentation_google_genai._translator import extract_usage
 from respan_instrumentation_google_genai._otel_emitter import build_generate_content_attrs
 from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
 from respan_sdk.constants.span_attributes import (
@@ -326,3 +330,52 @@ def test_deactivate_restores_original_methods(
     assert getattr(Models, GENERATE_CONTENT_STREAM_METHOD_NAME) is original_sync_stream
     assert getattr(AsyncModels, GENERATE_CONTENT_METHOD_NAME) is original_async
     assert getattr(AsyncModels, GENERATE_CONTENT_STREAM_METHOD_NAME) is original_async_stream
+
+
+def test_thinking_tokens_fold_into_the_output_count() -> None:
+    """Gemini reports thinking tokens separately but bills them at the output rate.
+
+    Left out of the completion count the span contradicts itself: prompt + completion
+    stops reconciling against the total the API returned, and the thinking tokens land
+    on no attribute at all, so anything costing off the span under-reports output.
+    """
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=800,
+        total_token_count=950,
+    )
+    result = extract_usage(make_response(usage=usage))
+
+    assert result[PROMPT_TOKEN_COUNT_KEY] == 100
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 850
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 950
+    assert (
+        result[PROMPT_TOKEN_COUNT_KEY] + result[CANDIDATES_TOKEN_COUNT_KEY]
+        == result[TOTAL_TOKEN_COUNT_KEY]
+    )
+
+
+def test_usage_is_unchanged_when_the_model_does_not_think() -> None:
+    """Control: no thoughts field at all, which is every non-thinking model.
+
+    This is why the defect went unnoticed - the existing fixtures all look like this.
+    """
+    result = extract_usage(make_response(usage=make_usage(100, 50)))
+
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 50
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 150
+
+
+def test_zero_thinking_tokens_leave_the_output_count_alone() -> None:
+    """Thinking budget set to zero still emits the field, and must be a no-op."""
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=0,
+        total_token_count=150,
+    )
+    result = extract_usage(make_response(usage=usage))
+
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 50
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 150

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_constants.py
@@ -39,6 +39,7 @@ SYSTEM_INSTRUCTION_KEY = "system_instruction"
 
 PROMPT_TOKEN_COUNT_KEY = "prompt_token_count"
 CANDIDATES_TOKEN_COUNT_KEY = "candidates_token_count"
+THOUGHTS_TOKEN_COUNT_KEY = "thoughts_token_count"
 TOTAL_TOKEN_COUNT_KEY = "total_token_count"
 
 ASSISTANT_ROLE = "assistant"

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_translator.py
@@ -10,6 +10,7 @@ from respan_instrumentation_vertexai._constants import (
     ASSISTANT_ROLE,
     CANDIDATES_KEY,
     CANDIDATES_TOKEN_COUNT_KEY,
+    THOUGHTS_TOKEN_COUNT_KEY,
     CONTENT_KEY,
     FUNCTION_CALL_KEY,
     FUNCTION_DECLARATIONS_KEY,
@@ -320,11 +321,17 @@ def extract_usage(response_or_chunks: Any) -> dict[str, int]:
     result: dict[str, int] = {}
     prompt_tokens = _field(usage, PROMPT_TOKEN_COUNT_KEY)
     completion_tokens = _field(usage, CANDIDATES_TOKEN_COUNT_KEY)
+    thoughts_tokens = _field(usage, THOUGHTS_TOKEN_COUNT_KEY)
     total_tokens = _field(usage, TOTAL_TOKEN_COUNT_KEY)
     if isinstance(prompt_tokens, int):
         result[PROMPT_TOKEN_COUNT_KEY] = prompt_tokens
     if isinstance(completion_tokens, int):
-        result[CANDIDATES_TOKEN_COUNT_KEY] = completion_tokens
+        # Gemini reports thinking tokens separately from candidatesTokenCount and
+        # bills them at the output rate, so they belong in the output count. This
+        # matches the google-adk instrumentation, which already folds them in.
+        result[CANDIDATES_TOKEN_COUNT_KEY] = completion_tokens + (
+            thoughts_tokens if isinstance(thoughts_tokens, int) else 0
+        )
     if isinstance(total_tokens, int):
         result[TOTAL_TOKEN_COUNT_KEY] = total_tokens
     return result

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_instrumentation.py
@@ -16,6 +16,9 @@ from opentelemetry.semconv_ai import SpanAttributes
 from respan_instrumentation_vertexai import VertexAIInstrumentor
 from respan_instrumentation_vertexai import _instrumentation
 from respan_instrumentation_vertexai._constants import (
+    CANDIDATES_TOKEN_COUNT_KEY,
+    PROMPT_TOKEN_COUNT_KEY,
+    TOTAL_TOKEN_COUNT_KEY,
     CHAT_SESSION_CLASS_NAME,
     GENERATE_CONTENT_ASYNC_METHOD_NAME,
     GENERATE_CONTENT_METHOD_NAME,
@@ -25,6 +28,7 @@ from respan_instrumentation_vertexai._constants import (
     VERTEXAI_GENERATIVE_MODELS_MODULE,
 )
 from respan_instrumentation_vertexai._otel_emitter import build_generate_content_attrs
+from respan_instrumentation_vertexai._translator import extract_usage
 from respan_instrumentation_vertexai._translator import request_payload_from_call
 from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
 from respan_sdk.constants.span_attributes import (
@@ -408,3 +412,52 @@ def test_request_payload_reads_model_defaults(
     assert payload["contents"] == "Hello"
     assert payload["system_instruction"] == "Use short answers"
     assert payload["tools"] == [tool]
+
+
+def test_thinking_tokens_fold_into_the_output_count() -> None:
+    """Gemini reports thinking tokens separately but bills them at the output rate.
+
+    Left out of the completion count the span contradicts itself: prompt + completion
+    stops reconciling against the total the API returned, and the thinking tokens land
+    on no attribute at all, so anything costing off the span under-reports output.
+    """
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=800,
+        total_token_count=950,
+    )
+    result = extract_usage(make_response(usage=usage))
+
+    assert result[PROMPT_TOKEN_COUNT_KEY] == 100
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 850
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 950
+    assert (
+        result[PROMPT_TOKEN_COUNT_KEY] + result[CANDIDATES_TOKEN_COUNT_KEY]
+        == result[TOTAL_TOKEN_COUNT_KEY]
+    )
+
+
+def test_usage_is_unchanged_when_the_model_does_not_think() -> None:
+    """Control: no thoughts field at all, which is every non-thinking model.
+
+    This is why the defect went unnoticed - the existing fixtures all look like this.
+    """
+    result = extract_usage(make_response(usage=make_usage(100, 50)))
+
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 50
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 150
+
+
+def test_zero_thinking_tokens_leave_the_output_count_alone() -> None:
+    """Thinking budget set to zero still emits the field, and must be a no-op."""
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=0,
+        total_token_count=150,
+    )
+    result = extract_usage(make_response(usage=usage))
+
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 50
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 150


### PR DESCRIPTION
## The repo disagrees with itself

Gemini reports `thoughtsTokenCount` separately from `candidatesTokenCount`, and bills it at the output rate.

`respan-instrumentation-google-adk` reads that field and folds it into the output count ([`index.ts` L399-410](https://github.com/respanai/respan/blob/main/javascript-sdks/instrumentations/respan-instrumentation-google-adk/src/index.ts)):

```ts
const thoughtsTokens = numberValue(firstDefined(usage?.thoughtsTokenCount, usage?.thoughts_token_count));
const normalizedOutputTokens = outputTokens === undefined ? undefined : outputTokens + (thoughtsTokens ?? 0);
```

Three other instrumentations in the same monorepo read only prompt, candidates and total, and drop it:

- `python-sdks/instrumentations/respan-instrumentation-vertexai`
- `python-sdks/instrumentations/respan-instrumentation-google-genai`
- `javascript-sdks/instrumentations/respan-instrumentation-vertexai`

So this is not a claim about what the right behaviour is. It is your behaviour, applied inconsistently across four packages.

## What the span looks like today

A Gemini 2.5 Flash call with thinking enabled returns `prompt=100, candidates=50, thoughts=800, total=950`. The three packages above emit:

| attribute | emitted | correct |
|---|---|---|
| prompt tokens | 100 | 100 |
| completion tokens | **50** | **850** |
| total tokens | 950 | 950 |

Two things go wrong. The span contradicts itself on its face, because 100 + 50 is not 950. And the 800 thinking tokens land on no attribute at all, so they are not merely mislabelled, they are unrecoverable downstream. On 2.5 Pro, output bills at $10/1M against $1.25/1M for input, so anything costing off these spans under-reports output by about 94% on that call.

## The fix

Fold `thoughtsTokenCount` into the output count, exactly as `google-adk` does. Six source files, 32 lines.

Scope is deliberately narrow. Emitting thinking tokens as their own attribute is defensible and `crewai` and `pydantic-ai` in this repo already do something like it, but that is a feature and this is a wrong number. Happy to follow up with it separately if you want it.

## Why the existing tests passed

Every usage fixture in the three suites looks like this:

```python
def make_usage(prompt_tokens: int = 3, completion_tokens: int = 4) -> Obj:
    return Obj(
        prompt_token_count=prompt_tokens,
        candidates_token_count=completion_tokens,
        total_token_count=prompt_tokens + completion_tokens,
    )
```

No thoughts field, and `total` computed as `prompt + completion`. Under that fixture the identity holds and the assertion passes whether or not the fold is present. The defect was invisible to the suite by construction.

## Tests added

Each package gets the thinking-enabled case plus two controls:

- thinking enabled: output goes 50 to 850, and `prompt + completion == total` reconciles
- no thoughts field at all, which is every non-thinking model: unchanged
- thoughts present but zero, which is thinking budget set to zero: unchanged

The controls are the point. They pass with and without the fix, which is what shows this does not regress non-thinking models. The thinking-enabled test fails on `main`:

```
FAILED tests/test_instrumentation.py::test_thinking_tokens_fold_into_the_output_count
E   assert 50 == 850
```

The TypeScript package also gets a snake_case variant, since `_translator.ts` accepts both key styles and the fix has to work through the same `getField` path.

Local runs: `respan-instrumentation-vertexai` 12 passed, `respan-instrumentation-google-genai` 10 passed. I could not build the TypeScript package locally to run its suite against `dist/`, so those four tests have not been executed by me; the transform logic was verified separately against all four input shapes, including snake_case. CI will be their first real run.

## Notes

- `.release-intents/20260729-gemini-thinking-tokens.json` added, patch on all three packages.
- No behaviour change for any model that does not emit `thoughtsTokenCount`.
