### PR TITLE
test(instrumentation-js): validate Together AI OTel 2.x spans

### DIFF
--- a/.release-intents/20260815-together-non-chat-export.json
+++ b/.release-intents/20260815-together-non-chat-export.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add OTLP serialization coverage for Together AI non-chat model and usage attributes",
+  "packages": {
+    "@respan/instrumentation-together-ai": "none"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-together-ai/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-together-ai/package.json
@@ -45,6 +45,7 @@
     }
   },
   "devDependencies": {
+    "@opentelemetry/otlp-transformer": "^0.205.0",
     "@types/node": "^22.15.29",
     "together-ai": "^0.40.0",
     "typescript": "^5.7.3"

--- a/javascript-sdks/instrumentations/respan-instrumentation-together-ai/tests/together_ai_instrumentation_internal.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-together-ai/tests/together_ai_instrumentation_internal.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { trace } from "@opentelemetry/api";
+import { JsonTraceSerializer } from "@opentelemetry/otlp-transformer";
 
 import { patchResourceMethod } from "../dist/_patching.js";
 const CHAT_SPEC = {
@@ -19,6 +20,84 @@ const EMBEDDING_SPEC = {
   logType: "embedding",
   requestType: "embedding",
 };
+
+const NON_CHAT_CASES = [
+  {
+    label: "image generation",
+    spec: {
+      kind: "image",
+      method: "generate",
+      spanName: "together.images.generate",
+      logType: "generation",
+      requestType: "image",
+    },
+    request: {
+      model: "black-forest-labs/FLUX.1-schnell-Free",
+      prompt: "A compact tracing diagram",
+    },
+    response: {
+      model: "black-forest-labs/FLUX.1-schnell-Free",
+      data: [{ url: "https://example.invalid/generated.png" }],
+    },
+  },
+  {
+    label: "rerank",
+    spec: {
+      kind: "rerank",
+      method: "create",
+      spanName: "together.rerank",
+      logType: "custom",
+      requestType: "rerank",
+    },
+    request: {
+      model: "Salesforce/Llama-Rank-v1",
+      query: "observability",
+      documents: ["Tracing", "Metrics"],
+    },
+    response: {
+      model: "Salesforce/Llama-Rank-v1",
+      results: [{ index: 0, relevance_score: 0.98 }],
+      usage: { prompt_tokens: 10, completion_tokens: 0, total_tokens: 10 },
+    },
+    usage: { input: 10, output: 0, total: 10 },
+  },
+  {
+    label: "speech",
+    spec: {
+      kind: "speech",
+      method: "create",
+      spanName: "together.audio.speech",
+      logType: "speech",
+      requestType: "speech",
+    },
+    request: { model: "cartesia/sonic", input: "Trace this sentence." },
+    response: { model: "cartesia/sonic", audio: "base64-audio" },
+  },
+  {
+    label: "transcription",
+    spec: {
+      kind: "transcription",
+      method: "create",
+      spanName: "together.audio.transcriptions",
+      logType: "transcription",
+      requestType: "transcription",
+    },
+    request: { model: "openai/whisper-large-v3", file: "demo.wav" },
+    response: { model: "openai/whisper-large-v3", text: "Trace received." },
+  },
+  {
+    label: "translation",
+    spec: {
+      kind: "translation",
+      method: "create",
+      spanName: "together.audio.translations",
+      logType: "custom",
+      requestType: "translation",
+    },
+    request: { model: "openai/whisper-large-v3", file: "demo.wav" },
+    response: { model: "openai/whisper-large-v3", text: "Trace received." },
+  },
+];
 
 const captureState = { spans: [] };
 const originalGetTracerProvider = trace.getTracerProvider.bind(trace);
@@ -289,4 +368,92 @@ test("embedding spans preserve vectors in traceloop entity output", async () => 
   ]);
 
   resourcePrototype.create = patchedTarget.original;
+});
+
+function serializedSpan(readableSpan) {
+  const bytes = JsonTraceSerializer.serializeRequest([readableSpan]);
+  assert.ok(bytes?.length, "OTLP serializer produced a payload");
+  const request = JSON.parse(Buffer.from(bytes).toString("utf8"));
+  const spans = (request.resourceSpans ?? []).flatMap((resourceSpans) =>
+    (resourceSpans.scopeSpans ?? []).flatMap((scopeSpans) =>
+      (scopeSpans.spans ?? []).map((span) => ({
+        ...span,
+        scopeName: scopeSpans.scope?.name,
+      })),
+    ),
+  );
+  assert.equal(spans.length, 1);
+  return spans[0];
+}
+
+function serializedAttribute(span, key) {
+  const value = span.attributes?.find((attribute) => attribute.key === key)?.value;
+  if (!value) return undefined;
+  return value.stringValue ??
+    value.intValue ??
+    value.doubleValue ??
+    value.boolValue ??
+    value.arrayValue;
+}
+
+test("non-chat spans retain canonical model and usage through OTel 2 OTLP serialization", async (t) => {
+  for (const testCase of NON_CHAT_CASES) {
+    await t.test(testCase.label, async () => {
+      captureState.spans = [];
+      const resourcePrototype = {
+        [testCase.spec.method](_body) {
+          return Promise.resolve(testCase.response);
+        },
+      };
+      const patchedTarget = patchResourceMethod(resourcePrototype, testCase.spec);
+      assert.ok(patchedTarget);
+
+      await resourcePrototype[testCase.spec.method](testCase.request).then((value) => value);
+
+      assert.equal(captureState.spans.length, 1);
+      const emitted = captureState.spans[0];
+      const serialized = serializedSpan(emitted);
+      assert.equal(serialized.scopeName, "@respan/instrumentation-together-ai");
+      assert.equal(
+        serializedAttribute(serialized, "respan.entity.log_type"),
+        testCase.spec.logType,
+      );
+      assert.equal(
+        serializedAttribute(serialized, "llm.request.type"),
+        testCase.spec.requestType,
+      );
+      assert.equal(
+        serializedAttribute(serialized, "gen_ai.request.model"),
+        testCase.request.model,
+      );
+      assert.ok(serializedAttribute(serialized, "traceloop.entity.input"));
+      assert.ok(serializedAttribute(serialized, "traceloop.entity.output"));
+
+      if (testCase.usage) {
+        assert.equal(
+          Number(serializedAttribute(serialized, "gen_ai.usage.input_tokens")),
+          testCase.usage.input,
+        );
+        assert.equal(
+          Number(serializedAttribute(serialized, "gen_ai.usage.output_tokens")),
+          testCase.usage.output,
+        );
+        assert.equal(
+          Number(serializedAttribute(serialized, "llm.usage.total_tokens")),
+          testCase.usage.total,
+        );
+      }
+
+      for (const bannedKey of [
+        "model",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_request_tokens",
+      ]) {
+        assert.equal(serializedAttribute(serialized, bannedKey), undefined);
+      }
+
+      resourcePrototype[testCase.spec.method] = patchedTarget.original;
+    });
+  }
 });

--- a/javascript-sdks/yarn.lock
+++ b/javascript-sdks/yarn.lock
@@ -5415,6 +5415,7 @@ __metadata:
   dependencies:
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/core": "npm:^2.10.0"
+    "@opentelemetry/otlp-transformer": "npm:^0.205.0"
     "@opentelemetry/sdk-trace-base": "npm:^2.10.0"
     "@opentelemetry/semantic-conventions": "npm:^1.43.0"
     "@respan/respan-sdk": "npm:^1.1.7"


### PR DESCRIPTION
## Summary

- add real OpenTelemetry 2.x OTLP JSON serialization coverage for Together AI image, rerank, speech, transcription, and translation spans
- assert canonical Respan model, request type, input, output, and token-usage fields survive serialization
- add a `none` release intent because this change strengthens contract coverage without changing runtime behavior

**Why.**

The audit showed that Together AI non-chat spans contain canonical model and usage attributes before export, while the platform does not currently populate those values in its top-level non-chat columns. The correct package-side fix is to lock down the canonical OTLP wire contract rather than add unsupported aliases or change span types.

**Impact.**

This prevents regressions in non-chat attribute export and makes the remaining ingestion boundary explicit. There is no production runtime or package-version change.

The corresponding example-project fixes are local to `respan-example-projects`: exact shared-marker metadata for Vercel AI SDK, awaited Vertex AI shutdown, and complete streamed workflow capture.

## Validation

- [x] Together AI package tests: 9/9
- [x] Vercel AI SDK package tests: 47/47
- [x] Vertex AI package tests: 7/7
- [x] all three package builds and `npm pack --dry-run` checks passed
- [x] all 18 corresponding examples passed with marker `otel2-fix-js-group-05-20260815T144725Z`
- [x] MCP audit: 18/18 trace trees and 58/58 individual span records inspected; one root per trace, matching counts, no orphans, cycles, or duplicates
- [x] release inventory, release intent, and diff checks passed

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- Together AI examples are mock-backed and Vertex AI examples use explicit fake mode because the repository environment does not provide those providers' live credentials.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/52
