### PR TITLE
fix(cli): correct LangChain/LangGraph skill guidance

### DIFF
--- a/.release-intents/20260807-cli-langchain-guidance-fix.json
+++ b/.release-intents/20260807-cli-langchain-guidance-fix.json
@@ -1,0 +1,6 @@
+{
+  "summary": "CLI: correct LangChain/LangGraph skill guidance. Python uses Respan(instrumentations=[LangChainInstrumentor()]) (global callback-manager patching, add_respan_callback optional); TypeScript needs instrumentor.addCallback(...) on the outermost invocation. Fills in the @respan/instrumentation-langchain JS package. Regenerated bundled skill-refs.",
+  "packages": {
+    "@respan/cli": "patch"
+  }
+}

--- a/javascript-sdks/respan-cli/src/lib/skill-refs.generated.ts
+++ b/javascript-sdks/respan-cli/src/lib/skill-refs.generated.ts
@@ -142,8 +142,8 @@ Check higher-priority categories first. If a match is found, use that instrument
 | OpenAI Agents SDK | \`openai-agents\` | \`@openai/agents\` | \`respan-instrumentation-openai-agents\` | \`@respan/instrumentation-openai-agents\` | [docs](https://respan.ai/docs/integrations/openai-agents-sdk.md) |
 | Claude Agent SDK | \`claude-agent-sdk\` | — | \`respan-instrumentation-claude-agent-sdk\` | — | [docs](https://respan.ai/docs/integrations/claude-agents-sdk.md) |
 | Pydantic AI | \`pydantic-ai\` | — | \`respan-instrumentation-pydantic-ai\` | — | [docs](https://respan.ai/docs/integrations/pydantic-ai.md) |
-| LangChain | \`langchain\` | \`langchain\` | \`respan-instrumentation-langchain\` (callback) | — | [docs](https://respan.ai/docs/integrations/langchain.md) |
-| LangGraph | \`langgraph\` | — | \`respan-instrumentation-langchain\` (callback) | — | [docs](https://respan.ai/docs/integrations/langgraph.md) |
+| LangChain | \`langchain\` | \`langchain\` | \`respan-instrumentation-langchain\` | \`@respan/instrumentation-langchain\` | [docs](https://respan.ai/docs/integrations/langchain.md) |
+| LangGraph | \`langgraph\` | \`@langchain/langgraph\` | \`respan-instrumentation-langchain\` | \`@respan/instrumentation-langchain\` | [docs](https://respan.ai/docs/integrations/langgraph.md) |
 | CrewAI | \`crewai\` | — | \`respan-instrumentation-crewai\` | — | [docs](https://respan.ai/docs/integrations/crewai.md) |
 | LlamaIndex | \`llama-index\` | — | \`respan-instrumentation-llama-index\` | — | [docs](https://respan.ai/docs/integrations/llama-index.md) |
 | Haystack | \`haystack-ai\` | — | \`respan-instrumentation-haystack\` | — | [docs](https://respan.ai/docs/integrations/haystack.md) |
@@ -152,7 +152,7 @@ Check higher-priority categories first. If a match is found, use that instrument
 
 If a Priority 1 framework is found, use its instrumentation. Do NOT also add Priority 2 instrumentation for the same provider.
 
-**LangChain / LangGraph use a callback pattern, not \`Respan(instrumentations=[...])\`.** Set up \`RespanTelemetry\` and pass \`add_respan_callback(config=...)\` into the chain/graph invocation: \`from respan_tracing import RespanTelemetry\` + \`from respan_instrumentation_langchain import add_respan_callback\`. (The other Priority-1 frameworks use the standard \`Respan(instrumentations=[XInstrumentor()])\` plugin pattern.)
+**LangChain / LangGraph setup differs by language** (one package covers both frameworks: \`respan-instrumentation-langchain\` / \`@respan/instrumentation-langchain\`). In **Python**, pass \`LangChainInstrumentor()\` to \`Respan(instrumentations=[...])\` — it patches the LangChain and LangGraph callback managers globally on init, so every chain, graph, node, LLM, tool, and retriever run is traced **automatically with no per-call setup**. \`add_respan_callback(config=...)\` is optional and only labels a run with a name, tags, or metadata. In **TypeScript**, create a \`LangChainInstrumentor\`, pass it to \`new Respan({ instrumentations: [...] })\`, **and** attach \`instrumentor.addCallback(...)\` to the **outermost** chain or graph invocation (\`.invoke()\` / \`.stream()\`, not inside a node — LangChain/LangGraph propagate it to nested runs); the TypeScript instrumentor does **not** patch globally, so without the callback no spans are emitted. (The other Priority-1 frameworks use the standard \`Respan(instrumentations=[XInstrumentor()])\` plugin pattern.)
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 

--- a/plugin/skills/respan/references/tracing.md
+++ b/plugin/skills/respan/references/tracing.md
@@ -93,8 +93,8 @@ Check higher-priority categories first. If a match is found, use that instrument
 | OpenAI Agents SDK | `openai-agents` | `@openai/agents` | `respan-instrumentation-openai-agents` | `@respan/instrumentation-openai-agents` | [docs](https://respan.ai/docs/integrations/openai-agents-sdk.md) |
 | Claude Agent SDK | `claude-agent-sdk` | — | `respan-instrumentation-claude-agent-sdk` | — | [docs](https://respan.ai/docs/integrations/claude-agents-sdk.md) |
 | Pydantic AI | `pydantic-ai` | — | `respan-instrumentation-pydantic-ai` | — | [docs](https://respan.ai/docs/integrations/pydantic-ai.md) |
-| LangChain | `langchain` | `langchain` | `respan-instrumentation-langchain` (callback) | — | [docs](https://respan.ai/docs/integrations/langchain.md) |
-| LangGraph | `langgraph` | — | `respan-instrumentation-langchain` (callback) | — | [docs](https://respan.ai/docs/integrations/langgraph.md) |
+| LangChain | `langchain` | `langchain` | `respan-instrumentation-langchain` | `@respan/instrumentation-langchain` | [docs](https://respan.ai/docs/integrations/langchain.md) |
+| LangGraph | `langgraph` | `@langchain/langgraph` | `respan-instrumentation-langchain` | `@respan/instrumentation-langchain` | [docs](https://respan.ai/docs/integrations/langgraph.md) |
 | CrewAI | `crewai` | — | `respan-instrumentation-crewai` | — | [docs](https://respan.ai/docs/integrations/crewai.md) |
 | LlamaIndex | `llama-index` | — | `respan-instrumentation-llama-index` | — | [docs](https://respan.ai/docs/integrations/llama-index.md) |
 | Haystack | `haystack-ai` | — | `respan-instrumentation-haystack` | — | [docs](https://respan.ai/docs/integrations/haystack.md) |
@@ -103,7 +103,7 @@ Check higher-priority categories first. If a match is found, use that instrument
 
 If a Priority 1 framework is found, use its instrumentation. Do NOT also add Priority 2 instrumentation for the same provider.
 
-**LangChain / LangGraph use a callback pattern, not `Respan(instrumentations=[...])`.** Set up `RespanTelemetry` and pass `add_respan_callback(config=...)` into the chain/graph invocation: `from respan_tracing import RespanTelemetry` + `from respan_instrumentation_langchain import add_respan_callback`. (The other Priority-1 frameworks use the standard `Respan(instrumentations=[XInstrumentor()])` plugin pattern.)
+**LangChain / LangGraph setup differs by language** (one package covers both frameworks: `respan-instrumentation-langchain` / `@respan/instrumentation-langchain`). In **Python**, pass `LangChainInstrumentor()` to `Respan(instrumentations=[...])` — it patches the LangChain and LangGraph callback managers globally on init, so every chain, graph, node, LLM, tool, and retriever run is traced **automatically with no per-call setup**. `add_respan_callback(config=...)` is optional and only labels a run with a name, tags, or metadata. In **TypeScript**, create a `LangChainInstrumentor`, pass it to `new Respan({ instrumentations: [...] })`, **and** attach `instrumentor.addCallback(...)` to the **outermost** chain or graph invocation (`.invoke()` / `.stream()`, not inside a node — LangChain/LangGraph propagate it to nested runs); the TypeScript instrumentor does **not** patch globally, so without the callback no spans are emitted. (The other Priority-1 frameworks use the standard `Respan(instrumentations=[XInstrumentor()])` plugin pattern.)
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 

--- a/skills/references/tracing.md
+++ b/skills/references/tracing.md
@@ -93,8 +93,8 @@ Check higher-priority categories first. If a match is found, use that instrument
 | OpenAI Agents SDK | `openai-agents` | `@openai/agents` | `respan-instrumentation-openai-agents` | `@respan/instrumentation-openai-agents` | [docs](https://respan.ai/docs/integrations/openai-agents-sdk.md) |
 | Claude Agent SDK | `claude-agent-sdk` | — | `respan-instrumentation-claude-agent-sdk` | — | [docs](https://respan.ai/docs/integrations/claude-agents-sdk.md) |
 | Pydantic AI | `pydantic-ai` | — | `respan-instrumentation-pydantic-ai` | — | [docs](https://respan.ai/docs/integrations/pydantic-ai.md) |
-| LangChain | `langchain` | `langchain` | `respan-instrumentation-langchain` (callback) | — | [docs](https://respan.ai/docs/integrations/langchain.md) |
-| LangGraph | `langgraph` | — | `respan-instrumentation-langchain` (callback) | — | [docs](https://respan.ai/docs/integrations/langgraph.md) |
+| LangChain | `langchain` | `langchain` | `respan-instrumentation-langchain` | `@respan/instrumentation-langchain` | [docs](https://respan.ai/docs/integrations/langchain.md) |
+| LangGraph | `langgraph` | `@langchain/langgraph` | `respan-instrumentation-langchain` | `@respan/instrumentation-langchain` | [docs](https://respan.ai/docs/integrations/langgraph.md) |
 | CrewAI | `crewai` | — | `respan-instrumentation-crewai` | — | [docs](https://respan.ai/docs/integrations/crewai.md) |
 | LlamaIndex | `llama-index` | — | `respan-instrumentation-llama-index` | — | [docs](https://respan.ai/docs/integrations/llama-index.md) |
 | Haystack | `haystack-ai` | — | `respan-instrumentation-haystack` | — | [docs](https://respan.ai/docs/integrations/haystack.md) |
@@ -103,7 +103,7 @@ Check higher-priority categories first. If a match is found, use that instrument
 
 If a Priority 1 framework is found, use its instrumentation. Do NOT also add Priority 2 instrumentation for the same provider.
 
-**LangChain / LangGraph use a callback pattern, not `Respan(instrumentations=[...])`.** Set up `RespanTelemetry` and pass `add_respan_callback(config=...)` into the chain/graph invocation: `from respan_tracing import RespanTelemetry` + `from respan_instrumentation_langchain import add_respan_callback`. (The other Priority-1 frameworks use the standard `Respan(instrumentations=[XInstrumentor()])` plugin pattern.)
+**LangChain / LangGraph setup differs by language** (one package covers both frameworks: `respan-instrumentation-langchain` / `@respan/instrumentation-langchain`). In **Python**, pass `LangChainInstrumentor()` to `Respan(instrumentations=[...])` — it patches the LangChain and LangGraph callback managers globally on init, so every chain, graph, node, LLM, tool, and retriever run is traced **automatically with no per-call setup**. `add_respan_callback(config=...)` is optional and only labels a run with a name, tags, or metadata. In **TypeScript**, create a `LangChainInstrumentor`, pass it to `new Respan({ instrumentations: [...] })`, **and** attach `instrumentor.addCallback(...)` to the **outermost** chain or graph invocation (`.invoke()` / `.stream()`, not inside a node — LangChain/LangGraph propagate it to nested runs); the TypeScript instrumentor does **not** patch globally, so without the callback no spans are emitted. (The other Priority-1 frameworks use the standard `Respan(instrumentations=[XInstrumentor()])` plugin pattern.)
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 


### PR DESCRIPTION
## What
Fixes the LangChain/LangGraph guidance in the CLI setup skill, which was **factually wrong on main**.

Main told users: *"LangChain / LangGraph use a callback pattern, not `Respan(instrumentations=[...])`"* and pointed at `RespanTelemetry` + `add_respan_callback`.

Verified against the instrumentor source + official docs, that's incorrect:
- **Python** — `LangChainInstrumentor.activate()` globally patches the LangChain **and** LangGraph callback managers on init ([_instrumentation.py](python-sdks/instrumentations/respan-instrumentation-langchain/src/respan_instrumentation_langchain/_instrumentation.py)), so `Respan(instrumentations=[LangChainInstrumentor()])` traces everything automatically with **no per-call setup**. `add_respan_callback(config=...)` is *optional* (labels/tags/metadata). This is what [the docs](https://respan.ai/docs/integrations/langchain.md) recommend.
- **TypeScript** — the instrumentor does **not** patch globally; `addCallback(...)` must be attached to the **outermost** `.invoke()`/`.stream()` or no spans are emitted. This is the case that actually needs the callback.

## Changes
- Rewrote the note to be language-split and accurate (Python auto via `instrumentations=[...]`; TS needs `addCallback` on the outermost invocation).
- Priority-1 table: filled in `@respan/instrumentation-langchain` (JS) + `@langchain/langgraph`, dropped the misleading `(callback)` suffix.
- Synced the plugin mirror; regenerated the bundled `skill-refs.generated.ts`; added the `@respan/cli` patch release-intent.

Supersedes #321 (same fix, conflicted with #335's Auto-vs-Full rewrite). `tsc --noEmit` clean; release-intents gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)