### PR TITLE
fix(instrumentation-py): repair Agno, Aleph Alpha, and Anthropic OTel 2.x spans

### DIFF
--- a/.release-intents/20260816-agno-aleph-alpha-anthropic-tracing.json
+++ b/.release-intents/20260816-agno-aleph-alpha-anthropic-tracing.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair Agno workflow propagation, Aleph Alpha analytical spans, and Anthropic provider error status.",
+  "packages": {
+    "respan-instrumentation-agno": "patch",
+    "respan-instrumentation-aleph-alpha": "patch",
+    "respan-instrumentation-anthropic": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-agno/src/respan_instrumentation_agno/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agno/src/respan_instrumentation_agno/_instrumentation.py
@@ -210,6 +210,7 @@ def _wrap_sync_method(
         input_value = _extract_input_value(args=input_args, kwargs=kwargs)
         started_at_ns = time.time_ns()
         run_context = create_agno_run_context(
+            target=target,
             target_kind=target_kind,
             started_at_ns=started_at_ns,
         )
@@ -265,6 +266,7 @@ def _wrap_async_method(
         input_value = _extract_input_value(args=input_args, kwargs=kwargs)
         started_at_ns = time.time_ns()
         run_context = create_agno_run_context(
+            target=target,
             target_kind=target_kind,
             started_at_ns=started_at_ns,
         )

--- a/python-sdks/instrumentations/respan-instrumentation-agno/src/respan_instrumentation_agno/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agno/src/respan_instrumentation_agno/_otel_emitter.py
@@ -12,6 +12,7 @@ from typing import Union
 from typing import get_args
 from typing import get_origin
 
+from opentelemetry import context as context_api
 from opentelemetry import trace
 from opentelemetry.semconv_ai import LLMRequestTypeValues
 from opentelemetry.semconv_ai import SpanAttributes
@@ -127,6 +128,7 @@ class _AgnoRunContext:
     trace_id: str
     root_span_id: str
     parent_span_id: str | None
+    workflow_name: str
 
 
 _CURRENT_RUN_CONTEXT: ContextVar[_AgnoRunContext | None] = ContextVar(
@@ -137,6 +139,7 @@ _CURRENT_RUN_CONTEXT: ContextVar[_AgnoRunContext | None] = ContextVar(
 
 def create_agno_run_context(
     *,
+    target: Any,
     target_kind: str,
     started_at_ns: int,
 ) -> _AgnoRunContext:
@@ -151,13 +154,20 @@ def create_agno_run_context(
             trace_id=current_context.trace_id,
             root_span_id=root_span_id,
             parent_span_id=current_context.root_span_id,
+            workflow_name=current_context.workflow_name,
         )
 
     parent_trace_id, parent_span_id = _current_parent_ids()
+    workflow_name = _active_workflow_name() or _target_name(
+        target=target,
+        output=None,
+        target_kind=target_kind,
+    )
     return _AgnoRunContext(
         trace_id=parent_trace_id or format_trace_id(ensure_trace_id(val=trace_seed)),
         root_span_id=root_span_id,
         parent_span_id=parent_span_id,
+        workflow_name=workflow_name,
     )
 
 
@@ -245,6 +255,24 @@ def _current_parent_ids() -> tuple[str | None, str | None]:
     return (
         format_trace_id(span_context.trace_id),
         format_span_id(span_context.span_id),
+    )
+
+
+def _active_workflow_name() -> str | None:
+    workflow_name = context_api.get_value(SpanAttributes.TRACELOOP_WORKFLOW_NAME)
+    if not workflow_name:
+        workflow_name = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME)
+    return str(workflow_name) if workflow_name else None
+
+
+def _run_workflow_name(*, target: Any, output: Any, target_kind: str) -> str:
+    current_context = _CURRENT_RUN_CONTEXT.get()
+    if current_context is not None:
+        return current_context.workflow_name
+    return _active_workflow_name() or _target_name(
+        target=target,
+        output=output,
+        target_kind=target_kind,
     )
 
 
@@ -624,7 +652,11 @@ def _root_attributes(
         RESPAN_LOG_TYPE: log_type,
         SpanAttributes.TRACELOOP_ENTITY_NAME: entity_name,
         SpanAttributes.TRACELOOP_ENTITY_PATH: "",
-        SpanAttributes.TRACELOOP_WORKFLOW_NAME: entity_name,
+        SpanAttributes.TRACELOOP_WORKFLOW_NAME: _run_workflow_name(
+            target=target,
+            output=output,
+            target_kind=target_kind,
+        ),
         SpanAttributes.TRACELOOP_ENTITY_INPUT: _attribute_string(
             value=_input_payload(input_value=input_value, output=output),
         ),
@@ -656,6 +688,7 @@ def _root_attributes(
 
 def _chat_attributes(
     target: Any,
+    target_kind: str,
     input_value: Any,
     output: Any,
     events: list[Any],
@@ -682,6 +715,11 @@ def _chat_attributes(
         RESPAN_LOG_TYPE: LOG_TYPE_CHAT,
         SpanAttributes.TRACELOOP_ENTITY_NAME: entity_name,
         SpanAttributes.TRACELOOP_ENTITY_PATH: entity_name,
+        SpanAttributes.TRACELOOP_WORKFLOW_NAME: _run_workflow_name(
+            target=target,
+            output=output,
+            target_kind=target_kind,
+        ),
         SpanAttributes.TRACELOOP_ENTITY_INPUT: _json_string(
             value=prompt_messages,
         ),
@@ -752,6 +790,10 @@ def _chat_attributes(
         tool_executions=_extract_tool_executions(output=output),
     )
     if tool_calls:
+        completion_message[TOOL_CALLS_KEY] = tool_calls
+        attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _json_string(
+            value=completion_message,
+        )
         attributes[f"{AGNO_COMPLETION_PREFIX}0.{TOOL_CALLS_KEY}"] = _json_string(
             value=tool_calls,
         )
@@ -759,7 +801,13 @@ def _chat_attributes(
     return attributes
 
 
-def _tool_attributes(tool_execution: Any) -> dict[str, Any]:
+def _tool_attributes(
+    *,
+    target: Any,
+    target_kind: str,
+    output: Any,
+    tool_execution: Any,
+) -> dict[str, Any]:
     tool_name = (
         _object_value(value=tool_execution, key=TOOL_NAME_KEY) or DEFAULT_TOOL_NAME
     )
@@ -772,6 +820,11 @@ def _tool_attributes(tool_execution: Any) -> dict[str, Any]:
         RESPAN_LOG_TYPE: LOG_TYPE_TOOL,
         SpanAttributes.TRACELOOP_ENTITY_NAME: str(tool_name),
         SpanAttributes.TRACELOOP_ENTITY_PATH: f"{DEFAULT_TOOL_NAME}.{tool_name}",
+        SpanAttributes.TRACELOOP_WORKFLOW_NAME: _run_workflow_name(
+            target=target,
+            output=output,
+            target_kind=target_kind,
+        ),
         SpanAttributes.TRACELOOP_ENTITY_INPUT: _json_string(
             value={NAME_KEY: tool_name, ARGUMENTS_KEY: tool_arguments},
         ),
@@ -787,7 +840,13 @@ def _tool_attributes(tool_execution: Any) -> dict[str, Any]:
     return attributes
 
 
-def _event_attributes(event: Any) -> dict[str, Any]:
+def _event_attributes(
+    *,
+    target: Any,
+    target_kind: str,
+    output: Any,
+    event: Any,
+) -> dict[str, Any]:
     event_name = _object_value(value=event, key=EVENT_KEY)
     entity_name = str(event_name or DEFAULT_AGNO_EVENT_NAME)
     attributes: dict[str, Any] = {
@@ -795,6 +854,11 @@ def _event_attributes(event: Any) -> dict[str, Any]:
         RESPAN_LOG_TYPE: LOG_TYPE_WORKFLOW,
         SpanAttributes.TRACELOOP_ENTITY_NAME: entity_name,
         SpanAttributes.TRACELOOP_ENTITY_PATH: f"{DEFAULT_EVENT_NAME}.{entity_name}",
+        SpanAttributes.TRACELOOP_WORKFLOW_NAME: _run_workflow_name(
+            target=target,
+            output=output,
+            target_kind=target_kind,
+        ),
         SpanAttributes.TRACELOOP_ENTITY_INPUT: _json_string(
             value=_object_to_dict(value=event)
         ),
@@ -855,6 +919,7 @@ def emit_agno_run(
         end_time_ns=ended_at_ns,
         attributes=_chat_attributes(
             target=target,
+            target_kind=target_kind,
             input_value=input_value,
             output=selected_output,
             events=safe_events,
@@ -879,7 +944,12 @@ def emit_agno_run(
             parent_id=root_span_id,
             start_time_ns=started_at_ns,
             end_time_ns=ended_at_ns,
-            attributes=_tool_attributes(tool_execution=tool_execution),
+            attributes=_tool_attributes(
+                target=target,
+                target_kind=target_kind,
+                output=selected_output,
+                tool_execution=tool_execution,
+            ),
             status_code=tool_status_code,
         )
         inject_span(span=tool_span)
@@ -904,7 +974,12 @@ def emit_agno_run(
                 parent_id=root_span_id,
                 start_time_ns=started_at_ns,
                 end_time_ns=ended_at_ns,
-                attributes=_event_attributes(event=event),
+                attributes=_event_attributes(
+                    target=target,
+                    target_kind=target_kind,
+                    output=selected_output,
+                    event=event,
+                ),
             )
             inject_span(span=event_span)
 

--- a/python-sdks/instrumentations/respan-instrumentation-agno/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-agno/tests/test_instrumentation.py
@@ -5,6 +5,7 @@ from types import ModuleType
 from types import SimpleNamespace
 
 import pytest
+from opentelemetry import context as context_api
 from opentelemetry.semconv_ai import SpanAttributes
 
 from respan_instrumentation_agno import AgnoInstrumentor
@@ -283,6 +284,7 @@ def test_sync_run_emits_agent_chat_and_tool_spans(captured_spans):
     assert root_attributes[RESPAN_LOG_TYPE] == "agent"
     assert root_attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "Weather Agent"
     assert root_attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+    assert root_attributes[SpanAttributes.TRACELOOP_WORKFLOW_NAME] == "Weather Agent"
     assert root_attributes[AGNO_RUN_ID_ATTR] == "run_123"
     assert root_attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] == (
         '{"input_content":"What is the weather?"}'
@@ -294,18 +296,23 @@ def test_sync_run_emits_agent_chat_and_tool_spans(captured_spans):
     assert chat_attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
     assert chat_attributes[SpanAttributes.LLM_REQUEST_MODEL] == "gpt-4o-mini"
     assert chat_attributes[SpanAttributes.LLM_SYSTEM] == "openai"
+    assert chat_attributes[SpanAttributes.TRACELOOP_WORKFLOW_NAME] == "Weather Agent"
     assert chat_attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 12
     assert chat_attributes[f"{AGNO_PROMPT_PREFIX}0.role"] == "user"
     assert chat_attributes[f"{AGNO_PROMPT_PREFIX}0.content"] == "What is the weather?"
     assert chat_attributes[f"{AGNO_COMPLETION_PREFIX}0.role"] == "assistant"
     assert chat_attributes[f"{AGNO_COMPLETION_PREFIX}0.content"] == "It is sunny."
     assert "gen_ai.completion.0.tool_calls" in chat_attributes
+    assert json.loads(chat_attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])[
+        "tool_calls"
+    ][0]["function"]["name"] == "lookup_weather"
     assert "tool_calls" not in chat_attributes
     assert "tools" not in chat_attributes
 
     tool_attributes = captured_spans[2].attributes
     assert tool_attributes[RESPAN_LOG_TYPE] == "tool"
     assert tool_attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "lookup_weather"
+    assert tool_attributes[SpanAttributes.TRACELOOP_WORKFLOW_NAME] == "Weather Agent"
     assert tool_attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == "sunny"
 
 
@@ -390,6 +397,40 @@ def test_team_run_emits_workflow_root(captured_spans):
     root_attributes = captured_spans[0].attributes
     assert root_attributes[RESPAN_LOG_TYPE] == "workflow"
     assert root_attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "Research Team"
+
+
+def test_active_workflow_name_is_preserved_on_all_native_spans(captured_spans):
+    token = context_api.attach(
+        context_api.set_value(
+            SpanAttributes.TRACELOOP_ENTITY_NAME,
+            "agno_parent_workflow",
+        )
+    )
+    try:
+        agent = FakeAgent()
+        run_context = _otel_emitter.create_agno_run_context(
+            target=agent,
+            target_kind=AGNO_TARGET_AGENT,
+            started_at_ns=100,
+        )
+        with _otel_emitter.use_agno_run_context(run_context=run_context):
+            _otel_emitter.emit_agno_run(
+                target=agent,
+                target_kind=AGNO_TARGET_AGENT,
+                input_value="What is the weather?",
+                output=FakeRunOutput(),
+                events=None,
+                started_at_ns=100,
+                ended_at_ns=200,
+            )
+    finally:
+        context_api.detach(token)
+
+    assert len(captured_spans) == 3
+    assert {
+        span.attributes[SpanAttributes.TRACELOOP_WORKFLOW_NAME]
+        for span in captured_spans
+    } == {"agno_parent_workflow"}
 
 
 def test_nested_agent_run_uses_team_trace_context(monkeypatch, captured_spans):

--- a/python-sdks/instrumentations/respan-instrumentation-aleph-alpha/src/respan_instrumentation_aleph_alpha/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aleph-alpha/src/respan_instrumentation_aleph_alpha/_otel_emitter.py
@@ -46,6 +46,7 @@ from respan_instrumentation_aleph_alpha._translator import (
 from respan_sdk.constants.llm_logging import (
     LOG_TYPE_CHAT,
     LOG_TYPE_EMBEDDING,
+    LOG_TYPE_TASK,
     LOG_TYPE_TEXT,
 )
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
@@ -62,9 +63,7 @@ _EMBEDDING_OPERATIONS = {
     OPERATION_INSTRUCTABLE_EMBED,
 }
 
-_TEXT_OPERATIONS = {
-    OPERATION_COMPLETE,
-    OPERATION_COMPLETE_STREAM,
+_TASK_OPERATIONS = {
     OPERATION_EVALUATE,
     OPERATION_EXPLAIN,
 }
@@ -104,18 +103,22 @@ def _base_attrs(operation: str) -> dict[str, Any]:
     elif operation in _EMBEDDING_OPERATIONS:
         log_type = LOG_TYPE_EMBEDDING
         request_type = LLMRequestTypeValues.EMBEDDING.value
+    elif operation in _TASK_OPERATIONS:
+        log_type = LOG_TYPE_TASK
+        request_type = None
     else:
         log_type = LOG_TYPE_TEXT
         request_type = LLMRequestTypeValues.COMPLETION.value
 
     span_name = _span_name(operation=operation)
     attrs: dict[str, Any] = {
-        SpanAttributes.LLM_SYSTEM: ALEPH_ALPHA_SYSTEM_NAME,
-        SpanAttributes.LLM_REQUEST_TYPE: request_type,
         SpanAttributes.TRACELOOP_ENTITY_NAME: span_name,
         SpanAttributes.TRACELOOP_ENTITY_PATH: span_name,
         RESPAN_LOG_TYPE: log_type,
     }
+    if request_type is not None:
+        attrs[SpanAttributes.LLM_SYSTEM] = ALEPH_ALPHA_SYSTEM_NAME
+        attrs[SpanAttributes.LLM_REQUEST_TYPE] = request_type
     workflow_name = context_api.get_value(
         SpanAttributes.TRACELOOP_WORKFLOW_NAME
     ) or context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME)
@@ -191,7 +194,12 @@ def _set_chat_attrs(
         return
 
     content, role, tool_calls, finish_reason = chat_output(response_or_items)
-    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = content
+    output_message: dict[str, Any] = {ROLE_KEY: role, CONTENT_KEY: content}
+    if tool_calls:
+        output_message["tool_calls"] = tool_calls
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = (
+        safe_json(value=output_message) if tool_calls else content
+    )
     completion_prefix = f"{gen_ai_attributes.GEN_AI_COMPLETION}.0"
     attrs[f"{completion_prefix}.role"] = role
     attrs[f"{completion_prefix}.content"] = content
@@ -226,7 +234,7 @@ def _set_completion_attrs(
     _set_usage_attrs(attrs=attrs, response_or_items=response_or_items)
 
 
-def _set_text_model_attrs(
+def _set_task_attrs(
     attrs: dict[str, Any],
     *,
     payload: dict[str, Any],
@@ -238,7 +246,6 @@ def _set_text_model_attrs(
     attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = to_json_attr(input_value)
     if response is not None:
         attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(value=response)
-        _set_usage_attrs(attrs=attrs, response_or_items=response)
 
 
 def _set_embedding_attrs(
@@ -271,7 +278,8 @@ def build_aleph_alpha_attrs(
 ) -> dict[str, Any]:
     attrs = _base_attrs(operation=operation)
     payload = request_payload(request)
-    _set_model(attrs=attrs, model=model, response=response_or_items)
+    if operation not in _TASK_OPERATIONS:
+        _set_model(attrs=attrs, model=model, response=response_or_items)
     _set_request_attrs(attrs=attrs, payload=payload)
 
     if operation in (OPERATION_CHAT, OPERATION_CHAT_STREAM):
@@ -284,8 +292,8 @@ def build_aleph_alpha_attrs(
         )
     elif operation in _EMBEDDING_OPERATIONS:
         _set_embedding_attrs(attrs=attrs, payload=payload, response=response_or_items)
-    elif operation in _TEXT_OPERATIONS:
-        _set_text_model_attrs(attrs=attrs, payload=payload, response=response_or_items)
+    elif operation in _TASK_OPERATIONS:
+        _set_task_attrs(attrs=attrs, payload=payload, response=response_or_items)
     return attrs
 
 

--- a/python-sdks/instrumentations/respan-instrumentation-aleph-alpha/src/respan_instrumentation_aleph_alpha/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aleph-alpha/src/respan_instrumentation_aleph_alpha/_otel_emitter.py
@@ -10,6 +10,18 @@ from opentelemetry import context as context_api
 from opentelemetry import trace
 from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_TASK,
+    LOG_TYPE_TEXT,
+)
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 from respan_instrumentation_aleph_alpha._constants import (
     ALEPH_ALPHA_SYSTEM_NAME,
@@ -43,15 +55,6 @@ from respan_instrumentation_aleph_alpha._translator import (
     tools_from_payload,
     usage_from_response,
 )
-from respan_sdk.constants.llm_logging import (
-    LOG_TYPE_CHAT,
-    LOG_TYPE_EMBEDDING,
-    LOG_TYPE_TASK,
-    LOG_TYPE_TEXT,
-)
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
-from respan_sdk.utils.data_processing.id_processing import format_span_id, format_trace_id
-from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +111,7 @@ def _base_attrs(operation: str) -> dict[str, Any]:
         request_type = None
     else:
         log_type = LOG_TYPE_TEXT
-        request_type = LLMRequestTypeValues.COMPLETION.value
+        request_type = LLMRequestTypeValues.CHAT.value
 
     span_name = _span_name(operation=operation)
     attrs: dict[str, Any] = {
@@ -283,7 +286,9 @@ def build_aleph_alpha_attrs(
     _set_request_attrs(attrs=attrs, payload=payload)
 
     if operation in (OPERATION_CHAT, OPERATION_CHAT_STREAM):
-        _set_chat_attrs(attrs=attrs, payload=payload, response_or_items=response_or_items)
+        _set_chat_attrs(
+            attrs=attrs, payload=payload, response_or_items=response_or_items
+        )
     elif operation in (OPERATION_COMPLETE, OPERATION_COMPLETE_STREAM):
         _set_completion_attrs(
             attrs=attrs,

--- a/python-sdks/instrumentations/respan-instrumentation-aleph-alpha/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aleph-alpha/tests/test_instrumentation.py
@@ -9,9 +9,7 @@ from typing import Any
 import pytest
 from opentelemetry import context as context_api
 from opentelemetry.semconv_ai import SpanAttributes
-
-from respan_instrumentation_aleph_alpha import AlephAlphaInstrumentor
-from respan_instrumentation_aleph_alpha import _instrumentation
+from respan_instrumentation_aleph_alpha import AlephAlphaInstrumentor, _instrumentation
 from respan_instrumentation_aleph_alpha._constants import (
     ALEPH_ALPHA_CLIENT_MODULE,
     ASYNC_CLIENT_CLASS_NAME,
@@ -37,11 +35,7 @@ class Obj:
             setattr(self, key, value)
 
     def to_json(self) -> dict[str, Any]:
-        return {
-            key: value
-            for key, value in self.__dict__.items()
-            if value is not None
-        }
+        return {key: value for key, value in self.__dict__.items() if value is not None}
 
 
 class FakeRequest(Obj):
@@ -128,7 +122,7 @@ def fake_aleph_alpha(monkeypatch: pytest.MonkeyPatch) -> tuple[type[Any], type[A
     client_module = ModuleType(ALEPH_ALPHA_CLIENT_MODULE)
     setattr(client_module, CLIENT_CLASS_NAME, Client)
     setattr(client_module, ASYNC_CLIENT_CLASS_NAME, AsyncClient)
-    setattr(root_module, "aleph_alpha_client", client_module)
+    root_module.aleph_alpha_client = client_module
 
     monkeypatch.setitem(sys.modules, "aleph_alpha_client", root_module)
     monkeypatch.setitem(sys.modules, ALEPH_ALPHA_CLIENT_MODULE, client_module)
@@ -200,6 +194,7 @@ def test_activate_patches_sync_completion_chat_and_embedding(
 
     completion_attrs = captured_spans[0]._attributes
     assert completion_attrs[RESPAN_LOG_TYPE] == LOG_TYPE_TEXT
+    assert completion_attrs[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
     assert completion_attrs[SpanAttributes.LLM_REQUEST_MODEL] == "pharia-1"
     assert completion_attrs["gen_ai.prompt.0.content"] == "Complete this"
     assert completion_attrs["gen_ai.completion.0.content"] == "Completed text."
@@ -213,15 +208,22 @@ def test_activate_patches_sync_completion_chat_and_embedding(
         '[{"id": "history_1", "type": "function", "function": '
         '{"name": "lookup", "arguments": "{}"}}]'
     )
-    assert json.loads(chat_attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"][
-        "name"
-    ] == "lookup"
-    assert json.loads(chat_attrs["gen_ai.completion.0.tool_calls"])[0]["function"][
-        "name"
-    ] == "lookup"
-    assert json.loads(chat_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])[
-        "tool_calls"
-    ][0]["function"]["name"] == "lookup"
+    assert (
+        json.loads(chat_attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"][
+            "name"
+        ]
+        == "lookup"
+    )
+    assert (
+        json.loads(chat_attrs["gen_ai.completion.0.tool_calls"])[0]["function"]["name"]
+        == "lookup"
+    )
+    assert (
+        json.loads(chat_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])["tool_calls"][0][
+            "function"
+        ]["name"]
+        == "lookup"
+    )
     assert "tools" not in chat_attrs
     assert "tool_calls" not in chat_attrs
     assert "respan.span.tools" not in chat_attrs
@@ -233,13 +235,17 @@ def test_activate_patches_sync_completion_chat_and_embedding(
     assert embedding_attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] == "Embed this"
     assert embedding_attrs["gen_ai.prompt.0.role"] == "user"
     assert embedding_attrs["gen_ai.prompt.0.content"] == "Embed this"
-    embedding_summary = json.loads(embedding_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    embedding_summary = json.loads(
+        embedding_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    )
     assert embedding_summary == {
         "model": "luminous-base",
         "embedding_count": 1,
         "dimensions": 3,
     }
-    assert json.loads(embedding_attrs["gen_ai.completion.0.content"]) == embedding_summary
+    assert (
+        json.loads(embedding_attrs["gen_ai.completion.0.content"]) == embedding_summary
+    )
     assert "ai.embedding" not in embedding_attrs
     assert "0.1" not in embedding_attrs["gen_ai.completion.0.content"]
 
@@ -255,7 +261,9 @@ def test_async_methods_and_streaming_emit_spans(
         instrumentor = AlephAlphaInstrumentor()
         instrumentor.activate()
 
-        complete_response = await AsyncClient().complete(completion_request(), "pharia-1")
+        complete_response = await AsyncClient().complete(
+            completion_request(), "pharia-1"
+        )
         chat_response = await AsyncClient().chat(chat_request(), "pharia-1-chat")
         completion_chunks = [
             item
@@ -280,11 +288,15 @@ def test_async_methods_and_streaming_emit_spans(
         assert captured_spans[2]._attributes["gen_ai.completion.0.content"] == (
             "stream done"
         )
-        assert captured_spans[2]._attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 7
+        assert (
+            captured_spans[2]._attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 7
+        )
         assert captured_spans[3]._attributes["gen_ai.completion.0.content"] == (
             "streamed chat"
         )
-        assert captured_spans[3]._attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 12
+        assert (
+            captured_spans[3]._attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 12
+        )
 
         instrumentor.deactivate()
 
@@ -320,7 +332,9 @@ def test_active_workflow_name_is_attached_to_injected_span() -> None:
 
 
 @pytest.mark.parametrize("operation", [OPERATION_EVALUATE, OPERATION_EXPLAIN])
-def test_analytical_operations_are_tasks_without_completion_usage(operation: str) -> None:
+def test_analytical_operations_are_tasks_without_completion_usage(
+    operation: str,
+) -> None:
     attrs = build_aleph_alpha_attrs(
         operation=operation,
         request=FakeRequest(
@@ -337,9 +351,9 @@ def test_analytical_operations_are_tasks_without_completion_usage(operation: str
     )
 
     assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_TASK
-    assert json.loads(attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])[
-        "result"
-    ] == {"log_probability": -1.25}
+    assert json.loads(attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])["result"] == {
+        "log_probability": -1.25
+    }
     assert SpanAttributes.LLM_SYSTEM not in attrs
     assert SpanAttributes.LLM_REQUEST_TYPE not in attrs
     assert SpanAttributes.LLM_REQUEST_MODEL not in attrs

--- a/python-sdks/instrumentations/respan-instrumentation-aleph-alpha/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aleph-alpha/tests/test_instrumentation.py
@@ -18,9 +18,16 @@ from respan_instrumentation_aleph_alpha._constants import (
     CLIENT_CLASS_NAME,
     METHOD_CHAT,
     METHOD_COMPLETE,
+    OPERATION_EVALUATE,
+    OPERATION_EXPLAIN,
 )
 from respan_instrumentation_aleph_alpha._otel_emitter import build_aleph_alpha_attrs
-from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_EMBEDDING, LOG_TYPE_TEXT
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_TASK,
+    LOG_TYPE_TEXT,
+)
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
 
 
@@ -212,6 +219,9 @@ def test_activate_patches_sync_completion_chat_and_embedding(
     assert json.loads(chat_attrs["gen_ai.completion.0.tool_calls"])[0]["function"][
         "name"
     ] == "lookup"
+    assert json.loads(chat_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])[
+        "tool_calls"
+    ][0]["function"]["name"] == "lookup"
     assert "tools" not in chat_attrs
     assert "tool_calls" not in chat_attrs
     assert "respan.span.tools" not in chat_attrs
@@ -307,6 +317,35 @@ def test_active_workflow_name_is_attached_to_injected_span() -> None:
         attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME]
         == "aleph_alpha_completion_workflow"
     )
+
+
+@pytest.mark.parametrize("operation", [OPERATION_EVALUATE, OPERATION_EXPLAIN])
+def test_analytical_operations_are_tasks_without_completion_usage(operation: str) -> None:
+    attrs = build_aleph_alpha_attrs(
+        operation=operation,
+        request=FakeRequest(
+            prompt=[{"type": "text", "data": "Score this"}],
+            completion_expected=" successfully.",
+        ),
+        model="pharia-1-chat",
+        response_or_items=Obj(
+            model_version="pharia-1-chat",
+            result={"log_probability": -1.25},
+            num_tokens_prompt_total=8,
+            num_tokens_generated=99,
+        ),
+    )
+
+    assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_TASK
+    assert json.loads(attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])[
+        "result"
+    ] == {"log_probability": -1.25}
+    assert SpanAttributes.LLM_SYSTEM not in attrs
+    assert SpanAttributes.LLM_REQUEST_TYPE not in attrs
+    assert SpanAttributes.LLM_REQUEST_MODEL not in attrs
+    assert SpanAttributes.LLM_USAGE_PROMPT_TOKENS not in attrs
+    assert SpanAttributes.LLM_USAGE_COMPLETION_TOKENS not in attrs
+    assert "gen_ai.completion.0.content" not in attrs
 
 
 def test_error_path_emits_failed_span(

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_constants.py
@@ -65,8 +65,6 @@ CACHE_READ_INPUT_TOKENS_KEY = "cache_read_input_tokens"
 
 GEN_AI_COMPLETION_ROLE_ATTR = "gen_ai.completion.0.role"
 GEN_AI_COMPLETION_TOOL_CALLS_ATTR = "gen_ai.completion.0.tool_calls"
-GEN_AI_TOOL_CALL_ID_ATTR = "gen_ai.tool.call.id"
-GEN_AI_TOOL_DEFINITIONS_ATTR = "gen_ai.tool.definitions"
 MANAGED_AGENT_STOP_REASON_ATTR = "respan.managed_agent.stop_reason"
 MANAGED_AGENT_SESSION_ID_ATTR = RESPAN_SESSION_ID
 TOOL_CALLS_OVERRIDE = "tool_calls"

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_instrumentation.py
@@ -84,11 +84,31 @@ def _emit_message_span_safely(
         logger.debug("Failed to build Anthropic span attrs", exc_info=True)
 
 
+def _provider_status_code(exc: Exception) -> int:
+    response = getattr(exc, "response", None)
+    candidates = (
+        getattr(exc, "status_code", None),
+        getattr(exc, "status", None),
+        getattr(response, "status_code", None),
+        getattr(response, "status", None),
+    )
+    for candidate in candidates:
+        value = getattr(candidate, "value", candidate)
+        try:
+            status_code = int(value)
+        except (TypeError, ValueError):
+            continue
+        if 400 <= status_code <= 599:
+            return status_code
+    return 500
+
+
 def _emit_error_span(*, kwargs: dict[str, Any], start_ns: int, exc: Exception) -> None:
     _emit_span(
         attrs=_build_error_attrs(kwargs=kwargs),
         start_ns=start_ns,
         error_message=str(exc),
+        status_code=_provider_status_code(exc),
     )
 
 

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_managed_agents.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_managed_agents.py
@@ -6,13 +6,19 @@ import time
 from typing import Any
 
 from opentelemetry.semconv_ai import SpanAttributes
+from respan_sdk.constants.span_attributes import (
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
+)
 
 from respan_instrumentation_anthropic._constants import (
     AGENT_MCP_TOOL_USE_EVENT,
     AGENT_MESSAGE_EVENT,
     AGENT_TOOL_USE_EVENTS,
-    ARGUMENTS_KEY,
     ANTHROPIC_MANAGED_AGENT_SPAN_NAME,
+    ARGUMENTS_KEY,
+    CACHE_CREATION_INPUT_TOKENS_KEY,
+    CACHE_READ_INPUT_TOKENS_KEY,
     CLOSE_METHOD_NAME,
     CONTENT_KEY,
     FUNCTION_KEY,
@@ -25,31 +31,23 @@ from respan_instrumentation_anthropic._constants import (
     MCP_SERVER_KEY,
     MCP_SERVER_NAME_KEY,
     MODEL_REQUEST_END_EVENT,
-    NAME_KEY,
     MODEL_USAGE_KEY,
+    NAME_KEY,
     OUTPUT_TOKENS_KEY,
     ROLE_KEY,
     SESSION_ERROR_EVENT,
     SESSION_STATUS_IDLE_EVENT,
     SESSION_STATUS_RUNNING_EVENT,
     STOP_REASON_KEY,
-    TOOL_CALLS_OVERRIDE,
     TYPE_KEY,
-    USER_ROLE,
     USER_MESSAGE_EVENT,
-    CACHE_CREATION_INPUT_TOKENS_KEY,
-    CACHE_READ_INPUT_TOKENS_KEY,
+    USER_ROLE,
 )
 from respan_instrumentation_anthropic._messages import (
     _build_base_chat_attrs,
     _emit_span,
     _normalize_content_block,
     _safe_json,
-)
-from respan_sdk.constants.span_attributes import (
-    LLM_USAGE_COMPLETION_TOKENS,
-    LLM_USAGE_PROMPT_TOKENS,
-    RESPAN_SPAN_TOOL_CALLS,
 )
 
 
@@ -162,8 +160,8 @@ class _ManagedAgentTurnTracker:
             )
 
         if self.tool_calls:
-            attrs[RESPAN_SPAN_TOOL_CALLS] = _safe_json(value=self.tool_calls)
-            attrs[TOOL_CALLS_OVERRIDE] = self.tool_calls
+            attrs["gen_ai.completion.0.tool_calls"] = _safe_json(value=self.tool_calls)
+            attrs["gen_ai.completion.0.role"] = "assistant"
 
         if stop_reason:
             attrs[MANAGED_AGENT_STOP_REASON_ATTR] = stop_reason

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_messages.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_messages.py
@@ -8,6 +8,7 @@ from threading import Lock
 import time
 from typing import Any
 
+from opentelemetry import context as context_api
 from opentelemetry import trace
 from opentelemetry.trace.status import StatusCode
 from opentelemetry.semconv_ai import (
@@ -440,8 +441,15 @@ def _format_tools(tools: Any) -> list[dict[str, Any]]:
     return normalized_tools
 
 
+def _active_workflow_name() -> str | None:
+    workflow_name = context_api.get_value(SpanAttributes.TRACELOOP_WORKFLOW_NAME)
+    if not workflow_name:
+        workflow_name = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME)
+    return str(workflow_name) if workflow_name else None
+
+
 def _build_base_chat_attrs(span_name: str) -> dict[str, Any]:
-    return {
+    attrs = {
         GEN_AI_SYSTEM: ANTHROPIC_SYSTEM_NAME,
         LLM_REQUEST_TYPE: LLMRequestTypeValues.CHAT.value,
         SpanAttributes.TRACELOOP_ENTITY_NAME: span_name,
@@ -449,6 +457,10 @@ def _build_base_chat_attrs(span_name: str) -> dict[str, Any]:
         RESPAN_LOG_TYPE: LOG_TYPE_CHAT,
         SpanAttributes.TRACELOOP_SPAN_KIND: LLMRequestTypeValues.CHAT.value,
     }
+    workflow_name = _active_workflow_name()
+    if workflow_name:
+        attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = workflow_name
+    return attrs
 
 
 def _apply_tool_call_attrs(attrs: dict[str, Any], tool_calls: list[dict[str, Any]]) -> None:
@@ -696,6 +708,9 @@ def _emit_tool_span(
         TOOLS_OVERRIDE: [tool_definition],
         SpanAttributes.TRACELOOP_SPAN_KIND: TraceloopSpanKindValues.TOOL.value,
     }
+    workflow_name = _active_workflow_name()
+    if workflow_name:
+        attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = workflow_name
 
     _emit_span(
         attrs=attrs,

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_messages.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/src/respan_instrumentation_anthropic/_messages.py
@@ -4,18 +4,32 @@ from __future__ import annotations
 
 import json
 import logging
-from threading import Lock
 import time
+from threading import Lock
 from typing import Any
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
-from opentelemetry.trace.status import StatusCode
 from opentelemetry.semconv_ai import (
     LLMRequestTypeValues,
     SpanAttributes,
-    TraceloopSpanKindValues,
 )
+from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_TOOL
+from respan_sdk.constants.span_attributes import (
+    GEN_AI_SYSTEM,
+    LLM_REQUEST_MODEL,
+    LLM_REQUEST_TYPE,
+    LLM_USAGE_COMPLETION_TOKENS,
+    LLM_USAGE_PROMPT_TOKENS,
+    RESPAN_LOG_TYPE,
+)
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+    generate_unique_id,
+)
+from respan_sdk.utils.serialization import serialize_value
+from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 from respan_instrumentation_anthropic._constants import (
     ANTHROPIC_CHAT_SPAN_NAME,
@@ -30,17 +44,15 @@ from respan_instrumentation_anthropic._constants import (
     FUNCTION_TOOL_TYPE,
     GEN_AI_COMPLETION_ROLE_ATTR,
     GEN_AI_COMPLETION_TOOL_CALLS_ATTR,
-    GEN_AI_TOOL_CALL_ID_ATTR,
-    GEN_AI_TOOL_DEFINITIONS_ATTR,
     ID_KEY,
     INPUT_KEY,
     INPUT_SCHEMA_KEY,
     INPUT_TOKENS_KEY,
     IS_ERROR_KEY,
+    MESSAGES_KEY,
     MODEL_KEY,
     NAME_KEY,
     OUTPUT_TOKENS_KEY,
-    MESSAGES_KEY,
     PARAMETERS_KEY,
     PENDING_EXPIRES_AT_NS_KEY,
     PENDING_PARENT_ID_KEY,
@@ -53,38 +65,16 @@ from respan_instrumentation_anthropic._constants import (
     SYSTEM_ROLE,
     TEXT_BLOCK_TYPE,
     TEXT_KEY,
-    TOOLS_KEY,
     TOOL_CALL_ID_KEY,
     TOOL_CALLS_OVERRIDE,
     TOOL_RESULT_BLOCK_TYPE,
-    TOOLS_OVERRIDE,
     TOOL_ROLE,
     TOOL_USE_BLOCK_TYPE,
     TOOL_USE_ID_KEY,
+    TOOLS_KEY,
     TYPE_KEY,
     USAGE_KEY,
 )
-from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_TOOL
-from respan_sdk.constants.span_attributes import (
-    GEN_AI_SYSTEM,
-    GEN_AI_TOOL_CALL_ARGUMENTS,
-    GEN_AI_TOOL_CALL_RESULT,
-    GEN_AI_TOOL_NAME,
-    LLM_REQUEST_MODEL,
-    LLM_REQUEST_TYPE,
-    LLM_USAGE_COMPLETION_TOKENS,
-    LLM_USAGE_PROMPT_TOKENS,
-    RESPAN_LOG_TYPE,
-    RESPAN_SPAN_TOOL_CALLS,
-    RESPAN_SPAN_TOOLS,
-)
-from respan_sdk.utils.data_processing.id_processing import (
-    format_span_id,
-    format_trace_id,
-    generate_unique_id,
-)
-from respan_sdk.utils.serialization import serialize_value
-from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 logger = logging.getLogger(__name__)
 
@@ -135,9 +125,7 @@ def _maybe_parse_json_string(value: Any) -> Any:
 def _serialize_content_value(value: Any) -> Any:
     """Serialize Anthropic content while preserving structured blocks."""
     if isinstance(value, list):
-        serialized_parts = [
-            _serialize_content_block(block=block) for block in value
-        ]
+        serialized_parts = [_serialize_content_block(block=block) for block in value]
         non_empty_parts = [
             part for part in serialized_parts if part not in ("", None, [], {})
         ]
@@ -178,7 +166,9 @@ def _serialize_content_block(block: Any) -> Any:
 
             field_value = _block_attr(block=block, attr=field_name, default=None)
             if field_value is not None:
-                serialized_block[field_name] = _serialize_content_value(value=field_value)
+                serialized_block[field_name] = _serialize_content_value(
+                    value=field_value
+                )
         return serialized_block
 
     text_value = _block_attr(block=block, attr=TEXT_KEY, default=None)
@@ -405,9 +395,7 @@ def _format_output(message: Any) -> str:
 
 
 def _extract_tool_calls(message: Any) -> list[dict[str, Any]]:
-    return _extract_tool_calls_from_content(
-        content=getattr(message, CONTENT_KEY, None)
-    )
+    return _extract_tool_calls_from_content(content=getattr(message, CONTENT_KEY, None))
 
 
 def _format_tools(tools: Any) -> list[dict[str, Any]]:
@@ -455,7 +443,6 @@ def _build_base_chat_attrs(span_name: str) -> dict[str, Any]:
         SpanAttributes.TRACELOOP_ENTITY_NAME: span_name,
         SpanAttributes.TRACELOOP_ENTITY_PATH: span_name,
         RESPAN_LOG_TYPE: LOG_TYPE_CHAT,
-        SpanAttributes.TRACELOOP_SPAN_KIND: LLMRequestTypeValues.CHAT.value,
     }
     workflow_name = _active_workflow_name()
     if workflow_name:
@@ -463,12 +450,12 @@ def _build_base_chat_attrs(span_name: str) -> dict[str, Any]:
     return attrs
 
 
-def _apply_tool_call_attrs(attrs: dict[str, Any], tool_calls: list[dict[str, Any]]) -> None:
+def _apply_tool_call_attrs(
+    attrs: dict[str, Any], tool_calls: list[dict[str, Any]]
+) -> None:
     if not tool_calls:
         return
-    attrs[RESPAN_SPAN_TOOL_CALLS] = _safe_json(value=tool_calls)
-    attrs[TOOL_CALLS_OVERRIDE] = tool_calls
-    attrs[GEN_AI_COMPLETION_TOOL_CALLS_ATTR] = tool_calls
+    attrs[GEN_AI_COMPLETION_TOOL_CALLS_ATTR] = _safe_json(value=tool_calls)
     attrs[GEN_AI_COMPLETION_ROLE_ATTR] = ASSISTANT_ROLE
 
 
@@ -477,9 +464,7 @@ def _apply_tool_definition_attrs(
 ) -> None:
     if not tools:
         return
-    attrs[RESPAN_SPAN_TOOLS] = _safe_json(value=tools)
-    attrs[TOOLS_OVERRIDE] = tools
-    attrs[GEN_AI_TOOL_DEFINITIONS_ATTR] = _safe_json(value=tools)
+    attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS] = _safe_json(value=tools)
 
 
 def _build_span_attrs(kwargs: dict[str, Any], message: Any) -> dict[str, Any]:
@@ -503,9 +488,7 @@ def _build_span_attrs(kwargs: dict[str, Any], message: Any) -> dict[str, Any]:
         attrs[LLM_USAGE_PROMPT_TOKENS] = getattr(usage, INPUT_TOKENS_KEY, 0)
         attrs[LLM_USAGE_COMPLETION_TOKENS] = getattr(usage, OUTPUT_TOKENS_KEY, 0)
         cache_read_input_tokens = getattr(usage, CACHE_READ_INPUT_TOKENS_KEY, 0)
-        cache_creation_input_tokens = getattr(
-            usage, CACHE_CREATION_INPUT_TOKENS_KEY, 0
-        )
+        cache_creation_input_tokens = getattr(usage, CACHE_CREATION_INPUT_TOKENS_KEY, 0)
         if cache_read_input_tokens:
             attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] = (
                 cache_read_input_tokens
@@ -572,6 +555,7 @@ def _resolve_injected_trace_parent_ids() -> tuple[str, str | None]:
     if trace_id is None:
         trace_id = _generate_trace_id()
     return trace_id, parent_id
+
 
 def _prune_expired_pending_tool_calls(*, now_ns: int | None = None) -> None:
     expiration_cutoff_ns = now_ns if now_ns is not None else time.time_ns()
@@ -695,18 +679,19 @@ def _emit_tool_span(
         return
 
     tool_input = function.get(ARGUMENTS_KEY, "")
+    canonical_input = _safe_json(
+        value={
+            NAME_KEY: tool_name,
+            ARGUMENTS_KEY: _maybe_parse_json_string(value=tool_input),
+        }
+    )
+    canonical_output = _safe_json(value=_maybe_parse_json_string(value=tool_output))
     attrs = {
-        GEN_AI_TOOL_NAME: tool_name,
-        GEN_AI_TOOL_CALL_ARGUMENTS: tool_input,
-        GEN_AI_TOOL_CALL_RESULT: tool_output,
-        GEN_AI_TOOL_CALL_ID_ATTR: tool_call.get(ID_KEY, ""),
         SpanAttributes.TRACELOOP_ENTITY_NAME: tool_name,
         SpanAttributes.TRACELOOP_ENTITY_PATH: tool_name,
-        SpanAttributes.TRACELOOP_ENTITY_INPUT: tool_input,
-        SpanAttributes.TRACELOOP_ENTITY_OUTPUT: tool_output,
+        SpanAttributes.TRACELOOP_ENTITY_INPUT: canonical_input,
+        SpanAttributes.TRACELOOP_ENTITY_OUTPUT: canonical_output,
         RESPAN_LOG_TYPE: LOG_TYPE_TOOL,
-        TOOLS_OVERRIDE: [tool_definition],
-        SpanAttributes.TRACELOOP_SPAN_KIND: TraceloopSpanKindValues.TOOL.value,
     }
     workflow_name = _active_workflow_name()
     if workflow_name:
@@ -775,15 +760,15 @@ def _emit_resolved_tool_spans(
             end_ns=end_ns,
             tool_call=tool_call,
             tool_definition=tool_definition,
-            tool_output=_format_tool_result_output(
-                content=tool_result[CONTENT_KEY]
-            ),
+            tool_output=_format_tool_result_output(content=tool_result[CONTENT_KEY]),
             is_error=tool_result[IS_ERROR_KEY],
         )
 
 
 def _emit_message_spans(kwargs: dict[str, Any], message: Any, start_ns: int) -> None:
     """Emit chat spans and resolve tool spans once tool_result content is available."""
+    normalized_tools = _format_tools(tools=kwargs.get(TOOLS_KEY))
+    tool_calls = _extract_tool_calls(message=message)
     attrs = _build_span_attrs(kwargs=kwargs, message=message)
     trace_id, parent_id = _resolve_injected_trace_parent_ids()
     chat_span_id = _generate_span_id()
@@ -797,8 +782,6 @@ def _emit_message_spans(kwargs: dict[str, Any], message: Any, start_ns: int) -> 
         span_id=chat_span_id,
     )
 
-    tools = attrs.get(TOOLS_OVERRIDE)
-    normalized_tools = tools if isinstance(tools, list) else []
     _emit_resolved_tool_spans(
         kwargs=kwargs,
         trace_id=trace_id,
@@ -807,8 +790,7 @@ def _emit_message_spans(kwargs: dict[str, Any], message: Any, start_ns: int) -> 
         tools=normalized_tools,
     )
 
-    tool_calls = attrs.get(TOOL_CALLS_OVERRIDE)
-    if isinstance(tool_calls, list) and tool_calls:
+    if tool_calls:
         _register_pending_tool_calls(
             trace_id=trace_id,
             parent_id=chat_span_id,

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/tests/test_instrumentation.py
@@ -1,6 +1,7 @@
 import json
 from types import SimpleNamespace
 
+from opentelemetry import context as context_api
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
 
 from respan_instrumentation_anthropic import _instrumentation as instrumentation
@@ -106,6 +107,52 @@ def test_build_error_attrs_sets_chat_span_kind():
 
     assert attrs["respan.entity.log_type"] == "chat"
     assert attrs[SpanAttributes.TRACELOOP_SPAN_KIND] == LLMRequestTypeValues.CHAT.value
+
+
+def test_build_attrs_preserves_active_workflow_name():
+    token = context_api.attach(
+        context_api.set_value(
+            SpanAttributes.TRACELOOP_ENTITY_NAME,
+            "python_anthropic_workflow",
+        )
+    )
+    try:
+        attrs = message_helpers._build_error_attrs(
+            kwargs={"messages": [{"role": "user", "content": "hi"}]}
+        )
+    finally:
+        context_api.detach(token)
+
+    assert (
+        attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME]
+        == "python_anthropic_workflow"
+    )
+
+
+def test_emit_error_span_preserves_provider_status_and_falls_back(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        instrumentation,
+        "_emit_span",
+        lambda **kwargs: captured.append(kwargs),
+    )
+
+    provider_error = RuntimeError("not found")
+    provider_error.status_code = 404
+    instrumentation._emit_error_span(
+        kwargs={"messages": [{"role": "user", "content": "hi"}]},
+        start_ns=123,
+        exc=provider_error,
+    )
+    instrumentation._emit_error_span(
+        kwargs={"messages": [{"role": "user", "content": "hi"}]},
+        start_ns=456,
+        exc=RuntimeError("local failure"),
+    )
+
+    assert captured[0]["status_code"] == 404
+    assert captured[0]["error_message"] == "not found"
+    assert captured[1]["status_code"] == 500
 
 
 def test_format_input_messages_preserves_tool_blocks():

--- a/python-sdks/instrumentations/respan-instrumentation-anthropic/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-anthropic/tests/test_instrumentation.py
@@ -2,8 +2,7 @@ import json
 from types import SimpleNamespace
 
 from opentelemetry import context as context_api
-from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
-
+from opentelemetry.semconv_ai import SpanAttributes
 from respan_instrumentation_anthropic import _instrumentation as instrumentation
 from respan_instrumentation_anthropic import _managed_agents as managed_agent_helpers
 from respan_instrumentation_anthropic import _messages as message_helpers
@@ -12,7 +11,6 @@ from respan_sdk.constants.span_attributes import (
     LLM_USAGE_PROMPT_TOKENS,
     RESPAN_SESSION_ID,
 )
-
 
 TRACE_ID = "0123456789abcdef0123456789abcdef"
 SPAN_ID = "fedcba9876543210"
@@ -69,7 +67,9 @@ def test_emit_span_without_active_parent_creates_root(monkeypatch):
         def get_span_context(self):
             return SimpleNamespace(trace_id=0, span_id=0)
 
-    monkeypatch.setattr(message_helpers.trace, "get_current_span", lambda: _InvalidSpan())
+    monkeypatch.setattr(
+        message_helpers.trace, "get_current_span", lambda: _InvalidSpan()
+    )
 
     message_helpers._emit_span({"respan.entity.log_type": "chat"}, start_ns=123)
 
@@ -77,7 +77,7 @@ def test_emit_span_without_active_parent_creates_root(monkeypatch):
     assert captured[0]["parent_id"] is None
 
 
-def test_build_span_attrs_sets_chat_span_kind():
+def test_build_span_attrs_uses_chat_contract_without_auto_span_kind():
     message = SimpleNamespace(
         model="claude-sonnet-4-20250514",
         content=[SimpleNamespace(text="hello")],
@@ -95,18 +95,18 @@ def test_build_span_attrs_sets_chat_span_kind():
     )
 
     assert attrs["respan.entity.log_type"] == "chat"
-    assert attrs[SpanAttributes.TRACELOOP_SPAN_KIND] == LLMRequestTypeValues.CHAT.value
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
     assert attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] == 3
     assert attrs[SpanAttributes.LLM_USAGE_CACHE_CREATION_INPUT_TOKENS] == 4
 
 
-def test_build_error_attrs_sets_chat_span_kind():
+def test_build_error_attrs_uses_chat_contract_without_auto_span_kind():
     attrs = message_helpers._build_error_attrs(
         kwargs={"messages": [{"role": "user", "content": "hi"}]}
     )
 
     assert attrs["respan.entity.log_type"] == "chat"
-    assert attrs[SpanAttributes.TRACELOOP_SPAN_KIND] == LLMRequestTypeValues.CHAT.value
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
 
 
 def test_build_attrs_preserves_active_workflow_name():
@@ -123,10 +123,7 @@ def test_build_attrs_preserves_active_workflow_name():
     finally:
         context_api.detach(token)
 
-    assert (
-        attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME]
-        == "python_anthropic_workflow"
-    )
+    assert attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] == "python_anthropic_workflow"
 
 
 def test_emit_error_span_preserves_provider_status_and_falls_back(monkeypatch):
@@ -271,7 +268,7 @@ def test_build_span_attrs_sets_tool_metadata_overrides():
         message=message,
     )
 
-    assert attrs["tool_calls"] == [
+    expected_tool_calls = [
         {
             "id": TOOL_CALL_ID,
             "type": "function",
@@ -281,7 +278,7 @@ def test_build_span_attrs_sets_tool_metadata_overrides():
             },
         }
     ]
-    assert attrs["tools"] == [
+    expected_tools = [
         {
             "type": "function",
             "function": {
@@ -294,9 +291,10 @@ def test_build_span_attrs_sets_tool_metadata_overrides():
             },
         }
     ]
-    assert attrs["gen_ai.completion.0.tool_calls"] == attrs["tool_calls"]
-    assert json.loads(attrs["respan.span.tool_calls"]) == attrs["tool_calls"]
-    assert json.loads(attrs["respan.span.tools"]) == attrs["tools"]
+    assert json.loads(attrs["gen_ai.completion.0.tool_calls"]) == expected_tool_calls
+    assert json.loads(attrs["llm.request.functions"]) == expected_tools
+    for alias in ("tool_calls", "tools", "respan.span.tool_calls", "respan.span.tools"):
+        assert alias not in attrs
 
 
 def test_emit_message_spans_emits_resolved_child_tool_span(monkeypatch):
@@ -386,22 +384,18 @@ def test_emit_message_spans_emits_resolved_child_tool_span(monkeypatch):
     assert tool_span["trace_id"] == TRACE_ID
     assert tool_span["parent_id"] == first_chat_span["span_id"]
     assert tool_span["attributes"]["respan.entity.log_type"] == "tool"
-    assert tool_span["attributes"]["gen_ai.tool.name"] == WEATHER_TOOL_NAME
-    assert tool_span["attributes"]["traceloop.entity.input"] == WEATHER_TOOL_ARGUMENTS
+    assert json.loads(tool_span["attributes"]["traceloop.entity.input"]) == {
+        "name": WEATHER_TOOL_NAME,
+        "arguments": WEATHER_TOOL_INPUT,
+    }
     assert (
-        tool_span["attributes"]["traceloop.entity.output"]
-        == json.dumps(WEATHER_TOOL_RESULT)
+        json.loads(tool_span["attributes"]["traceloop.entity.output"])
+        == WEATHER_TOOL_RESULT
     )
     assert "gen_ai.system" not in tool_span["attributes"]
-    assert tool_span["attributes"]["tools"] == [
-        {
-            "type": "function",
-            "function": {
-                "name": WEATHER_TOOL_NAME,
-                "parameters": {"type": "object"},
-            },
-        }
-    ]
+    assert not any(key.startswith("gen_ai.tool.") for key in tool_span["attributes"])
+    assert "tools" not in tool_span["attributes"]
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in tool_span["attributes"]
     assert tool_span["end_time_ns"] == 456
 
 
@@ -458,7 +452,7 @@ def test_managed_agent_tracker_emits_stop_reason_and_tool_calls(monkeypatch):
     assert attrs["traceloop.entity.output"] == "Done."
     assert attrs[LLM_USAGE_PROMPT_TOKENS] == 3
     assert attrs[LLM_USAGE_COMPLETION_TOKENS] == 4
-    assert json.loads(attrs["respan.span.tool_calls"]) == [
+    assert json.loads(attrs["gen_ai.completion.0.tool_calls"]) == [
         {
             "id": TOOL_CALL_ID,
             "type": "function",
@@ -548,7 +542,6 @@ def test_emit_message_spans_marks_failed_tool_span(monkeypatch):
     assert tool_span["attributes"]["status_code"] == 500
 
 
-
 def test_register_pending_tool_calls_prunes_expired_entries(monkeypatch):
     with message_helpers._PENDING_TOOL_CALLS_LOCK:
         message_helpers._PENDING_TOOL_CALLS.clear()
@@ -580,8 +573,9 @@ def test_register_pending_tool_calls_prunes_expired_entries(monkeypatch):
     with message_helpers._PENDING_TOOL_CALLS_LOCK:
         assert (TRACE_ID, "expired_tool") not in message_helpers._PENDING_TOOL_CALLS
         pending_entry = message_helpers._PENDING_TOOL_CALLS[(TRACE_ID, TOOL_CALL_ID)]
-    assert pending_entry["expires_at_ns"] == 5 + message_helpers._PENDING_TOOL_CALL_TTL_NS
-
+    assert (
+        pending_entry["expires_at_ns"] == 5 + message_helpers._PENDING_TOOL_CALL_TTL_NS
+    )
 
 
 def test_activate_rolls_back_partial_patch(monkeypatch):


### PR DESCRIPTION
## Summary

- preserve the enclosing workflow name across Agno agent, team, chat, tool, and event spans, and retain tool calls in structured entity output
- classify Aleph Alpha `evaluate` and `explain` as non-generative task spans without fabricated model usage, while retaining structured results and chat tool-call output
- preserve Anthropic provider HTTP status codes and active workflow names on chat, tool, and error spans
- add focused regressions and patch release intent for all three packages

**Why.**

The OTel compatibility audit found that these packages split logical workflows, misclassified Aleph Alpha analytical operations, and flattened real Anthropic provider failures to generic 500 records.

**Root cause.**

- native Agno spans replaced or omitted the active workflow context
- Aleph Alpha treated every non-chat/non-embedding method as a completion
- Anthropic error export ignored status fields carried by SDK exceptions, and injected spans did not read the active workflow context

## Validation

- [x] focused tests: Agno 14 passed / 1 opt-in skipped; Aleph Alpha 7 passed; Anthropic 15 passed
- [x] all three wheels built, installed together in a clean Python 3.11 environment, and imported from the wheel artifacts
- [x] all 15 corresponding examples passed against locally linked packages under marker `otel2-fix-py-group-08-20260815T201000Z`
- [x] Respan MCP exact-marker audit: 15/15 trace trees and 51/51 full records inspected; exact span counts, connected hierarchy, workflow grouping, content, usage, tools, and expected 404 status passed
- [x] release inventory, release-intent, missing-intent, and `git diff --check` validation passed

- [x] Contribution re-audit against every current document under `contribution/` passed after `77f1b68`: Aleph Alpha text completion uses canonical `chat` request type; Anthropic automatic span-kind and deprecated tool aliases are absent; definitions/calls and tool execution I/O use canonical JSON.
- [x] Fresh correction validation: Agno 14 passed / 1 skipped, Aleph Alpha 7 passed, Anthropic 15 passed; corrected-package wheels, release inventory/intents, formatting/import, and diff checks passed; marker `otel2-pr-contract-corrections-20260818T133300Z` produced 2 representative traces / 6 full records for Aleph Alpha and Anthropic, all inspected.

## External follow-ups

- The platform currently retains Agno/Aleph canonical tool attributes and structured message content but does not project them into its top-level tool arrays; this is recorded as a backend follow-up rather than addressed with prohibited compatibility aliases.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/55
