### PR TITLE
fix(instrumentation-js): repair Anthropic OTel 2.x spans

### DIFF
--- a/.release-intents/20260816-anthropic-span-contract.json
+++ b/.release-intents/20260816-anthropic-span-contract.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Fix Anthropic error status, propagated metadata, tool fields, and scope version",
+  "packages": {
+    "@respan/instrumentation-anthropic": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-anthropic/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-anthropic/package.json
@@ -31,6 +31,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
+    "@opentelemetry/semantic-conventions": "^1.43.0",
     "@respan/respan-sdk": "^1.1.7",
     "@respan/tracing": "^1.1.4",
     "@traceloop/ai-semantic-conventions": "^0.13.0"

--- a/javascript-sdks/instrumentations/respan-instrumentation-anthropic/src/_helpers.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-anthropic/src/_helpers.ts
@@ -8,7 +8,11 @@ import {
   ToolCallSchema,
 } from "@respan/respan-sdk";
 
-export const PACKAGE_VERSION = "1.1.1";
+const packageManifest = createRequire(import.meta.url)("../package.json") as {
+  version?: string;
+};
+
+export const PACKAGE_VERSION = packageManifest.version ?? "unknown";
 export const INSTRUMENTATION_LIBRARY_NAME = "@respan/instrumentation-anthropic";
 export const ANTHROPIC_CHAT_ENTITY_NAME = "anthropic.chat";
 export const STREAM_INSTRUMENTED = Symbol("respan.anthropic.stream.instrumented");
@@ -82,6 +86,28 @@ export function stringifyStructured(value: unknown): string {
     return serialized;
   }
   return safeJson(serialized);
+}
+
+export function resolveErrorStatusCode(error: unknown): number {
+  if (!error || typeof error !== "object") return 500;
+
+  const candidate = error as Record<string, any>;
+  const values = [
+    candidate.status,
+    candidate.statusCode,
+    candidate.response?.status,
+    candidate.cause?.status,
+    candidate.cause?.statusCode,
+  ];
+
+  for (const value of values) {
+    const statusCode = typeof value === "number" ? value : Number(value);
+    if (Number.isInteger(statusCode) && statusCode >= 400 && statusCode <= 599) {
+      return statusCode;
+    }
+  }
+
+  return 500;
 }
 
 export interface ToolExecution {

--- a/javascript-sdks/instrumentations/respan-instrumentation-anthropic/src/_span_emitter.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-anthropic/src/_span_emitter.ts
@@ -1,6 +1,14 @@
 import { context, trace, TraceFlags } from "@opentelemetry/api";
 import { hrTime } from "@opentelemetry/core";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  ATTR_GEN_AI_COMPLETION,
+  ATTR_GEN_AI_PROMPT,
+  ATTR_GEN_AI_USAGE_COMPLETION_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_PROMPT_TOKENS,
+} from "@opentelemetry/semantic-conventions/incubating";
 import { buildReadableSpan, injectSpan } from "@respan/tracing";
 import { RespanLogType, RespanSpanAttributes } from "@respan/respan-sdk";
 import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
@@ -9,22 +17,29 @@ import {
   INSTRUMENTATION_LIBRARY_NAME,
   PACKAGE_VERSION,
   extractToolCalls,
-  extractToolCallsFromInputMessages,
   extractToolExecutions,
   formatInputMessages,
   formatOutputMessage,
   formatTools,
-  mergeToolCalls,
+  resolveErrorStatusCode,
   safeJson,
   stringifyStructured,
   type ToolExecution,
 } from "./_helpers.js";
+
+const COMPLETION_ZERO = `${ATTR_GEN_AI_COMPLETION}.0`;
+const COMPLETION_TOOL_CALLS = `${COMPLETION_ZERO}.tool_calls`;
+const LLM_IS_STREAMING =
+  (SpanAttributes as unknown as Record<string, string>).LLM_IS_STREAMING ??
+  "llm.is_streaming";
+const STATUS_CODE_ATTR = "status_code";
 
 function buildInstrumentedReadableSpan(opts: {
   name: string;
   startTime: [number, number];
   endTime: [number, number];
   attributes: Record<string, any>;
+  statusCode?: number;
   errorMessage?: string;
 }): ReadableSpan {
   const activeSpanContext = trace.getSpan(context.active())?.spanContext();
@@ -35,8 +50,8 @@ function buildInstrumentedReadableSpan(opts: {
     startTimeHr: opts.startTime,
     endTimeHr: opts.endTime,
     attributes: opts.attributes,
+    statusCode: opts.statusCode,
     errorMessage: opts.errorMessage,
-    mergePropagated: false,
   }) as ReadableSpan & {
     instrumentationScope?: { name: string; version?: string };
     spanContext: () => ReturnType<ReadableSpan["spanContext"]>;
@@ -57,22 +72,18 @@ function buildInstrumentedReadableSpan(opts: {
   return mutableSpan;
 }
 
-function setStructuredAttr(
-  attrs: Record<string, any>,
-  key: string,
-  value: unknown,
-): void {
-  attrs[key] = value;
-}
-
-function setStructuredCompatibilityAttrs(
-  attrs: Record<string, any>,
-  key: RespanSpanAttributes.RESPAN_SPAN_TOOLS | RespanSpanAttributes.RESPAN_SPAN_TOOL_CALLS,
-  legacyKey: "tools" | "tool_calls",
-  value: unknown,
-): void {
-  setStructuredAttr(attrs, key, value);
-  setStructuredAttr(attrs, legacyKey, value);
+function setPromptAttrs(attrs: Record<string, any>, messages: Record<string, any>[]): void {
+  messages.forEach((message, index) => {
+    const prefix = `${ATTR_GEN_AI_PROMPT}.${index}`;
+    attrs[`${prefix}.role`] = message.role;
+    attrs[`${prefix}.content`] = stringifyStructured(message.content ?? "");
+    if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+      attrs[`${prefix}.tool_calls`] = safeJson(message.tool_calls);
+    }
+    if (message.tool_call_id) {
+      attrs[`${prefix}.tool_call_id`] = String(message.tool_call_id);
+    }
+  });
 }
 
 function buildBaseChatAttrs(kwargs: Record<string, any>, model?: string): Record<string, any> {
@@ -83,6 +94,7 @@ function buildBaseChatAttrs(kwargs: Record<string, any>, model?: string): Record
     [RespanSpanAttributes.RESPAN_LOG_TYPE]: RespanLogType.CHAT,
     [RespanSpanAttributes.LLM_REQUEST_TYPE]: RespanLogType.CHAT,
     [RespanSpanAttributes.LLM_SYSTEM]: "anthropic",
+    [LLM_IS_STREAMING]: kwargs.stream === true,
   };
 
   const resolvedModel = model ?? kwargs.model;
@@ -90,18 +102,13 @@ function buildBaseChatAttrs(kwargs: Record<string, any>, model?: string): Record
     attrs[RespanSpanAttributes.GEN_AI_REQUEST_MODEL] = resolvedModel;
   }
 
-  attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(
-    formatInputMessages(kwargs.messages ?? [], kwargs.system),
-  );
+  const inputMessages = formatInputMessages(kwargs.messages ?? [], kwargs.system);
+  attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(inputMessages);
+  setPromptAttrs(attrs, inputMessages);
 
   const tools = formatTools(kwargs.tools);
   if (tools) {
-    setStructuredCompatibilityAttrs(
-      attrs,
-      RespanSpanAttributes.RESPAN_SPAN_TOOLS,
-      "tools",
-      tools,
-    );
+    attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS] = safeJson(tools);
   }
 
   return attrs;
@@ -109,45 +116,33 @@ function buildBaseChatAttrs(kwargs: Record<string, any>, model?: string): Record
 
 function buildSuccessAttrs(kwargs: Record<string, any>, message: any): Record<string, any> {
   const attrs = buildBaseChatAttrs(kwargs, message?.model ?? kwargs.model);
-  attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson([formatOutputMessage(message)]);
+  const outputMessage = formatOutputMessage(message);
+  attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson([outputMessage]);
+  attrs[`${COMPLETION_ZERO}.role`] = outputMessage.role ?? "assistant";
+  attrs[`${COMPLETION_ZERO}.content`] = stringifyStructured(
+    outputMessage.content ?? "",
+  );
 
   if (message?.usage) {
-    attrs[RespanSpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS] =
-      message.usage.input_tokens ?? 0;
-    attrs[RespanSpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS] =
-      message.usage.output_tokens ?? 0;
+    const inputTokens = message.usage.input_tokens ?? 0;
+    const outputTokens = message.usage.output_tokens ?? 0;
+    attrs[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = inputTokens;
+    attrs[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] = outputTokens;
+    attrs[ATTR_GEN_AI_USAGE_PROMPT_TOKENS] = inputTokens;
+    attrs[ATTR_GEN_AI_USAGE_COMPLETION_TOKENS] = outputTokens;
+    attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = inputTokens + outputTokens;
   }
 
-  const toolCalls = mergeToolCalls(
-    extractToolCalls(message),
-    extractToolCallsFromInputMessages(kwargs.messages),
-  );
+  const toolCalls = extractToolCalls(message);
   if (toolCalls) {
-    setStructuredCompatibilityAttrs(
-      attrs,
-      RespanSpanAttributes.RESPAN_SPAN_TOOL_CALLS,
-      "tool_calls",
-      toolCalls,
-    );
+    attrs[COMPLETION_TOOL_CALLS] = safeJson(toolCalls);
   }
 
   return attrs;
 }
 
 function buildErrorAttrs(kwargs: Record<string, any>): Record<string, any> {
-  const attrs = buildBaseChatAttrs(kwargs);
-
-  const toolCalls = extractToolCallsFromInputMessages(kwargs.messages);
-  if (toolCalls) {
-    setStructuredCompatibilityAttrs(
-      attrs,
-      RespanSpanAttributes.RESPAN_SPAN_TOOL_CALLS,
-      "tool_calls",
-      toolCalls,
-    );
-  }
-
-  return attrs;
+  return buildBaseChatAttrs(kwargs);
 }
 
 function emitSpan(
@@ -155,6 +150,7 @@ function emitSpan(
   attrs: Record<string, any>,
   startTime: [number, number],
   errorMessage?: string,
+  statusCode?: number,
 ): void {
   try {
     const span = buildInstrumentedReadableSpan({
@@ -162,6 +158,7 @@ function emitSpan(
       startTime,
       endTime: hrTime(),
       attributes: attrs,
+      statusCode,
       errorMessage,
     });
     injectSpan(span);
@@ -193,9 +190,11 @@ export function emitErrorSpan(
 ): void {
   try {
     const errorMessage = String(err);
+    const statusCode = resolveErrorStatusCode(err);
     const attrs = buildErrorAttrs(kwargs);
     attrs["error.message"] = errorMessage;
-    emitSpan(ANTHROPIC_CHAT_ENTITY_NAME, attrs, startTime, errorMessage);
+    attrs[STATUS_CODE_ATTR] = statusCode;
+    emitSpan(ANTHROPIC_CHAT_ENTITY_NAME, attrs, startTime, errorMessage, statusCode);
   } catch {
     // Never break the application.
   }
@@ -221,6 +220,7 @@ export function emitToolSpan(toolExecution: ToolExecution): void {
   }
   if (toolExecution.isError) {
     attrs["error.message"] = stringifyStructured(toolExecution.output);
+    attrs[STATUS_CODE_ATTR] = 500;
   }
 
   emitSpan(
@@ -228,6 +228,7 @@ export function emitToolSpan(toolExecution: ToolExecution): void {
     attrs,
     startTime,
     toolExecution.isError ? stringifyStructured(toolExecution.output) : undefined,
+    toolExecution.isError ? 500 : undefined,
   );
 }
 

--- a/javascript-sdks/instrumentations/respan-instrumentation-anthropic/tests/anthropic_instrumentation_internal.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-anthropic/tests/anthropic_instrumentation_internal.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { AsyncLocalStorage } from "node:async_hooks";
 import test from "node:test";
 
-import { trace } from "@opentelemetry/api";
+import { context, ROOT_CONTEXT, SpanStatusCode, trace } from "@opentelemetry/api";
+import { hrTime } from "@opentelemetry/core";
+import { propagateAttributes } from "@respan/tracing";
 
 import {
   formatInputMessages,
@@ -11,12 +14,33 @@ import {
   createStreamState,
   patchMessagesPrototype,
   updateStreamState,
+  wrapStreamingCreateResult,
 } from "../dist/_streaming.js";
 
 const captureState = { spans: [] };
 const originalGetTracerProvider = trace.getTracerProvider.bind(trace);
+const contextStorage = new AsyncLocalStorage();
+const contextManager = {
+  active() {
+    return contextStorage.getStore() ?? ROOT_CONTEXT;
+  },
+  with(ctx, fn, thisArg, ...args) {
+    return contextStorage.run(ctx, () => fn.apply(thisArg, args));
+  },
+  bind(_ctx, target) {
+    return target;
+  },
+  enable() {
+    return this;
+  },
+  disable() {
+    contextStorage.disable();
+    return this;
+  },
+};
 
 test.before(() => {
+  context.setGlobalContextManager(contextManager);
   Object.defineProperty(trace, "getTracerProvider", {
     configurable: true,
     writable: true,
@@ -33,6 +57,7 @@ test.before(() => {
 });
 
 test.after(() => {
+  context.disable();
   Object.defineProperty(trace, "getTracerProvider", {
     configurable: true,
     writable: true,
@@ -169,6 +194,60 @@ test("stream reconstruction reassembles tool input deltas and usage", () => {
   });
 });
 
+test("stream consumption emits one streaming chat span", async () => {
+  captureState.spans = [];
+  const events = [
+    {
+      type: "message_start",
+      message: {
+        model: "claude-3-7-sonnet",
+        usage: { input_tokens: 11 },
+        content: [],
+      },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "Streamed response." },
+    },
+    {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: { output_tokens: 3 },
+    },
+  ];
+  const stream = {
+    async *[Symbol.asyncIterator]() {
+      yield* events;
+    },
+  };
+
+  const wrapped = wrapStreamingCreateResult(
+    stream,
+    {
+      model: "claude-3-7-sonnet",
+      stream: true,
+      messages: [{ role: "user", content: "Stream this" }],
+    },
+    hrTime(),
+  );
+  for await (const _event of wrapped) {
+    // Consume the complete stream so the instrumentation emits its final span.
+  }
+
+  assert.equal(captureState.spans.length, 1);
+  const [span] = captureState.spans;
+  assert.equal(span.attributes["llm.is_streaming"], true);
+  assert.equal(span.attributes["gen_ai.usage.input_tokens"], 11);
+  assert.equal(span.attributes["gen_ai.usage.output_tokens"], 3);
+  assert.equal(span.attributes["llm.usage.total_tokens"], 14);
+});
+
 test("patchMessagesPrototype emits a chat span for successful create calls", async () => {
   captureState.spans = [];
 
@@ -218,6 +297,7 @@ test("patchMessagesPrototype emits a chat span for successful create calls", asy
 
   const [span] = captureState.spans;
   assert.equal(span.instrumentationScope?.name, "@respan/instrumentation-anthropic");
+  assert.equal(span.instrumentationScope?.version, "1.1.2");
   assert.equal(span.attributes["respan.entity.log_method"], "ts_tracing");
   assert.equal(span.attributes["respan.entity.log_type"], "chat");
   assert.deepEqual(JSON.parse(span.attributes["traceloop.entity.input"]), [
@@ -239,7 +319,7 @@ test("patchMessagesPrototype emits a chat span for successful create calls", asy
       ],
     },
   ]);
-  assert.deepEqual(span.attributes["respan.span.tools"], [
+  assert.deepEqual(JSON.parse(span.attributes["llm.request.functions"]), [
     {
       type: "function",
       function: {
@@ -254,7 +334,7 @@ test("patchMessagesPrototype emits a chat span for successful create calls", asy
       },
     },
   ]);
-  assert.deepEqual(span.attributes["respan.span.tool_calls"], [
+  assert.deepEqual(JSON.parse(span.attributes["gen_ai.completion.0.tool_calls"]), [
     {
       id: "toolu_123",
       type: "function",
@@ -264,31 +344,114 @@ test("patchMessagesPrototype emits a chat span for successful create calls", asy
       },
     },
   ]);
-  assert.deepEqual(span.attributes.tools, [
+  assert.equal(span.attributes["gen_ai.usage.input_tokens"], 4);
+  assert.equal(span.attributes["gen_ai.usage.output_tokens"], 2);
+  assert.equal(span.attributes["gen_ai.usage.prompt_tokens"], 4);
+  assert.equal(span.attributes["gen_ai.usage.completion_tokens"], 2);
+  assert.equal(span.attributes["llm.usage.total_tokens"], 6);
+  assert.equal(span.attributes["gen_ai.prompt.0.role"], "user");
+  assert.equal(span.attributes["gen_ai.prompt.0.content"], "Hi");
+  assert.equal(span.attributes["gen_ai.completion.0.role"], "assistant");
+  assert.equal(span.attributes["gen_ai.completion.0.content"], "Hello from Anthropic.");
+  assert.equal(span.attributes["llm.is_streaming"], false);
+
+  for (const alias of ["respan.span.tools", "respan.span.tool_calls", "tools", "tool_calls"]) {
+    assert.equal(span.attributes[alias], undefined, `${alias} must not be emitted`);
+  }
+
+  messagesPrototype.create = patchedTarget.originalCreate;
+});
+
+test("rejecting create calls preserve status and propagated audit attributes", async () => {
+  captureState.spans = [];
+  const rejection = Object.assign(new Error("Anthropic model was not found"), {
+    status: 404,
+  });
+  const messagesPrototype = {
+    create() {
+      return Promise.reject(rejection);
+    },
+  };
+
+  const patchedTarget = patchMessagesPrototype(messagesPrototype);
+  assert.ok(patchedTarget);
+
+  await propagateAttributes(
     {
-      type: "function",
-      function: {
-        name: "get_weather",
-        description: "Lookup the current weather.",
-        parameters: {
-          type: "object",
-          properties: {
-            city: { type: "string" },
+      custom_identifier: "anthropic-error-case",
+      trace_group_identifier: "anthropic-error-group",
+      metadata: {
+        run_id: "anthropic-error-marker",
+        case_id: "failure",
+      },
+    },
+    async () => {
+      await messagesPrototype.create({
+        model: "missing-model",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_history",
+                name: "lookup_weather",
+                input: { city: "Tokyo" },
+              },
+            ],
           },
-        },
-      },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_history",
+                content: "sunny",
+              },
+            ],
+          },
+        ],
+      }).catch((error) => {
+        assert.equal(error, rejection);
+      });
     },
-  ]);
-  assert.deepEqual(span.attributes.tool_calls, [
+  );
+
+  assert.equal(captureState.spans.length, 2);
+  const span = captureState.spans.find(
+    (candidate) => candidate.attributes["respan.entity.log_type"] === "chat",
+  );
+  const toolSpan = captureState.spans.find(
+    (candidate) => candidate.attributes["respan.entity.log_type"] === "tool",
+  );
+  assert.ok(span);
+  assert.ok(toolSpan);
+  assert.equal(span.status.code, SpanStatusCode.ERROR);
+  assert.equal(span.status.message, "Error: Anthropic model was not found");
+  assert.equal(span.attributes.status_code, 404);
+  assert.equal(span.attributes["error.message"], "Error: Anthropic model was not found");
+  assert.equal(span.attributes["respan.span_params.custom_identifier"], "anthropic-error-case");
+  assert.equal(span.attributes["respan.trace.trace_group_identifier"], "anthropic-error-group");
+  assert.equal(span.attributes["respan.metadata.run_id"], "anthropic-error-marker");
+  assert.equal(span.attributes["respan.metadata.case_id"], "failure");
+  assert.deepEqual(JSON.parse(span.attributes["gen_ai.prompt.0.tool_calls"]), [
     {
-      id: "toolu_123",
+      id: "toolu_history",
       type: "function",
       function: {
-        name: "get_weather",
+        name: "lookup_weather",
         arguments: "{\"city\":\"Tokyo\"}",
       },
     },
   ]);
+  assert.equal(span.attributes["gen_ai.prompt.1.role"], "tool");
+  assert.equal(span.attributes["gen_ai.prompt.1.content"], "sunny");
+  assert.equal(span.attributes["gen_ai.prompt.1.tool_call_id"], "toolu_history");
+  assert.equal(span.attributes["gen_ai.completion.0.tool_calls"], undefined);
+  assert.equal(span.instrumentationScope?.version, "1.1.2");
+  assert.equal(toolSpan.attributes["respan.metadata.run_id"], "anthropic-error-marker");
+  assert.equal(toolSpan.attributes["respan.metadata.case_id"], "failure");
+  assert.equal(toolSpan.instrumentationScope?.version, "1.1.2");
 
   messagesPrototype.create = patchedTarget.originalCreate;
 });

--- a/javascript-sdks/yarn.lock
+++ b/javascript-sdks/yarn.lock
@@ -4900,6 +4900,7 @@ __metadata:
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/core": "npm:^2.10.0"
     "@opentelemetry/sdk-trace-base": "npm:^2.10.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.43.0"
     "@respan/respan-sdk": "npm:^1.1.7"
     "@respan/tracing": "npm:^1.1.4"
     "@traceloop/ai-semantic-conventions": "npm:^0.13.0"


### PR DESCRIPTION
## Summary

- preserve Anthropic provider HTTP failures as failed spans, with a safe 500 fallback for unknown errors
- merge propagated Respan marker, group, case, and custom identifiers into Anthropic chat and tool spans
- emit canonical prompt, completion, tool, streaming, and usage attributes without duplicate compatibility aliases
- retain tool-call and tool-result identity on the correct conversation turns
- source the instrumentation scope version from the installed package manifest
- add a patch release intent and focused regressions for success, streaming, tool history, error status, propagation, and scope metadata

**Why.**

The Anthropic emitter previously omitted the provider status when constructing rejected spans, disabled propagated attributes, duplicated tool fields under competing aliases, reported a hard-coded stale scope version, marked streams as non-streaming, and dropped tool-result IDs during prompt reconstruction. These issues caused false success/error counts and incomplete or ambiguous platform records.

**Impact.**

Anthropic traces now expose accurate failure status, complete audit metadata, canonical tool history, exact streaming and token semantics, and the installed package scope version while retaining the existing connected trace structure.

## Validation

- [x] package build passed
- [x] focused tests: 5/5
- [x] npm pack dry-run passed
- [x] release inventory, release intent, and missing-intent checks passed
- [x] dedicated locally linked example set typechecked
- [x] four live examples passed with the repository environment: basic, streaming, forced two-turn tool, and expected 404
- [x] MCP marker `otel2-fix-js-group-06-20260815T161035Z`: 4 trace trees and 10/10 full records inspected
- [x] no orphans, duplicates, cycles, or synthetic roots
- [x] expected failure stored as failed/404 with trace error_count=1
- [x] streaming stored with stream=true
- [x] all Anthropic/tool children report scope version 1.1.2

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- None documented.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/51
