### PR TITLE
fix(sdk): preserve service tier

### DIFF
--- a/.release-intents/20260730-service-tier-param.json
+++ b/.release-intents/20260730-service-tier-param.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Preserve service_tier in provider-bound LLM completion parameters",
+  "packages": {
+    "respan-sdk": "patch"
+  }
+}

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
@@ -249,6 +249,7 @@ class BasicLLMParams(RespanBaseModel):
     tools: Optional[List[dict]] = None
     response_format: Optional[Dict] = None
     reasoning_effort: Optional[Union[str, None]] = None
+    service_tier: Optional[str] = None
     tool_choice: Optional[Union[Literal["auto", "none", "required"], ToolChoice]] = None
     top_logprobs: Optional[int] = None
     top_p: Optional[float] = None

--- a/python-sdks/respan-sdk/tests/test_llm_completion_params.py
+++ b/python-sdks/respan-sdk/tests/test_llm_completion_params.py
@@ -1,0 +1,14 @@
+from respan_sdk.respan_types._internal_types import LiteLLMCompletionParams
+
+
+def test_service_tier_is_preserved_for_provider_request():
+    params = LiteLLMCompletionParams.model_validate(
+        {
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hello"}],
+            "service_tier": "flex",
+        }
+    )
+
+    assert params.service_tier == "flex"
+    assert params.model_dump()["service_tier"] == "flex"


### PR DESCRIPTION
## Summary

- add `service_tier` to provider-bound LLM completion parameters
- verify Flex tier survives Pydantic validation and serialization
- add a patch release intent for `respan-sdk`

## Root cause

`service_tier` existed on Respan logging parameters but not on `LiteLLMCompletionParams`. The SDK's Pydantic split therefore discarded it before the backend called LiteLLM/OpenAI.

## Impact

OpenAI Flex and Priority tier requests can pass through the Respan gateway once the backend consumes the released SDK version.

## Validation

- [x] `poetry run pytest tests/test_llm_completion_params.py -q` — 1 passed
- [x] release inventory validation passed
- [x] release intent validation and plan passed

The full package suite currently has two unrelated collection failures on `main`: an undeclared `openai` test dependency and a stale `RespanTextLogParams` import.