### PR TITLE
fix(vertexai, google-genai): include Gemini thinking tokens in output usage

### DIFF
--- a/.release-intents/20260805-gemini-thinking-token-accounting.json
+++ b/.release-intents/20260805-gemini-thinking-token-accounting.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Include Gemini thinking tokens in output usage for the Vertex AI and Google Gen AI instrumentations",
+  "packages": {
+    "@respan/instrumentation-vertexai": "patch",
+    "respan-instrumentation-google-genai": "patch",
+    "respan-instrumentation-vertexai": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/_constants.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/_constants.ts
@@ -49,6 +49,8 @@ export const PROMPT_TOKEN_COUNT_KEY = "promptTokenCount";
 export const PROMPT_TOKEN_COUNT_SNAKE_KEY = "prompt_token_count";
 export const CANDIDATES_TOKEN_COUNT_KEY = "candidatesTokenCount";
 export const CANDIDATES_TOKEN_COUNT_SNAKE_KEY = "candidates_token_count";
+export const THOUGHTS_TOKEN_COUNT_KEY = "thoughtsTokenCount";
+export const THOUGHTS_TOKEN_COUNT_SNAKE_KEY = "thoughts_token_count";
 export const TOTAL_TOKEN_COUNT_KEY = "totalTokenCount";
 export const TOTAL_TOKEN_COUNT_SNAKE_KEY = "total_token_count";
 

--- a/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/_translator.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vertexai/src/_translator.ts
@@ -29,6 +29,8 @@ import {
   SYSTEM_INSTRUCTION_SNAKE_KEY,
   SYSTEM_ROLE,
   TEXT_KEY,
+  THOUGHTS_TOKEN_COUNT_KEY,
+  THOUGHTS_TOKEN_COUNT_SNAKE_KEY,
   TOOL_CONFIG_KEY,
   TOOL_CONFIG_SNAKE_KEY,
   TOOL_ROLE,
@@ -352,11 +354,18 @@ export function extractUsage(responseOrChunks: unknown): Record<string, number> 
     CANDIDATES_TOKEN_COUNT_KEY,
     CANDIDATES_TOKEN_COUNT_SNAKE_KEY,
   );
+  const thoughtsTokens = getField(
+    usage,
+    THOUGHTS_TOKEN_COUNT_KEY,
+    THOUGHTS_TOKEN_COUNT_SNAKE_KEY,
+  );
   const totalTokens = getField(usage, TOTAL_TOKEN_COUNT_KEY, TOTAL_TOKEN_COUNT_SNAKE_KEY);
 
   if (typeof promptTokens === "number") result[PROMPT_TOKEN_COUNT_KEY] = promptTokens;
   if (typeof completionTokens === "number") {
-    result[CANDIDATES_TOKEN_COUNT_KEY] = completionTokens;
+    // Gemini reports thought tokens separately, but output usage includes them.
+    result[CANDIDATES_TOKEN_COUNT_KEY] =
+      completionTokens + (typeof thoughtsTokens === "number" ? thoughtsTokens : 0);
   }
   if (typeof totalTokens === "number") result[TOTAL_TOKEN_COUNT_KEY] = totalTokens;
   return result;

--- a/javascript-sdks/instrumentations/respan-instrumentation-vertexai/tests/vertexai_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-vertexai/tests/vertexai_instrumentor.test.mjs
@@ -208,6 +208,49 @@ test("buildGenerateContentAttrs emits canonical chat fields without banned alias
   }
 });
 
+test("buildGenerateContentAttrs includes thinking tokens in output usage", () => {
+  const attrs = buildGenerateContentAttrs({
+    requestPayload: {
+      model: "gemini-2.5-flash",
+      contents: "Explain the result",
+    },
+    responseOrChunks: makeResponse("Reasoned answer", {
+      usage: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 50,
+        thoughtsTokenCount: 800,
+        totalTokenCount: 950,
+      },
+    }),
+  });
+
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 100);
+  assert.equal(attrs["gen_ai.usage.output_tokens"], 850);
+  assert.equal(attrs["gen_ai.usage.completion_tokens"], 850);
+  assert.equal(attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS], 950);
+});
+
+test("buildGenerateContentAttrs supports snake_case thinking usage", () => {
+  const attrs = buildGenerateContentAttrs({
+    requestPayload: {
+      model: "gemini-2.5-flash",
+      contents: "Explain the result",
+    },
+    responseOrChunks: {
+      candidates: [],
+      usage_metadata: {
+        prompt_token_count: 100,
+        candidates_token_count: 50,
+        thoughts_token_count: 800,
+        total_token_count: 950,
+      },
+    },
+  });
+
+  assert.equal(attrs["gen_ai.usage.output_tokens"], 850);
+  assert.equal(attrs["gen_ai.usage.completion_tokens"], 850);
+});
+
 test("patches generate, stream, and chat methods and emits spans", async () => {
   resetTraceCapture();
   const sdkModule = createFakeVertexAIModule();

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_constants.py
@@ -42,6 +42,7 @@ USAGE_METADATA_KEY = "usage_metadata"
 
 AUTOMATIC_FUNCTION_CALLING_HISTORY_KEY = "automatic_function_calling_history"
 CANDIDATES_TOKEN_COUNT_KEY = "candidates_token_count"
+THOUGHTS_TOKEN_COUNT_KEY = "thoughts_token_count"
 PROMPT_TOKEN_COUNT_KEY = "prompt_token_count"
 TOTAL_TOKEN_COUNT_KEY = "total_token_count"
 

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/src/respan_instrumentation_google_genai/_translator.py
@@ -33,6 +33,7 @@ from respan_instrumentation_google_genai._constants import (
     ROLE_KEY,
     SYSTEM_ROLE,
     TEXT_KEY,
+    THOUGHTS_TOKEN_COUNT_KEY,
     TOOLS_KEY,
     TOTAL_TOKEN_COUNT_KEY,
     TYPE_KEY,
@@ -297,11 +298,15 @@ def extract_usage(response_or_chunks: Any) -> dict[str, int]:
     result: dict[str, int] = {}
     prompt_tokens = _field(usage, PROMPT_TOKEN_COUNT_KEY)
     completion_tokens = _field(usage, CANDIDATES_TOKEN_COUNT_KEY)
+    thoughts_tokens = _field(usage, THOUGHTS_TOKEN_COUNT_KEY)
     total_tokens = _field(usage, TOTAL_TOKEN_COUNT_KEY)
     if isinstance(prompt_tokens, int):
         result[PROMPT_TOKEN_COUNT_KEY] = prompt_tokens
     if isinstance(completion_tokens, int):
-        result[CANDIDATES_TOKEN_COUNT_KEY] = completion_tokens
+        # Gemini reports thought tokens separately, but output usage includes them.
+        result[CANDIDATES_TOKEN_COUNT_KEY] = completion_tokens + (
+            thoughts_tokens if isinstance(thoughts_tokens, int) else 0
+        )
     if isinstance(total_tokens, int):
         result[TOTAL_TOKEN_COUNT_KEY] = total_tokens
     return result

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/tests/test_instrumentation.py
@@ -168,6 +168,24 @@ def test_activate_patches_sync_generate_content_and_emits_chat_span(
     instrumentor.deactivate()
 
 
+def test_thinking_tokens_are_included_in_output_usage() -> None:
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=800,
+        total_token_count=950,
+    )
+
+    attrs = build_generate_content_attrs(
+        request_kwargs={"model": "gemini-2.5-flash", "contents": "Explain"},
+        response_or_chunks=make_response(text="Reasoned answer", usage=usage),
+    )
+
+    assert attrs[LLM_USAGE_PROMPT_TOKENS] == 100
+    assert attrs[LLM_USAGE_COMPLETION_TOKENS] == 850
+    assert attrs["gen_ai.usage.total_tokens"] == 950
+
+
 def test_stream_emits_one_span_after_iterator_is_consumed(
     fake_google_genai: tuple[type[Any], type[Any]],
     captured_spans: list[Any],

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_constants.py
@@ -39,6 +39,7 @@ SYSTEM_INSTRUCTION_KEY = "system_instruction"
 
 PROMPT_TOKEN_COUNT_KEY = "prompt_token_count"
 CANDIDATES_TOKEN_COUNT_KEY = "candidates_token_count"
+THOUGHTS_TOKEN_COUNT_KEY = "thoughts_token_count"
 TOTAL_TOKEN_COUNT_KEY = "total_token_count"
 
 ASSISTANT_ROLE = "assistant"

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_translator.py
@@ -29,6 +29,7 @@ from respan_instrumentation_vertexai._constants import (
     SYSTEM_INSTRUCTION_KEY,
     SYSTEM_ROLE,
     TEXT_KEY,
+    THOUGHTS_TOKEN_COUNT_KEY,
     TOOL_CONFIG_KEY,
     TOOL_ROLE,
     TOOLS_KEY,
@@ -320,11 +321,15 @@ def extract_usage(response_or_chunks: Any) -> dict[str, int]:
     result: dict[str, int] = {}
     prompt_tokens = _field(usage, PROMPT_TOKEN_COUNT_KEY)
     completion_tokens = _field(usage, CANDIDATES_TOKEN_COUNT_KEY)
+    thoughts_tokens = _field(usage, THOUGHTS_TOKEN_COUNT_KEY)
     total_tokens = _field(usage, TOTAL_TOKEN_COUNT_KEY)
     if isinstance(prompt_tokens, int):
         result[PROMPT_TOKEN_COUNT_KEY] = prompt_tokens
     if isinstance(completion_tokens, int):
-        result[CANDIDATES_TOKEN_COUNT_KEY] = completion_tokens
+        # Gemini reports thought tokens separately, but output usage includes them.
+        result[CANDIDATES_TOKEN_COUNT_KEY] = completion_tokens + (
+            thoughts_tokens if isinstance(thoughts_tokens, int) else 0
+        )
     if isinstance(total_tokens, int):
         result[TOTAL_TOKEN_COUNT_KEY] = total_tokens
     return result

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_instrumentation.py
@@ -192,6 +192,25 @@ def test_activate_patches_generate_content_and_emits_chat_span(
     instrumentor.deactivate()
 
 
+def test_thinking_tokens_are_included_in_output_usage() -> None:
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=800,
+        total_token_count=950,
+    )
+
+    attrs = build_generate_content_attrs(
+        request_payload={"model": "gemini-2.5-flash", "contents": "Explain"},
+        response_or_chunks=make_response(text="Reasoned answer", usage=usage),
+    )
+
+    assert attrs[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 100
+    assert attrs[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 850
+    assert attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 850
+    assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 950
+
+
 def test_stream_emits_one_span_after_iterator_is_consumed(
     fake_vertexai: tuple[type[Any], type[Any]],
     captured_spans: list[Any],


### PR DESCRIPTION
## Summary

- include Gemini `thoughtsTokenCount` / `thoughts_token_count` in output and completion usage for the JavaScript Vertex AI, Python Vertex AI, and Python Google Gen AI instrumentations
- preserve existing behavior for responses without thinking tokens and retain the provider-reported total token count
- add focused canonical-attribute coverage for all three adapters, including camelCase and snake_case JavaScript payloads

Gemini reports candidate and thinking tokens separately, while thinking tokens are part of output usage. The affected translators mapped only the candidate count, so thinking-enabled requests underreported output usage and could understate derived cost.

This is an independent, convention-compliant implementation of the accounting fix discussed in #339. Translation helpers remain private, and tests exercise the canonical span attributes through each package's attribute builder.

## Release Intent

Patch releases for:

- `@respan/instrumentation-vertexai`
- `respan-instrumentation-vertexai`
- `respan-instrumentation-google-genai`

## Validation

- [x] JavaScript Vertex AI build and 7 tests
- [x] JavaScript package dry-run
- [x] Python Vertex AI: 10 tests
- [x] Python Google Gen AI: 8 tests
- [x] Python source distributions, wheels, and clean install smoke checks
- [x] Release inventory and release-intent validation
- [x] Ref-based affected-package and release-plan validation
