### PR TITLE
fix(instrumentation-js): repair Strands and Superagent OTel 2.x spans

### DIFF
--- a/.release-intents/20260815-strands-superagent-span-content.json
+++ b/.release-intents/20260815-strands-superagent-span-content.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Preserve Strands structured agent output and expose Superagent model operation content and usage",
+  "packages": {
+    "@respan/instrumentation-strands-agents": "patch",
+    "@respan/instrumentation-superagent": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-strands-agents/README.md
+++ b/javascript-sdks/instrumentations/respan-instrumentation-strands-agents/README.md
@@ -67,3 +67,6 @@ await respan.flush();
   canonical `llm.request.functions` attributes when Strands emits them.
 - The instrumentor translates Strands agent, model, tool, loop, graph, swarm,
   and node spans without adding off-contract `respan.span.*` aliases.
+- When Strands returns structured output only through its internal
+  `strands_structured_output` tool, the instrumentor preserves that validated
+  object on the owning agent span as canonical agent output.

--- a/javascript-sdks/instrumentations/respan-instrumentation-strands-agents/src/_constants.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-strands-agents/src/_constants.ts
@@ -13,6 +13,8 @@ export const STRANDS_OPERATION_EXECUTE_NODE = "execute_node";
 export const STRANDS_OPERATION_INVOKE_GRAPH = "invoke_graph";
 export const STRANDS_OPERATION_INVOKE_SWARM = "invoke_swarm";
 export const STRANDS_OPERATION_INVOKE_PREFIX = "invoke_";
+export const STRANDS_STRUCTURED_OUTPUT_TOOL_NAME =
+  "strands_structured_output";
 
 export const STRANDS_AGENT_TOOLS_ATTR = "gen_ai.agent.tools";
 export const STRANDS_TOOL_STATUS_ATTR = "gen_ai.tool.status";

--- a/javascript-sdks/instrumentations/respan-instrumentation-strands-agents/src/_processor.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-strands-agents/src/_processor.ts
@@ -53,6 +53,7 @@ import {
   STRANDS_OPERATION_INVOKE_PREFIX,
   STRANDS_OPERATION_INVOKE_SWARM,
   STRANDS_RAW_ATTR_PREFIXES_TO_STRIP,
+  STRANDS_STRUCTURED_OUTPUT_TOOL_NAME,
   STRANDS_SYSTEM_NAME,
   STRANDS_TOP_LEVEL_ALIAS_ATTRS_TO_STRIP,
   STRANDS_TOOL_JSON_SCHEMA_ATTR,
@@ -65,6 +66,15 @@ type SpanAttributesRecord = Record<string, any>;
 type SpanEventRecord = {
   name?: string;
   attributes?: Record<string, any>;
+};
+
+type StructuredOutputCandidate = {
+  output: unknown;
+};
+
+type StrandsTraceState = {
+  parents: Map<string, string | undefined>;
+  structuredOutputs: Map<string, StructuredOutputCandidate>;
 };
 
 const RESPAN_LOG_METHOD_TS_TRACING = "ts_tracing";
@@ -118,21 +128,152 @@ const OFF_CONTRACT_ALIAS_ATTRS = new Set([
 ]);
 
 export class StrandsAgentsSpanProcessor implements SpanProcessor {
+  private readonly _traceStates = new Map<string, StrandsTraceState>();
+
   onStart(_span: Span, _parentContext: Context): void {
     // Translation happens on ended spans so message/usage events are complete.
   }
 
   onEnd(span: ReadableSpan): void {
+    const traceId = span.spanContext().traceId;
+    const spanId = span.spanContext().spanId;
+    const parentSpanId = span.parentSpanContext?.spanId;
+    const state = this._traceState(traceId);
+    state.parents.set(spanId, parentSpanId);
+
     enrichStrandsAgentsSpan(span);
+
+    const attrs = (span as any).attributes as SpanAttributesRecord | undefined;
+    if (
+      attrs?.[RespanSpanAttributes.RESPAN_LOG_TYPE] === RespanLogType.TOOL &&
+      attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] ===
+        STRANDS_STRUCTURED_OUTPUT_TOOL_NAME
+    ) {
+      const output = normalizeStructuredOutput(
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT],
+      );
+      if (!isEmptyValue(output)) {
+        state.structuredOutputs.set(spanId, { output });
+      }
+    }
+
+    if (attrs?.[RespanSpanAttributes.RESPAN_LOG_TYPE] === RespanLogType.AGENT) {
+      this._recoverStructuredAgentOutput(attrs, spanId, state);
+      this._clearAgentState(spanId, state);
+    }
+
+    if (!parentSpanId) {
+      this._traceStates.delete(traceId);
+    }
   }
 
   shutdown(): Promise<void> {
+    this._traceStates.clear();
     return Promise.resolve();
   }
 
   forceFlush(): Promise<void> {
     return Promise.resolve();
   }
+
+  private _traceState(traceId: string): StrandsTraceState {
+    let state = this._traceStates.get(traceId);
+    if (!state) {
+      state = {
+        parents: new Map(),
+        structuredOutputs: new Map(),
+      };
+      this._traceStates.set(traceId, state);
+    }
+    return state;
+  }
+
+  private _recoverStructuredAgentOutput(
+    attrs: SpanAttributesRecord,
+    agentSpanId: string,
+    state: StrandsTraceState,
+  ): void {
+    if (hasMeaningfulAgentOutput(attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])) {
+      return;
+    }
+
+    let recovered: unknown;
+    for (const [toolSpanId, candidate] of state.structuredOutputs) {
+      if (isDescendantSpan(toolSpanId, agentSpanId, state.parents)) {
+        recovered = candidate.output;
+      }
+    }
+    if (recovered === undefined) {
+      return;
+    }
+
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson([
+      { role: "assistant", content: recovered },
+    ]);
+  }
+
+  private _clearAgentState(
+    agentSpanId: string,
+    state: StrandsTraceState,
+  ): void {
+    for (const toolSpanId of state.structuredOutputs.keys()) {
+      if (isDescendantSpan(toolSpanId, agentSpanId, state.parents)) {
+        state.structuredOutputs.delete(toolSpanId);
+      }
+    }
+    for (const spanId of state.parents.keys()) {
+      if (
+        spanId === agentSpanId ||
+        isDescendantSpan(spanId, agentSpanId, state.parents)
+      ) {
+        state.parents.delete(spanId);
+      }
+    }
+  }
+}
+
+function isDescendantSpan(
+  spanId: string,
+  ancestorSpanId: string,
+  parents: Map<string, string | undefined>,
+): boolean {
+  const visited = new Set<string>();
+  let current = parents.get(spanId);
+  while (current && !visited.has(current)) {
+    if (current === ancestorSpanId) {
+      return true;
+    }
+    visited.add(current);
+    current = parents.get(current);
+  }
+  return false;
+}
+
+function normalizeStructuredOutput(value: unknown): unknown {
+  let parsed = safeJsonLoads(value);
+  if (typeof parsed === "string") {
+    parsed = safeJsonLoads(parsed);
+  }
+  if (Array.isArray(parsed) && parsed.length === 1) {
+    parsed = parsed[0];
+  }
+  if (isRecord(parsed) && "json" in parsed) {
+    return toSerializableValue(parsed.json);
+  }
+  return toSerializableValue(parsed);
+}
+
+function hasMeaningfulAgentOutput(value: unknown): boolean {
+  const parsed = safeJsonLoads(value);
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    return !isEmptyValue(parsed);
+  }
+  return parsed.some((message) => {
+    if (!isRecord(message)) {
+      return !isEmptyValue(message);
+    }
+    return !isEmptyValue(message.content);
+  });
 }
 
 export function enrichStrandsAgentsSpan(span: ReadableSpan): void {

--- a/javascript-sdks/instrumentations/respan-instrumentation-strands-agents/tests/strands_agents_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-strands-agents/tests/strands_agents_instrumentor.test.mjs
@@ -6,6 +6,7 @@ import { RespanCompositeProcessor } from "../../../respan-tracing/dist/processor
 
 import {
   StrandsAgentsInstrumentor,
+  StrandsAgentsSpanProcessor,
   enrichStrandsAgentsSpan,
 } from "../dist/index.js";
 
@@ -24,16 +25,26 @@ const EVENT_USER_MESSAGE = "gen_ai.user.message";
 const EVENT_TOOL_MESSAGE = "gen_ai.tool.message";
 const EVENT_CHOICE = "gen_ai.choice";
 
-function makeSpan({ name, attributes = {}, events = [] }) {
+function makeSpan({
+  name,
+  attributes = {},
+  events = [],
+  traceId = "11111111111111111111111111111111",
+  spanId = "2222222222222222",
+  parentSpanId,
+}) {
   const attrs = { ...attributes };
   return {
     name,
     attributes: attrs,
     events,
+    parentSpanContext: parentSpanId
+      ? { traceId, spanId: parentSpanId, traceFlags: 1 }
+      : undefined,
     spanContext() {
       return {
-        traceId: "11111111111111111111111111111111",
-        spanId: "2222222222222222",
+        traceId,
+        spanId,
         traceFlags: 1,
       };
     },
@@ -225,6 +236,83 @@ test("enriches Strands graph and swarm spans as workflows", () => {
   assert.equal(graphSpan.attributes[WORKFLOW_NAME], "graph:graph-demo");
   assert.equal(graphSpan.attributes["gen_ai.operation.name"], undefined);
   assertNoOffContractAliases(graphSpan.attributes);
+});
+
+test("recovers tool-only structured output on its owning agent and clears it", async () => {
+  const processor = new StrandsAgentsSpanProcessor();
+  const traceId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const agentSpanId = "aaaaaaaaaaaaaaaa";
+  const cycleSpanId = "bbbbbbbbbbbbbbbb";
+  const structured = {
+    city: "Tokyo",
+    score: 92,
+    rationale: "Reliable transit, compact neighborhoods, and strong food options.",
+  };
+  const toolSpan = makeSpan({
+    name: "execute_tool strands_structured_output",
+    traceId,
+    spanId: "cccccccccccccccc",
+    parentSpanId: cycleSpanId,
+    attributes: {
+      "gen_ai.system": "strands-agents",
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": "strands_structured_output",
+      "gen_ai.tool.call.id": "structured-1",
+    },
+    events: [
+      event(EVENT_TOOL_MESSAGE, { content: JSON.stringify(structured) }),
+      event(EVENT_CHOICE, {
+        message: JSON.stringify([{ json: structured }]),
+      }),
+    ],
+  });
+  const cycleSpan = makeSpan({
+    name: "execute_event_loop_cycle",
+    traceId,
+    spanId: cycleSpanId,
+    parentSpanId: agentSpanId,
+    attributes: {
+      "gen_ai.system": "strands-agents",
+      "gen_ai.operation.name": "execute_event_loop_cycle",
+    },
+  });
+  const agentSpan = makeSpan({
+    name: "invoke_agent Structured",
+    traceId,
+    spanId: agentSpanId,
+    attributes: {
+      "gen_ai.system": "strands-agents",
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "Structured",
+    },
+    events: [event(EVENT_CHOICE, { message: "" })],
+  });
+
+  processor.onEnd(toolSpan);
+  processor.onEnd(cycleSpan);
+  processor.onEnd(agentSpan);
+
+  assert.deepEqual(JSON.parse(agentSpan.attributes[ENTITY_OUTPUT]), [
+    { role: "assistant", content: structured },
+  ]);
+
+  const reusedAgent = makeSpan({
+    name: "invoke_agent ReusedTrace",
+    traceId,
+    spanId: "dddddddddddddddd",
+    attributes: {
+      "gen_ai.system": "strands-agents",
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "ReusedTrace",
+    },
+    events: [event(EVENT_CHOICE, { message: "" })],
+  });
+  processor.onEnd(reusedAgent);
+  assert.deepEqual(JSON.parse(reusedAgent.attributes[ENTITY_OUTPUT]), [
+    { role: "assistant", content: "" },
+  ]);
+
+  await processor.shutdown();
 });
 
 test("multiple instrumentors retain the semconv opt-in until the final owner deactivates", async () => {

--- a/javascript-sdks/instrumentations/respan-instrumentation-superagent/README.md
+++ b/javascript-sdks/instrumentations/respan-instrumentation-superagent/README.md
@@ -44,6 +44,12 @@ operations into the shared Respan OpenTelemetry pipeline.
 - `redact()` emits `respan.entity.log_type=tool`.
 - `scan()` emits `respan.entity.log_type=tool`.
 
+Each traced method also emits a child chat span for the underlying model
+operation. That child carries the configured model, canonical prompt and
+completion content, and the real token usage returned by `safety-agent`.
+Keeping model fields on the child preserves the common-only contract of the
+parent guardrail/tool span.
+
 Auto-emitted Superagent spans intentionally do not set `traceloop.span.kind`;
 that attribute is reserved for user-created Respan workflow/task/agent/tool
 spans.

--- a/javascript-sdks/instrumentations/respan-instrumentation-superagent/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-superagent/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/semantic-conventions": "^1.43.0",
     "@respan/respan-sdk": "^1.0.0",
     "@respan/tracing": "^1.0.0",
     "@traceloop/ai-semantic-conventions": "^0.13.0"

--- a/javascript-sdks/instrumentations/respan-instrumentation-superagent/src/_span_attributes.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-superagent/src/_span_attributes.ts
@@ -1,5 +1,13 @@
-import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
+import {
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_SYSTEM,
+  ATTR_GEN_AI_USAGE_COMPLETION_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_PROMPT_TOKENS,
+} from "@opentelemetry/semantic-conventions/incubating";
 import { RespanLogType, RespanSpanAttributes } from "@respan/respan-sdk";
+import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 import {
   GUARD_METHOD,
   SUPERAGENT_INSTRUMENTATION_NAME,
@@ -11,6 +19,7 @@ import {
 } from "./_constants.js";
 import {
   extractModel,
+  extractPrimaryInput,
   getAttr,
   normalizeCallInput,
   safeJsonStringify,
@@ -30,6 +39,9 @@ export interface BuildSuperagentSpanAttributesOptions {
   error?: unknown;
   workflowName?: string;
 }
+
+export type BuildSuperagentModelSpanAttributesOptions =
+  BuildSuperagentSpanAttributesOptions;
 
 function operationLogType(methodName: string): RespanLogType {
   return methodName === GUARD_METHOD ? RespanLogType.GUARDRAIL : RespanLogType.TOOL;
@@ -66,6 +78,110 @@ function addResultMetadata(
       attrs[SUPERAGENT_METADATA_REDACT_FINDINGS] = safeJsonStringify(findings);
     }
   }
+}
+
+function tokenCount(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.trunc(value);
+}
+
+function addUsageAttributes(
+  attrs: SuperagentSpanAttributes,
+  result: unknown,
+): void {
+  const usage = getAttr(result, "usage");
+  const inputTokens = tokenCount(
+    getAttr(usage, "promptTokens") ?? getAttr(usage, "inputTokens"),
+  );
+  const outputTokens = tokenCount(
+    getAttr(usage, "completionTokens") ?? getAttr(usage, "outputTokens"),
+  );
+  const totalTokens =
+    tokenCount(getAttr(usage, "totalTokens")) ??
+    (inputTokens !== undefined || outputTokens !== undefined
+      ? (inputTokens ?? 0) + (outputTokens ?? 0)
+      : undefined);
+
+  if (inputTokens !== undefined) {
+    attrs[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = inputTokens;
+    attrs[ATTR_GEN_AI_USAGE_PROMPT_TOKENS] = inputTokens;
+  }
+  if (outputTokens !== undefined) {
+    attrs[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] = outputTokens;
+    attrs[ATTR_GEN_AI_USAGE_COMPLETION_TOKENS] = outputTokens;
+  }
+  if (totalTokens !== undefined) {
+    attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = totalTokens;
+  }
+}
+
+function modelProvider(model: string): string {
+  const provider = model.split("/", 1)[0]?.toLowerCase();
+  if (provider === "openai-compatible") {
+    return "openai";
+  }
+  return provider || "superagent";
+}
+
+function messageContent(value: unknown): string {
+  return typeof value === "string" ? value : safeJsonStringify(value);
+}
+
+export function buildSuperagentModelSpanAttributes({
+  methodName,
+  args,
+  result,
+  error,
+  workflowName,
+}: BuildSuperagentModelSpanAttributesOptions): SuperagentSpanAttributes {
+  const operationName = `superagent.${methodName}.model`;
+  const input =
+    extractPrimaryInput(methodName, args) ?? normalizeCallInput(methodName, args);
+  const inputContent = messageContent(input);
+  const attrs: SuperagentSpanAttributes = {
+    [RespanSpanAttributes.RESPAN_LOG_TYPE]: RespanLogType.CHAT,
+    [SpanAttributes.TRACELOOP_ENTITY_NAME]: operationName,
+    [SpanAttributes.TRACELOOP_ENTITY_PATH]: operationName,
+    [SpanAttributes.TRACELOOP_ENTITY_INPUT]: safeJsonStringify([
+      { role: "user", content: input },
+    ]),
+    [SpanAttributes.LLM_REQUEST_TYPE]: RespanLogType.CHAT,
+    "gen_ai.prompt.0.role": "user",
+    "gen_ai.prompt.0.content": inputContent,
+  };
+
+  if (workflowName) {
+    attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = workflowName;
+  }
+
+  const model = extractModel(args);
+  if (model) {
+    attrs[ATTR_GEN_AI_SYSTEM] = modelProvider(model);
+    attrs[ATTR_GEN_AI_REQUEST_MODEL] = model;
+  }
+
+  if (error !== undefined) {
+    const output = { error: errorMessage(error) };
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJsonStringify([
+      { role: "assistant", content: output },
+    ]);
+    attrs["gen_ai.completion.0.role"] = "assistant";
+    attrs["gen_ai.completion.0.content"] = safeJsonStringify(output);
+    return attrs;
+  }
+
+  if (result !== undefined) {
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJsonStringify([
+      { role: "assistant", content: result },
+    ]);
+    attrs["gen_ai.completion.0.role"] = "assistant";
+    attrs["gen_ai.completion.0.content"] = messageContent(result);
+    addUsageAttributes(attrs, result);
+  }
+
+  return attrs;
 }
 
 export function buildSuperagentSpanAttributes({

--- a/javascript-sdks/instrumentations/respan-instrumentation-superagent/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-superagent/src/index.ts
@@ -20,7 +20,10 @@ import {
   SUPERAGENT_INSTRUMENTATION_NAME,
   SUPPORTED_METHODS,
 } from "./_constants.js";
-import { buildSuperagentSpanAttributes } from "./_span_attributes.js";
+import {
+  buildSuperagentModelSpanAttributes,
+  buildSuperagentSpanAttributes,
+} from "./_span_attributes.js";
 
 type OriginalMethod = (
   this: SafetyClient,
@@ -73,7 +76,50 @@ function wrapMethod(methodName: string, original: OriginalMethod): OriginalMetho
       },
       async (span) => {
         try {
-          const result = await original.apply(this, args);
+          const result = await tracer.startActiveSpan(
+            `${operationName}.model`,
+            {
+              attributes: buildSuperagentModelSpanAttributes({
+                methodName,
+                args,
+                workflowName,
+              }),
+            },
+            async (modelSpan) => {
+              try {
+                const result = await original.apply(this, args);
+                setSpanAttributes(
+                  modelSpan,
+                  buildSuperagentModelSpanAttributes({
+                    methodName,
+                    args,
+                    result,
+                    workflowName,
+                  }),
+                );
+                modelSpan.setStatus({ code: SpanStatusCode.OK });
+                return result;
+              } catch (error) {
+                setSpanAttributes(
+                  modelSpan,
+                  buildSuperagentModelSpanAttributes({
+                    methodName,
+                    args,
+                    error,
+                    workflowName,
+                  }),
+                );
+                modelSpan.recordException(error as Error);
+                modelSpan.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message: error instanceof Error ? error.message : String(error),
+                });
+                throw error;
+              } finally {
+                modelSpan.end();
+              }
+            },
+          );
           setSpanAttributes(
             span,
             buildSuperagentSpanAttributes({

--- a/javascript-sdks/instrumentations/respan-instrumentation-superagent/tests/span-attributes.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-superagent/tests/span-attributes.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildSuperagentSpanAttributes } from "../dist/_span_attributes.js";
+import {
+  buildSuperagentModelSpanAttributes,
+  buildSuperagentSpanAttributes,
+} from "../dist/_span_attributes.js";
 import {
   extractModel,
   extractPrimaryInput,
@@ -19,6 +22,12 @@ const SUPERAGENT_METADATA_METHOD = "respan.metadata.superagent_method";
 const SUPERAGENT_METADATA_MODEL = "respan.metadata.superagent_model";
 const SUPERAGENT_METADATA_CLASSIFICATION = "respan.metadata.superagent_classification";
 const SUPERAGENT_METADATA_REDACT_FINDINGS = "respan.metadata.superagent_redact_findings";
+const GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
+const GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens";
+const GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens";
+const GEN_AI_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens";
+const GEN_AI_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens";
+const LLM_USAGE_TOTAL_TOKENS = "llm.usage.total_tokens";
 
 const OFF_CONTRACT_ALIASES = new Set([
   "respan.span.tools",
@@ -54,6 +63,11 @@ test("guard attrs use canonical guardrail contract", () => {
       classification: "block",
       reasoning: "Prompt injection attempt.",
       violation_types: ["prompt_injection"],
+      usage: {
+        promptTokens: 641,
+        completionTokens: 74,
+        totalTokens: 715,
+      },
     },
   });
 
@@ -63,6 +77,10 @@ test("guard attrs use canonical guardrail contract", () => {
   assert.equal(attrs[SUPERAGENT_METADATA_INTEGRATION], "superagent");
   assert.equal(attrs[SUPERAGENT_METADATA_METHOD], "guard");
   assert.equal(attrs[SUPERAGENT_METADATA_MODEL], "superagent/guard-1.7b");
+  assert.equal(attrs[GEN_AI_REQUEST_MODEL], undefined);
+  assert.equal(attrs[GEN_AI_USAGE_INPUT_TOKENS], undefined);
+  assert.equal(attrs[GEN_AI_USAGE_OUTPUT_TOKENS], undefined);
+  assert.equal(attrs[LLM_USAGE_TOTAL_TOKENS], undefined);
   assert.equal(attrs[SUPERAGENT_METADATA_CLASSIFICATION], "block");
   assert.equal(attrs[RESPAN_METADATA_GUARDRAIL_NAME], "superagent.guard");
   assert.equal(attrs[RESPAN_METADATA_TRIGGERED], true);
@@ -100,6 +118,42 @@ test("error attrs keep canonical output shape", () => {
 
   assert.equal(attrs[RESPAN_LOG_TYPE], "tool");
   assert.match(attrs["traceloop.entity.output"], /scan failed/);
+  assertNoOffContractAliases(attrs);
+});
+
+test("model-operation attrs map request, output, model, and provider usage", () => {
+  const attrs = buildSuperagentModelSpanAttributes({
+    methodName: "scan",
+    args: [
+      {
+        repo: "https://github.com/example/repo",
+        model: "openai-compatible/gpt-4o-mini",
+      },
+    ],
+    result: {
+      result: "No critical findings.",
+      usage: {
+        inputTokens: 120,
+        outputTokens: 15,
+        reasoningTokens: 3,
+        cost: 0.001,
+      },
+    },
+  });
+
+  assert.equal(attrs[GEN_AI_REQUEST_MODEL], "openai-compatible/gpt-4o-mini");
+  assert.equal(attrs[RESPAN_LOG_TYPE], "chat");
+  assert.equal(attrs["gen_ai.system"], "openai");
+  assert.equal(attrs["llm.request.type"], "chat");
+  assert.equal(attrs["gen_ai.prompt.0.role"], "user");
+  assert.match(attrs["gen_ai.prompt.0.content"], /example\/repo/);
+  assert.equal(attrs["gen_ai.completion.0.role"], "assistant");
+  assert.match(attrs["gen_ai.completion.0.content"], /No critical findings/);
+  assert.equal(attrs[GEN_AI_USAGE_INPUT_TOKENS], 120);
+  assert.equal(attrs[GEN_AI_USAGE_PROMPT_TOKENS], 120);
+  assert.equal(attrs[GEN_AI_USAGE_OUTPUT_TOKENS], 15);
+  assert.equal(attrs[GEN_AI_USAGE_COMPLETION_TOKENS], 15);
+  assert.equal(attrs[LLM_USAGE_TOTAL_TOKENS], 135);
   assertNoOffContractAliases(attrs);
 });
 

--- a/javascript-sdks/yarn.lock
+++ b/javascript-sdks/yarn.lock
@@ -5395,6 +5395,7 @@ __metadata:
   resolution: "@respan/instrumentation-superagent@workspace:instrumentations/respan-instrumentation-superagent"
   dependencies:
     "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.43.0"
     "@respan/respan-sdk": "npm:^1.0.0"
     "@respan/tracing": "npm:^1.0.0"
     "@traceloop/ai-semantic-conventions": "npm:^0.13.0"


### PR DESCRIPTION
## Summary

- recover tool-only Strands structured output on its owning agent without duplicating the child tool result
- add contribution-contract-compliant Superagent child chat spans for model, input/output, and usage while keeping outer guardrail/tool spans type-safe
- add focused regressions, package documentation, and patch release intents

## Validation

- [x] package builds and focused tests: Pydantic AI 5/5, Strands Agents 8/8, Superagent 5/5
- [x] `npm pack --dry-run` passed for all three Group 4 packages
- [x] all three corresponding example sets typecheck against their locally linked packages
- [x] release inventory, release intents, missing-intent coverage, and `git diff --check` passed
- [x] exact marker: `otel2-fix-js-group-04-20260815T135107Z`
- [x] Respan MCP: 17 complete trees and 74 individually inspected full span records, with matching counts, resolved parents, and no duplicates or orphans
- [x] Pydantic tool scenario is one connected workflow with tool/chat siblings
- [x] Strands structured agent contains the Tokyo object while its five-span workflow/agent/task/chat/tool tree and usage remain intact
- [x] Superagent guard/redact/combined trees expose exact model-child token totals while outer guardrail/tool spans retain their contract

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- The Pydantic AI change for this group is confined to `respan-example-projects`, so this Respan PR contains only the Strands Agents and Superagent package fixes.
- The Superagent live scan example remains credential-gated because `DAYTONA_API_KEY` is not configured.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/50
