### PR TITLE
feat(sdk): add first-token timeout

### DIFF
--- a/.release-intents/20260730-first-token-timeout.json
+++ b/.release-intents/20260730-first-token-timeout.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Expose a per-request first-token timeout for streaming gateway requests",
+  "packages": {
+    "respan-sdk": "patch"
+  }
+}

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/log_types.py
@@ -211,6 +211,7 @@ class RespanLogParams(PreprocessLogDataMixin, RespanBaseModel):
     fallback_models: Optional[List[str]] = None
     load_balance_group: Optional[LoadBalanceGroup] = None
     load_balance_models: Optional[List[LoadBalanceModel]] = None
+    first_token_timeout: Optional[float] = None
     retry_params: Optional[RetryParams] = None
     respan_params: Optional[dict] = None
     # region: deprecated

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/param_types.py
@@ -381,6 +381,7 @@ class RespanParams(RespanBaseModel, PreprocessLogDataMixin):
     fallback_models: Optional[List[str]] = None
     load_balance_group: Optional[LoadBalanceGroup] = None
     load_balance_models: Optional[List[LoadBalanceModel]] = None
+    first_token_timeout: Optional[float] = None
     retry_params: Optional[RetryParams] = None
     respan_params: Optional[dict] = (
         None  # Nested respan params for special cases

--- a/python-sdks/respan-sdk/tests/test_first_token_timeout_param.py
+++ b/python-sdks/respan-sdk/tests/test_first_token_timeout_param.py
@@ -1,0 +1,8 @@
+from respan_sdk.respan_types.param_types import RespanParams
+
+
+def test_first_token_timeout_is_preserved_for_gateway_request():
+    params = RespanParams.model_validate({"first_token_timeout": "120"})
+
+    assert params.first_token_timeout == 120.0
+    assert params.model_dump()["first_token_timeout"] == 120.0


### PR DESCRIPTION
## Summary

- add `first_token_timeout` to the public Respan request parameter contract
- preserve and coerce the value through Pydantic serialization
- add a patch release intent for `respan-sdk`

## Why

The backend streaming gateway already reads `first_token_timeout`, but the SDK-backed request model silently dropped the field on Chat Completions and Responses requests. Publishing this field makes the existing per-request timeout override reachable without changing the global 30-second default.

## Validation

- [x] focused parameter preservation test passes
- [x] Python package build passes
- [x] release inventory and release intent validation pass
- [x] release planner selects a `respan-sdk` patch release