### PR TITLE
fix: repair broken links in package metadata and READMEs

### DIFF
--- a/.release-intents/20260811-metadata-link-fixes.json
+++ b/.release-intents/20260811-metadata-link-fixes.json
@@ -1,0 +1,13 @@
+{
+  "summary": "Patch package metadata and READMEs to repair broken documentation, GitHub, and CDN asset links",
+  "packages": {
+    "@respan/respan": "patch",
+    "@respan/respan-sdk": "patch",
+    "@respan/tracing": "patch",
+    "respan-ai": "patch",
+    "respan-exporter-openai-agents": "patch",
+    "respan-instrumentation-langfuse": "patch",
+    "respan-sdk": "patch",
+    "respan-tracing": "patch"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
 <a href="https://www.respan.ai#gh-light-mode-only">
-<img width="800" src="https://respan-static.s3.us-east-1.amazonaws.com/social_media_images/logo-header.jpg">
+<img width="800" src="https://cdn.respan.ai/Respan-Brand-Assets/wordmark-light.png">
 </a>
 <a href="https://www.respan.ai#gh-dark-mode-only">
-<img width="800" src="https://respan-static.s3.us-east-1.amazonaws.com/social_media_images/logo-header-dark.jpg">
+<img width="800" src="https://cdn.respan.ai/Respan-Brand-Assets/wordmark-dark.png">
 </a>
 </p>
 <p align="center">
@@ -13,7 +13,7 @@
 <div align="center">
   <a href="https://www.ycombinator.com/companies/respan"><img src="https://img.shields.io/badge/Y%20Combinator-W24-orange" alt="Y Combinator W24"></a>
   <a href="https://www.respan.ai"><img src="https://img.shields.io/badge/Platform-green.svg?style=flat-square" alt="Platform" style="height: 20px;"></a>
-  <a href="https://docs.respan.ai/get-started/overview"><img src="https://img.shields.io/badge/Documentation-blue.svg?style=flat-square" alt="Documentation" style="height: 20px;"></a>
+  <a href="https://www.respan.ai/docs/documentation/get-started/quickstart"><img src="https://img.shields.io/badge/Documentation-blue.svg?style=flat-square" alt="Documentation" style="height: 20px;"></a>
   <a href="https://x.com/respan/"><img src="https://img.shields.io/twitter/follow/respan?style=social" alt="Twitter" style="height: 20px;"></a>
   <a href="https://discord.com/invite/KEanfAafQQ"><img src="https://img.shields.io/badge/discord-7289da.svg?style=flat-square&logo=discord" alt="Discord" style="height: 20px;"></a>
 
@@ -21,7 +21,7 @@
 
 # Respan Tracing
 <div align="center">
-<img src="https://respan-static.s3.us-east-1.amazonaws.com/social_media_images/github-cover.jpg" width="800"></img>
+<img src="https://cdn.respan.ai/respan_landing/respan/og-home-tracing.png" width="800"></img>
 </div>
 
 Respan's library for sending telemetries of LLM applications in [OpenLLMetry](https://github.com/traceloop/openllmetry) format.
@@ -30,9 +30,9 @@ Respan's library for sending telemetries of LLM applications in [OpenLLMetry](ht
 ## Integrations
 <div align="center" style="background-color: white; padding: 20px; border-radius: 10px; margin: 0 auto; max-width: 800px;">
   <div style="display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 120px; margin-bottom: 20px;">
-    <a href="https://docs.respan.ai/features/monitoring/traces/integrations/openai-agents-sdk"><img src="https://respan-static.s3.us-east-1.amazonaws.com/github/openai-agents-sdk.jpg" height="45" alt="OpenAI Agents SDK"></a>
-        <a href="https://docs.respan.ai/features/monitoring/traces/integrations/langgraph"><img src="https://respan-static.s3.us-east-1.amazonaws.com/github/langgraph.jpg" height="45" alt="LangGraph"></a>
-    <a href="https://docs.respan.ai/features/monitoring/traces/integrations/vercel-ai-sdk"><img src="https://respan-static.s3.us-east-1.amazonaws.com/github/vercel.jpg" height="45" alt="Vercel AI SDK"></a>
+    <a href="https://www.respan.ai/docs/integrations/openai-agents-sdk"><img src="https://cdn.respan.ai/github/openai-agents-sdk.jpg" height="45" alt="OpenAI Agents SDK"></a>
+        <a href="https://www.respan.ai/docs/integrations/langgraph"><img src="https://cdn.respan.ai/github/langgraph.jpg" height="45" alt="LangGraph"></a>
+    <a href="https://www.respan.ai/docs/integrations/vercel-ai-sdk"><img src="https://cdn.respan.ai/github/vercel.jpg" height="45" alt="Vercel AI SDK"></a>
   </div>
 
 </div>
@@ -125,7 +125,7 @@ await respan.shutdown();
 See your traces in the [Respan platform](https://platform.respan.ai).
 
 <div align="center">
-<img src="https://respan-static.s3.us-east-1.amazonaws.com/github/traces-output.png" width="800"> </img>
+<img src="https://cdn.respan.ai/github/traces-output.png" width="800"> </img>
 </div>
 
 ## Further Reading

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
 <a href="https://www.respan.ai#gh-light-mode-only">
-<img width="800" src="https://cdn.respan.ai/Respan-Brand-Assets/wordmark-light.png">
+<img width="800" src="https://cdn.respan.ai/Respan-Brand-Assets/wordmark-dark.png">
 </a>
 <a href="https://www.respan.ai#gh-dark-mode-only">
-<img width="800" src="https://cdn.respan.ai/Respan-Brand-Assets/wordmark-dark.png">
+<img width="800" src="https://cdn.respan.ai/Respan-Brand-Assets/wordmark-light.png">
 </a>
 </p>
 <p align="center">

--- a/javascript-sdks/legacy/respan-exporter-anthropic-agents/README.md
+++ b/javascript-sdks/legacy/respan-exporter-anthropic-agents/README.md
@@ -1,6 +1,6 @@
 # Respan Exporter for Anthropic Agent SDK
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)**
 
 Exporter for Anthropic Agent SDK telemetry to Respan.
 

--- a/javascript-sdks/legacy/respan-exporter-n8n/README.md
+++ b/javascript-sdks/legacy/respan-exporter-n8n/README.md
@@ -1,6 +1,6 @@
 # Respan Node for n8n
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)**
 
 A custom n8n node for integrating Respan's LLM Gateway and Prompt Management features into your n8n workflows.
 

--- a/javascript-sdks/legacy/respan-exporter-openai-agents/README.md
+++ b/javascript-sdks/legacy/respan-exporter-openai-agents/README.md
@@ -1,5 +1,5 @@
 # Respan Exporter for OpenAI Agents SDK
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)**
 
 Exporter for OpenAI Agents telemetry to Respan.

--- a/javascript-sdks/legacy/respan-exporter-vercel/README.md
+++ b/javascript-sdks/legacy/respan-exporter-vercel/README.md
@@ -1,6 +1,6 @@
 # Respan Exporter for Vercel AI SDK
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)**
 
 Respan's integration with [Vercel AI SDK](https://github.com/vercel/ai)
 ```

--- a/javascript-sdks/respan-sdk/README.md
+++ b/javascript-sdks/respan-sdk/README.md
@@ -1,5 +1,5 @@
 # Respan SDK
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)**
 
 Respan SDK allows you to interact with the Respan API smoothly.

--- a/javascript-sdks/respan-tracing/README.md
+++ b/javascript-sdks/respan-tracing/README.md
@@ -1,6 +1,6 @@
 # Respan Tracing SDK
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)**
 
 A lightweight OpenTelemetry-based tracing SDK for Respan, built with minimal dependencies and optional instrumentation support.
 Inspired by [Openllmetry](https://github.com/traceloop/openllmetry-js)

--- a/javascript-sdks/respan/README.md
+++ b/javascript-sdks/respan/README.md
@@ -1,6 +1,6 @@
 # Respan TypeScript SDK
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[npm](https://www.npmjs.com/package/@respan/respan)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)** | **[npm](https://www.npmjs.com/package/@respan/respan)**
 
 `@respan/respan` is the unified TypeScript and JavaScript entry point for Respan tracing, lifecycle management, context propagation, and first-party instrumentation plugins. It automatically discovers eligible direct LLM SDK adapters while keeping frameworks, agents, wrappers, and observability bridges explicit to avoid duplicate spans.
 
@@ -156,5 +156,5 @@ Apache 2.0 — see the repository [LICENSE](../../LICENSE).
 ## Support
 
 - Email: [team@respan.ai](mailto:team@respan.ai)
-- Documentation: [https://docs.respan.ai](https://docs.respan.ai)
+- Documentation: [https://www.respan.ai/docs](https://www.respan.ai/docs)
 - Issues: [GitHub Issues](https://github.com/respanai/respan/issues)

--- a/javascript-sdks/respan/examples/prompt_workflow_example.py
+++ b/javascript-sdks/respan/examples/prompt_workflow_example.py
@@ -313,6 +313,6 @@ if __name__ == "__main__":
 
     print("\n🎉 All examples completed!")
     print("\nFor more information, check out:")
-    print("- Respan Documentation: https://docs.respan.ai")
-    print("- API Reference: https://docs.respan.ai/api")
-    print("- Testing Guide: https://github.com/Repsan/respan/blob/main/python-sdks/respan/TESTING_STRATEGY.md")
+    print("- Respan Documentation: https://www.respan.ai/docs")
+    print("- API Reference: https://www.respan.ai/docs")
+    print("- Testing Guide: https://github.com/respanai/respan/blob/main/python-sdks/respan/TESTING_STRATEGY.md")

--- a/python-sdks/instrumentations/respan-instrumentation-langfuse/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-langfuse/README.md
@@ -1,6 +1,6 @@
 # Respan Instrumentation for Langfuse
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-instrumentation-langfuse/)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)** | **[PyPI](https://pypi.org/project/respan-instrumentation-langfuse/)**
 
 **OTEL-compliant** automatic instrumentation for Langfuse to send traces to Respan.
 
@@ -200,6 +200,6 @@ Apache 2.0
 
 ## Support
 
-- Documentation: https://docs.respan.ai
-- Issues: https://github.com/Repsan/respan/issues
+- Documentation: https://www.respan.ai/docs
+- Issues: https://github.com/respanai/respan/issues
 - Email: support@respan.ai

--- a/python-sdks/legacy/respan-exporter-agno/README.md
+++ b/python-sdks/legacy/respan-exporter-agno/README.md
@@ -1,6 +1,6 @@
 # Respan Exporter for Agno
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-exporter-agno/)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)** | **[PyPI](https://pypi.org/project/respan-exporter-agno/)**
 
 Respan exporter for Agno traces.
 

--- a/python-sdks/legacy/respan-exporter-haystack/README.md
+++ b/python-sdks/legacy/respan-exporter-haystack/README.md
@@ -1,6 +1,6 @@
 # Respan Haystack Integration
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-exporter-haystack/)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)** | **[PyPI](https://pypi.org/project/respan-exporter-haystack/)**
 
 Respan integration for Haystack pipelines with tracing and logging support.
 
@@ -316,9 +316,9 @@ python examples/combined_example.py
 
 ## Support
 
-- **Documentation:** https://docs.respan.ai/
+- **Documentation:** https://www.respan.ai/docs/
 - **Dashboard:** https://platform.respan.ai/
-- **Issues:** [GitHub Issues](https://github.com/Repsan/respan/issues)
+- **Issues:** [GitHub Issues](https://github.com/respanai/respan/issues)
 
 ---
 

--- a/python-sdks/legacy/respan-exporter-haystack/pyproject.toml
+++ b/python-sdks/legacy/respan-exporter-haystack/pyproject.toml
@@ -7,8 +7,8 @@ readme = "README.md"
 license = "MIT"
 packages = [{include = "respan_exporter_haystack", from = "src"}]
 homepage = "https://respan.ai"
-repository = "https://github.com/respan-ai/respan-sdks"
-documentation = "https://docs.respan.ai"
+repository = "https://github.com/respanai/respan"
+documentation = "https://www.respan.ai/docs"
 keywords = ["haystack", "respan", "llm", "observability", "tracing", "monitoring"]
 
 [tool.poetry.dependencies]

--- a/python-sdks/legacy/respan-exporter-litellm/README.md
+++ b/python-sdks/legacy/respan-exporter-litellm/README.md
@@ -1,6 +1,6 @@
 # Respan LiteLLM Exporter
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-exporter-litellm/)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)** | **[PyPI](https://pypi.org/project/respan-exporter-litellm/)**
 
 LiteLLM integration for exporting logs and traces to Respan.
 

--- a/python-sdks/legacy/respan-exporter-pydantic-ai/README.md
+++ b/python-sdks/legacy/respan-exporter-pydantic-ai/README.md
@@ -1,6 +1,6 @@
 # Respan Exporter for Pydantic AI
 
-**[respan.ai](https://respan.ai)** · **[Documentation](https://docs.respan.ai)** · **[PyPI](https://pypi.org/project/respan-exporter-pydantic-ai/)**
+**[respan.ai](https://respan.ai)** · **[Documentation](https://www.respan.ai/docs)** · **[PyPI](https://pypi.org/project/respan-exporter-pydantic-ai/)**
 
 Instrument [Pydantic AI](https://ai.pydantic.dev/) agents with Respan: traces, spans, and metrics are sent to Respan via OpenTelemetry and standard semantic conventions. Requires [respan-tracing](https://pypi.org/project/respan-tracing/) (installed automatically).
 
@@ -125,7 +125,7 @@ RESPAN_API_KEY="your-key" poetry run python scripts/run_real_gateway_test.py
 ## Further Reading
 
 - [Pydantic AI example project](https://github.com/Nightingalelyy/respan-example-projects/tree/main/python/tracing/pydantic-ai) — runnable integration examples
-- [Respan documentation](https://docs.respan.ai)
+- [Respan documentation](https://www.respan.ai/docs)
 - [Pydantic AI documentation](https://ai.pydantic.dev/)
 - [respan-tracing on PyPI](https://pypi.org/project/respan-tracing/)
 - [OpenTelemetry Semantic Conventions for LLM spans](https://opentelemetry.io/docs/semconv/ai/llm-spans/)

--- a/python-sdks/respan-exporter-openai-agents/README.md
+++ b/python-sdks/respan-exporter-openai-agents/README.md
@@ -1,5 +1,5 @@
 # Respan Exporter for OpenAI Agents SDK
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-exporter-openai-agents/)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)** | **[PyPI](https://pypi.org/project/respan-exporter-openai-agents/)**
 
 Exporter for OpenAI Agents telemetry to Respan.

--- a/python-sdks/respan-sdk/README.md
+++ b/python-sdks/respan-sdk/README.md
@@ -1,6 +1,6 @@
 ## Respan SDK
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-sdk/)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)** | **[PyPI](https://pypi.org/project/respan-sdk/)**
 
 Light weight library for Respan type definitions and API payload preprocessing
 
@@ -10,7 +10,7 @@ Features:
 - Conversion, converting input types from Anthropic API format into OpenAI API format.
 - **Filter types** — typed vocabulary for the Respan filter system, shared across BE and SDKs.
 
-For **tracing**, please go to [Respan Tracing](https://github.com/respan-ai/respan-sdks/tree/main/python-sdks/respan-tracing) instead.
+For **tracing**, please go to [Respan Tracing](https://github.com/respanai/respan/tree/main/python-sdks/respan-tracing) instead.
 
 ### Filter Types
 

--- a/python-sdks/respan-sdk/pyproject.toml
+++ b/python-sdks/respan-sdk/pyproject.toml
@@ -33,5 +33,5 @@ dev = ["pytest", "python-dotenv"]
 
 [tool.poetry.urls]
 Homepage = "https://respan.ai"
-Repository = "https://github.com/respan-ai/respan-sdks.git"
-Documentation = "https://docs.respan.ai"
+Repository = "https://github.com/respanai/respan.git"
+Documentation = "https://www.respan.ai/docs"

--- a/python-sdks/respan-tracing/README.md
+++ b/python-sdks/respan-tracing/README.md
@@ -1,6 +1,6 @@
 # Building an LLM Workflow with Respan Tracing
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-tracing/)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)** | **[PyPI](https://pypi.org/project/respan-tracing/)**
 
 This tutorial demonstrates how to build and trace complex LLM workflows using Respan Tracing. We'll create an example that generates jokes, translates them to pirate language, and simulates audience reactions - all while capturing detailed telemetry of our LLM calls.
 

--- a/python-sdks/respan/README.md
+++ b/python-sdks/respan/README.md
@@ -1,6 +1,6 @@
 # Respan Python SDK
 
-**[respan.ai](https://respan.ai)** | **[Documentation](https://docs.respan.ai)** | **[PyPI](https://pypi.org/project/respan-ai/)**
+**[respan.ai](https://respan.ai)** | **[Documentation](https://www.respan.ai/docs)** | **[PyPI](https://pypi.org/project/respan-ai/)**
 
 `respan-ai` is the unified Python entry point for Respan tracing, decorators, context propagation, and first-party instrumentation plugins. It automatically discovers eligible direct LLM SDK adapters while keeping frameworks, agents, wrappers, and observability bridges explicit to avoid duplicate spans.
 
@@ -160,5 +160,5 @@ Apache 2.0 — see the repository [LICENSE](../../LICENSE).
 ## Support
 
 - Email: [team@respan.ai](mailto:team@respan.ai)
-- Documentation: [https://docs.respan.ai](https://docs.respan.ai)
+- Documentation: [https://www.respan.ai/docs](https://www.respan.ai/docs)
 - Issues: [GitHub Issues](https://github.com/respanai/respan/issues)


### PR DESCRIPTION
## Summary
- `docs.respan.ai` no longer resolves (DNS failure). Replaced with `www.respan.ai/docs`, remapping deep paths to the site's current structure where the plain domain swap 404'd (e.g. `/docs/get-started/overview` → `/docs/documentation/get-started/quickstart`, `/docs/features/monitoring/traces/integrations/*` → `/docs/integrations/*`).
- `github.com/respan-ai/respan-sdks` (404, org no longer exists under that name) → `github.com/respanai/respan`.
- `github.com/Repsan/respan` (letter-transposition typo) → `github.com/respanai/respan`.
- `README.md`: the `respan-static.s3.us-east-1.amazonaws.com` bucket referenced for header/cover images no longer exists at all. Swapped to the live `cdn.respan.ai` CDN. The exact original `logo-header.jpg`, `logo-header-dark.jpg`, and `github-cover.jpg` objects are gone from the origin bucket with no trace (versioning was never enabled, no delete markers) — replaced with the closest current brand assets (`wordmark-light.png`, `wordmark-dark.png`, `og-home-tracing.png`).

All replacement URLs were verified with live HTTP 200 checks before committing.

## Test plan
- [x] Every replacement URL curl'd for a 200 response
- [x] `grep`'d the repo for remaining occurrences of the old broken patterns — none found outside an auto-generated `CHANGELOG.md` (left untouched since it's tied to real commit hashes and GitHub still redirects the old org name)