### PR TITLE
feat(sdk): add OpenRouter request types

### DIFF
--- a/.release-intents/20260810-openrouter-completion-params.json
+++ b/.release-intents/20260810-openrouter-completion-params.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Add canonical OpenRouter reasoning and provider request parameter types",
+  "packages": {
+    "@respan/respan-sdk": "patch",
+    "respan-sdk": "patch"
+  }
+}

--- a/javascript-sdks/respan-sdk/src/types/logTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/logTypes.ts
@@ -403,6 +403,15 @@ const BasicLLMParamsSchema = z.object({
   top_p: z.number().optional(),
 });
 
+const OpenRouterCompletionParamsSchema = BasicLLMParamsSchema.extend({
+  reasoning: z.record(z.string(), z.any()).optional(),
+  provider: z.record(z.string(), z.any()).optional(),
+});
+
+export type OpenRouterCompletionParams = z.input<
+  typeof OpenRouterCompletionParamsSchema
+>;
+
 // Basic Embedding Parameters Schema (placeholder)
 const BasicEmbeddingParamsSchema = z.object({
   input: z.union([z.string(), z.array(z.string())]).optional(),
@@ -589,6 +598,7 @@ export type RespanPayload = z.input<typeof RespanPayloadSchema>;
 export {
   RespanParamsSchema,
   BasicLLMParamsSchema,
+  OpenRouterCompletionParamsSchema,
   BasicEmbeddingParamsSchema,
   MessageSchema,
   ToolCallSchema,

--- a/python-sdks/respan-sdk/src/respan_sdk/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/__init__.py
@@ -12,6 +12,7 @@ from .respan_types import (
     EvaluationParams,
     RetryParams,
     Message,
+    OpenRouterCompletionParams,
     Usage,
 )
 
@@ -40,6 +41,7 @@ __all__ = [
     "EvaluationParams",
     "RetryParams",
     "Message",
+    "OpenRouterCompletionParams",
     "Usage",
 
     # Filter types

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
@@ -24,6 +24,7 @@ from ._internal_types import (
     Message,
     Usage,
     LiteLLMCompletionParams,
+    OpenRouterCompletionParams,
     BasicEmbeddingParams,
 )
 from .exporter_session_types import ExporterSessionState, PendingToolState
@@ -80,6 +81,7 @@ __all__ = [
     "Message",
     "Usage",
     "LiteLLMCompletionParams",
+    "OpenRouterCompletionParams",
     "BasicEmbeddingParams",
     "ExporterSessionState",
     "PendingToolState",

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
@@ -276,6 +276,13 @@ class LiteLLMCompletionParams(BasicLLMParams):
         return v
 
 
+class OpenRouterCompletionParams(LiteLLMCompletionParams):
+    """OpenRouter-native request parameters accepted by the gateway."""
+
+    reasoning: Optional[Dict[str, Any]] = None
+    provider: Optional[Dict[str, Any]] = None
+
+
 class Usage(RespanBaseModel):
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None

--- a/python-sdks/respan-sdk/tests/test_llm_completion_params.py
+++ b/python-sdks/respan-sdk/tests/test_llm_completion_params.py
@@ -1,3 +1,7 @@
+import pytest
+from pydantic import ValidationError
+
+from respan_sdk import OpenRouterCompletionParams
 from respan_sdk.respan_types._internal_types import LiteLLMCompletionParams
 
 
@@ -12,3 +16,43 @@ def test_service_tier_is_preserved_for_provider_request():
 
     assert params.service_tier == "flex"
     assert params.model_dump()["service_tier"] == "flex"
+
+
+def test_openrouter_request_params_are_preserved():
+    params = OpenRouterCompletionParams.model_validate(
+        {
+            "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning": {"enabled": False},
+            "provider": {"zdr": True},
+        }
+    )
+
+    assert params.model_dump()["reasoning"] == {"enabled": False}
+    assert params.model_dump()["provider"] == {"zdr": True}
+
+
+def test_openrouter_reasoning_rejects_log_output_list():
+    with pytest.raises(ValidationError):
+        OpenRouterCompletionParams.model_validate(
+            {
+                "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+                "messages": [{"role": "user", "content": "hello"}],
+                "reasoning": [{"type": "reasoning"}],
+            }
+        )
+
+
+def test_generic_completion_params_do_not_claim_openrouter_fields():
+    params = LiteLLMCompletionParams.model_validate(
+        {
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning": {"enabled": False},
+            "provider": {"zdr": True},
+        }
+    )
+
+    dumped = params.model_dump()
+    assert "reasoning" not in dumped
+    assert "provider" not in dumped


### PR DESCRIPTION
## Summary

- add a canonical Python `OpenRouterCompletionParams` request type and export it from `respan_sdk`
- add the equivalent TypeScript `OpenRouterCompletionParamsSchema` and inferred type without changing the shared logging payload schema
- add patch release intents for both SDK packages

## Why

[Backend PR #4604](https://github.com/respanai/respan-backend/pull/4604) accepts OpenRouter-native object-shaped `reasoning` and `provider` request parameters. Those public request fields should live in the shared SDK instead of a backend-local completion type.

Keeping the OpenRouter type separate also avoids colliding with the existing list-shaped `RespanParams.reasoning` logging field.

## Validation

- Python focused tests: `4 passed`
- SDK release-intent validation: passed
- TypeScript SDK build: passed from a clean temporary dependency install
- TypeScript runtime schema checks: object-shaped values accepted and list-shaped reasoning rejected
- Backend PR #4604 focused tests against the editable SDK: `10 passed`

The broader Python SDK suite retains unrelated baseline collection and legacy compatibility failures.
