### PR TITLE
fix(js): repair workspace: dep leak that broke npm install of @respan/respan

### DIFF
--- a/.release-intents/20260810-js-workspace-dep-leak.json
+++ b/.release-intents/20260810-js-workspace-dep-leak.json
@@ -1,0 +1,11 @@
+{
+  "summary": "Replace unreleasable workspace: dependency ranges in JS instrumentation packages and republish the broken tarballs (aws-bedrock, openrouter, codex-sdk, cursor, llama-index, pydantic-ai)",
+  "packages": {
+    "@respan/instrumentation-aws-bedrock": "patch",
+    "@respan/instrumentation-openrouter": "patch",
+    "@respan/instrumentation-codex-sdk": "patch",
+    "@respan/instrumentation-cursor": "patch",
+    "@respan/instrumentation-llama-index": "patch",
+    "@respan/instrumentation-pydantic-ai": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-aws-bedrock/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-aws-bedrock/package.json
@@ -31,8 +31,8 @@
     "@opentelemetry/core": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",
-    "@respan/respan-sdk": "workspace:^",
-    "@respan/tracing": "workspace:^",
+    "@respan/respan-sdk": "^1.1.7",
+    "@respan/tracing": "^1.1.4",
     "@traceloop/ai-semantic-conventions": "^0.13.0"
   },
   "peerDependencies": {

--- a/javascript-sdks/instrumentations/respan-instrumentation-codex-sdk/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-codex-sdk/package.json
@@ -29,8 +29,8 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.10.0",
-    "@respan/respan-sdk": "workspace:^",
-    "@respan/tracing": "workspace:^",
+    "@respan/respan-sdk": "^1.1.7",
+    "@respan/tracing": "^1.1.4",
     "@traceloop/ai-semantic-conventions": "^0.13.0"
   },
   "peerDependencies": {

--- a/javascript-sdks/instrumentations/respan-instrumentation-cursor/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-cursor/package.json
@@ -31,8 +31,8 @@
     "@opentelemetry/core": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",
-    "@respan/respan-sdk": "workspace:^",
-    "@respan/tracing": "workspace:^",
+    "@respan/respan-sdk": "^1.1.7",
+    "@respan/tracing": "^1.1.4",
     "@traceloop/ai-semantic-conventions": "^0.13.0"
   },
   "peerDependencies": {

--- a/javascript-sdks/instrumentations/respan-instrumentation-llama-index/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-llama-index/package.json
@@ -31,8 +31,8 @@
     "@opentelemetry/core": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",
-    "@respan/respan-sdk": "workspace:^",
-    "@respan/tracing": "workspace:^",
+    "@respan/respan-sdk": "^1.1.7",
+    "@respan/tracing": "^1.1.4",
     "@traceloop/ai-semantic-conventions": "^0.13.0"
   },
   "peerDependencies": {

--- a/javascript-sdks/instrumentations/respan-instrumentation-pydantic-ai/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-pydantic-ai/package.json
@@ -31,7 +31,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",
-    "@respan/respan-sdk": "workspace:^",
+    "@respan/respan-sdk": "^1.1.7",
     "@traceloop/ai-semantic-conventions": "^0.13.0"
   },
   "devDependencies": {

--- a/scripts/release_inventory.py
+++ b/scripts/release_inventory.py
@@ -391,6 +391,17 @@ def validate(entries: list[dict]) -> list[str]:
             publish_access = manifest.get("publishConfig", {}).get("access")
             if entry["registry"] == "npm" and publish_access != "public":
                 errors.append(f"{entry['name']} is missing publishConfig.access=public")
+            # `npm publish` does not rewrite the `workspace:` protocol (only
+            # yarn berry / pnpm do), so any workspace: range leaks verbatim into
+            # the published tarball and makes the package uninstallable from npm.
+            for section in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+                for dep_name, dep_range in (manifest.get(section) or {}).items():
+                    if isinstance(dep_range, str) and dep_range.startswith("workspace:"):
+                        errors.append(
+                            f"{entry['name']} declares {section}.{dep_name} as "
+                            f"'{dep_range}'; replace the workspace: range with a "
+                            f"concrete version before publishing"
+                        )
         else:
             project_version = manifest.get("project", {}).get("version")
             poetry_version = manifest["tool"]["poetry"]["version"]


### PR DESCRIPTION
## Problem

`npm install @respan/respan` (the exact command in the [Claude Agent SDK docs](https://www.respan.ai/docs/integrations/claude-agents-sdk) and elsewhere) **fails** — `npm` exits 1 during resolution with no useful error; `yarn` shows the real cause:

```
Couldn't find any versions for "@respan/respan-sdk" that matches "workspace:*"
```

**Root cause:** the publish job publishes with `npm publish` (not `yarn npm publish`). Only yarn berry / pnpm rewrite the `workspace:` protocol at pack time; `npm` ships it verbatim. Six published instrumentation packages carried `workspace:*` / `workspace:^` ranges, so their npm tarballs are uninstallable — and because they are transitive deps of the `@respan/respan` umbrella, they break the umbrella's install too.

Confirmed broken on npm (published `dependencies`):

| Package | Published spec |
|---|---|
| `@respan/instrumentation-aws-bedrock@1.0.0` | `workspace:^` |
| `@respan/instrumentation-openrouter@0.1.0` | `workspace:*` |
| `@respan/instrumentation-codex-sdk@1.0.0` | `workspace:^` |
| `@respan/instrumentation-cursor@0.1.0` | `workspace:^` |
| `@respan/instrumentation-llama-index@0.1.0` | `workspace:^` |
| `@respan/instrumentation-pydantic-ai@0.1.0` | `workspace:^` |

## Fix

- **Pin the five source manifests** that still used `workspace:` ranges to the concrete versions every other instrumentation package already uses (`@respan/respan-sdk ^1.1.7`, `@respan/tracing ^1.1.4`). `openrouter` was already clean in source but its published `0.1.0` tarball is broken, so it is included for a republish.
- **Release intent** marking all six for a `patch` republish (verified: `release_intents.py plan` queues exactly these six).
- **Recurrence guard** in `release_inventory.py --validate` (already run by the publish workflow's `discover` job): validation now fails if any release-managed JS package declares a `workspace:` dependency range. Chosen over silent auto-rewrite so a leak fails loudly at CI instead of shipping.

## Verification

- `release_inventory.py --validate` → passes (all six clean); fires correctly when a `workspace:` range is reintroduced.
- `release_intents.py validate` → passes.
- Local workspace versions satisfy the new ranges (sdk 1.3.2 ⊇ ^1.1.7, tracing 1.1.6 ⊇ ^1.1.4); repo uses yarn 4 berry, which links workspaces transparently by satisfied semver, so local dev is unaffected.
- The `@respan/instrumentation-claude-agent-sdk` integration itself was tested end-to-end (Python + TS) and works — this PR only unblocks installing it via the umbrella.

## Follow-up (not in this PR)

The four remaining latent packages are now covered by the guard. Longer term, switching the publish step to `yarn npm publish` would rewrite `workspace:` automatically, but the fail-fast guard is the safer immediate net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)