### PR TITLE
fix(instrumentation-py): repair Arize, AutoGen, and AWS Bedrock OTel 2.x spans

### DIFF
--- a/.release-intents/20260816-python-arize-autogen-aws-bedrock-tracing.json
+++ b/.release-intents/20260816-python-arize-autogen-aws-bedrock-tracing.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair Arize failure status, AutoGen logical span and tool context, and AWS Bedrock tool schema and provider error tracing",
+  "packages": {
+    "respan-instrumentation-arize": "patch",
+    "respan-instrumentation-autogen": "patch",
+    "respan-instrumentation-aws-bedrock": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-arize/src/respan_instrumentation_arize/_span_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-arize/src/respan_instrumentation_arize/_span_emitter.py
@@ -102,6 +102,10 @@ def build_arize_span_attributes(
     }
 
     status_code = _status_code_from_result(result)
+    if error is not None:
+        status_code = 500
+        attrs["error.message"] = str(error)
+    attrs["status_code"] = status_code
     if status_code != 200:
         attrs[ARIZE_METADATA_STATUS_CODE] = status_code
 

--- a/python-sdks/instrumentations/respan-instrumentation-arize/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-arize/tests/test_instrumentation.py
@@ -4,8 +4,10 @@ import asyncio
 import logging
 import sys
 from types import ModuleType
+from typing import Any
 
 import pytest
+from opentelemetry.trace import StatusCode
 
 from respan_instrumentation_arize import ArizeInstrumentor
 from respan_instrumentation_arize import _instrumentation
@@ -190,6 +192,33 @@ def test_error_methods_emit_error_span(monkeypatch) -> None:
     assert emitted[0]["resource"] == "error_resource"
     assert emitted[0]["method_name"] == "explode"
     assert isinstance(emitted[0]["error"], RuntimeError)
+
+
+def test_error_span_exposes_backend_visible_status_and_message(monkeypatch) -> None:
+    from respan_instrumentation_arize._span_emitter import emit_arize_span
+
+    spans: list[Any] = []
+    monkeypatch.setattr(
+        "respan_instrumentation_arize._span_emitter.inject_span",
+        lambda span: spans.append(span) or True,
+    )
+
+    emitted = emit_arize_span(
+        resource="datasets",
+        method_name="get",
+        args=(),
+        kwargs={"dataset": "missing"},
+        result=None,
+        start_time_ns=1,
+        end_time_ns=2,
+        error=RuntimeError("dataset unavailable"),
+    )
+
+    assert emitted is True
+    assert len(spans) == 1
+    assert spans[0]._attributes["status_code"] == 500
+    assert spans[0]._attributes["error.message"] == "dataset unavailable"
+    assert spans[0].status.status_code is StatusCode.ERROR
 
 
 def test_activate_skips_when_respan_tracing_is_disabled(monkeypatch, caplog) -> None:

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_instrumentation.py
@@ -2,8 +2,11 @@
 
 import importlib
 import logging
+from collections.abc import Mapping, Sequence
+from threading import Lock
 from typing import Any
 
+from opentelemetry import context as context_api
 from opentelemetry import trace
 
 from respan_instrumentation_autogen._native_processor import (
@@ -18,12 +21,135 @@ AUTOGEN_INSTRUMENTATION_NAME = "autogen"
 OPENINFERENCE_AUTOGEN_AGENTCHAT_MODULE = (
     "openinference.instrumentation.autogen_agentchat"
 )
+OPENINFERENCE_AUTOGEN_AGENTCHAT_WRAPPERS_MODULE = (
+    "openinference.instrumentation.autogen_agentchat._wrappers"
+)
 OPENINFERENCE_AUTOGEN_AGENTCHAT_CLASS_NAMES = (
     "AutogenAgentChatInstrumentor",
     "AutoGenAgentChatInstrumentor",
     "AutoGenInstrumentor",
 )
 TRACER_PROVIDER_KWARG = "tracer_provider"
+
+_TOOL_EXTRACTOR_PATCH_LOCK = Lock()
+_TOOL_EXTRACTOR_PATCH_REFCOUNT = 0
+_ORIGINAL_TOOL_EXTRACTOR = None
+_AGENT_WRAPPER_PATCHES: list[tuple[type, Any, Any]] = []
+
+_AGENT_WRAPPER_CLASS_NAMES = (
+    "_AssistantAgentOnMessagesStreamWrapper",
+    "_BaseChatAgentOnMessagesStreamWrapper",
+)
+
+
+def _respan_get_llm_tool_attributes(tools: Any) -> dict[str, Any]:
+    """Capture both AutoGen Tool objects and current ToolSchema mappings.
+
+    OpenInference AutoGen 0.1.11 accepts ``Tool | ToolSchema`` at the model
+    boundary but serializes only ``Tool`` instances. AutoGen AgentChat 0.7.5
+    normally passes the mapping form returned by a workbench, so its complete
+    name/description/parameter schema otherwise disappears before the span is
+    started.
+    """
+
+    if not isinstance(tools, Sequence) or isinstance(tools, str | bytes):
+        return {}
+
+    from openinference.instrumentation import safe_json_dumps
+    from openinference.semconv.trace import SpanAttributes, ToolAttributes
+
+    attributes: dict[str, Any] = {}
+    for tool_index, tool in enumerate(tools):
+        if isinstance(tool, Mapping):
+            tool_schema: Any = dict(tool)
+        else:
+            tool_schema = getattr(tool, "schema", None)
+        if tool_schema is None:
+            continue
+
+        if not isinstance(tool_schema, str):
+            tool_schema = safe_json_dumps(tool_schema)
+        attributes[
+            f"{SpanAttributes.LLM_TOOLS}.{tool_index}."
+            f"{ToolAttributes.TOOL_JSON_SCHEMA}"
+        ] = tool_schema
+    return attributes
+
+
+def _capture_current_agent_output(event: Any) -> None:
+    """Attach an AutoGen Response while the owning agent span is current."""
+
+    from autogen_agentchat.base import Response
+    from openinference.instrumentation import get_output_attributes
+
+    if not isinstance(event, Response):
+        return
+    span = trace.get_current_span()
+    set_attributes = getattr(span, "set_attributes", None)
+    if callable(set_attributes):
+        set_attributes(dict(get_output_attributes(event)))
+
+
+def _agent_wrapper_with_output_capture(original_call: Any) -> Any:
+    def call(self: Any, wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:
+        generator = original_call(self, wrapped, instance, args, kwargs)
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return generator
+
+        async def generator_with_output_capture():
+            async for event in generator:
+                _capture_current_agent_output(event)
+                yield event
+
+        return generator_with_output_capture()
+
+    return call
+
+
+def _patch_openinference_tool_extractor() -> None:
+    global _ORIGINAL_TOOL_EXTRACTOR, _TOOL_EXTRACTOR_PATCH_REFCOUNT
+
+    with _TOOL_EXTRACTOR_PATCH_LOCK:
+        wrappers = importlib.import_module(
+            OPENINFERENCE_AUTOGEN_AGENTCHAT_WRAPPERS_MODULE
+        )
+        if _TOOL_EXTRACTOR_PATCH_REFCOUNT == 0:
+            _ORIGINAL_TOOL_EXTRACTOR = wrappers._get_llm_tool_attributes
+            wrappers._get_llm_tool_attributes = _respan_get_llm_tool_attributes
+            for class_name in _AGENT_WRAPPER_CLASS_NAMES:
+                wrapper_class = getattr(wrappers, class_name)
+                original_call = wrapper_class.__call__
+                patched_call = _agent_wrapper_with_output_capture(original_call)
+                wrapper_class.__call__ = patched_call
+                _AGENT_WRAPPER_PATCHES.append(
+                    (wrapper_class, original_call, patched_call)
+                )
+        _TOOL_EXTRACTOR_PATCH_REFCOUNT += 1
+
+
+def _unpatch_openinference_tool_extractor() -> None:
+    global _ORIGINAL_TOOL_EXTRACTOR, _TOOL_EXTRACTOR_PATCH_REFCOUNT
+
+    with _TOOL_EXTRACTOR_PATCH_LOCK:
+        if _TOOL_EXTRACTOR_PATCH_REFCOUNT == 0:
+            return
+        _TOOL_EXTRACTOR_PATCH_REFCOUNT -= 1
+        if _TOOL_EXTRACTOR_PATCH_REFCOUNT != 0:
+            return
+
+        wrappers = importlib.import_module(
+            OPENINFERENCE_AUTOGEN_AGENTCHAT_WRAPPERS_MODULE
+        )
+        if (
+            wrappers._get_llm_tool_attributes is _respan_get_llm_tool_attributes
+            and _ORIGINAL_TOOL_EXTRACTOR is not None
+        ):
+            wrappers._get_llm_tool_attributes = _ORIGINAL_TOOL_EXTRACTOR
+        for wrapper_class, original_call, patched_call in _AGENT_WRAPPER_PATCHES:
+            if wrapper_class.__call__ is patched_call:
+                wrapper_class.__call__ = original_call
+        _AGENT_WRAPPER_PATCHES.clear()
+        _ORIGINAL_TOOL_EXTRACTOR = None
 
 
 def _load_openinference_autogen_agentchat_class() -> type:
@@ -54,6 +180,7 @@ class AutoGenInstrumentor:
         self._instrumentor_kwargs = instrumentor_kwargs
         self._delegate = None
         self._native_processor = AutoGenNativeSpanProcessor()
+        self._tool_extractor_patched = False
         self._is_instrumented = False
 
     @staticmethod
@@ -124,6 +251,8 @@ class AutoGenInstrumentor:
             return
 
         try:
+            _patch_openinference_tool_extractor()
+            self._tool_extractor_patched = True
             self._register_native_processor(
                 trace.get_tracer_provider(),
                 self._native_processor,
@@ -133,6 +262,13 @@ class AutoGenInstrumentor:
                 **self._instrumentor_kwargs,
             )
             self._delegate.activate()
+            # OpenInference rebuilds the processor chain with its generic
+            # translator first. Move the AutoGen adapter back to the front so
+            # it can repair vendor-only history fields before translation.
+            self._register_native_processor(
+                trace.get_tracer_provider(),
+                self._native_processor,
+            )
             self._is_instrumented = True
             logger.info("AutoGen instrumentation activated")
         except Exception:
@@ -145,6 +281,9 @@ class AutoGenInstrumentor:
                 trace.get_tracer_provider(),
                 self._native_processor,
             )
+            if self._tool_extractor_patched:
+                _unpatch_openinference_tool_extractor()
+                self._tool_extractor_patched = False
             self._delegate = None
             self._is_instrumented = False
             logger.exception("Failed to activate AutoGen instrumentation")
@@ -160,6 +299,9 @@ class AutoGenInstrumentor:
             trace.get_tracer_provider(),
             self._native_processor,
         )
+        if self._tool_extractor_patched:
+            _unpatch_openinference_tool_extractor()
+            self._tool_extractor_patched = False
         self._delegate = None
         self._is_instrumented = False
         logger.info("AutoGen instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_native_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_native_processor.py
@@ -1,95 +1,216 @@
-"""Normalize native AutoGen OTel spans before Respan export."""
+"""Remove AutoGen runtime noise and repair AutoGen OpenInference payloads."""
 
 from __future__ import annotations
 
+import json
+import re
+from threading import Lock
 from typing import Any
 
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceSpanKindValues,
+    SpanAttributes as OISpanAttributes,
+)
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
-from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
-    GEN_AI_AGENT_NAME,
-    GEN_AI_OPERATION_NAME,
-    GEN_AI_SYSTEM,
-    GEN_AI_TOOL_NAME,
-)
-from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
 
-from respan_sdk.constants.llm_logging import LOG_TYPE_AGENT, LOG_TYPE_TOOL
-from respan_sdk.constants.span_attributes import (
-    RESPAN_LOG_TYPE,
-)
 
 AUTOGEN_CORE_SCOPE_NAME = "autogen-core"
+AUTOGEN_RUNTIME_SCOPE_PREFIX = "autogen "
+AUTOGEN_OPENINFERENCE_SCOPE_NAME = (
+    "openinference.instrumentation.autogen_agentchat"
+)
 AUTOGEN_OPERATION_INVOKE_AGENT = "invoke_agent"
 AUTOGEN_OPERATION_EXECUTE_TOOL = "execute_tool"
 
-_AUTOGEN_OPERATION_LOG_TYPES = {
-    AUTOGEN_OPERATION_INVOKE_AGENT: LOG_TYPE_AGENT,
-    AUTOGEN_OPERATION_EXECUTE_TOOL: LOG_TYPE_TOOL,
-}
+_OI_INPUT_MESSAGE_PREFIX = "llm.input_messages."
+_FUNCTION_RESULT_RE = re.compile(
+    r"^llm\.input_messages\.(\d+)\.(?:message\.)?function\.(\d+)$"
+)
+_OI_FIRST_OUTPUT_CONTENT = (
+    f"{OISpanAttributes.LLM_OUTPUT_MESSAGES}.0."
+    f"{MessageAttributes.MESSAGE_CONTENT}"
+)
 
 
-def _get_mutable_attributes(span: ReadableSpan) -> dict[str, Any] | None:
-    # An ended span's ``_attributes`` is a ``BoundedAttributes`` that is frozen
-    # (``_immutable``) on opentelemetry-sdk once the span has ended, so writing
-    # to it in place raises ``TypeError``. Return a mutable copy; the caller
-    # reassigns ``span._attributes`` after normalizing.
-    attrs = getattr(span, "_attributes", None)
-    if attrs is None:
-        return None
-    return dict(attrs)
-
-
-def _get_scope_name(span: ReadableSpan) -> str | None:
+def _get_scope_name(span: Any) -> str | None:
     scope = getattr(span, "instrumentation_scope", None)
     return getattr(scope, "name", None)
 
 
-def _get_entity_name(attrs: dict[str, Any], span_name: str) -> str:
-    return (
-        attrs.get(GEN_AI_AGENT_NAME)
-        or attrs.get(GEN_AI_TOOL_NAME)
-        or span_name
+def _is_native_scope(scope_name: str | None) -> bool:
+    return scope_name == AUTOGEN_CORE_SCOPE_NAME or bool(
+        scope_name and scope_name.startswith(AUTOGEN_RUNTIME_SCOPE_PREFIX)
     )
 
 
-class AutoGenNativeSpanProcessor(SpanProcessor):
-    """Map AutoGen's native GenAI spans to non-LLM Respan log types.
+def _get_span_id(span: Any) -> int | None:
+    get_context = getattr(span, "get_span_context", None)
+    context = get_context() if callable(get_context) else getattr(span, "context", None)
+    span_id = getattr(context, "span_id", None)
+    return span_id if isinstance(span_id, int) and span_id else None
 
-    AutoGen AgentChat emits native spans from the ``autogen-core`` scope with
-    ``gen_ai.system=autogen`` for agent and tool operations. Respan's generic
-    GenAI exporter treats GenAI system spans without a request type as chat
-    spans, so this processor marks native agent/tool spans explicitly and
-    removes the LLM-only marker before export.
+
+def _get_parent(span: Any) -> Any:
+    return getattr(span, "parent", None)
+
+
+def _parse_result(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return dict(value)
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return dict(parsed) if isinstance(parsed, dict) else None
+
+
+def _normalize_function_result_messages(attrs: dict[str, Any]) -> None:
+    """Promote AutoGen's vendor-only function result fields to messages.
+
+    OpenInference AutoGen 0.1.11 stores a function-result input as
+    ``message.function.N`` while emitting only ``role=function``. The generic
+    translator does not understand that vendor extension, so Respan receives
+    an empty history entry. Preserve the complete result as canonical indexed
+    message fields before the generic translator removes the raw OI keys.
     """
 
-    def on_start(self, span, parent_context=None) -> None:
+    results_by_message: dict[int, list[tuple[int, dict[str, Any]]]] = {}
+    raw_result_keys: list[str] = []
+    for key, value in attrs.items():
+        match = _FUNCTION_RESULT_RE.match(key)
+        if match is None:
+            continue
+        result = _parse_result(value)
+        if result is None:
+            continue
+        message_index = int(match.group(1))
+        result_index = int(match.group(2))
+        results_by_message.setdefault(message_index, []).append(
+            (result_index, result)
+        )
+        raw_result_keys.append(key)
+
+    for message_index, indexed_results in results_by_message.items():
+        results = [result for _, result in sorted(indexed_results)]
+        prefix = f"{_OI_INPUT_MESSAGE_PREFIX}{message_index}.message"
+        attrs[f"{prefix}.role"] = "tool"
+        attrs.pop(f"{prefix}.message.role", None)
+        attrs[f"{prefix}.content"] = json.dumps(
+            results[0] if len(results) == 1 else results,
+            default=str,
+            separators=(",", ":"),
+        )
+
+        if len(results) == 1:
+            result = results[0]
+            call_id = result.get("call_id")
+            name = result.get("name")
+            canonical_prefix = f"gen_ai.prompt.{message_index}"
+            if call_id not in (None, ""):
+                attrs[f"{canonical_prefix}.tool_call_id"] = str(call_id)
+            if name not in (None, ""):
+                attrs[f"{canonical_prefix}.name"] = str(name)
+
+    for key in raw_result_keys:
+        attrs.pop(key, None)
+
+
+def _agent_output_from_llm_attrs(attrs: dict[str, Any]) -> str | None:
+    content = attrs.get(_OI_FIRST_OUTPUT_CONTENT)
+    if content not in (None, ""):
+        return json.dumps(
+            {"content": content, "role": "assistant"},
+            default=str,
+            separators=(",", ":"),
+        )
+
+    output = attrs.get(OISpanAttributes.OUTPUT_VALUE)
+    if output in (None, ""):
         return None
+    if isinstance(output, str):
+        return output
+    return json.dumps(output, default=str, separators=(",", ":"))
+
+
+class AutoGenNativeSpanProcessor(SpanProcessor):
+    """Keep only the meaningful OpenInference AutoGen operation tree.
+
+    AutoGen Core emits internal runtime spans for agent creation, message bus
+    publish/process/ack operations, native agent invocations, and native tool
+    execution. OpenInference AgentChat already emits content-complete logical
+    agent, LLM, and tool spans for the same work. Native spans are therefore
+    made unprocessable, and any meaningful child is reparented to the nearest
+    non-native ancestor before its ``ReadableSpan`` is created.
+    """
+
+    def __init__(self) -> None:
+        self._native_export_parents: dict[int, Any] = {}
+        self._agent_outputs: dict[int, str] = {}
+        self._lock = Lock()
+
+    def on_start(self, span: Any, parent_context: Any = None) -> None:
+        parent = _get_parent(span)
+        parent_id = getattr(parent, "span_id", None)
+
+        with self._lock:
+            if parent_id in self._native_export_parents:
+                export_parent = self._native_export_parents[parent_id]
+                span._parent = export_parent
+            else:
+                export_parent = parent
+
+            if _is_native_scope(_get_scope_name(span)):
+                span_id = _get_span_id(span)
+                if span_id is not None:
+                    self._native_export_parents[span_id] = export_parent
 
     def on_end(self, span: ReadableSpan) -> None:
-        if _get_scope_name(span) != AUTOGEN_CORE_SCOPE_NAME:
+        scope_name = _get_scope_name(span)
+        if scope_name == AUTOGEN_OPENINFERENCE_SCOPE_NAME:
+            attrs = dict(getattr(span, "_attributes", None) or {})
+            span_kind = attrs.get(OISpanAttributes.OPENINFERENCE_SPAN_KIND)
+
+            if span_kind == OpenInferenceSpanKindValues.LLM.value:
+                agent_id = getattr(_get_parent(span), "span_id", None)
+                output = _agent_output_from_llm_attrs(attrs)
+                if isinstance(agent_id, int) and agent_id and output is not None:
+                    with self._lock:
+                        self._agent_outputs[agent_id] = output
+            elif span_kind == OpenInferenceSpanKindValues.AGENT.value:
+                span_id = _get_span_id(span)
+                if span_id is not None:
+                    with self._lock:
+                        output = self._agent_outputs.pop(span_id, None)
+                    if output is not None:
+                        attrs.setdefault(
+                            TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                            output,
+                        )
+
+            _normalize_function_result_messages(attrs)
+            span._attributes = attrs
             return
 
-        attrs = _get_mutable_attributes(span)
-        if attrs is None:
+        if not _is_native_scope(scope_name):
             return
 
-        log_type = _AUTOGEN_OPERATION_LOG_TYPES.get(attrs.get(GEN_AI_OPERATION_NAME))
-        if log_type is None:
-            return
+        span_id = _get_span_id(span)
+        if span_id is not None:
+            with self._lock:
+                self._native_export_parents.pop(span_id, None)
 
-        attrs[RESPAN_LOG_TYPE] = log_type
-        attrs.setdefault(
-            SpanAttributes.TRACELOOP_ENTITY_NAME,
-            _get_entity_name(attrs, span.name),
-        )
-        attrs.pop(GEN_AI_SYSTEM, None)
-        attrs.pop(SpanAttributes.LLM_REQUEST_TYPE, None)
-        # Reassign the normalized copy; the original frozen BoundedAttributes
-        # cannot be mutated in place after the span has ended.
-        span._attributes = attrs
+        # The downstream Respan filter rejects an attribute-free runtime span.
+        # Reassigning also works for ended spans whose BoundedAttributes froze.
+        span._attributes = {}
 
     def shutdown(self) -> None:
-        return None
+        with self._lock:
+            self._native_export_parents.clear()
+            self._agent_outputs.clear()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return True

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/tests/test_instrumentation.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sys
 from types import ModuleType, SimpleNamespace
@@ -9,8 +10,11 @@ from respan_instrumentation_autogen import _instrumentation
 from respan_instrumentation_autogen._instrumentation import (
     OPENINFERENCE_AUTOGEN_AGENTCHAT_CLASS_NAMES,
     OPENINFERENCE_AUTOGEN_AGENTCHAT_MODULE,
+    OPENINFERENCE_AUTOGEN_AGENTCHAT_WRAPPERS_MODULE,
     TRACER_PROVIDER_KWARG,
+    _capture_current_agent_output,
     _load_openinference_autogen_agentchat_class,
+    _respan_get_llm_tool_attributes,
 )
 from respan_instrumentation_autogen._native_processor import AutoGenNativeSpanProcessor
 from respan_tracing.core.tracer import RespanTracer
@@ -41,6 +45,35 @@ def _install_fake_modules(monkeypatch, *, class_name: str | None = None):
     openinference_module = ModuleType("openinference")
     openinference_instrumentation_module = ModuleType("openinference.instrumentation")
     openinference_autogen_module = ModuleType(OPENINFERENCE_AUTOGEN_AGENTCHAT_MODULE)
+    openinference_autogen_wrappers_module = ModuleType(
+        OPENINFERENCE_AUTOGEN_AGENTCHAT_WRAPPERS_MODULE
+    )
+
+    def original_tool_extractor(tools):
+        return {"original": tools}
+
+    openinference_autogen_wrappers_module._get_llm_tool_attributes = (
+        original_tool_extractor
+    )
+
+    class FakeAssistantWrapper:
+        def __call__(self, wrapped, instance, args, kwargs):
+            return wrapped(*args, **kwargs)
+
+    class FakeBaseWrapper:
+        def __call__(self, wrapped, instance, args, kwargs):
+            return wrapped(*args, **kwargs)
+
+    openinference_autogen_wrappers_module._AssistantAgentOnMessagesStreamWrapper = (
+        FakeAssistantWrapper
+    )
+    openinference_autogen_wrappers_module._BaseChatAgentOnMessagesStreamWrapper = (
+        FakeBaseWrapper
+    )
+    original_agent_calls = (
+        FakeAssistantWrapper.__call__,
+        FakeBaseWrapper.__call__,
+    )
     setattr(
         openinference_autogen_module,
         selected_class_name,
@@ -59,6 +92,11 @@ def _install_fake_modules(monkeypatch, *, class_name: str | None = None):
         OPENINFERENCE_AUTOGEN_AGENTCHAT_MODULE,
         openinference_autogen_module,
     )
+    monkeypatch.setitem(
+        sys.modules,
+        OPENINFERENCE_AUTOGEN_AGENTCHAT_WRAPPERS_MODULE,
+        openinference_autogen_wrappers_module,
+    )
 
     monkeypatch.setattr(
         _instrumentation,
@@ -69,6 +107,10 @@ def _install_fake_modules(monkeypatch, *, class_name: str | None = None):
     return SimpleNamespace(
         autogen_instrumentor_class=FakeAutogenAgentChatInstrumentor,
         openinference_instrumentor_class=FakeOpenInferenceInstrumentor,
+        wrappers_module=openinference_autogen_wrappers_module,
+        original_tool_extractor=original_tool_extractor,
+        agent_wrapper_classes=(FakeAssistantWrapper, FakeBaseWrapper),
+        original_agent_calls=original_agent_calls,
     )
 
 
@@ -125,12 +167,82 @@ def test_activate_uses_openinference_autogen_defaults(
     assert delegate.kwargs == {}
     assert delegate.is_activated is True
     assert instrumentor._is_instrumented is True
+    assert (
+        fake.wrappers_module._get_llm_tool_attributes
+        is _respan_get_llm_tool_attributes
+    )
+    assert tuple(
+        wrapper_class.__call__ for wrapper_class in fake.agent_wrapper_classes
+    ) != fake.original_agent_calls
 
     instrumentor.deactivate()
 
     assert delegate.is_deactivated is True
     assert instrumentor._is_instrumented is False
+    assert (
+        fake.wrappers_module._get_llm_tool_attributes
+        is fake.original_tool_extractor
+    )
+    assert tuple(
+        wrapper_class.__call__ for wrapper_class in fake.agent_wrapper_classes
+    ) == fake.original_agent_calls
     assert fake_tracer_provider._active_span_processor._span_processors == ("exporter",)
+
+
+def test_current_autogen_tool_schema_mapping_is_preserved() -> None:
+    from openinference.semconv.trace import SpanAttributes, ToolAttributes
+
+    attributes = _respan_get_llm_tool_attributes(
+        [
+            {
+                "name": "estimate_latency",
+                "description": "Estimate API latency.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "service": {"type": "string"},
+                        "requests_per_minute": {"type": "integer"},
+                    },
+                    "required": ["service", "requests_per_minute"],
+                },
+            }
+        ]
+    )
+
+    key = f"{SpanAttributes.LLM_TOOLS}.0.{ToolAttributes.TOOL_JSON_SCHEMA}"
+    schema = json.loads(attributes[key])
+    assert schema["name"] == "estimate_latency"
+    assert schema["parameters"]["properties"]["service"] == {"type": "string"}
+    assert schema["parameters"]["required"] == [
+        "service",
+        "requests_per_minute",
+    ]
+
+
+def test_agent_response_is_captured_while_agent_span_is_current(monkeypatch) -> None:
+    from autogen_agentchat.base import Response
+    from autogen_agentchat.messages import TextMessage
+
+    class FakeSpan:
+        def __init__(self) -> None:
+            self.attributes = {}
+
+        def set_attributes(self, attributes) -> None:
+            self.attributes.update(attributes)
+
+    span = FakeSpan()
+    monkeypatch.setattr(_instrumentation.trace, "get_current_span", lambda: span)
+
+    _capture_current_agent_output(
+        Response(
+            chat_message=TextMessage(
+                content="final answer",
+                source="assistant",
+            )
+        )
+    )
+
+    assert "final answer" in span.attributes["output.value"]
 
 
 def test_activate_passes_custom_openinference_kwargs(monkeypatch, fake_tracer_provider):

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/tests/test_native_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/tests/test_native_processor.py
@@ -1,103 +1,260 @@
+import json
 from types import SimpleNamespace
 
-from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
-    GEN_AI_AGENT_NAME,
-    GEN_AI_OPERATION_NAME,
-    GEN_AI_SYSTEM,
-    GEN_AI_TOOL_NAME,
+from opentelemetry.attributes import BoundedAttributes
+from opentelemetry.trace import SpanContext, TraceFlags
+from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceSpanKindValues,
+    SpanAttributes as OISpanAttributes,
 )
-from opentelemetry.semconv_ai import SpanAttributes
 
 from respan_instrumentation_autogen._native_processor import (
     AUTOGEN_CORE_SCOPE_NAME,
-    AUTOGEN_OPERATION_EXECUTE_TOOL,
-    AUTOGEN_OPERATION_INVOKE_AGENT,
+    AUTOGEN_OPENINFERENCE_SCOPE_NAME,
     AutoGenNativeSpanProcessor,
 )
-from respan_sdk.constants.llm_logging import LOG_TYPE_AGENT, LOG_TYPE_TOOL
-from respan_sdk.constants.span_attributes import (
-    RESPAN_LOG_TYPE,
-)
+from respan_instrumentation_openinference._translator import OpenInferenceTranslator
 
 
-def _make_span(attrs: dict, *, scope_name: str = AUTOGEN_CORE_SCOPE_NAME):
+def _context(span_id: int) -> SpanContext:
+    return SpanContext(
+        trace_id=1,
+        span_id=span_id,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+
+
+def _make_span(
+    attrs: dict,
+    *,
+    scope_name: str,
+    span_id: int = 2,
+    parent: SpanContext | None = None,
+):
+    context = _context(span_id)
     return SimpleNamespace(
         name="test-span",
         _attributes=dict(attrs),
+        _parent=parent,
+        parent=parent,
         instrumentation_scope=SimpleNamespace(name=scope_name),
+        context=context,
+        get_span_context=lambda: context,
     )
 
 
-def test_processor_maps_native_invoke_agent_to_agent_log_type():
-    span = _make_span({
-        GEN_AI_OPERATION_NAME: AUTOGEN_OPERATION_INVOKE_AGENT,
-        GEN_AI_SYSTEM: "autogen",
-        GEN_AI_AGENT_NAME: "planner",
-    })
-
-    AutoGenNativeSpanProcessor().on_end(span)
-
-    assert span._attributes[RESPAN_LOG_TYPE] == LOG_TYPE_AGENT
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "planner"
-    assert GEN_AI_SYSTEM not in span._attributes
-    assert SpanAttributes.LLM_REQUEST_TYPE not in span._attributes
-
-
-def test_processor_maps_native_execute_tool_to_tool_log_type():
-    span = _make_span({
-        GEN_AI_OPERATION_NAME: AUTOGEN_OPERATION_EXECUTE_TOOL,
-        GEN_AI_SYSTEM: "autogen",
-        GEN_AI_TOOL_NAME: "estimate_latency",
-        SpanAttributes.LLM_REQUEST_TYPE: "chat",
-    })
-
-    AutoGenNativeSpanProcessor().on_end(span)
-
-    assert span._attributes[RESPAN_LOG_TYPE] == LOG_TYPE_TOOL
-    assert (
-        span._attributes[SpanAttributes.TRACELOOP_ENTITY_NAME]
-        == "estimate_latency"
-    )
-    assert GEN_AI_SYSTEM not in span._attributes
-    assert SpanAttributes.LLM_REQUEST_TYPE not in span._attributes
-
-
-def test_processor_handles_immutable_ended_span_attributes():
-    """Regression: a real *ended* span exposes ``_attributes`` as a frozen
-    ``BoundedAttributes``. Mutating it in place raises ``TypeError`` (which
-    previously propagated out of the user's ``agent.run()``). The processor
-    must copy + reassign instead."""
-    from opentelemetry.attributes import BoundedAttributes
-
-    frozen = BoundedAttributes(
-        attributes={
-            GEN_AI_OPERATION_NAME: AUTOGEN_OPERATION_INVOKE_AGENT,
-            GEN_AI_SYSTEM: "autogen",
-            GEN_AI_AGENT_NAME: "planner",
-        },
-        immutable=True,
-    )
-    span = SimpleNamespace(
-        name="test-span",
-        _attributes=frozen,
-        instrumentation_scope=SimpleNamespace(name=AUTOGEN_CORE_SCOPE_NAME),
-    )
-
-    # Must not raise TypeError.
-    AutoGenNativeSpanProcessor().on_end(span)
-
-    assert span._attributes[RESPAN_LOG_TYPE] == LOG_TYPE_AGENT
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "planner"
-    assert GEN_AI_SYSTEM not in span._attributes
-
-
-def test_processor_ignores_non_autogen_core_scope():
+def test_native_runtime_span_is_removed_from_export() -> None:
     span = _make_span(
         {
-            GEN_AI_OPERATION_NAME: AUTOGEN_OPERATION_INVOKE_AGENT,
-            GEN_AI_SYSTEM: "autogen",
+            "gen_ai.operation.name": "create_agent",
+            "gen_ai.system": "autogen",
+            "traceloop.entity.path": "workflow.agent",
+            "llm.request.type": "chat",
+            "respan.entity.log_type": "chat",
         },
-        scope_name="openinference.instrumentation.autogen_agentchat",
+        scope_name=AUTOGEN_CORE_SCOPE_NAME,
+    )
+
+    AutoGenNativeSpanProcessor().on_end(span)
+
+    assert span._attributes == {}
+
+
+def test_named_autogen_runtime_scope_is_removed_from_export() -> None:
+    span = _make_span(
+        {"messaging.operation": "publish"},
+        scope_name="autogen SingleThreadedAgentRuntime",
+    )
+
+    AutoGenNativeSpanProcessor().on_end(span)
+
+    assert span._attributes == {}
+
+
+def test_native_runtime_span_handles_frozen_attributes() -> None:
+    span = _make_span({}, scope_name=AUTOGEN_CORE_SCOPE_NAME)
+    span._attributes = BoundedAttributes(
+        attributes={"gen_ai.operation.name": "publish"},
+        immutable=True,
+    )
+
+    AutoGenNativeSpanProcessor().on_end(span)
+
+    assert span._attributes == {}
+
+
+def test_meaningful_child_is_reparented_around_native_runtime_span() -> None:
+    processor = AutoGenNativeSpanProcessor()
+    workflow = _context(10)
+    native = _make_span(
+        {"gen_ai.operation.name": "invoke_agent"},
+        scope_name=AUTOGEN_CORE_SCOPE_NAME,
+        span_id=20,
+        parent=workflow,
+    )
+    processor.on_start(native)
+
+    child = _make_span(
+        {"openinference.span.kind": "AGENT"},
+        scope_name=AUTOGEN_OPENINFERENCE_SCOPE_NAME,
+        span_id=30,
+        parent=native.context,
+    )
+    processor.on_start(child)
+
+    assert child._parent is workflow
+
+    processor.on_end(native)
+    assert processor._native_export_parents == {}
+
+
+def test_nested_native_runtime_spans_share_nearest_export_parent() -> None:
+    processor = AutoGenNativeSpanProcessor()
+    workflow = _context(10)
+    outer = _make_span(
+        {},
+        scope_name=AUTOGEN_CORE_SCOPE_NAME,
+        span_id=20,
+        parent=workflow,
+    )
+    processor.on_start(outer)
+    inner = _make_span(
+        {},
+        scope_name=AUTOGEN_CORE_SCOPE_NAME,
+        span_id=21,
+        parent=outer.context,
+    )
+    processor.on_start(inner)
+
+    child = _make_span(
+        {},
+        scope_name=AUTOGEN_OPENINFERENCE_SCOPE_NAME,
+        span_id=30,
+        parent=inner.context,
+    )
+    processor.on_start(child)
+
+    assert child._parent is workflow
+
+
+def test_function_result_history_is_preserved_canonically() -> None:
+    span = _make_span(
+        {
+            "openinference.span.kind": "LLM",
+            "llm.input_messages.2.message.role": "function",
+            "llm.input_messages.2.function.0": json.dumps(
+                {
+                    "name": "estimate_latency",
+                    "content": "tracing-api: about 155 ms",
+                    "call_id": "call-1",
+                    "is_error": False,
+                }
+            ),
+        },
+        scope_name=AUTOGEN_OPENINFERENCE_SCOPE_NAME,
+    )
+
+    AutoGenNativeSpanProcessor().on_end(span)
+
+    assert span._attributes["llm.input_messages.2.message.role"] == "tool"
+    assert "llm.input_messages.2.function.0" not in span._attributes
+    assert json.loads(span._attributes["llm.input_messages.2.message.content"]) == {
+        "name": "estimate_latency",
+        "content": "tracing-api: about 155 ms",
+        "call_id": "call-1",
+        "is_error": False,
+    }
+    assert span._attributes["gen_ai.prompt.2.tool_call_id"] == "call-1"
+    assert span._attributes["gen_ai.prompt.2.name"] == "estimate_latency"
+
+    OpenInferenceTranslator().on_end(span)
+    assert span._attributes["gen_ai.prompt.2.role"] == "tool"
+    assert span._attributes["gen_ai.prompt.2.tool_call_id"] == "call-1"
+    assert span._attributes["gen_ai.prompt.2.name"] == "estimate_latency"
+    assert json.loads(span._attributes["gen_ai.prompt.2.content"])["content"] == (
+        "tracing-api: about 155 ms"
+    )
+
+
+def test_final_llm_output_is_promoted_to_owning_agent() -> None:
+    processor = AutoGenNativeSpanProcessor()
+    workflow = _context(10)
+    agent = _make_span(
+        {OISpanAttributes.OPENINFERENCE_SPAN_KIND: "AGENT"},
+        scope_name=AUTOGEN_OPENINFERENCE_SCOPE_NAME,
+        span_id=20,
+        parent=workflow,
+    )
+    llm = _make_span(
+        {
+            OISpanAttributes.OPENINFERENCE_SPAN_KIND: (
+                OpenInferenceSpanKindValues.LLM.value
+            ),
+            (
+                f"{OISpanAttributes.LLM_OUTPUT_MESSAGES}.0."
+                f"{MessageAttributes.MESSAGE_CONTENT}"
+            ): "final answer",
+        },
+        scope_name=AUTOGEN_OPENINFERENCE_SCOPE_NAME,
+        span_id=30,
+        parent=agent.context,
+    )
+
+    processor.on_end(llm)
+    processor.on_end(agent)
+
+    assert json.loads(
+        agent._attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    ) == {"content": "final answer", "role": "assistant"}
+    assert processor._agent_outputs == {}
+
+
+def test_latest_llm_output_wins_for_tool_reflection_agent() -> None:
+    processor = AutoGenNativeSpanProcessor()
+    agent = _make_span(
+        {OISpanAttributes.OPENINFERENCE_SPAN_KIND: "AGENT"},
+        scope_name=AUTOGEN_OPENINFERENCE_SCOPE_NAME,
+        span_id=20,
+        parent=_context(10),
+    )
+    tool_request = _make_span(
+        {
+            OISpanAttributes.OPENINFERENCE_SPAN_KIND: "LLM",
+            OISpanAttributes.OUTPUT_VALUE: "tool request",
+        },
+        scope_name=AUTOGEN_OPENINFERENCE_SCOPE_NAME,
+        span_id=30,
+        parent=agent.context,
+    )
+    final_llm = _make_span(
+        {
+            OISpanAttributes.OPENINFERENCE_SPAN_KIND: "LLM",
+            (
+                f"{OISpanAttributes.LLM_OUTPUT_MESSAGES}.0."
+                f"{MessageAttributes.MESSAGE_CONTENT}"
+            ): "reflected answer",
+        },
+        scope_name=AUTOGEN_OPENINFERENCE_SCOPE_NAME,
+        span_id=31,
+        parent=agent.context,
+    )
+
+    processor.on_end(tool_request)
+    processor.on_end(final_llm)
+    processor.on_end(agent)
+
+    assert json.loads(
+        agent._attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    )["content"] == "reflected answer"
+
+
+def test_processor_ignores_unrelated_scope() -> None:
+    span = _make_span(
+        {"gen_ai.operation.name": "invoke_agent"},
+        scope_name="other-instrumentation",
     )
     original_attrs = dict(span._attributes)
 

--- a/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_instrumentation.py
@@ -49,6 +49,12 @@ def _status_code_from_response(response: Any) -> int:
     return value if isinstance(value, int) else 200
 
 
+def _status_code_from_exception(error: BaseException) -> int:
+    response = getattr(error, "response", None)
+    status_code = _status_code_from_response(response)
+    return status_code if status_code >= 400 else 500
+
+
 class _InstrumentedEventStream:
     def __init__(
         self,
@@ -152,7 +158,7 @@ def _wrap_make_api_call(original: Any) -> Any:
                 api_params=api_params,
                 start_ns=start_ns,
                 error_message=str(exc),
-                status_code=500,
+                status_code=_status_code_from_exception(exc),
             )
             raise
 

--- a/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_otel_emitter.py
@@ -168,6 +168,7 @@ def emit_bedrock_span(
         if error_message:
             attrs["error.message"] = error_message
             status_code = status_code if status_code >= 400 else 500
+        attrs["status_code"] = status_code
 
         trace_id, parent_id = _current_trace_parent_ids()
         span = build_readable_span(

--- a/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/src/respan_instrumentation_aws_bedrock/_translator.py
@@ -365,7 +365,9 @@ def _normalize_tool_definition(tool: Any) -> dict[str, Any] | None:
     if not isinstance(name, str) or not name:
         return None
 
-    schema = tool.get(INPUT_SCHEMA_KEY)
+    schema = tool.get("inputSchema")
+    if schema is None:
+        schema = tool.get(INPUT_SCHEMA_KEY)
     if isinstance(schema, Mapping) and "json" in schema:
         schema = schema["json"]
     if schema is None:

--- a/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-aws-bedrock/tests/test_instrumentation.py
@@ -6,6 +6,7 @@ from types import ModuleType, SimpleNamespace
 from typing import Any
 
 import pytest
+from botocore.exceptions import ClientError
 from opentelemetry import context as context_api
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
@@ -231,6 +232,7 @@ def test_converse_promotes_tools_and_tool_calls_without_aliases(
                                 "json": {
                                     "type": "object",
                                     "properties": {"city": {"type": "string"}},
+                                    "required": ["city"],
                                 }
                             },
                         }
@@ -244,6 +246,11 @@ def test_converse_promotes_tools_and_tool_calls_without_aliases(
     tools = json.loads(attrs[TLSpanAttributes.LLM_REQUEST_FUNCTIONS])
     tool_calls = json.loads(attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])
     assert tools[0]["function"]["name"] == "get_weather"
+    assert tools[0]["function"]["parameters"] == {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
     assert tool_calls[0]["function"]["name"] == "get_weather"
     assert tool_calls[0]["function"]["arguments"] == '{"city": "Tokyo"}'
     assert not OFF_CONTRACT_ALIASES.intersection(attrs)
@@ -318,3 +325,68 @@ def test_active_workflow_name_is_attached_to_chat_span() -> None:
         context_api.detach(token)
 
     assert attrs[TLSpanAttributes.TRACELOOP_WORKFLOW_NAME] == "aws_bedrock_invoke_model"
+
+
+def test_client_error_preserves_http_status_for_backend(
+    fake_botocore: type[Any],
+    captured_spans: list[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_with_not_found(
+        self: Any,
+        operation_name: str,
+        api_params: dict[str, Any],
+    ) -> Any:
+        raise ClientError(
+            {
+                "Error": {"Code": "ResourceNotFoundException", "Message": "missing"},
+                "ResponseMetadata": {"HTTPStatusCode": 404},
+            },
+            operation_name,
+        )
+
+    monkeypatch.setattr(fake_botocore, "_make_api_call", fail_with_not_found)
+    instrumentor = AWSBedrockInstrumentor()
+    instrumentor.activate()
+
+    with pytest.raises(ClientError):
+        fake_botocore()._make_api_call(
+            "Converse",
+            {"modelId": "missing-model", "messages": []},
+        )
+
+    assert len(captured_spans) == 1
+    attrs = captured_spans[0]._attributes
+    assert attrs["status_code"] == 404
+    assert "ResourceNotFoundException" in attrs["error.message"]
+    assert captured_spans[0].status.status_code.name == "ERROR"
+
+    instrumentor.deactivate()
+
+
+def test_unknown_exception_uses_backend_visible_500(
+    fake_botocore: type[Any],
+    captured_spans: list[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail(
+        self: Any,
+        operation_name: str,
+        api_params: dict[str, Any],
+    ) -> Any:
+        raise RuntimeError("transport failed")
+
+    monkeypatch.setattr(fake_botocore, "_make_api_call", fail)
+    instrumentor = AWSBedrockInstrumentor()
+    instrumentor.activate()
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        fake_botocore()._make_api_call(
+            "InvokeModel",
+            {"modelId": "model", "body": "{}"},
+        )
+
+    assert captured_spans[0]._attributes["status_code"] == 500
+    assert captured_spans[0]._attributes["error.message"] == "transport failed"
+
+    instrumentor.deactivate()


### PR DESCRIPTION
## Summary

- export backend-visible Arize operation status so deterministic SDK failures remain failed 500 spans with their input, output, and error
- remove duplicate/noisy AutoGen runtime spans while preserving connected agent, chat, and tool trees; retain current ToolSchema definitions, calls, complete tool-result history, and direct-agent Response output
- preserve AWS Bedrock ClientError HTTP status and current camelCase inputSchema, including complete properties and required fields
- add focused regressions and patch release intents for all three packages

## Validation

- [x] `respan-instrumentation-arize`: 9/9 tests
- [x] `respan-instrumentation-autogen`: 18/18 tests
- [x] `respan-instrumentation-aws-bedrock`: 7/7 tests
- [x] final wheels built and clean-installed together; imports resolved from `site-packages`
- [x] release-intent validation and changed-package coverage passed
- [x] all 12 corresponding locally linked examples completed with `RESPAN_EXAMPLE_RUN_ID=otel2-fix-py-group-09-20260815T212000Z`
- [x] MCP inspected all 12 trace trees and all 152 full records: counts, hierarchy, parents, content, types, model/provider, exact usage, tool identity/history, and intentional 404/500 failures passed

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- AWS Bedrock emits the contribution-approved canonical `llm.request.functions` and completion tool-call content with the complete schema and call. Platform full detail still projects top-level `tools=[]` and `tool_calls=[]`; this PR intentionally does not add prohibited alias attributes as a package workaround.
- The corresponding example-project changes were used for live validation and are not included in this Respan repository PR.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/56
