### PR TITLE
fix(instrumentation/claude-agent-sdk): capture content by default

### DIFF
--- a/.release-intents/20260812-claude-agent-sdk-capture-content-default.json
+++ b/.release-intents/20260812-claude-agent-sdk-capture-content-default.json
@@ -1,0 +1,6 @@
+{
+  "summary": "claude-agent-sdk instrumentation: default capture_content=True so traces carry prompts, tool arguments, and tool results by default. It silently overrode the upstream default to False, leaving Claude Agent SDK traces content-empty while every other Respan instrumentation captures content by default. Pass capture_content=False to opt out.",
+  "packages": {
+    "respan-instrumentation-claude-agent-sdk": "minor"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
@@ -48,8 +48,16 @@ class ClaudeAgentSDKInstrumentor:
         self,
         *,
         agent_name: str | None = None,
-        capture_content: bool = False,
+        capture_content: bool = True,
     ) -> None:
+        """
+        Args:
+            agent_name: Optional name applied to the root agent span.
+            capture_content: Capture prompts, tool arguments, and tool results as
+                span content. Defaults to True to match Respan's other
+                instrumentations (which capture content by default); pass False to
+                emit structure-only spans when content must not leave the process.
+        """
         self._agent_name = agent_name
         self._capture_content = capture_content
         self._otel_instrumentor = None


### PR DESCRIPTION
## Problem
`ClaudeAgentSDKInstrumentor` defaulted `capture_content=False`, **silently overriding** the upstream `opentelemetry-claude-agent-sdk` default (`True`). Result: every Claude Agent SDK trace was **structure-only** — span names + hierarchy, but **no prompts, tool arguments, or tool results** — while every *other* Respan instrumentation (OpenAI, Anthropic, …) captures content by default. A customer tracing a Claude Agent SDK app got empty, useless traces unless they found the undocumented flag.

## Fix
Flip the default to `capture_content=True` ([`_instrumentation.py:51`](python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py:51)) so it matches the rest of the SDK. Pass `capture_content=False` to opt out.

## How it was found
Dogfooding the Respan integration agent (built on the Claude Agent SDK): its own onboarding session traced as **0/24 spans with content**. With the fix: **24/24 spans have input, 11/24 output** — you can see the agent read `tracing.md`, run commands, edit files.

Release-intent: `respan-instrumentation-claude-agent-sdk` minor (default behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)