### PR TITLE
refactor(sdk): generalize provider type name

### DIFF
--- a/.release-intents/20260810-litellm-openrouter-param-name.json
+++ b/.release-intents/20260810-litellm-openrouter-param-name.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Clarify that OpenRouter completion parameters extend LiteLLM",
+  "packages": {
+    "@respan/respan-sdk": "patch",
+    "respan-sdk": "patch"
+  }
+}

--- a/.release-intents/20260810-litellm-openrouter-param-name.json
+++ b/.release-intents/20260810-litellm-openrouter-param-name.json
@@ -1,5 +1,5 @@
 {
-  "summary": "Clarify that OpenRouter completion parameters extend LiteLLM",
+  "summary": "Add a shared LiteLLM provider completion parameter contract",
   "packages": {
     "@respan/respan-sdk": "patch",
     "respan-sdk": "patch"

--- a/javascript-sdks/respan-sdk/src/types/logTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/logTypes.ts
@@ -403,21 +403,21 @@ const BasicLLMParamsSchema = z.object({
   top_p: z.number().optional(),
 });
 
-const LiteLLMOpenRouterCompletionParamsSchema = BasicLLMParamsSchema.extend({
+const LiteLLMProviderCompletionParamsSchema = BasicLLMParamsSchema.extend({
   reasoning: z.record(z.string(), z.any()).optional(),
   provider: z.record(z.string(), z.any()).optional(),
 });
 
-export type LiteLLMOpenRouterCompletionParams = z.input<
-  typeof LiteLLMOpenRouterCompletionParamsSchema
+export type LiteLLMProviderCompletionParams = z.input<
+  typeof LiteLLMProviderCompletionParamsSchema
 >;
 
-/** @deprecated Use LiteLLMOpenRouterCompletionParamsSchema. */
+/** @deprecated Use LiteLLMProviderCompletionParamsSchema. */
 const OpenRouterCompletionParamsSchema =
-  LiteLLMOpenRouterCompletionParamsSchema;
+  LiteLLMProviderCompletionParamsSchema;
 
-/** @deprecated Use LiteLLMOpenRouterCompletionParams. */
-export type OpenRouterCompletionParams = LiteLLMOpenRouterCompletionParams;
+/** @deprecated Use LiteLLMProviderCompletionParams. */
+export type OpenRouterCompletionParams = LiteLLMProviderCompletionParams;
 
 // Basic Embedding Parameters Schema (placeholder)
 const BasicEmbeddingParamsSchema = z.object({
@@ -605,7 +605,7 @@ export type RespanPayload = z.input<typeof RespanPayloadSchema>;
 export {
   RespanParamsSchema,
   BasicLLMParamsSchema,
-  LiteLLMOpenRouterCompletionParamsSchema,
+  LiteLLMProviderCompletionParamsSchema,
   OpenRouterCompletionParamsSchema,
   BasicEmbeddingParamsSchema,
   MessageSchema,

--- a/javascript-sdks/respan-sdk/src/types/logTypes.ts
+++ b/javascript-sdks/respan-sdk/src/types/logTypes.ts
@@ -403,14 +403,21 @@ const BasicLLMParamsSchema = z.object({
   top_p: z.number().optional(),
 });
 
-const OpenRouterCompletionParamsSchema = BasicLLMParamsSchema.extend({
+const LiteLLMOpenRouterCompletionParamsSchema = BasicLLMParamsSchema.extend({
   reasoning: z.record(z.string(), z.any()).optional(),
   provider: z.record(z.string(), z.any()).optional(),
 });
 
-export type OpenRouterCompletionParams = z.input<
-  typeof OpenRouterCompletionParamsSchema
+export type LiteLLMOpenRouterCompletionParams = z.input<
+  typeof LiteLLMOpenRouterCompletionParamsSchema
 >;
+
+/** @deprecated Use LiteLLMOpenRouterCompletionParamsSchema. */
+const OpenRouterCompletionParamsSchema =
+  LiteLLMOpenRouterCompletionParamsSchema;
+
+/** @deprecated Use LiteLLMOpenRouterCompletionParams. */
+export type OpenRouterCompletionParams = LiteLLMOpenRouterCompletionParams;
 
 // Basic Embedding Parameters Schema (placeholder)
 const BasicEmbeddingParamsSchema = z.object({
@@ -598,6 +605,7 @@ export type RespanPayload = z.input<typeof RespanPayloadSchema>;
 export {
   RespanParamsSchema,
   BasicLLMParamsSchema,
+  LiteLLMOpenRouterCompletionParamsSchema,
   OpenRouterCompletionParamsSchema,
   BasicEmbeddingParamsSchema,
   MessageSchema,

--- a/python-sdks/respan-sdk/src/respan_sdk/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/__init__.py
@@ -12,6 +12,7 @@ from .respan_types import (
     EvaluationParams,
     RetryParams,
     Message,
+    LiteLLMOpenRouterCompletionParams,
     OpenRouterCompletionParams,
     Usage,
 )
@@ -41,6 +42,7 @@ __all__ = [
     "EvaluationParams",
     "RetryParams",
     "Message",
+    "LiteLLMOpenRouterCompletionParams",
     "OpenRouterCompletionParams",
     "Usage",
 

--- a/python-sdks/respan-sdk/src/respan_sdk/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/__init__.py
@@ -12,7 +12,7 @@ from .respan_types import (
     EvaluationParams,
     RetryParams,
     Message,
-    LiteLLMOpenRouterCompletionParams,
+    LiteLLMProviderCompletionParams,
     OpenRouterCompletionParams,
     Usage,
 )
@@ -42,7 +42,7 @@ __all__ = [
     "EvaluationParams",
     "RetryParams",
     "Message",
-    "LiteLLMOpenRouterCompletionParams",
+    "LiteLLMProviderCompletionParams",
     "OpenRouterCompletionParams",
     "Usage",
 

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
@@ -24,7 +24,7 @@ from ._internal_types import (
     Message,
     Usage,
     LiteLLMCompletionParams,
-    LiteLLMOpenRouterCompletionParams,
+    LiteLLMProviderCompletionParams,
     OpenRouterCompletionParams,
     BasicEmbeddingParams,
 )
@@ -82,7 +82,7 @@ __all__ = [
     "Message",
     "Usage",
     "LiteLLMCompletionParams",
-    "LiteLLMOpenRouterCompletionParams",
+    "LiteLLMProviderCompletionParams",
     "OpenRouterCompletionParams",
     "BasicEmbeddingParams",
     "ExporterSessionState",

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/__init__.py
@@ -24,6 +24,7 @@ from ._internal_types import (
     Message,
     Usage,
     LiteLLMCompletionParams,
+    LiteLLMOpenRouterCompletionParams,
     OpenRouterCompletionParams,
     BasicEmbeddingParams,
 )
@@ -81,6 +82,7 @@ __all__ = [
     "Message",
     "Usage",
     "LiteLLMCompletionParams",
+    "LiteLLMOpenRouterCompletionParams",
     "OpenRouterCompletionParams",
     "BasicEmbeddingParams",
     "ExporterSessionState",

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
@@ -276,15 +276,15 @@ class LiteLLMCompletionParams(BasicLLMParams):
         return v
 
 
-class LiteLLMOpenRouterCompletionParams(LiteLLMCompletionParams):
-    """LiteLLM completion parameters with OpenRouter-native extensions."""
+class LiteLLMProviderCompletionParams(LiteLLMCompletionParams):
+    """LiteLLM completion parameters with provider-specific extensions."""
 
     reasoning: Optional[Dict[str, Any]] = None
     provider: Optional[Dict[str, Any]] = None
 
 
 # Backward-compatible alias for the name published in respan-sdk 2.7.3.
-OpenRouterCompletionParams = LiteLLMOpenRouterCompletionParams
+OpenRouterCompletionParams = LiteLLMProviderCompletionParams
 
 
 class Usage(RespanBaseModel):

--- a/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/respan_types/_internal_types.py
@@ -276,11 +276,15 @@ class LiteLLMCompletionParams(BasicLLMParams):
         return v
 
 
-class OpenRouterCompletionParams(LiteLLMCompletionParams):
-    """OpenRouter-native request parameters accepted by the gateway."""
+class LiteLLMOpenRouterCompletionParams(LiteLLMCompletionParams):
+    """LiteLLM completion parameters with OpenRouter-native extensions."""
 
     reasoning: Optional[Dict[str, Any]] = None
     provider: Optional[Dict[str, Any]] = None
+
+
+# Backward-compatible alias for the name published in respan-sdk 2.7.3.
+OpenRouterCompletionParams = LiteLLMOpenRouterCompletionParams
 
 
 class Usage(RespanBaseModel):

--- a/python-sdks/respan-sdk/tests/test_llm_completion_params.py
+++ b/python-sdks/respan-sdk/tests/test_llm_completion_params.py
@@ -1,7 +1,10 @@
 import pytest
 from pydantic import ValidationError
 
-from respan_sdk import OpenRouterCompletionParams
+from respan_sdk import (
+    LiteLLMOpenRouterCompletionParams,
+    OpenRouterCompletionParams,
+)
 from respan_sdk.respan_types._internal_types import LiteLLMCompletionParams
 
 
@@ -19,7 +22,7 @@ def test_service_tier_is_preserved_for_provider_request():
 
 
 def test_openrouter_request_params_are_preserved():
-    params = OpenRouterCompletionParams.model_validate(
+    params = LiteLLMOpenRouterCompletionParams.model_validate(
         {
             "model": "openrouter/deepseek/deepseek-v4-flash-0731",
             "messages": [{"role": "user", "content": "hello"}],
@@ -34,7 +37,7 @@ def test_openrouter_request_params_are_preserved():
 
 def test_openrouter_reasoning_rejects_log_output_list():
     with pytest.raises(ValidationError):
-        OpenRouterCompletionParams.model_validate(
+        LiteLLMOpenRouterCompletionParams.model_validate(
             {
                 "model": "openrouter/deepseek/deepseek-v4-flash-0731",
                 "messages": [{"role": "user", "content": "hello"}],
@@ -56,3 +59,7 @@ def test_generic_completion_params_do_not_claim_openrouter_fields():
     dumped = params.model_dump()
     assert "reasoning" not in dumped
     assert "provider" not in dumped
+
+
+def test_previous_openrouter_type_name_remains_compatible():
+    assert OpenRouterCompletionParams is LiteLLMOpenRouterCompletionParams

--- a/python-sdks/respan-sdk/tests/test_llm_completion_params.py
+++ b/python-sdks/respan-sdk/tests/test_llm_completion_params.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from respan_sdk import (
-    LiteLLMOpenRouterCompletionParams,
+    LiteLLMProviderCompletionParams,
     OpenRouterCompletionParams,
 )
 from respan_sdk.respan_types._internal_types import LiteLLMCompletionParams
@@ -22,7 +22,7 @@ def test_service_tier_is_preserved_for_provider_request():
 
 
 def test_openrouter_request_params_are_preserved():
-    params = LiteLLMOpenRouterCompletionParams.model_validate(
+    params = LiteLLMProviderCompletionParams.model_validate(
         {
             "model": "openrouter/deepseek/deepseek-v4-flash-0731",
             "messages": [{"role": "user", "content": "hello"}],
@@ -37,7 +37,7 @@ def test_openrouter_request_params_are_preserved():
 
 def test_openrouter_reasoning_rejects_log_output_list():
     with pytest.raises(ValidationError):
-        LiteLLMOpenRouterCompletionParams.model_validate(
+        LiteLLMProviderCompletionParams.model_validate(
             {
                 "model": "openrouter/deepseek/deepseek-v4-flash-0731",
                 "messages": [{"role": "user", "content": "hello"}],
@@ -62,4 +62,4 @@ def test_generic_completion_params_do_not_claim_openrouter_fields():
 
 
 def test_previous_openrouter_type_name_remains_compatible():
-    assert OpenRouterCompletionParams is LiteLLMOpenRouterCompletionParams
+    assert OpenRouterCompletionParams is LiteLLMProviderCompletionParams


### PR DESCRIPTION
## Summary

- Add the provider extension contract as `LiteLLMProviderCompletionParams`
- Keep `OpenRouterCompletionParams` as a compatibility alias for 2.7.3 consumers
- Apply the same precise naming to the TypeScript schema and type
- Add patch release intents for both SDK packages

## Why

`OpenRouterCompletionParams` implied a complete canonical OpenRouter request model and left no natural home for future fields from other providers. `LiteLLMProviderCompletionParams` describes a shared LiteLLM contract for provider-specific passthrough fields while backend routing controls which fields reach each provider.

## Validation

- Python focused tests: 5 passed
- TypeScript: `tsc --noEmit` passed
- Release inventory validation passed
- Release intent validation and plan passed
