### PR TITLE
fix(release): tolerate PyPI propagation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -329,11 +329,11 @@ jobs:
           . .smoke-venv/bin/activate
           python -m pip install --upgrade pip
 
-          for attempt in 1 2 3 4 5 6 7 8 9 10; do
-            if python -m pip install "${PACKAGE_NAME}==${PACKAGE_VERSION}" >/tmp/pip-install.log 2>&1; then
+          for attempt in {1..40}; do
+            if python -m pip install --no-cache-dir "${PACKAGE_NAME}==${PACKAGE_VERSION}" >/tmp/pip-install.log 2>&1; then
               break
             fi
-            if [ "${attempt}" -eq 10 ]; then
+            if [ "${attempt}" -eq 40 ]; then
               cat /tmp/pip-install.log
               exit 1
             fi

--- a/.release-intents/20260730-respan-sdk-manifest-sync.json
+++ b/.release-intents/20260730-respan-sdk-manifest-sync.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Sync respan-sdk to the already published 2.7.1 release",
+  "packages": {
+    "respan-sdk": "none"
+  }
+}

--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "respan-sdk"
-version = "2.6.27"
+version = "2.7.1"
 description = "Respan SDK allows you to interact with the Respan API smoothly"
 authors = ["Respan <team@respan.ai>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- sync the `respan-sdk` source manifest to the already published `2.7.1`
- extend the PyPI smoke-test propagation window from 2.5 to 10 minutes
- disable pip caching while polling for the newly uploaded version
- mark the manifest sync with a `none` release intent so this PR does not
  publish another SDK version

## Context

The original publish run uploaded `respan-sdk==2.7.1` successfully, but its
registry smoke test timed out before the PyPI index exposed the new version:
https://github.com/respanai/respan/actions/runs/30589495564

PyPI now exposes `2.7.1`, and the published package was independently installed
and verified to preserve `service_tier`.

## Validation

- `python3 scripts/release_inventory.py --validate`
- `python3 scripts/release_intents.py validate`
- release plan from `upstream/main` is empty
- publish workflow YAML parses successfully
