### PR TITLE
fix(instrumentation-js): repair BeeAI, Flue, and Google ADK OTel 2.x spans

### DIFF
--- a/.release-intents/20260815-otel2-js-group-1.json
+++ b/.release-intents/20260815-otel2-js-group-1.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Fix OTel 2.x BeeAI agent, Flue compaction, and Google ADK streaming spans",
+  "packages": {
+    "@respan/instrumentation-beeai": "patch",
+    "@respan/instrumentation-flue": "patch",
+    "@respan/instrumentation-google-adk": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-beeai/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-beeai/src/index.ts
@@ -56,6 +56,7 @@ const BEEAI_TARGET = "target";
 const BEEAI_DATA = "data";
 const BEEAI_TRACE_ID = "traceId";
 const BEEAI_VERSION = "beeai.version";
+const BEEAI_HISTORY = "history";
 const OTEL_SCOPE_NAME = "otel.scope.name";
 const MAX_PENDING_CHAT_INPUTS = 20;
 const MAX_PENDING_CHAT_SPANS_PER_TRACE = 64;
@@ -84,6 +85,7 @@ interface PendingChatSpan {
 
 const droppedSpanParentsByTrace = new Map<string, Map<string, string | undefined>>();
 const workflowSpanIdsByTrace = new Map<string, string>();
+const toolCallingAgentWrapperSpanIdsByTrace = new Map<string, Set<string>>();
 const pendingChatInputsByTrace = new Map<string, unknown[]>();
 const pendingChatSpansByTrace = new Map<string, PendingChatSpan[]>();
 const traceStateTouchedAt = new Map<string, number>();
@@ -93,6 +95,7 @@ function clearTraceState(traceId: string, flushPending = true): void {
 
   droppedSpanParentsByTrace.delete(traceId);
   workflowSpanIdsByTrace.delete(traceId);
+  toolCallingAgentWrapperSpanIdsByTrace.delete(traceId);
   pendingChatInputsByTrace.delete(traceId);
   pendingChatSpansByTrace.delete(traceId);
   traceStateTouchedAt.delete(traceId);
@@ -300,6 +303,50 @@ function getOtelParentSpanId(span: ReadableSpan): string | undefined {
     : undefined;
 }
 
+function isBeeAIStructuralSpanName(name: string): boolean {
+  return /\.(?:start|finish)(?:-\d+)?$/.test(name);
+}
+
+function rememberToolCallingAgentWrapper(span: ReadableSpan): void {
+  if (!span.name.startsWith("agent.toolCalling.")) return;
+
+  const traceId = getOtelTraceId(span);
+  const wrapperSpanId = getOtelParentSpanId(span);
+  if (!traceId || !wrapperSpanId) return;
+
+  const wrapperSpanIds = toolCallingAgentWrapperSpanIdsByTrace.get(traceId) ?? new Set();
+  wrapperSpanIds.delete(wrapperSpanId);
+  wrapperSpanIds.add(wrapperSpanId);
+  while (wrapperSpanIds.size > MAX_DROPPED_SPAN_PARENTS_PER_TRACE) {
+    const oldestWrapperSpanId = wrapperSpanIds.values().next().value as string | undefined;
+    if (!oldestWrapperSpanId) break;
+    wrapperSpanIds.delete(oldestWrapperSpanId);
+  }
+  toolCallingAgentWrapperSpanIdsByTrace.set(traceId, wrapperSpanIds);
+  droppedSpanParentsByTrace.get(traceId)?.delete(wrapperSpanId);
+  touchTraceState(traceId);
+}
+
+function isToolCallingAgentWrapper(span: ReadableSpan): boolean {
+  const traceId = getOtelTraceId(span);
+  const spanId = getOtelSpanId(span);
+  return Boolean(
+    traceId &&
+    spanId &&
+    toolCallingAgentWrapperSpanIdsByTrace.get(traceId)?.has(spanId)
+  );
+}
+
+function isToolCallingAgentEventForRecoveredWrapper(span: ReadableSpan): boolean {
+  const traceId = getOtelTraceId(span);
+  const parentSpanId = getOtelParentSpanId(span);
+  return Boolean(
+    traceId &&
+    parentSpanId &&
+    toolCallingAgentWrapperSpanIdsByTrace.get(traceId)?.has(parentSpanId)
+  );
+}
+
 function rememberDroppedSpanParent(span: ReadableSpan): void {
   const traceId = getOtelTraceId(span);
   const spanId = getOtelSpanId(span);
@@ -358,7 +405,7 @@ function reparentFromDroppedSpans(span: ReadableSpan): void {
   const currentParentSpanId = getOtelParentSpanId(span);
   const traceId = getOtelTraceId(span);
   const workflowSpanId = traceId ? workflowSpanIdsByTrace.get(traceId) : undefined;
-  const resolvedParentSpanId = workflowSpanId ?? resolveExportParentSpanId(span);
+  const resolvedParentSpanId = resolveExportParentSpanId(span) ?? workflowSpanId;
   if (resolvedParentSpanId === currentParentSpanId) return;
 
   Object.defineProperty(span, "parentSpanId", {
@@ -873,6 +920,76 @@ function getOpenInferenceOutput(attrs: Record<string, any>): unknown {
   return parseJson(attrs[OPENINFERENCE_OUTPUT_VALUE]);
 }
 
+function normalizeToolCallingAgentOutput(output: unknown): unknown {
+  const record = asRecord(output);
+  if (!record || record.text === undefined || record.content !== undefined) {
+    return normalizeOutputValue(output);
+  }
+
+  return {
+    role: typeof record.role === "string" ? record.role : "assistant",
+    content: record.text,
+  };
+}
+
+function normalizeToolCallingAgentHistory(history: unknown): unknown[] | undefined {
+  const parsedHistory = parseJson(history);
+  if (!Array.isArray(parsedHistory)) return undefined;
+
+  const normalizedHistory = parsedHistory.flatMap((message) => {
+    const record = asRecord(message);
+    if (!record) return [];
+
+    const normalized: Record<string, unknown> = {};
+    if (typeof record.role === "string" && record.role.length > 0) {
+      normalized.role = record.role;
+    }
+
+    const content = firstDefined(record.content, record.text);
+    if (content !== undefined) {
+      normalized.content = content;
+    }
+
+    return isMeaningfulStructuredValue(normalized) ? [normalized] : [];
+  });
+  return normalizedHistory.length > 0 ? normalizedHistory : undefined;
+}
+
+function translateToolCallingAgentWrapper(
+  span: ReadableSpan,
+  attrs: Record<string, any>,
+): void {
+  setDefault(attrs, RespanSpanAttributes.RESPAN_LOG_TYPE, RespanLogType.AGENT);
+  setDefault(
+    attrs,
+    SpanAttributes.TRACELOOP_ENTITY_NAME,
+    typeof attrs.source === "string" && attrs.source.length > 0
+      ? attrs.source
+      : "ToolCallingAgent",
+  );
+  setDefault(attrs, SpanAttributes.TRACELOOP_ENTITY_PATH, span.name);
+
+  const prompt = normalizeMeaningfulInputValue(getOpenInferenceInput(attrs));
+  const history = normalizeToolCallingAgentHistory(attrs[BEEAI_HISTORY]);
+  const input = history
+    ? {
+        ...(prompt !== undefined ? { prompt } : {}),
+        history,
+      }
+    : prompt;
+  if (input !== undefined) {
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJsonStr(input);
+  }
+
+  const output = normalizeToolCallingAgentOutput(getOpenInferenceOutput(attrs));
+  if (isMeaningfulStructuredValue(output)) {
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJsonStr(output);
+  }
+
+  reparentFromDroppedSpans(span);
+  cleanupBeeAIRawAttributes(attrs);
+}
+
 function cacheBeeAIStartSpan(span: ReadableSpan): void {
   const attrs = (span as any).attributes as Record<string, any> | undefined;
   if (!attrs) return;
@@ -880,11 +997,22 @@ function cacheBeeAIStartSpan(span: ReadableSpan): void {
   rememberWorkflowSpan(span, attrs);
 
   if (span.name === "beeai-framework-main" || isBeeAIFrameworkParentSpan(span, attrs)) {
-    rememberDroppedSpanParent(span);
+    if (!isToolCallingAgentWrapper(span)) {
+      rememberDroppedSpanParent(span);
+    }
     return;
   }
 
   if (getInstrumentationScopeName(span) !== BEEAI_SCOPE_NAME) return;
+
+  // OITracer applies attributes after onStart, but the upstream event name and
+  // OTEL parent are already available. Record the ToolCallingAgent wrapper and
+  // structural parents here so children can be reparented before their parent
+  // event spans finish.
+  rememberToolCallingAgentWrapper(span);
+  if (isBeeAIStructuralSpanName(span.name)) {
+    rememberDroppedSpanParent(span);
+  }
 
   const target = attrs[BEEAI_TARGET];
   const data = asRecord(parseJson(attrs[BEEAI_DATA]));
@@ -921,6 +1049,7 @@ function cleanupBeeAIRawAttributes(attrs: Record<string, any>): void {
   delete attrs[OPENINFERENCE_METADATA];
   delete attrs[BEEAI_TRACE_ID];
   delete attrs[BEEAI_VERSION];
+  delete attrs[BEEAI_HISTORY];
   delete attrs.source;
   delete attrs[OPENINFERENCE_INPUT_VALUE];
   delete attrs[OPENINFERENCE_OUTPUT_VALUE];
@@ -1034,6 +1163,10 @@ function translateBeeAIEventSpan(span: ReadableSpan): void {
   cacheBeeAIStartSpan(span);
 
   if (isBeeAIFrameworkParentSpan(span, attrs)) {
+    if (isToolCallingAgentWrapper(span)) {
+      translateToolCallingAgentWrapper(span, attrs);
+      return;
+    }
     dropSpan(span, attrs);
     return;
   }
@@ -1100,7 +1233,10 @@ function translateBeeAIEventSpan(span: ReadableSpan): void {
   setInputOutputAttributes(span, attrs, logType, target, data, value);
   if (
     target === "agent.toolCalling.success" &&
-    !hasMeaningfulCanonicalEntityContent(attrs)
+    (
+      isToolCallingAgentEventForRecoveredWrapper(span) ||
+      !hasMeaningfulCanonicalEntityContent(attrs)
+    )
   ) {
     dropSpan(span, attrs);
     cleanupBeeAIRawAttributes(attrs);
@@ -1501,6 +1637,7 @@ export class BeeAIInstrumentor {
     pendingChatSpansByTrace.clear();
     droppedSpanParentsByTrace.clear();
     workflowSpanIdsByTrace.clear();
+    toolCallingAgentWrapperSpanIdsByTrace.clear();
     traceStateTouchedAt.clear();
     BeeAIInstrumentor._trackedBeeAISpans.clear();
     BeeAIInstrumentor._patchedProcessor = null;

--- a/javascript-sdks/instrumentations/respan-instrumentation-beeai/tests/beeai_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-beeai/tests/beeai_instrumentor.test.mjs
@@ -627,13 +627,6 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
         is_error: false,
       },
     ];
-    const normalizedAgentInput = {
-      iteration: 1,
-      messages: [
-        { role: "user", content: `Compute ${expression}` },
-        { role: "assistant", content: "", tool_calls: [normalizedToolCall] },
-      ],
-    };
     const basicUserMessage = {
       role: "user",
       content: [{ type: "text", text: "Explain tracing in one sentence." }],
@@ -729,7 +722,7 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
       name: "tool.calculator.success-1",
       traceId: "otel-trace-1",
       spanId: "tool-span-1",
-      parentSpanId: "chat-span-1",
+      parentSpanId: "start-span-1",
       attributes: {
         target: "tool.calculator.success",
         traceId: "trace-1",
@@ -743,7 +736,7 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
       name: "agent.toolCalling.success-1",
       traceId: "otel-trace-1",
       spanId: "agent-span-1",
-      parentSpanId: "chat-span-1",
+      parentSpanId: "framework-span",
       attributes: {
         target: "agent.toolCalling.success",
         traceId: "trace-1",
@@ -783,7 +776,7 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
       name: "tool.dynamic.finalAnswer.success-1",
       traceId: "otel-trace-1",
       spanId: "final-answer-span-1",
-      parentSpanId: "chat-span-2",
+      parentSpanId: "agent-span-1",
       attributes: {
         target: "tool.dynamic.finalAnswer.success",
         traceId: "trace-1",
@@ -811,6 +804,12 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
         traceId: "trace-1",
         source: "ToolCallingAgent",
         "beeai.version": "0.1.13",
+        "input.value": `Compute ${expression}`,
+        "output.value": JSON.stringify({ role: "assistant", text: "84" }),
+        history: JSON.stringify([
+          { role: "user", text: `Compute ${expression}` },
+          { role: "assistant", text: "84" },
+        ]),
       },
     });
     const workflowSpan = makeSpan({
@@ -856,15 +855,16 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
       basicChatSpan,
       toolSpan,
       chatSpan,
-      agentSpan,
       chat2Span,
       finalAnswerSpan,
+      parentSpan,
     ]);
     assert.deepEqual(agentStartSpan.attributes["respan.processors"], []);
+    assert.deepEqual(agentSpan.attributes["respan.processors"], []);
     assert.deepEqual(emptyAgentSpan.attributes["respan.processors"], []);
     assert.equal(emptyAgentSpan.attributes.target, undefined);
     assert.deepEqual(finishSpan.attributes["respan.processors"], []);
-    assert.deepEqual(parentSpan.attributes["respan.processors"], []);
+    assert.equal(parentSpan.attributes["respan.processors"], undefined);
 
     assert.equal(basicChatSpan.attributes["respan.entity.log_type"], "chat");
     assert.equal(basicChatSpan.attributes["llm.request.type"], "chat");
@@ -891,7 +891,7 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
       "Tracing shows each step and value in a run.",
     );
 
-    assert.equal(chatSpan.parentSpanId, "workflow-span");
+    assert.equal(chatSpan.parentSpanId, "framework-span");
     assert.equal(chatSpan.attributes["respan.entity.log_type"], "chat");
     assert.equal(chatSpan.attributes["llm.request.type"], "chat");
     assert.equal(chatSpan.attributes["gen_ai.system"], "openai");
@@ -913,20 +913,30 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
       JSON.stringify([normalizedToolCall]),
     );
 
-    assert.equal(toolSpan.parentSpanId, "workflow-span");
+    assert.equal(toolSpan.parentSpanId, "framework-span");
     assert.equal(toolSpan.attributes["respan.entity.log_type"], "tool");
     assert.equal(toolSpan.attributes["traceloop.entity.input"], JSON.stringify({ expression }));
     assert.equal(toolSpan.attributes["traceloop.entity.output"], JSON.stringify({ result: 84 }));
 
-    assert.equal(agentSpan.parentSpanId, "workflow-span");
-    assert.equal(agentSpan.attributes["respan.entity.log_type"], "agent");
-    assert.equal(agentSpan.attributes["traceloop.entity.input"], JSON.stringify(normalizedAgentInput));
+    assert.equal(parentSpan.parentSpanId, "workflow-span");
+    assert.equal(parentSpan.attributes["respan.entity.log_type"], "agent");
+    assert.equal(parentSpan.attributes["traceloop.entity.name"], "ToolCallingAgent");
+    assert.deepEqual(
+      JSON.parse(parentSpan.attributes["traceloop.entity.input"]),
+      {
+        prompt: `Compute ${expression}`,
+        history: [
+          { role: "user", content: `Compute ${expression}` },
+          { role: "assistant", content: "84" },
+        ],
+      },
+    );
     assert.equal(
-      agentSpan.attributes["traceloop.entity.output"],
-      JSON.stringify({ result: "84", is_error: false }),
+      parentSpan.attributes["traceloop.entity.output"],
+      JSON.stringify({ role: "assistant", content: "84" }),
     );
 
-    assert.equal(chat2Span.parentSpanId, "workflow-span");
+    assert.equal(chat2Span.parentSpanId, "framework-span");
     assert.equal(chat2Span.attributes["respan.entity.log_type"], "chat");
     assert.equal(chat2Span.attributes["llm.request.type"], "chat");
     assert.equal(chat2Span.attributes["gen_ai.request.model"], "gpt-4o-mini");
@@ -956,7 +966,7 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
       JSON.stringify([normalizedFinalToolCall]),
     );
 
-    assert.equal(finalAnswerSpan.parentSpanId, "workflow-span");
+    assert.equal(finalAnswerSpan.parentSpanId, "framework-span");
     assert.equal(finalAnswerSpan.attributes["respan.entity.log_type"], "tool");
     assert.equal(finalAnswerSpan.attributes["traceloop.entity.input"], JSON.stringify({ response: "84" }));
     assert.equal(finalAnswerSpan.attributes["traceloop.entity.output"], "84");
@@ -966,6 +976,9 @@ test("BeeAIInstrumentor exports only complete BeeAI event rows", async () => {
         "target",
         "data",
         "metadata",
+        "history",
+        "source",
+        "beeai.version",
         "traceId",
         "input.value",
         "output.value",

--- a/javascript-sdks/instrumentations/respan-instrumentation-beeai/tests/beeai_otel2_integration.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-beeai/tests/beeai_otel2_integration.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { AsyncLocalStorage } from "node:async_hooks";
 import test from "node:test";
 
-import { trace } from "@opentelemetry/api";
+import { context, ROOT_CONTEXT, trace } from "@opentelemetry/api";
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
@@ -9,22 +10,61 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { BeeAIInstrumentation as OpenInferenceBeeAIInstrumentation } from "@arizeai/openinference-instrumentation-beeai";
 import * as beeaiFramework from "beeai-framework";
+import { ToolCallingAgent } from "beeai-framework/agents/toolCalling/agent";
 import { DummyChatModel } from "beeai-framework/adapters/dummy/backend/chat";
 import { ChatModelOutput } from "beeai-framework/backend/chat";
 import { AssistantMessage, UserMessage } from "beeai-framework/backend/message";
+import { UnconstrainedMemory } from "beeai-framework/memory/unconstrainedMemory";
+import { CalculatorTool } from "beeai-framework/tools/calculator";
 
 import { BeeAIInstrumentor } from "../dist/index.js";
 
-function resetGlobalTracerProvider(provider) {
+class TestAsyncLocalContextManager {
+  storage = new AsyncLocalStorage();
+
+  active() {
+    return this.storage.getStore() ?? ROOT_CONTEXT;
+  }
+
+  with(activeContext, fn, thisArg, ...args) {
+    return this.storage.run(activeContext, () => fn.call(thisArg, ...args));
+  }
+
+  bind(activeContext, target) {
+    if (typeof target !== "function") return target;
+    return (...args) => this.with(activeContext, target, undefined, ...args);
+  }
+
+  enable() {
+    return this;
+  }
+
+  disable() {
+    this.storage.disable();
+    return this;
+  }
+}
+
+function resetGlobalTelemetry(provider, contextManager) {
   if (typeof trace.disable === "function") {
     trace.disable();
+  }
+  if (typeof context.disable === "function") {
+    context.disable();
+  }
+  if (contextManager) {
+    context.setGlobalContextManager(contextManager.enable());
   }
   if (provider) {
     trace.setGlobalTracerProvider(provider);
   }
 }
 
-test("real Arize BeeAI spans retain late OTel 2.x input, model, and usage", async () => {
+function getParentSpanId(span) {
+  return span.parentSpanId ?? span.parentSpanContext?.spanId;
+}
+
+test("real Arize BeeAI spans retain chat data and one complete ToolCallingAgent tree", async () => {
   const exporter = new InMemorySpanExporter();
   const onStartSnapshots = [];
   const startAuditProcessor = {
@@ -46,7 +86,8 @@ test("real Arize BeeAI spans retain late OTel 2.x input, model, and usage", asyn
   });
   const activeSpanProcessor = provider._activeSpanProcessor;
   const originalProcessorOnEnd = activeSpanProcessor.onEnd;
-  resetGlobalTracerProvider(provider);
+  const contextManager = new TestAsyncLocalContextManager();
+  resetGlobalTelemetry(provider, contextManager);
 
   const instrumentor = new BeeAIInstrumentor({
     sdkModule: beeaiFramework,
@@ -122,6 +163,158 @@ test("real Arize BeeAI spans retain late OTel 2.x input, model, and usage", asyn
     ]) {
       assert.equal(attrs[rawAttribute], undefined, `exported raw ${rawAttribute}`);
     }
+
+    let agentModelCall = 0;
+    const agentModel = new DummyChatModel("gpt-4o-mini");
+    agentModel._create = async () => {
+      agentModelCall += 1;
+      const message = agentModelCall === 1
+        ? new AssistantMessage({
+            type: "tool-call",
+            toolCallId: "call-calculator",
+            toolName: "Calculator",
+            args: { expression: "(19 + 23) * 2" },
+          })
+        : new AssistantMessage({
+            type: "tool-call",
+            toolCallId: "call-final-answer",
+            toolName: "final_answer",
+            args: { response: "84" },
+          });
+      return new ChatModelOutput(
+        [message],
+        {
+          promptTokens: agentModelCall * 10,
+          completionTokens: 2,
+          totalTokens: agentModelCall * 10 + 2,
+        },
+        "tool-call",
+      );
+    };
+
+    const agent = new ToolCallingAgent({
+      llm: agentModel,
+      memory: new UnconstrainedMemory(),
+      tools: [new CalculatorTool()],
+    });
+    const agentPrompt = "Compute (19 + 23) * 2";
+    const workflowTracer = trace.getTracer("beeai-otel2-integration");
+    const agentResult = await workflowTracer.startActiveSpan(
+      "beeai_tool_calling_agent.workflow.workflow",
+      { attributes: { "traceloop.span.kind": "workflow" } },
+      async (workflowSpan) => {
+        try {
+          return await agent.run({ prompt: agentPrompt });
+        } finally {
+          workflowSpan.end();
+        }
+      },
+    );
+    assert.equal(agentResult.result.text, "84");
+
+    await provider.forceFlush();
+
+    const finishedSpans = exporter.getFinishedSpans();
+    const visibleSpans = finishedSpans.filter(
+      (span) => !(
+        Array.isArray(span.attributes["respan.processors"]) &&
+        span.attributes["respan.processors"].length === 0
+      ),
+    );
+    const workflowSpan = visibleSpans.find(
+      (span) => span.name === "beeai_tool_calling_agent.workflow.workflow",
+    );
+    assert.ok(workflowSpan, "expected the enclosing workflow span");
+
+    const agentTraceId = workflowSpan.spanContext().traceId;
+    const allAgentTraceSpans = finishedSpans.filter(
+      (span) => span.spanContext().traceId === agentTraceId,
+    );
+    const agentTraceSpans = visibleSpans.filter(
+      (span) => span.spanContext().traceId === agentTraceId,
+    );
+    const agentSpans = agentTraceSpans.filter(
+      (span) => span.attributes["respan.entity.log_type"] === "agent",
+    );
+    assert.equal(agentSpans.length, 1, "expected one recovered agent span");
+
+    const agentSpan = agentSpans[0];
+    assert.equal(agentSpan.name, "beeai-framework-main");
+    assert.equal(getParentSpanId(agentSpan), workflowSpan.spanContext().spanId);
+    assert.equal(agentSpan.attributes["traceloop.entity.name"], "ToolCallingAgent");
+    const canonicalAgentInput = JSON.parse(
+      agentSpan.attributes["traceloop.entity.input"],
+    );
+    assert.equal(canonicalAgentInput.prompt, agentPrompt);
+    assert.deepEqual(
+      canonicalAgentInput.history.map((message) => message.role),
+      ["system", "user", "assistant", "tool", "assistant", "tool"],
+    );
+    assert.match(canonicalAgentInput.history[0].content, /final_answer/);
+    assert.equal(
+      canonicalAgentInput.history[1].content,
+      `Your task: ${agentPrompt}\n`,
+    );
+    assert.deepEqual(
+      canonicalAgentInput.history.slice(2).map((message) => message.content),
+      ["", "", "", ""],
+    );
+    assert.deepEqual(
+      JSON.parse(agentSpan.attributes["traceloop.entity.output"]),
+      { role: "assistant", content: "84" },
+    );
+    for (const rawAttribute of [
+      "input.value",
+      "output.value",
+      "history",
+      "source",
+      "beeai.version",
+      "traceId",
+    ]) {
+      assert.equal(agentSpan.attributes[rawAttribute], undefined, `exported raw ${rawAttribute}`);
+    }
+
+    const agentChildren = agentTraceSpans.filter((span) =>
+      ["chat", "tool"].includes(span.attributes["respan.entity.log_type"]),
+    );
+    assert.equal(
+      agentChildren.filter((span) => span.attributes["respan.entity.log_type"] === "chat").length,
+      2,
+    );
+    assert.equal(
+      agentChildren.filter((span) => span.attributes["respan.entity.log_type"] === "tool").length,
+      2,
+    );
+    for (const child of agentChildren) {
+      assert.equal(
+        getParentSpanId(child),
+        agentSpan.spanContext().spanId,
+        `${child.name} should be a direct agent child`,
+      );
+    }
+    assert.equal(
+      agentTraceSpans.filter((span) => span.name.startsWith("agent.toolCalling.")).length,
+      0,
+      "iteration callbacks must not create duplicate agent spans",
+    );
+    assert.equal(
+      agentTraceSpans.filter((span) => span.name === "beeai-framework-main").length,
+      1,
+      "the promoted wrapper must be the sole agent boundary",
+    );
+    const upstreamSuccessCallbacks = allAgentTraceSpans.filter(
+      (span) => span.name.startsWith("agent.toolCalling.success"),
+    );
+    assert.equal(
+      upstreamSuccessCallbacks.length,
+      2,
+      "the real two-iteration callback path should be exercised",
+    );
+    for (const callbackSpan of upstreamSuccessCallbacks) {
+      assert.deepEqual(callbackSpan.attributes["respan.processors"], []);
+      assert.equal(callbackSpan.attributes["traceloop.entity.input"], undefined);
+      assert.equal(callbackSpan.attributes["traceloop.entity.output"], undefined);
+    }
   } finally {
     instrumentor.deactivate();
     try {
@@ -132,7 +325,8 @@ test("real Arize BeeAI spans retain late OTel 2.x input, model, and usage", asyn
       );
     } finally {
       await provider.shutdown();
-      resetGlobalTracerProvider();
+      contextManager.disable();
+      resetGlobalTelemetry();
     }
   }
 });

--- a/javascript-sdks/instrumentations/respan-instrumentation-flue/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-flue/src/index.ts
@@ -59,6 +59,11 @@ interface StartedEvent {
   event: FlueEvent;
 }
 
+interface PendingCompaction {
+  event: Extract<FlueEvent, { type: "compaction" }>;
+  start?: StartedEvent;
+}
+
 interface TurnState {
   start?: StartedEvent;
   request?: Extract<FlueEvent, { type: "turn_request" }>;
@@ -97,7 +102,9 @@ export class FlueInstrumentor {
   private readonly _workflowNames = new Map<string, string>();
   private readonly _runStarts = new Map<string, StartedEvent>();
   private readonly _agentStarts = new Map<string, StartedEvent>();
-  private readonly _operationStarts = new Map<string, StartedEvent>();
+  private readonly _operationStarts = new Map<string, Map<string, StartedEvent>>();
+  private readonly _exportedOperationSpanIds = new Map<string, Set<string>>();
+  private readonly _pendingCompactions = new Map<string, PendingCompaction[]>();
   private readonly _taskStarts = new Map<string, StartedEvent>();
   private readonly _toolStarts = new Map<string, ToolState>();
   private readonly _turns = new Map<string, TurnState>();
@@ -128,11 +135,14 @@ export class FlueInstrumentor {
     this._unsubscribe?.();
     this._unsubscribe = undefined;
     this._isActive = false;
+    this._flushAllPendingCompactions();
     this._traceIds.clear();
     this._workflowNames.clear();
     this._runStarts.clear();
     this._agentStarts.clear();
     this._operationStarts.clear();
+    this._exportedOperationSpanIds.clear();
+    this._pendingCompactions.clear();
     this._taskStarts.clear();
     this._toolStarts.clear();
     this._turns.clear();
@@ -163,7 +173,7 @@ export class FlueInstrumentor {
         this._emitAgentEnd(event);
         break;
       case "operation_start":
-        this._operationStarts.set(event.operationId, { event, timestamp: event.timestamp });
+        this._rememberOperationStart(event);
         break;
       case "operation":
         this._emitOperation(event);
@@ -195,7 +205,7 @@ export class FlueInstrumentor {
         this._compactionStarts.set(this._compactionKey(event), { event, timestamp: event.timestamp });
         break;
       case "compaction":
-        this._emitCompaction(event);
+        this._handleCompaction(event);
         break;
       case "log":
         this._emitLog(event);
@@ -245,6 +255,8 @@ export class FlueInstrumentor {
       workflowName: String(workflowName),
     });
     this._runStarts.delete(event.runId);
+    this._flushPendingCompactionsForTrace(event);
+    this._clearOperationState(this._traceKey(event));
   }
 
   private _emitAgentEnd(event: Extract<FlueEvent, { type: "agent_end" }>): void {
@@ -262,10 +274,14 @@ export class FlueInstrumentor {
       parentId: this._rootParentId(event),
     });
     this._agentStarts.delete(this._agentKey(event));
+    if (!event.runId) {
+      this._settleDirectAgentOperationState(event);
+    }
   }
 
   private _emitOperation(event: Extract<FlueEvent, { type: "operation" }>): void {
-    const start = this._operationStarts.get(event.operationId);
+    const traceKey = this._traceKey(event);
+    const start = this._operationStarts.get(traceKey)?.get(event.operationId);
     const logType = event.operationKind === "shell" ? RespanLogType.TOOL : RespanLogType.TASK;
     this._emitSpan({
       name: `flue.operation.${event.operationKind}`,
@@ -281,12 +297,27 @@ export class FlueInstrumentor {
       durationMs: event.durationMs,
       error: event.error,
       spanId: this._operationSpanId(event),
-      parentId: this._rootParentId(event),
+      parentId: this._rootOrAgentParentId(event),
       attributes: {
         [metadataKey("flue_operation_kind")]: event.operationKind,
       },
     });
-    this._operationStarts.delete(event.operationId);
+    this._rememberExportedOperationSpan(event);
+    this._flushPendingCompactionsForOperation(event);
+    const traceStarts = this._operationStarts.get(traceKey);
+    traceStarts?.delete(event.operationId);
+    if (traceStarts?.size === 0) {
+      this._operationStarts.delete(traceKey);
+    }
+    if (!event.runId && !this._agentStarts.has(this._agentKey(event))) {
+      this._forgetExportedOperationSpan(event);
+      if (
+        !this._operationStarts.has(traceKey) &&
+        !this._pendingCompactions.has(traceKey)
+      ) {
+        this._clearOperationState(traceKey);
+      }
+    }
   }
 
   private _emitTask(event: Extract<FlueEvent, { type: "task" }>): void {
@@ -393,8 +424,29 @@ export class FlueInstrumentor {
     this._turns.delete(event.turnId);
   }
 
-  private _emitCompaction(event: Extract<FlueEvent, { type: "compaction" }>): void {
+  private _handleCompaction(event: Extract<FlueEvent, { type: "compaction" }>): void {
     const start = this._compactionStarts.get(this._compactionKey(event));
+    this._compactionStarts.delete(this._compactionKey(event));
+    const pending = { event, start };
+
+    if (event.operationId) {
+      const operationSpanId = this._operationSpanId(event as FlueEvent & { operationId: string });
+      if (this._hasExportedOperationSpan(event, operationSpanId)) {
+        this._emitCompaction(pending, operationSpanId);
+        return;
+      }
+      this._queuePendingCompaction(pending);
+      return;
+    }
+
+    this._emitCompaction(pending, this._rootOrAgentParentId(event));
+  }
+
+  private _emitCompaction(
+    pending: PendingCompaction,
+    parentId: string | undefined,
+  ): void {
+    const { event, start } = pending;
     const startEvent = start?.event as Extract<FlueEvent, { type: "compaction_start" }> | undefined;
     const attributes: Record<string, unknown> = {
       [metadataKey("flue_compaction_messages_before")]: event.messagesBefore,
@@ -424,11 +476,10 @@ export class FlueInstrumentor {
       start,
       durationMs: event.durationMs,
       error: event.error,
-      parentId: this._operationOrRootParentId(event),
+      parentId,
       spanId: this._compactionSpanId(event),
       attributes,
     });
-    this._compactionStarts.delete(this._compactionKey(event));
   }
 
   private _emitLog(event: Extract<FlueEvent, { type: "log" }>): void {
@@ -607,7 +658,7 @@ export class FlueInstrumentor {
     return this._eventSpanId(event, `agent:${this._agentName(event)}`);
   }
 
-  private _operationSpanId(event: Extract<FlueEvent, { operationId: string }>): string {
+  private _operationSpanId(event: FlueEvent & { operationId: string }): string {
     return this._eventSpanId(event, `operation:${event.operationId}`);
   }
 
@@ -640,11 +691,149 @@ export class FlueInstrumentor {
 
   private _operationOrRootParentId(event: FlueEvent): string | undefined {
     if (event.operationId) {
-      return this._operationSpanId(event as Extract<FlueEvent, { operationId: string }>);
+      return this._operationSpanId(event as FlueEvent & { operationId: string });
     }
+    return this._rootOrAgentParentId(event);
+  }
+
+  private _rootOrAgentParentId(event: FlueEvent): string | undefined {
     return this._rootParentId(event) ?? (
       event.instanceId ? this._agentSpanId(event) : undefined
     );
+  }
+
+  private _rememberOperationStart(
+    event: Extract<FlueEvent, { type: "operation_start" }>,
+  ): void {
+    const traceKey = this._traceKey(event);
+    const starts = this._operationStarts.get(traceKey) ?? new Map<string, StartedEvent>();
+    starts.set(event.operationId, { event, timestamp: event.timestamp });
+    this._operationStarts.set(traceKey, starts);
+  }
+
+  private _rememberExportedOperationSpan(
+    event: Extract<FlueEvent, { type: "operation" }>,
+  ): void {
+    const traceKey = this._traceKey(event);
+    const spanIds = this._exportedOperationSpanIds.get(traceKey) ?? new Set<string>();
+    spanIds.add(this._operationSpanId(event));
+    this._exportedOperationSpanIds.set(traceKey, spanIds);
+  }
+
+  private _hasExportedOperationSpan(event: FlueEvent, spanId: string): boolean {
+    return Boolean(
+      this._exportedOperationSpanIds.get(this._traceKey(event))?.has(spanId),
+    );
+  }
+
+  private _forgetExportedOperationSpan(
+    event: Extract<FlueEvent, { type: "operation" }>,
+  ): void {
+    const traceKey = this._traceKey(event);
+    const spanIds = this._exportedOperationSpanIds.get(traceKey);
+    spanIds?.delete(this._operationSpanId(event));
+    if (spanIds?.size === 0) {
+      this._exportedOperationSpanIds.delete(traceKey);
+    }
+  }
+
+  private _queuePendingCompaction(pending: PendingCompaction): void {
+    const traceKey = this._traceKey(pending.event);
+    const pendingCompactions = this._pendingCompactions.get(traceKey) ?? [];
+    pendingCompactions.push(pending);
+    this._pendingCompactions.set(traceKey, pendingCompactions);
+  }
+
+  private _flushPendingCompactionsForOperation(
+    event: Extract<FlueEvent, { type: "operation" }>,
+  ): void {
+    const traceKey = this._traceKey(event);
+    const pendingCompactions = this._pendingCompactions.get(traceKey);
+    if (!pendingCompactions) {
+      return;
+    }
+
+    const remaining: PendingCompaction[] = [];
+    const operationSpanId = this._operationSpanId(event);
+    for (const pending of pendingCompactions) {
+      if (pending.event.operationId === event.operationId) {
+        this._emitCompaction(pending, operationSpanId);
+      } else {
+        remaining.push(pending);
+      }
+    }
+
+    if (remaining.length > 0) {
+      this._pendingCompactions.set(traceKey, remaining);
+    } else {
+      this._pendingCompactions.delete(traceKey);
+    }
+  }
+
+  private _flushPendingCompactionsForTrace(event: FlueEvent): void {
+    const traceKey = this._traceKey(event);
+    const pendingCompactions = this._pendingCompactions.get(traceKey);
+    this._pendingCompactions.delete(traceKey);
+    if (!pendingCompactions) {
+      return;
+    }
+
+    for (const pending of pendingCompactions) {
+      this._emitCompaction(pending, this._rootOrAgentParentId(pending.event));
+    }
+  }
+
+  private _settleDirectAgentOperationState(event: FlueEvent): void {
+    const traceKey = this._traceKey(event);
+    const starts = this._operationStarts.get(traceKey);
+    const pendingCompactions = this._pendingCompactions.get(traceKey) ?? [];
+    const remaining: PendingCompaction[] = [];
+
+    for (const pending of pendingCompactions) {
+      if (pending.event.operationId && starts?.has(pending.event.operationId)) {
+        remaining.push(pending);
+      } else {
+        this._emitCompaction(pending, this._rootOrAgentParentId(pending.event));
+      }
+    }
+
+    if (remaining.length > 0) {
+      this._pendingCompactions.set(traceKey, remaining);
+    } else {
+      this._pendingCompactions.delete(traceKey);
+    }
+
+    if (starts) {
+      const retainedOperationIds = new Set(
+        remaining.flatMap((pending) =>
+          pending.event.operationId ? [pending.event.operationId] : [],
+        ),
+      );
+      for (const operationId of starts.keys()) {
+        if (!retainedOperationIds.has(operationId)) {
+          starts.delete(operationId);
+        }
+      }
+      if (starts.size === 0) {
+        this._operationStarts.delete(traceKey);
+      }
+    }
+
+    this._exportedOperationSpanIds.delete(traceKey);
+  }
+
+  private _flushAllPendingCompactions(): void {
+    const pendingCompactions = Array.from(this._pendingCompactions.values()).flat();
+    this._pendingCompactions.clear();
+    for (const pending of pendingCompactions) {
+      this._emitCompaction(pending, undefined);
+    }
+  }
+
+  private _clearOperationState(traceKey: string): void {
+    this._operationStarts.delete(traceKey);
+    this._exportedOperationSpanIds.delete(traceKey);
+    this._pendingCompactions.delete(traceKey);
   }
 }
 

--- a/javascript-sdks/instrumentations/respan-instrumentation-flue/tests/flue_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-flue/tests/flue_instrumentor.test.mjs
@@ -41,6 +41,28 @@ function event(partial) {
   };
 }
 
+function assertConnectedTree(spans) {
+  const spansById = new Map(spans.map((span) => [span.spanContext().spanId, span]));
+  const roots = spans.filter((span) => !span.parentSpanContext);
+
+  assert.equal(roots.length, 1);
+  for (const span of spans) {
+    const visited = new Set();
+    let current = span;
+    while (current.parentSpanContext) {
+      assert.ok(!visited.has(current.spanContext().spanId), `${span.name} has a parent cycle`);
+      visited.add(current.spanContext().spanId);
+      const parent = spansById.get(current.parentSpanContext.spanId);
+      assert.ok(
+        parent,
+        `${span.name} has an unexported parent`,
+      );
+      current = parent;
+    }
+    assert.equal(current.spanContext().spanId, roots[0].spanContext().spanId);
+  }
+}
+
 test("exports Flue workflow, operation, model turn, and tool events as canonical spans", () => {
   captureState.spans = [];
   const instrumentor = new FlueInstrumentor();
@@ -298,8 +320,263 @@ test("exports direct agent logs and compaction with fallback workflow name", () 
   assert.equal(logSpan.attributes["traceloop.workflow.name"], "Flue Direct Agent.workflow");
   assert.equal(compactionSpan.attributes["respan.metadata.flue_compaction_reason"], "manual");
   assert.equal(agentSpan.attributes["traceloop.entity.name"], "agent-1");
+  assert.equal(compactionSpan.parentSpanContext?.spanId, agentSpan.spanContext().spanId);
+  assertConnectedTree(captureState.spans);
 });
 
+test("parents compaction to the workflow when its started operation never finishes", () => {
+  captureState.spans = [];
+  const instrumentor = new FlueInstrumentor();
+
+  instrumentor.handleEvent(event({
+    type: "run_start",
+    eventIndex: 1,
+    runId: "run-compaction-fallback",
+    workflowName: "Flue Compaction Fallback.workflow",
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation_start",
+    eventIndex: 2,
+    runId: "run-compaction-fallback",
+    operationId: "missing-operation",
+    operationKind: "compact",
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction_start",
+    eventIndex: 3,
+    runId: "run-compaction-fallback",
+    operationId: "missing-operation",
+    reason: "manual",
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction",
+    eventIndex: 4,
+    runId: "run-compaction-fallback",
+    operationId: "missing-operation",
+    messagesBefore: 12,
+    messagesAfter: 4,
+    isError: false,
+  }));
+  instrumentor.handleEvent(event({
+    type: "run_end",
+    eventIndex: 5,
+    runId: "run-compaction-fallback",
+    result: { ok: true },
+    isError: false,
+  }));
+
+  assert.equal(captureState.spans.length, 2);
+  const compactionSpan = captureState.spans.find((span) => span.name === "flue.compaction");
+  const workflowSpan = captureState.spans.find(
+    (span) => span.attributes["respan.entity.log_type"] === "workflow",
+  );
+
+  assert.ok(compactionSpan);
+  assert.ok(workflowSpan);
+  assert.equal(compactionSpan.parentSpanContext?.spanId, workflowSpan.spanContext().spanId);
+  assertConnectedTree(captureState.spans);
+});
+
+test("parents compaction to a matching observed operation", () => {
+  captureState.spans = [];
+  const instrumentor = new FlueInstrumentor();
+
+  instrumentor.handleEvent(event({
+    type: "run_start",
+    eventIndex: 1,
+    runId: "run-operation-compaction",
+    workflowName: "Flue Operation Compaction.workflow",
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation_start",
+    eventIndex: 2,
+    runId: "run-operation-compaction",
+    operationId: "compact-operation",
+    operationKind: "prompt",
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction_start",
+    eventIndex: 3,
+    runId: "run-operation-compaction",
+    operationId: "compact-operation",
+    reason: "automatic",
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction",
+    eventIndex: 4,
+    runId: "run-operation-compaction",
+    operationId: "compact-operation",
+    messagesBefore: 20,
+    messagesAfter: 5,
+    isError: false,
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation",
+    eventIndex: 5,
+    runId: "run-operation-compaction",
+    operationId: "compact-operation",
+    operationKind: "prompt",
+    isError: false,
+    result: { compacted: true },
+  }));
+  instrumentor.handleEvent(event({
+    type: "run_end",
+    eventIndex: 6,
+    runId: "run-operation-compaction",
+    result: { ok: true },
+    isError: false,
+  }));
+
+  assert.equal(captureState.spans.length, 3);
+  const compactionSpan = captureState.spans.find((span) => span.name === "flue.compaction");
+  const operationSpan = captureState.spans.find(
+    (span) => span.name === "flue.operation.prompt",
+  );
+
+  assert.ok(compactionSpan);
+  assert.ok(operationSpan);
+  assert.equal(compactionSpan.parentSpanContext?.spanId, operationSpan.spanContext().spanId);
+  assertConnectedTree(captureState.spans);
+});
+
+test("clears direct-agent operation state before an operation id is reused", () => {
+  captureState.spans = [];
+  const instrumentor = new FlueInstrumentor();
+
+  instrumentor.handleEvent(event({
+    type: "agent_start",
+    eventIndex: 1,
+    timestamp: "2026-06-21T00:00:00.000Z",
+    instanceId: "reused-agent",
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation_start",
+    eventIndex: 2,
+    timestamp: "2026-06-21T00:00:01.000Z",
+    instanceId: "reused-agent",
+    operationId: "reused-operation",
+    operationKind: "compact",
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction_start",
+    eventIndex: 3,
+    timestamp: "2026-06-21T00:00:02.000Z",
+    instanceId: "reused-agent",
+    operationId: "reused-operation",
+    reason: "automatic",
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction",
+    eventIndex: 4,
+    timestamp: "2026-06-21T00:00:03.000Z",
+    instanceId: "reused-agent",
+    operationId: "reused-operation",
+    messagesBefore: 10,
+    messagesAfter: 3,
+    isError: false,
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation_start",
+    eventIndex: 5,
+    timestamp: "2026-06-21T00:00:03.500Z",
+    instanceId: "reused-agent",
+    operationId: "abandoned-operation",
+    operationKind: "prompt",
+  }));
+  instrumentor.handleEvent(event({
+    type: "agent_end",
+    eventIndex: 6,
+    timestamp: "2026-06-21T00:00:04.000Z",
+    instanceId: "reused-agent",
+    messages: [],
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation",
+    eventIndex: 7,
+    timestamp: "2026-06-21T00:00:05.000Z",
+    instanceId: "reused-agent",
+    operationId: "reused-operation",
+    operationKind: "compact",
+    isError: false,
+    result: { compacted: true },
+  }));
+
+  const firstCompactionSpan = captureState.spans.find(
+    (span) => span.name === "flue.compaction",
+  );
+  const firstOperationSpan = captureState.spans.find(
+    (span) => span.name === "flue.operation.compact",
+  );
+  assert.ok(firstCompactionSpan);
+  assert.ok(firstOperationSpan);
+  assert.equal(
+    firstCompactionSpan.parentSpanContext?.spanId,
+    firstOperationSpan.spanContext().spanId,
+  );
+  assertConnectedTree(captureState.spans);
+
+  captureState.spans = [];
+  instrumentor.handleEvent(event({
+    type: "agent_start",
+    eventIndex: 8,
+    timestamp: "2026-06-21T00:10:00.000Z",
+    instanceId: "reused-agent",
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction_start",
+    eventIndex: 9,
+    timestamp: "2026-06-21T00:10:01.000Z",
+    instanceId: "reused-agent",
+    operationId: "reused-operation",
+    reason: "manual",
+  }));
+  instrumentor.handleEvent(event({
+    type: "compaction",
+    eventIndex: 10,
+    timestamp: "2026-06-21T00:10:02.000Z",
+    instanceId: "reused-agent",
+    operationId: "reused-operation",
+    messagesBefore: 8,
+    messagesAfter: 2,
+    isError: false,
+  }));
+  instrumentor.handleEvent(event({
+    type: "operation",
+    eventIndex: 11,
+    timestamp: "2026-06-21T00:10:02.500Z",
+    instanceId: "reused-agent",
+    operationId: "abandoned-operation",
+    operationKind: "prompt",
+    isError: false,
+    result: { reused: true },
+  }));
+  instrumentor.handleEvent(event({
+    type: "agent_end",
+    eventIndex: 12,
+    timestamp: "2026-06-21T00:10:03.000Z",
+    instanceId: "reused-agent",
+    messages: [],
+  }));
+
+  assert.equal(captureState.spans.length, 3);
+  const compactionSpan = captureState.spans.find((span) => span.name === "flue.compaction");
+  const operationSpan = captureState.spans.find((span) => span.name === "flue.operation.prompt");
+  const agentSpan = captureState.spans.find(
+    (span) => span.attributes["respan.entity.log_type"] === "agent",
+  );
+
+  assert.ok(compactionSpan);
+  assert.ok(operationSpan);
+  assert.ok(agentSpan);
+  assert.equal(compactionSpan.parentSpanContext?.spanId, agentSpan.spanContext().spanId);
+  assert.equal(operationSpan.parentSpanContext?.spanId, agentSpan.spanContext().spanId);
+  assert.equal(
+    operationSpan.startTime[0],
+    Math.floor(Date.parse("2026-06-21T00:10:02.500Z") / 1000),
+  );
+  assert.equal(operationSpan.startTime[1], 500_000_000);
+  assertConnectedTree(captureState.spans);
+});
 
 test("marks failed Flue events with error status and backend status attributes", () => {
   captureState.spans = [];

--- a/javascript-sdks/instrumentations/respan-instrumentation-google-adk/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-google-adk/src/index.ts
@@ -48,7 +48,33 @@ const OFF_CONTRACT_ALIASES = new Set([
 ]);
 
 type Attributes = Record<string, any>;
+type SpanSetAttribute = (key: string, value: unknown) => Span;
+type ProcessorOnStart = (span: Span, parentContext: Context) => void;
 type ProcessorOnEnd = (span: ReadableSpan) => void;
+
+interface GoogleADKResponseCapture {
+  readonly accumulator: GoogleADKResponseAccumulator;
+  readonly originalSetAttribute: SpanSetAttribute;
+  readonly wrappedSetAttribute: SpanSetAttribute;
+}
+
+interface GoogleADKResponseAccumulator {
+  // Keep only assembled state: ADK may write a growing cumulative response on
+  // every chunk, so retaining raw frames would grow quadratically.
+  response?: Attributes;
+  content?: GoogleADKContentAccumulator;
+}
+
+interface GoogleADKContentAccumulator {
+  readonly attributes: Attributes;
+  readonly parts: Attributes[];
+  readonly partIndexes: Map<string, number>;
+}
+
+const GOOGLE_ADK_RESPONSE_CAPTURES = new WeakMap<
+  object,
+  GoogleADKResponseCapture
+>();
 
 export class GoogleADKTranslator implements SpanProcessor {
   onStart(span: Span, _parentContext: Context): void {
@@ -57,6 +83,10 @@ export class GoogleADKTranslator implements SpanProcessor {
     const logType = resolveLogTypeFromName(spanName);
     if (logType === undefined) {
       return;
+    }
+
+    if (logType === RespanLogType.CHAT) {
+      installResponseCapture(writableSpan);
     }
 
     writableSpan.setAttribute(
@@ -74,7 +104,11 @@ export class GoogleADKTranslator implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
-    translateGoogleADKSpan(span);
+    try {
+      translateGoogleADKSpan(span);
+    } finally {
+      restoreResponseCapture(span);
+    }
   }
 
   forceFlush(): Promise<void> {
@@ -127,7 +161,7 @@ export function translateGoogleADKSpan(span: ReadableSpan): void {
   );
 
   if (logType === RespanLogType.CHAT) {
-    normalizeChatSpan(attrs);
+    normalizeChatSpan(attrs, getCapturedResponse(span));
   } else if (logType === RespanLogType.TOOL) {
     normalizeToolSpan(attrs, entityName);
   } else if (logType === RespanLogType.AGENT) {
@@ -137,6 +171,7 @@ export function translateGoogleADKSpan(span: ReadableSpan): void {
   }
 
   cleanupAttrs(attrs);
+  restoreResponseCapture(span);
 }
 
 export class GoogleADKInstrumentor {
@@ -145,6 +180,8 @@ export class GoogleADKInstrumentor {
   private static _translatorRegistered = false;
   private static _translatorHookRefCount = 0;
   private static _patchedProcessor: any = null;
+  private static _originalProcessorOnStart: ProcessorOnStart | null = null;
+  private static _wrappedProcessorOnStart: ProcessorOnStart | null = null;
   private static _originalProcessorOnEnd: ProcessorOnEnd | null = null;
   private static _wrappedProcessorOnEnd: ProcessorOnEnd | null = null;
 
@@ -230,18 +267,43 @@ export class GoogleADKInstrumentor {
 
     GoogleADKInstrumentor._restoreTranslatorHook();
 
+    const translator = new GoogleADKTranslator();
+    const originalProcessorOnStart =
+      typeof processor.onStart === "function"
+        ? (processor.onStart as ProcessorOnStart)
+        : null;
+    const wrappedProcessorOnStart: ProcessorOnStart | null =
+      originalProcessorOnStart
+        ? (span: Span, parentContext: Context) => {
+            try {
+              translator.onStart(span, parentContext);
+            } catch {
+              // Translation must never block span creation.
+            }
+            return originalProcessorOnStart.call(
+              processor,
+              span,
+              parentContext,
+            );
+          }
+        : null;
     const originalProcessorOnEnd = processor.onEnd as ProcessorOnEnd;
     const wrappedProcessorOnEnd = (span: ReadableSpan) => {
       try {
-        translateGoogleADKSpan(span);
+        translator.onEnd(span);
       } catch {
         // Translation must never block span export.
       }
       return originalProcessorOnEnd.call(processor, span);
     };
 
+    if (wrappedProcessorOnStart) {
+      processor.onStart = wrappedProcessorOnStart;
+    }
     processor.onEnd = wrappedProcessorOnEnd;
     GoogleADKInstrumentor._patchedProcessor = processor;
+    GoogleADKInstrumentor._originalProcessorOnStart = originalProcessorOnStart;
+    GoogleADKInstrumentor._wrappedProcessorOnStart = wrappedProcessorOnStart;
     GoogleADKInstrumentor._originalProcessorOnEnd = originalProcessorOnEnd;
     GoogleADKInstrumentor._wrappedProcessorOnEnd = wrappedProcessorOnEnd;
     return true;
@@ -249,8 +311,20 @@ export class GoogleADKInstrumentor {
 
   private static _restoreTranslatorHook(): void {
     const processor = GoogleADKInstrumentor._patchedProcessor;
+    const originalOnStart = GoogleADKInstrumentor._originalProcessorOnStart;
+    const wrappedOnStart = GoogleADKInstrumentor._wrappedProcessorOnStart;
     const originalOnEnd = GoogleADKInstrumentor._originalProcessorOnEnd;
     const wrappedOnEnd = GoogleADKInstrumentor._wrappedProcessorOnEnd;
+
+    if (processor && originalOnStart) {
+      if (!wrappedOnStart || processor.onStart === wrappedOnStart) {
+        processor.onStart = originalOnStart;
+      } else {
+        console.warn(
+          "[respan] GoogleADKInstrumentor: active span processor onStart was modified externally; original handler could not be restored.",
+        );
+      }
+    }
 
     if (processor && originalOnEnd) {
       if (!wrappedOnEnd || processor.onEnd === wrappedOnEnd) {
@@ -263,6 +337,8 @@ export class GoogleADKInstrumentor {
     }
 
     GoogleADKInstrumentor._patchedProcessor = null;
+    GoogleADKInstrumentor._originalProcessorOnStart = null;
+    GoogleADKInstrumentor._wrappedProcessorOnStart = null;
     GoogleADKInstrumentor._originalProcessorOnEnd = null;
     GoogleADKInstrumentor._wrappedProcessorOnEnd = null;
   }
@@ -348,7 +424,71 @@ function resolveEntityName(
   return span.name || "google_adk.task";
 }
 
-function normalizeChatSpan(attrs: Attributes): void {
+function installResponseCapture(span: Span): void {
+  const writableSpan = span as any;
+  if (
+    GOOGLE_ADK_RESPONSE_CAPTURES.has(writableSpan) ||
+    typeof writableSpan.setAttribute !== "function"
+  ) {
+    return;
+  }
+
+  const accumulator: GoogleADKResponseAccumulator = {};
+  const originalSetAttribute = writableSpan.setAttribute as SpanSetAttribute;
+  const wrappedSetAttribute: SpanSetAttribute = function (
+    this: Span,
+    key: string,
+    value: unknown,
+  ): Span {
+    if (key === ADK_LLM_RESPONSE) {
+      accumulateResponse(accumulator, value);
+    }
+    return originalSetAttribute.call(this, key, value);
+  };
+
+  try {
+    writableSpan.setAttribute = wrappedSetAttribute;
+    GOOGLE_ADK_RESPONSE_CAPTURES.set(writableSpan, {
+      accumulator,
+      originalSetAttribute,
+      wrappedSetAttribute,
+    });
+  } catch {
+    // Some third-party Span implementations may not allow method wrapping.
+    // Their final scalar response still follows the existing unary path.
+  }
+}
+
+function getCapturedResponse(span: ReadableSpan): Attributes | undefined {
+  const accumulator = GOOGLE_ADK_RESPONSE_CAPTURES.get(
+    span as object,
+  )?.accumulator;
+  return accumulator ? materializeResponse(accumulator) : undefined;
+}
+
+function restoreResponseCapture(span: ReadableSpan): void {
+  const writableSpan = span as any;
+  const capture = GOOGLE_ADK_RESPONSE_CAPTURES.get(writableSpan);
+  if (!capture) {
+    return;
+  }
+
+  try {
+    if (writableSpan.setAttribute === capture.wrappedSetAttribute) {
+      writableSpan.setAttribute = capture.originalSetAttribute;
+    }
+  } catch {
+    // The response data has already been normalized; an ended span with a
+    // non-writable method does not need further mutation.
+  } finally {
+    GOOGLE_ADK_RESPONSE_CAPTURES.delete(writableSpan);
+  }
+}
+
+function normalizeChatSpan(
+  attrs: Attributes,
+  capturedResponse?: Attributes,
+): void {
   attrs[ATTR_GEN_AI_SYSTEM] = "google";
   attrs[SpanAttributes.LLM_REQUEST_TYPE] = RespanLogType.CHAT;
 
@@ -382,7 +522,7 @@ function normalizeChatSpan(attrs: Attributes): void {
     }
   }
 
-  const response = parseJson(attrs[ADK_LLM_RESPONSE]);
+  const response = capturedResponse ?? parseJson(attrs[ADK_LLM_RESPONSE]);
   if (isRecord(response)) {
     addContentMessage(attrs, ATTR_GEN_AI_COMPLETION, 0, response.content);
 
@@ -431,6 +571,336 @@ function normalizeChatSpan(attrs: Attributes): void {
     if (finishReason !== undefined) {
       attrs[`${ATTR_GEN_AI_COMPLETION}.0.finish_reason`] =
         String(finishReason).toLowerCase();
+    }
+  }
+}
+
+function accumulateResponse(
+  accumulator: GoogleADKResponseAccumulator,
+  value: unknown,
+): void {
+  const response = parseJson(value);
+  if (!isRecord(response)) {
+    return;
+  }
+
+  accumulator.response ??= {};
+  for (const [key, responseValue] of Object.entries(response)) {
+    if (key !== "content") {
+      accumulator.response[key] = responseValue;
+    }
+  }
+
+  if (isRecord(response.content)) {
+    accumulator.content ??= {
+      attributes: {},
+      parts: [],
+      partIndexes: new Map<string, number>(),
+    };
+    accumulateResponseContent(
+      accumulator.content,
+      response.content,
+      response.partial === true,
+    );
+  }
+}
+
+function materializeResponse(
+  accumulator: GoogleADKResponseAccumulator,
+): Attributes | undefined {
+  if (!accumulator.response && !accumulator.content) {
+    return undefined;
+  }
+
+  const response = { ...(accumulator.response ?? {}) };
+  if (accumulator.content) {
+    response.content = {
+      ...accumulator.content.attributes,
+      ...(accumulator.content.parts.length > 0
+        ? { parts: accumulator.content.parts }
+        : {}),
+    };
+  }
+  return response;
+}
+
+function accumulateResponseContent(
+  accumulator: GoogleADKContentAccumulator,
+  content: Attributes,
+  isPartialResponse: boolean,
+): void {
+  for (const [key, contentValue] of Object.entries(content)) {
+    if (key !== "parts") {
+      accumulator.attributes[key] = contentValue;
+    }
+  }
+  if (!Array.isArray(content.parts)) {
+    return;
+  }
+
+  const functionCallSequences = new Map<string, number>();
+  for (const part of content.parts) {
+    if (!isRecord(part)) {
+      continue;
+    }
+
+    if (isRecord(part.functionCall)) {
+      const name = String(part.functionCall.name ?? "");
+      const sequence = functionCallSequences.get(name) ?? 0;
+      functionCallSequences.set(name, sequence + 1);
+      accumulateFunctionCallPart(accumulator, part, name, sequence);
+      continue;
+    }
+
+    if (typeof part.text === "string") {
+      accumulateTextPart(accumulator, part, isPartialResponse);
+      continue;
+    }
+
+    const identity = `part:${safeJson(part)}`;
+    if (!accumulator.partIndexes.has(identity)) {
+      accumulator.partIndexes.set(identity, accumulator.parts.length);
+      accumulator.parts.push({ ...part });
+    }
+  }
+}
+
+function accumulateTextPart(
+  accumulator: GoogleADKContentAccumulator,
+  part: Attributes,
+  isPartialResponse: boolean,
+): void {
+  const textShape = { ...part };
+  delete textShape.text;
+  const identity = `text:${safeJson(textShape)}`;
+  const existingIndex = accumulator.partIndexes.get(identity);
+  if (existingIndex === undefined) {
+    accumulator.partIndexes.set(identity, accumulator.parts.length);
+    accumulator.parts.push({ ...part });
+    return;
+  }
+
+  const existingPart = accumulator.parts[existingIndex];
+  existingPart.text = mergeStreamText(
+    String(existingPart.text ?? ""),
+    part.text,
+    !isPartialResponse,
+  );
+}
+
+function accumulateFunctionCallPart(
+  accumulator: GoogleADKContentAccumulator,
+  part: Attributes,
+  name: string,
+  sequence: number,
+): void {
+  const functionCall = part.functionCall as Attributes;
+  const sequenceIdentity = `functionCall:name:${name}:sequence:${sequence}`;
+  const idIdentity = functionCall.id === undefined
+    ? undefined
+    : `functionCall:id:${String(functionCall.id)}`;
+  const existingIndex = (
+    idIdentity === undefined
+      ? undefined
+      : accumulator.partIndexes.get(idIdentity)
+  ) ?? accumulator.partIndexes.get(sequenceIdentity);
+
+  if (existingIndex === undefined) {
+    const nextIndex = accumulator.parts.length;
+    accumulator.parts.push(mergeFunctionCallPart({}, part));
+    accumulator.partIndexes.set(sequenceIdentity, nextIndex);
+    if (idIdentity !== undefined) {
+      accumulator.partIndexes.set(idIdentity, nextIndex);
+    }
+    return;
+  }
+
+  accumulator.parts[existingIndex] = mergeFunctionCallPart(
+    accumulator.parts[existingIndex],
+    part,
+  );
+  accumulator.partIndexes.set(sequenceIdentity, existingIndex);
+  if (idIdentity !== undefined) {
+    accumulator.partIndexes.set(idIdentity, existingIndex);
+  }
+}
+
+function mergeStreamText(
+  current: string,
+  next: string,
+  deduplicateEqualValue = false,
+): string {
+  if (!current) {
+    return next;
+  }
+  if (!next) {
+    return current;
+  }
+
+  // Some ADK providers emit deltas while others emit a cumulative terminal
+  // response. Replacing a prefix-complete value keeps each chunk exactly once.
+  if (
+    next.startsWith(current) &&
+    (next.length > current.length || deduplicateEqualValue)
+  ) {
+    return next;
+  }
+  return current + next;
+}
+
+function mergeFunctionCallPart(
+  current: Attributes,
+  next: Attributes,
+): Attributes {
+  const currentCall = isRecord(current.functionCall)
+    ? current.functionCall
+    : {};
+  const nextCall = isRecord(next.functionCall) ? next.functionCall : {};
+  const hasCurrentArgs = isRecord(currentCall.args);
+  const args = hasCurrentArgs ? currentCall.args : {};
+
+  if (Array.isArray(nextCall.partialArgs)) {
+    for (const partialArg of nextCall.partialArgs) {
+      applyPartialArg(args, partialArg);
+    }
+  }
+  if (isRecord(nextCall.args)) {
+    mergeRecordInPlace(args, nextCall.args);
+  }
+
+  const functionCall = { ...currentCall, ...nextCall };
+  delete functionCall.partialArgs;
+  delete functionCall.willContinue;
+  if (
+    hasCurrentArgs ||
+    Array.isArray(nextCall.partialArgs) ||
+    isRecord(nextCall.args)
+  ) {
+    functionCall.args = args;
+  }
+
+  return {
+    ...current,
+    ...next,
+    functionCall,
+  };
+}
+
+function applyPartialArg(args: Attributes, value: unknown): void {
+  if (!isRecord(value) || typeof value.jsonPath !== "string") {
+    return;
+  }
+
+  const path = parseJsonPath(value.jsonPath);
+  const partialValue = partialArgValue(value);
+  if (!path || path.length === 0 || !partialValue.present) {
+    return;
+  }
+
+  let target: any = args;
+  for (let index = 0; index < path.length - 1; index += 1) {
+    const key = path[index];
+    const nextKey = path[index + 1];
+    const expectedContainer = typeof nextKey === "number" ? [] : {};
+    const existing = target[key];
+    if (
+      (Array.isArray(expectedContainer) && !Array.isArray(existing)) ||
+      (!Array.isArray(expectedContainer) && !isRecord(existing))
+    ) {
+      target[key] = expectedContainer;
+    }
+    target = target[key];
+  }
+
+  const key = path[path.length - 1];
+  const existing = target[key];
+  target[key] =
+    typeof existing === "string" && typeof partialValue.value === "string"
+      ? existing + partialValue.value
+      : partialValue.value;
+}
+
+function partialArgValue(value: Attributes): {
+  present: boolean;
+  value?: unknown;
+} {
+  for (const key of [
+    "stringValue",
+    "numberValue",
+    "boolValue",
+    "nullValue",
+  ]) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) {
+      return {
+        present: true,
+        value: key === "nullValue" ? null : value[key],
+      };
+    }
+  }
+  return { present: false };
+}
+
+function parseJsonPath(path: string): Array<string | number> | undefined {
+  if (!path.startsWith("$")) {
+    return undefined;
+  }
+
+  const segments: Array<string | number> = [];
+  let index = 1;
+  while (index < path.length) {
+    if (path[index] === ".") {
+      const start = index + 1;
+      index = start;
+      while (index < path.length && path[index] !== "." && path[index] !== "[") {
+        index += 1;
+      }
+      if (index === start) {
+        return undefined;
+      }
+      segments.push(path.slice(start, index));
+      continue;
+    }
+
+    if (path[index] === "[") {
+      const end = path.indexOf("]", index + 1);
+      if (end === -1) {
+        return undefined;
+      }
+      const selector = path.slice(index + 1, end).trim();
+      if (/^\d+$/.test(selector)) {
+        segments.push(Number(selector));
+      } else if (
+        (selector.startsWith('"') && selector.endsWith('"')) ||
+        (selector.startsWith("'") && selector.endsWith("'"))
+      ) {
+        const quote = selector[0];
+        const property = selector
+          .slice(1, -1)
+          .replace(new RegExp(`\\\\${quote}`, "g"), quote)
+          .replace(/\\\\\\\\/g, "\\");
+        segments.push(property);
+      } else {
+        return undefined;
+      }
+      index = end + 1;
+      continue;
+    }
+
+    return undefined;
+  }
+  return segments;
+}
+
+function mergeRecordInPlace(target: Attributes, source: Attributes): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (isRecord(value) && isRecord(target[key])) {
+      mergeRecordInPlace(target[key], value);
+    } else if (isRecord(value)) {
+      target[key] = { ...value };
+    } else if (Array.isArray(value)) {
+      target[key] = [...value];
+    } else {
+      target[key] = value;
     }
   }
 }

--- a/javascript-sdks/instrumentations/respan-instrumentation-google-adk/tests/google_adk_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-google-adk/tests/google_adk_instrumentor.test.mjs
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { trace } from "@opentelemetry/api";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
 
 import {
   GoogleADKInstrumentor,
@@ -15,7 +20,60 @@ function createSpan(name, attributes) {
     name,
     attributes: { ...attributes },
     instrumentationScope: { name: "gcp.vertex.agent", version: "1.2.0" },
+    setAttribute(key, value) {
+      this.attributes[key] = value;
+      return this;
+    },
+    setAttributes(values) {
+      for (const [key, value] of Object.entries(values)) {
+        this.setAttribute(key, value);
+      }
+      return this;
+    },
   };
+}
+
+async function exportCapturedLlmResponses(responses) {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [
+      new GoogleADKTranslator(),
+      new SimpleSpanProcessor(exporter),
+    ],
+  });
+
+  try {
+    const span = provider
+      .getTracer("gcp.vertex.agent", "1.3.0")
+      .startSpan("call_llm");
+    span.setAttributes({
+      "gen_ai.system": "gcp.vertex.agent",
+      "gen_ai.request.model": "deterministic-gemini",
+      "gcp.vertex.agent.llm_request": JSON.stringify({
+        model: "deterministic-gemini",
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Stream a response." }],
+          },
+        ],
+      }),
+    });
+    for (const response of responses) {
+      span.setAttribute(
+        "gcp.vertex.agent.llm_response",
+        JSON.stringify(response),
+      );
+    }
+    span.end();
+    await provider.forceFlush();
+
+    const finishedSpans = exporter.getFinishedSpans();
+    assert.equal(finishedSpans.length, 1);
+    return finishedSpans[0];
+  } finally {
+    await provider.shutdown();
+  }
 }
 
 test("translates ADK LLM spans to canonical chat attrs and strips raw keys", () => {
@@ -120,6 +178,254 @@ test("translates ADK LLM spans to canonical chat attrs and strips raw keys", () 
   assert.equal(attrs.prompt_tokens, undefined);
 });
 
+test("assembles every ADK streaming response chunk with OTel 2.x", async () => {
+  const span = await exportCapturedLlmResponses([
+    {
+      content: { role: "model", parts: [{ text: "Streaming " }] },
+      partial: true,
+    },
+    {
+      content: { role: "model", parts: [{ text: "ADK telemetry " }] },
+      partial: true,
+    },
+    {
+      content: {
+        role: "model",
+        parts: [{ text: "complete with propagated Respan attributes." }],
+      },
+      usageMetadata: {
+        promptTokenCount: 14,
+        candidatesTokenCount: 7,
+        totalTokenCount: 21,
+      },
+      finishReason: "STOP",
+    },
+  ]);
+
+  const attrs = span.attributes;
+  assert.equal(
+    attrs["gen_ai.completion.0.content"],
+    "Streaming ADK telemetry complete with propagated Respan attributes.",
+  );
+  assert.equal(attrs["gen_ai.completion.0.role"], "assistant");
+  assert.equal(attrs["gen_ai.completion.0.finish_reason"], "stop");
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 14);
+  assert.equal(attrs["gen_ai.usage.output_tokens"], 7);
+  assert.equal(attrs["llm.usage.total_tokens"], 21);
+  assert.equal(attrs["gcp.vertex.agent.llm_response"], undefined);
+});
+
+test("retains repeated equal text deltas instead of treating them as cumulative", async () => {
+  const span = await exportCapturedLlmResponses([
+    {
+      content: { role: "model", parts: [{ text: "ha" }] },
+      partial: true,
+    },
+    {
+      content: { role: "model", parts: [{ text: "ha" }] },
+      partial: true,
+    },
+    {
+      usageMetadata: {
+        promptTokenCount: 2,
+        candidatesTokenCount: 1,
+        totalTokenCount: 3,
+      },
+      finishReason: "STOP",
+    },
+  ]);
+
+  assert.equal(span.attributes["gen_ai.completion.0.content"], "haha");
+});
+
+test("does not duplicate cumulative terminal content or streamed tool calls", async () => {
+  const span = await exportCapturedLlmResponses([
+    {
+      content: { role: "model", parts: [{ text: "Hello " }] },
+      partial: true,
+    },
+    {
+      content: { role: "model", parts: [{ text: "world" }] },
+      partial: true,
+    },
+    {
+      content: {
+        role: "model",
+        parts: [
+          { text: "Hello world" },
+          {
+            functionCall: {
+              id: "call_1",
+              name: "get_weather",
+              args: { city: "Tokyo" },
+            },
+          },
+        ],
+      },
+      finishReason: "STOP",
+    },
+    {
+      content: {
+        role: "model",
+        parts: [
+          { text: "Hello world" },
+          {
+            functionCall: {
+              id: "call_1",
+              name: "get_weather",
+              args: { city: "Tokyo" },
+            },
+          },
+        ],
+      },
+      finishReason: "STOP",
+    },
+  ]);
+
+  const attrs = span.attributes;
+  assert.equal(attrs["gen_ai.completion.0.content"], "Hello world");
+  assert.deepEqual(JSON.parse(attrs["gen_ai.completion.0.tool_calls"]), [
+    {
+      id: "call_1",
+      type: "function",
+      function: {
+        name: "get_weather",
+        arguments: JSON.stringify({ city: "Tokyo" }),
+      },
+    },
+  ]);
+});
+
+test("merges id-less streamed function calls by name and sequence", async () => {
+  const span = await exportCapturedLlmResponses([
+    {
+      content: {
+        role: "model",
+        parts: [
+          {
+            functionCall: {
+              name: "search_places",
+              partialArgs: [
+                {
+                  jsonPath: "$.query",
+                  stringValue: "weather ",
+                  willContinue: true,
+                },
+              ],
+              willContinue: true,
+            },
+          },
+          {
+            functionCall: {
+              name: "search_places",
+              partialArgs: [
+                {
+                  jsonPath: "$.query",
+                  stringValue: "muse",
+                  willContinue: true,
+                },
+              ],
+              willContinue: true,
+            },
+          },
+        ],
+      },
+      partial: true,
+    },
+    {
+      content: {
+        role: "model",
+        parts: [
+          {
+            functionCall: {
+              name: "search_places",
+              partialArgs: [
+                {
+                  jsonPath: "$.query",
+                  stringValue: "Tokyo",
+                  willContinue: false,
+                },
+                {
+                  jsonPath: "$.filters[0].kind",
+                  stringValue: "forecast",
+                  willContinue: false,
+                },
+              ],
+              willContinue: false,
+            },
+          },
+          {
+            functionCall: {
+              name: "search_places",
+              partialArgs: [
+                {
+                  jsonPath: "$.query",
+                  stringValue: "um",
+                  willContinue: false,
+                },
+              ],
+              willContinue: false,
+            },
+          },
+        ],
+      },
+      partial: true,
+    },
+    {
+      content: {
+        role: "model",
+        parts: [
+          {
+            functionCall: {
+              name: "search_places",
+              args: {
+                query: "weather Tokyo",
+                filters: [{ kind: "forecast" }],
+              },
+            },
+          },
+          {
+            functionCall: {
+              name: "search_places",
+              args: { query: "museum" },
+            },
+          },
+        ],
+      },
+      usageMetadata: {
+        promptTokenCount: 10,
+        candidatesTokenCount: 3,
+        totalTokenCount: 13,
+      },
+      finishReason: "STOP",
+    },
+  ]);
+
+  const attrs = span.attributes;
+  assert.deepEqual(JSON.parse(attrs["gen_ai.completion.0.tool_calls"]), [
+    {
+      type: "function",
+      function: {
+        name: "search_places",
+        arguments: JSON.stringify({
+          query: "weather Tokyo",
+          filters: [{ kind: "forecast" }],
+        }),
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "search_places",
+        arguments: JSON.stringify({ query: "museum" }),
+      },
+    },
+  ]);
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 10);
+  assert.equal(attrs["gen_ai.usage.output_tokens"], 3);
+  assert.equal(attrs["llm.usage.total_tokens"], 13);
+});
+
 test("translates ADK tool spans with normalized input and output", () => {
   const span = createSpan("execute_tool get_weather", {
     "gen_ai.operation.name": "execute_tool",
@@ -197,9 +503,13 @@ test("translator marks ADK span names at start so Respan exports them", () => {
 });
 
 test("translator hook mutates ADK spans before the active processor receives them", () => {
+  const startedSpans = [];
   const capturedSpans = [];
   const originalGetTracerProvider = trace.getTracerProvider.bind(trace);
   const activeSpanProcessor = {
+    onStart(span) {
+      startedSpans.push(span);
+    },
     onEnd(span) {
       capturedSpans.push(span);
     },
@@ -214,10 +524,12 @@ test("translator hook mutates ADK spans before the active processor receives the
   });
 
   try {
+    const originalOnStart = activeSpanProcessor.onStart;
     const originalOnEnd = activeSpanProcessor.onEnd;
     const instrumentor = new GoogleADKInstrumentor();
     instrumentor.activate();
     assert.equal(instrumentor.isActive(), true);
+    assert.notEqual(activeSpanProcessor.onStart, originalOnStart);
     assert.notEqual(activeSpanProcessor.onEnd, originalOnEnd);
 
     const span = createSpan("execute_tool get_weather", {
@@ -226,14 +538,17 @@ test("translator hook mutates ADK spans before the active processor receives the
       "gcp.vertex.agent.tool_call_args": JSON.stringify({ city: "Tokyo" }),
       "gcp.vertex.agent.tool_response": JSON.stringify({ forecast: "sunny" }),
     });
+    activeSpanProcessor.onStart(span, {});
     activeSpanProcessor.onEnd(span);
 
+    assert.equal(startedSpans.length, 1);
     assert.equal(capturedSpans.length, 1);
     assert.equal(capturedSpans[0].attributes["respan.entity.log_type"], "tool");
     assert.equal(capturedSpans[0].attributes["gcp.vertex.agent.tool_response"], undefined);
 
     instrumentor.deactivate();
     assert.equal(instrumentor.isActive(), false);
+    assert.equal(activeSpanProcessor.onStart, originalOnStart);
     assert.equal(activeSpanProcessor.onEnd, originalOnEnd);
   } finally {
     Object.defineProperty(trace, "getTracerProvider", {


### PR DESCRIPTION
## Summary

- Recover one canonical BeeAI ToolCallingAgent span from the populated framework wrapper, preserve prompt/history/final output, and keep chat/tool children beneath it without duplicate agent subtrees.
- Buffer Flue compactions until their operation is actually exported, fall back to the workflow/agent boundary when no operation completes, and clean trace-scoped direct-operation state.
- Assemble Google ADK streamed text and function-call parts incrementally, including id-less calls and partial arguments, without retaining every cumulative response frame.

**Release Intent.**

- Added `.release-intents/20260815-otel2-js-group-1.json`.
- Requests patch releases for:
  - `@respan/instrumentation-beeai`
  - `@respan/instrumentation-flue`
  - `@respan/instrumentation-google-adk`

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched
- [x] TypeScript builds passed for all three packages.
- [x] Package tests passed: BeeAI 11/11, Flue 7/7, Google ADK 9/9 (27/27 total).
- [x] `npm pack --dry-run` passed for all three packages.
- [x] All 8 corresponding `respan-example-projects` examples passed against the locally linked packages.
- [x] Release inventory and release intent validation passed.
- [x] Respan MCP audit marker: `otel2-fix-js-group-01-20260815T062556Z`.
- [x] MCP inspected 8 complete trees and all 41 full span records: one root per trace, no missing parents/cycles/duplicates, 38 successful spans, and only the 3 expected Flue failure spans.
- [x] Trace IDs:
  - BeeAI basic: `88f6d4d1a815c7991f6bce7feca6c8b7`
  - BeeAI tool agent: `7d30b5760e2dc567197916d4ac855577`
  - Flue runtime: `655a8397a6410b2953d6e721f7431005`
  - Flue direct agent: `e08ff7e11034843ccdcb1a7ad7178215`
  - Flue expected error: `ee2df3430a6958873a3bb3bc3099a001`
  - Google ADK hello: `1748d96645565c510c5c88bc686d3c42`
  - Google ADK tool: `fb255d18155394cae5a280174c7d6d79`
  - Google ADK streaming: `e786f1bc35f8ad97d9634e169a9c0cec`

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- None documented.

## Companion examples

- No separate companion PR is linked for this group.
