### PR TITLE
build(deps): patch Hono and Nano ID vulnerabilities

### DIFF
--- a/javascript-sdks/legacy/respan-exporter-n8n/package.json
+++ b/javascript-sdks/legacy/respan-exporter-n8n/package.json
@@ -61,6 +61,7 @@
 		"n8n-workflow": "*"
 	},
 	"resolutions": {
+		"nanoid": "3.3.18",
 		"uuid": "11.1.1"
 	}
 }

--- a/javascript-sdks/legacy/respan-exporter-n8n/yarn.lock
+++ b/javascript-sdks/legacy/respan-exporter-n8n/yarn.lock
@@ -4999,12 +4999,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
+"nanoid@npm:3.3.18":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 

--- a/javascript-sdks/legacy/respan-exporter-openai-agents/package.json
+++ b/javascript-sdks/legacy/respan-exporter-openai-agents/package.json
@@ -36,5 +36,8 @@
     "dotenv": "^16.5.0",
     "typescript": "^5.0.0"
   },
+  "resolutions": {
+    "hono": "4.13.2"
+  },
   "packageManager": "yarn@4.9.2"
 }

--- a/javascript-sdks/legacy/respan-exporter-openai-agents/tests/examples/basic/package.json
+++ b/javascript-sdks/legacy/respan-exporter-openai-agents/tests/examples/basic/package.json
@@ -30,5 +30,8 @@
   "devDependencies": {
     "tsx": "^4.20.3",
     "typescript": "^5.9.2"
+  },
+  "resolutions": {
+    "hono": "4.13.2"
   }
 }

--- a/javascript-sdks/legacy/respan-exporter-openai-agents/tests/examples/basic/yarn.lock
+++ b/javascript-sdks/legacy/respan-exporter-openai-agents/tests/examples/basic/yarn.lock
@@ -906,10 +906,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.11.4":
-  version: 4.13.0
-  resolution: "hono@npm:4.13.0"
-  checksum: 10c0/d7cfb4d1063be19bea1982ea2a6b3cfa1840e8403a03203e86d17278e76fed11e7483974738345257543e183a935ea73ffc6d4a1e6ad7f0008451f55cdf8be7b
+"hono@npm:4.13.2":
+  version: 4.13.2
+  resolution: "hono@npm:4.13.2"
+  checksum: 10c0/063daaa596bfb1ed3a4dc523a9f47725cf8d56e0918c21a241161f6f1996229f5525bf0f70d6b15cc28912720ddde519584eeb06fb92730a66f01e39faba8131
   languageName: node
   linkType: hard
 

--- a/javascript-sdks/legacy/respan-exporter-openai-agents/yarn.lock
+++ b/javascript-sdks/legacy/respan-exporter-openai-agents/yarn.lock
@@ -637,10 +637,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.11.4":
-  version: 4.13.0
-  resolution: "hono@npm:4.13.0"
-  checksum: 10c0/d7cfb4d1063be19bea1982ea2a6b3cfa1840e8403a03203e86d17278e76fed11e7483974738345257543e183a935ea73ffc6d4a1e6ad7f0008451f55cdf8be7b
+"hono@npm:4.13.2":
+  version: 4.13.2
+  resolution: "hono@npm:4.13.2"
+  checksum: 10c0/063daaa596bfb1ed3a4dc523a9f47725cf8d56e0918c21a241161f6f1996229f5525bf0f70d6b15cc28912720ddde519584eeb06fb92730a66f01e39faba8131
   languageName: node
   linkType: hard
 

--- a/javascript-sdks/package.json
+++ b/javascript-sdks/package.json
@@ -59,6 +59,7 @@
     "fast-xml-parser": "5.10.1",
     "form-data": "4.0.6",
     "glob": "13.0.6",
+    "hono": "4.13.2",
     "ip-address": "10.5.0",
     "js-yaml": "5.2.3",
     "jsondiffpatch": "0.7.6",

--- a/javascript-sdks/yarn.lock
+++ b/javascript-sdks/yarn.lock
@@ -9860,17 +9860,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.11.4":
-  version: 4.12.9
-  resolution: "hono@npm:4.12.9"
-  checksum: 10c0/393256552642f681e52935163508d9605e5552e186d9b99ff2caf219d4248341b83e3eb975c40a97149c86890d19d73421efc889aa465a28eb5920ccc42cff34
-  languageName: node
-  linkType: hard
-
-"hono@npm:^4.8.3":
-  version: 4.12.30
-  resolution: "hono@npm:4.12.30"
-  checksum: 10c0/3262ba275e44dc9515032e15aa6a88e8915bc65f5a4b9a1bc538f3ac2bdd19aa2235e6e2fdd6af3b0e5551c162856c3dccd4f353e721c43fe81e5f3268573dde
+"hono@npm:4.13.2":
+  version: 4.13.2
+  resolution: "hono@npm:4.13.2"
+  checksum: 10c0/063daaa596bfb1ed3a4dc523a9f47725cf8d56e0918c21a241161f6f1996229f5525bf0f70d6b15cc28912720ddde519584eeb06fb92730a66f01e39faba8131
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Updates the dependency resolutions surfaced by the Oneleet scan for `respanai/respan`.

## Changes

- Pin all JavaScript SDK Hono dependency paths to 4.13.2.
- Pin the legacy N8N exporter Nano ID dependency path to 3.3.18.
- Regenerate each affected Yarn 4 lockfile.

## Test plan

- `corepack yarn install --immutable` in all four affected projects.
- `corepack yarn build` in `respan-exporter-openai-agents`.
- `corepack yarn build-check` in the OpenAI exporter basic example.
- `corepack yarn build` in `respan-exporter-n8n`.

The root SDK immutable install retains pre-existing peer-dependency warnings only.