### PR TITLE
fix(py): repair autogen crash and smolagents import (found by trace verification)

### DIFF
--- a/.release-intents/20260812-python-autogen-smolagents-tracing-fixes.json
+++ b/.release-intents/20260812-python-autogen-smolagents-tracing-fixes.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Fix two broken Python instrumentations found by trace verification: autogen crashed the user's agent.run() by mutating an ended span's immutable attributes; smolagents failed to import due to six SPAN_ALIAS_* constants that were never published in respan-sdk",
+  "packages": {
+    "respan-instrumentation-autogen": "patch",
+    "respan-instrumentation-smolagents": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_native_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_native_processor.py
@@ -29,10 +29,14 @@ _AUTOGEN_OPERATION_LOG_TYPES = {
 
 
 def _get_mutable_attributes(span: ReadableSpan) -> dict[str, Any] | None:
+    # An ended span's ``_attributes`` is a ``BoundedAttributes`` that is frozen
+    # (``_immutable``) on opentelemetry-sdk once the span has ended, so writing
+    # to it in place raises ``TypeError``. Return a mutable copy; the caller
+    # reassigns ``span._attributes`` after normalizing.
     attrs = getattr(span, "_attributes", None)
     if attrs is None:
         return None
-    return attrs
+    return dict(attrs)
 
 
 def _get_scope_name(span: ReadableSpan) -> str | None:
@@ -80,6 +84,9 @@ class AutoGenNativeSpanProcessor(SpanProcessor):
         )
         attrs.pop(GEN_AI_SYSTEM, None)
         attrs.pop(SpanAttributes.LLM_REQUEST_TYPE, None)
+        # Reassign the normalized copy; the original frozen BoundedAttributes
+        # cannot be mutated in place after the span has ended.
+        span._attributes = attrs
 
     def shutdown(self) -> None:
         return None

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/tests/test_native_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/tests/test_native_processor.py
@@ -62,6 +62,35 @@ def test_processor_maps_native_execute_tool_to_tool_log_type():
     assert SpanAttributes.LLM_REQUEST_TYPE not in span._attributes
 
 
+def test_processor_handles_immutable_ended_span_attributes():
+    """Regression: a real *ended* span exposes ``_attributes`` as a frozen
+    ``BoundedAttributes``. Mutating it in place raises ``TypeError`` (which
+    previously propagated out of the user's ``agent.run()``). The processor
+    must copy + reassign instead."""
+    from opentelemetry.attributes import BoundedAttributes
+
+    frozen = BoundedAttributes(
+        attributes={
+            GEN_AI_OPERATION_NAME: AUTOGEN_OPERATION_INVOKE_AGENT,
+            GEN_AI_SYSTEM: "autogen",
+            GEN_AI_AGENT_NAME: "planner",
+        },
+        immutable=True,
+    )
+    span = SimpleNamespace(
+        name="test-span",
+        _attributes=frozen,
+        instrumentation_scope=SimpleNamespace(name=AUTOGEN_CORE_SCOPE_NAME),
+    )
+
+    # Must not raise TypeError.
+    AutoGenNativeSpanProcessor().on_end(span)
+
+    assert span._attributes[RESPAN_LOG_TYPE] == LOG_TYPE_AGENT
+    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "planner"
+    assert GEN_AI_SYSTEM not in span._attributes
+
+
 def test_processor_ignores_non_autogen_core_scope():
     span = _make_span(
         {

--- a/python-sdks/instrumentations/respan-instrumentation-smolagents/src/respan_instrumentation_smolagents/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-smolagents/src/respan_instrumentation_smolagents/_constants.py
@@ -37,3 +37,13 @@ OPENINFERENCE_MESSAGE_CONTENT_TYPE_ATTR = (
 OPENINFERENCE_MESSAGE_CONTENT_TEXT_ATTR = (
     OIMessageContentAttributes.MESSAGE_CONTENT_TEXT
 )
+
+# Off-contract OpenInference source attributes. The smolagents processor
+# translates these into the canonical Respan/GenAI contract and then strips the
+# raw aliases before export so they do not leak to the backend.
+SPAN_ALIAS_MODEL = OISpanAttributes.LLM_MODEL_NAME
+SPAN_ALIAS_PROMPT_TOKENS = OISpanAttributes.LLM_TOKEN_COUNT_PROMPT
+SPAN_ALIAS_COMPLETION_TOKENS = OISpanAttributes.LLM_TOKEN_COUNT_COMPLETION
+SPAN_ALIAS_TOTAL_REQUEST_TOKENS = OISpanAttributes.LLM_TOKEN_COUNT_TOTAL
+SPAN_ALIAS_TOOLS = OISpanAttributes.LLM_TOOLS
+SPAN_ALIAS_TOOL_CALLS = OIMessageAttributes.MESSAGE_TOOL_CALLS

--- a/python-sdks/instrumentations/respan-instrumentation-smolagents/src/respan_instrumentation_smolagents/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-smolagents/src/respan_instrumentation_smolagents/_processor.py
@@ -12,15 +12,15 @@ from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
 from respan_sdk.constants.span_attributes import (
     RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
+)
+from respan_instrumentation_smolagents._constants import (
+    ASSISTANT_ROLE,
     SPAN_ALIAS_COMPLETION_TOKENS,
     SPAN_ALIAS_MODEL,
     SPAN_ALIAS_PROMPT_TOKENS,
     SPAN_ALIAS_TOOL_CALLS,
     SPAN_ALIAS_TOOLS,
     SPAN_ALIAS_TOTAL_REQUEST_TOKENS,
-)
-from respan_instrumentation_smolagents._constants import (
-    ASSISTANT_ROLE,
     GEN_AI_COMPLETION_CONTENT_ATTR,
     GEN_AI_COMPLETION_ROLE_ATTR,
     GEN_AI_COMPLETION_TOOL_CALLS_ATTR,

--- a/python-sdks/instrumentations/respan-instrumentation-smolagents/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-smolagents/tests/test_instrumentation.py
@@ -8,6 +8,8 @@ from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
 from respan_sdk.constants.span_attributes import (
     RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
+)
+from respan_instrumentation_smolagents._constants import (
     SPAN_ALIAS_COMPLETION_TOKENS,
     SPAN_ALIAS_MODEL,
     SPAN_ALIAS_PROMPT_TOKENS,


### PR DESCRIPTION
Two published Python instrumentations were broken; both surfaced while verifying real traces end-to-end through the Respan gateway.

## `autogen` — instrumentation crashed the user's `agent.run()`
`AutoGenNativeSpanProcessor.on_end` mutated the ended span's `_attributes` in place. On `opentelemetry-sdk`, an ended span's attributes are a frozen `BoundedAttributes`, so the write raised `TypeError` — which propagated out of `agent.run()`, aborting the user's call and exporting **zero** spans. (The completion itself succeeded; only the instrumentation crashed.)

**Fix:** copy attributes into a plain dict, normalize, and reassign `span._attributes` — the same copy-and-reassign pattern the other native processors already use. Added a regression test that drives `on_end` with a real immutable `BoundedAttributes` (the prior tests used a plain `dict`, which is why this shipped).

**Verified end-to-end:** `agent.run()` now completes and `invoke_agent` is normalized to `kind=agent` with the LLM marker removed.

## `smolagents` — package unimportable
`_processor.py` imported six `SPAN_ALIAS_*` constants from `respan_sdk.constants.span_attributes` that **were never published there**. With a loose pin (`respan-sdk >=2.5.0`), pip installs an sdk without them and `import SmolagentsInstrumentor` fails with `ImportError` — the package is unusable as published.

**Fix:** these aliases are the raw OpenInference source keys the processor strips after translating to the Respan contract, so define them locally in `_constants.py` from the OpenInference semconv constants (`llm.model_name`, `llm.token_count.*`, `llm.tools`, `message.tool_calls`) and import from there. Also fixed the test module's identical broken import.

**Verified end-to-end:** smolagents emits its full `agent → workflow → chat + tool` span tree.

## Tests
- autogen: 4/4 (incl. new immutable-attrs regression)
- smolagents: 12/12
- Both also validated with a live gateway run (`<name>-integration_test` app names).

Part of a broader trace-verification sweep across the Python instrumentations (21/23 verified working; these two were the failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)