### PR TITLE
test(vertexai, google-genai): add control cases for the thinking-token fold

### DIFF
--- a/.release-intents/20260807-gemini-thinking-token-controls.json
+++ b/.release-intents/20260807-gemini-thinking-token-controls.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Add control tests around the Gemini thinking-token fold; tests only, no shipped behaviour change",
+  "packages": {
+    "respan-instrumentation-vertexai": "none",
+    "respan-instrumentation-google-genai": "none"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-google-genai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-genai/tests/test_instrumentation.py
@@ -14,12 +14,16 @@ from respan_instrumentation_google_genai import GoogleGenAIInstrumentor
 from respan_instrumentation_google_genai import _instrumentation
 from respan_instrumentation_google_genai._constants import (
     ASYNC_MODELS_CLASS_NAME,
+    CANDIDATES_TOKEN_COUNT_KEY,
     GENERATE_CONTENT_METHOD_NAME,
     GENERATE_CONTENT_STREAM_METHOD_NAME,
     GOOGLE_GENAI_MODELS_MODULE,
     MODELS_CLASS_NAME,
+    PROMPT_TOKEN_COUNT_KEY,
+    TOTAL_TOKEN_COUNT_KEY,
 )
 from respan_instrumentation_google_genai._otel_emitter import build_generate_content_attrs
+from respan_instrumentation_google_genai._translator import extract_usage
 from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
 from respan_sdk.constants.span_attributes import (
     LLM_REQUEST_MODEL,
@@ -344,3 +348,53 @@ def test_deactivate_restores_original_methods(
     assert getattr(Models, GENERATE_CONTENT_STREAM_METHOD_NAME) is original_sync_stream
     assert getattr(AsyncModels, GENERATE_CONTENT_METHOD_NAME) is original_async
     assert getattr(AsyncModels, GENERATE_CONTENT_STREAM_METHOD_NAME) is original_async_stream
+
+
+def test_thinking_tokens_reconcile_against_the_reported_total() -> None:
+    """Prompt plus completion must equal the total the API returned.
+
+    The merged change pins the individual values. This pins the invariant they have
+    to satisfy, which is what anything costing off the span actually depends on.
+    """
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=800,
+        total_token_count=950,
+    )
+
+    result = extract_usage(make_response(usage=usage))
+
+    assert result[PROMPT_TOKEN_COUNT_KEY] == 100
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 850
+    assert (
+        result[PROMPT_TOKEN_COUNT_KEY] + result[CANDIDATES_TOKEN_COUNT_KEY]
+        == result[TOTAL_TOKEN_COUNT_KEY]
+    )
+
+
+def test_usage_is_unchanged_when_the_model_does_not_think() -> None:
+    """Control: no thoughts field at all, which is every non-thinking model.
+
+    This is the shape of every pre-existing fixture, which is why the defect went
+    unnoticed. It pins that the fold stays inert on the common path.
+    """
+    result = extract_usage(make_response(usage=make_usage(100, 50)))
+
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 50
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 150
+
+
+def test_zero_thinking_tokens_leave_the_output_count_alone() -> None:
+    """A thinking budget of zero still emits the field, and must be a no-op."""
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=0,
+        total_token_count=150,
+    )
+
+    result = extract_usage(make_response(usage=usage))
+
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 50
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 150

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_instrumentation.py
@@ -16,15 +16,19 @@ from opentelemetry.semconv_ai import SpanAttributes
 from respan_instrumentation_vertexai import VertexAIInstrumentor
 from respan_instrumentation_vertexai import _instrumentation
 from respan_instrumentation_vertexai._constants import (
+    CANDIDATES_TOKEN_COUNT_KEY,
     CHAT_SESSION_CLASS_NAME,
     GENERATE_CONTENT_ASYNC_METHOD_NAME,
     GENERATE_CONTENT_METHOD_NAME,
     GENERATIVE_MODEL_CLASS_NAME,
+    PROMPT_TOKEN_COUNT_KEY,
     SEND_MESSAGE_ASYNC_METHOD_NAME,
     SEND_MESSAGE_METHOD_NAME,
+    TOTAL_TOKEN_COUNT_KEY,
     VERTEXAI_GENERATIVE_MODELS_MODULE,
 )
 from respan_instrumentation_vertexai._otel_emitter import build_generate_content_attrs
+from respan_instrumentation_vertexai._translator import extract_usage
 from respan_instrumentation_vertexai._translator import request_payload_from_call
 from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
 from respan_sdk.constants.span_attributes import (
@@ -427,3 +431,53 @@ def test_request_payload_reads_model_defaults(
     assert payload["contents"] == "Hello"
     assert payload["system_instruction"] == "Use short answers"
     assert payload["tools"] == [tool]
+
+
+def test_thinking_tokens_reconcile_against_the_reported_total() -> None:
+    """Prompt plus completion must equal the total the API returned.
+
+    The merged change pins the individual values. This pins the invariant they have
+    to satisfy, which is what anything costing off the span actually depends on.
+    """
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=800,
+        total_token_count=950,
+    )
+
+    result = extract_usage(make_response(usage=usage))
+
+    assert result[PROMPT_TOKEN_COUNT_KEY] == 100
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 850
+    assert (
+        result[PROMPT_TOKEN_COUNT_KEY] + result[CANDIDATES_TOKEN_COUNT_KEY]
+        == result[TOTAL_TOKEN_COUNT_KEY]
+    )
+
+
+def test_usage_is_unchanged_when_the_model_does_not_think() -> None:
+    """Control: no thoughts field at all, which is every non-thinking model.
+
+    This is the shape of every pre-existing fixture, which is why the defect went
+    unnoticed. It pins that the fold stays inert on the common path.
+    """
+    result = extract_usage(make_response(usage=make_usage(100, 50)))
+
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 50
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 150
+
+
+def test_zero_thinking_tokens_leave_the_output_count_alone() -> None:
+    """A thinking budget of zero still emits the field, and must be a no-op."""
+    usage = Obj(
+        prompt_token_count=100,
+        candidates_token_count=50,
+        thoughts_token_count=0,
+        total_token_count=150,
+    )
+
+    result = extract_usage(make_response(usage=usage))
+
+    assert result[CANDIDATES_TOKEN_COUNT_KEY] == 50
+    assert result[TOTAL_TOKEN_COUNT_KEY] == 150


### PR DESCRIPTION
Follow-up to #344, taking @fran3cc up on the offer on #339:

> Your extra test cases (snake_case + zero-thoughts controls, google-adk parity note) were a nice touch; if you'd like, they're welcome as a small follow-up on top of the merged change.

Rebased onto the merged change rather than resubmitted as they were, so this is additive only and duplicates nothing already covered.

## What #344 already covers

The thinking path itself, through `build_generate_content_attrs`: camelCase for all three SDKs, plus a snake_case variant for the JS instrumentation.

## What these add

Three cases per Python SDK, against `extract_usage` directly so the translator is pinned rather than only the attribute mapping downstream of it.

| case | why it is worth a test |
|---|---|
| `test_thinking_tokens_reconcile_against_the_reported_total` | #344 pins the individual values. This pins the invariant they have to satisfy: prompt plus completion equals the total the API returned. That reconciliation is what anything costing off the span actually depends on, and it is the property that broke when thoughts were dropped. |
| `test_usage_is_unchanged_when_the_model_does_not_think` | The control. A usage payload with no thoughts field at all is every non-thinking model, and is the shape of every pre-existing fixture in these suites. That is precisely why the defect went unnoticed, so it is worth pinning that the fold stays inert here. |
| `test_zero_thinking_tokens_leave_the_output_count_alone` | A thinking budget explicitly set to zero still emits the field. `extract_usage` reads it through `_field` and adds it, so zero has to be a no-op rather than an accident of falsiness. |

The second and third both exercise the `isinstance(thoughts_tokens, int)` guard from the opposite side to #344: once with the field absent, once with it present and zero.

## Not included

No snake_case cases on the Python side. `_field` does no case aliasing and the Python payloads are natively snake_case, so there is nothing there that the JS snake_case test in #344 is not already covering for the JS shape.

The same two controls apply to the JS instrumentation and are not here, because the workspace needs yarn 4 through corepack, which is not available on this machine, and I would rather not add tests I have not run. Glad to add them if you want them, or they are a two-minute job for anyone with the workspace already set up.

## Verification

Both Python suites, full runs:

```
respan-instrumentation-vertexai      13 passed
respan-instrumentation-google-genai  11 passed
```

Tests only, no source changes, so the release intent is `none` for both packages.

Thanks for the review on #339 and for flagging where the tests should land.
