### PR TITLE
fix(instrumentation-py): repair Cursor SDK, Dify, and DSPy OTel 2.x spans

### DIFF
--- a/.release-intents/20260816-cursor-dify-dspy-fixes.json
+++ b/.release-intents/20260816-cursor-dify-dspy-fixes.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Fix Cursor cancellation roots, preserve Dify response models, and lock DSPy agent spans to the common contract",
+  "packages": {
+    "respan-instrumentation-cursor-sdk": "patch",
+    "respan-instrumentation-dify": "patch",
+    "respan-instrumentation-dspy": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-cursor-sdk/src/respan_instrumentation_cursor_sdk/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-cursor-sdk/src/respan_instrumentation_cursor_sdk/_processor.py
@@ -108,8 +108,7 @@ class CursorHookProcessor:
             self._handle_before_submit_prompt(event=event, state=state)
             return CursorHookResult(event_name=event_name, emitted=False)
         if event_name == CURSOR_EVENT_STOP:
-            self._handle_stop(event=event, state=state)
-            return CursorHookResult(event_name=event_name, emitted=False)
+            return self._handle_stop(event=event, state=state)
 
         if event_name == CURSOR_EVENT_AFTER_AGENT_THOUGHT:
             return self._emit_agent_thought(event=event, state=state)
@@ -134,17 +133,61 @@ class CursorHookProcessor:
         attachments = event.get("attachments")
         state[generation_id] = {
             "prompt": _string(event.get("prompt")),
-            "attachments_count": len(attachments) if isinstance(attachments, list) else 0,
+            "attachments_count": (
+                len(attachments) if isinstance(attachments, list) else 0
+            ),
             "start_time": _event_time(event),
             "child_count": 0,
         }
         self._state.save(state)
 
-    def _handle_stop(self, *, event: Mapping[str, Any], state: dict[str, Any]) -> None:
+    def _handle_stop(
+        self,
+        *,
+        event: Mapping[str, Any],
+        state: dict[str, Any],
+    ) -> CursorHookResult:
         generation_id = _string(event.get(CURSOR_GENERATION_ID))
-        if generation_id and generation_id in state:
+        generation_state = state.get(generation_id)
+        if not generation_id or not isinstance(generation_state, Mapping):
+            return CursorHookResult(event_name=CURSOR_EVENT_STOP, emitted=False)
+
+        stop_status = _string(event.get("status")).strip().lower() or "cancelled"
+        is_cancelled = stop_status in {"aborted", "canceled", "cancelled", "stopped"}
+        user_prompt = _string(generation_state.get("prompt")) or "[No prompt captured]"
+        child_count = generation_state.get("child_count")
+        start_time = _string(generation_state.get("start_time")) or _event_time(event)
+
+        result = self._emit_span(
+            event=event,
+            span_name=f"Cursor generation {_short_id(generation_id)}",
+            span_id=_root_span_id(event),
+            parent_id=None,
+            log_type=LOG_TYPE_AGENT,
+            entity_path="",
+            entity_input=[{"role": "user", "content": user_prompt}],
+            entity_output={"status": stop_status},
+            metadata={
+                "cursor.event": CURSOR_EVENT_STOP,
+                "cursor.stop_status": stop_status,
+                "cursor.child_count": (
+                    child_count if isinstance(child_count, int) else 0
+                ),
+                "cursor.attachments_count": generation_state.get(
+                    "attachments_count", 0
+                ),
+                "cursor.loop_count": event.get("loop_count"),
+            },
+            start_time=start_time,
+            end_time=_event_time(event),
+            status_code=499 if is_cancelled else 200,
+            error_message="Cursor generation cancelled" if is_cancelled else None,
+        )
+
+        if result.emitted:
             del state[generation_id]
             self._state.save(state)
+        return result
 
     def _emit_agent_thought(
         self,
@@ -304,14 +347,18 @@ class CursorHookProcessor:
             entity_output=[{"role": "assistant", "content": response_text}],
             metadata={
                 "cursor.event": CURSOR_EVENT_AFTER_AGENT_RESPONSE,
-                "cursor.child_count": child_count if isinstance(child_count, int) else 0,
-                "cursor.attachments_count": generation_state.get("attachments_count", 0),
+                "cursor.child_count": (
+                    child_count if isinstance(child_count, int) else 0
+                ),
+                "cursor.attachments_count": generation_state.get(
+                    "attachments_count", 0
+                ),
             },
             start_time=start_time,
             end_time=end_time,
         )
 
-        if generation_id in state:
+        if result.emitted and generation_id in state:
             del state[generation_id]
             self._state.save(state)
 
@@ -347,6 +394,8 @@ class CursorHookProcessor:
         metadata: Mapping[str, Any],
         start_time: str,
         end_time: str,
+        status_code: int = 200,
+        error_message: str | None = None,
     ) -> CursorHookResult:
         trace_id = _trace_id(event)
         attrs = _base_attributes(
@@ -358,6 +407,10 @@ class CursorHookProcessor:
             entity_output=entity_output,
             metadata=metadata,
         )
+        if status_code >= 400:
+            attrs["status_code"] = status_code
+        if error_message:
+            attrs["error.message"] = error_message
         span = build_readable_span(
             name=span_name,
             trace_id=trace_id,
@@ -366,6 +419,8 @@ class CursorHookProcessor:
             start_time_iso=start_time,
             end_time_iso=end_time,
             attributes=attrs,
+            status_code=status_code,
+            error_message=error_message,
         )
         emitted = inject_span(span=span)
         return CursorHookResult(
@@ -427,9 +482,14 @@ def _format_edits(edits: Any) -> list[dict[str, Any]] | str:
                     "index": index,
                     "start_line": edit.get("startLine")
                     or _nested_get(edit, ("start", "line")),
-                    "end_line": edit.get("endLine") or _nested_get(edit, ("end", "line")),
-                    "old": _truncate(_string(edit.get("oldText") or edit.get("old")), 500),
-                    "new": _truncate(_string(edit.get("newText") or edit.get("new")), 500),
+                    "end_line": edit.get("endLine")
+                    or _nested_get(edit, ("end", "line")),
+                    "old": _truncate(
+                        _string(edit.get("oldText") or edit.get("old")), 500
+                    ),
+                    "new": _truncate(
+                        _string(edit.get("newText") or edit.get("new")), 500
+                    ),
                 }
             )
         else:

--- a/python-sdks/instrumentations/respan-instrumentation-cursor-sdk/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-cursor-sdk/tests/test_instrumentation.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import json
 from opentelemetry.semconv_ai import SpanAttributes
-from respan_sdk.constants.llm_logging import LOG_TYPE_AGENT, LOG_TYPE_TASK, LOG_TYPE_TOOL
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_AGENT,
+    LOG_TYPE_TASK,
+    LOG_TYPE_TOOL,
+)
 from respan_sdk.constants.span_attributes import (
     RESPAN_LOG_METHOD,
     RESPAN_LOG_TYPE,
@@ -190,15 +194,63 @@ def test_agent_turn_replay_emits_canonical_spans(tmp_path, monkeypatch):
     _assert_contract_attrs(root_attrs)
 
 
-def test_stop_cleans_generation_state(tmp_path, monkeypatch):
-    _capture_spans(monkeypatch)
+def test_stop_emits_cancelled_agent_root_after_child(tmp_path, monkeypatch):
+    captured = _capture_spans(monkeypatch)
     processor = CursorHookProcessor(state_path=tmp_path / "state.json")
 
     processor.process_event(_event("beforeSubmitPrompt", prompt="Will be stopped"))
+    thought = processor.process_event(
+        _event(
+            "afterAgentThought",
+            text="I started the requested work.",
+            duration_ms=120,
+        )
+    )
+    result = processor.process_event(_event("stop", status="cancelled", loop_count=1))
+
+    assert thought.emitted is True
+    assert result.emitted is True
+    assert len(captured) == 2
+    assert captured[0]["parent_id"] == "gen_def456-root"
+    assert captured[1]["span_id"] == "gen_def456-root"
+    assert captured[1]["parent_id"] is None
+    assert captured[1]["status_code"] == 499
+    assert captured[1]["error_message"] == "Cursor generation cancelled"
+    root_attrs = captured[1]["attributes"]
+    assert root_attrs[RESPAN_LOG_TYPE] == LOG_TYPE_AGENT
+    assert json.loads(root_attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == [
+        {"role": "user", "content": "Will be stopped"}
+    ]
+    assert json.loads(root_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "status": "cancelled"
+    }
+    assert root_attrs[f"{RESPAN_METADATA}.cursor.stop_status"] == "cancelled"
+    assert root_attrs[f"{RESPAN_METADATA}.cursor.child_count"] == 1
+    assert root_attrs[f"{RESPAN_METADATA}.cursor.loop_count"] == 1
+    assert root_attrs["status_code"] == 499
+    assert root_attrs["error.message"] == "Cursor generation cancelled"
+    _assert_contract_attrs(root_attrs)
+    assert json.loads((tmp_path / "state.json").read_text()) == {}
+
+
+def test_terminal_state_is_retained_when_root_export_fails(tmp_path, monkeypatch):
+    captured = []
+
+    def fake_build_readable_span(name, **kwargs):
+        span = {"name": name, **kwargs}
+        captured.append(span)
+        return span
+
+    monkeypatch.setattr(_processor, "build_readable_span", fake_build_readable_span)
+    monkeypatch.setattr(_processor, "inject_span", lambda span: False)
+    processor = CursorHookProcessor(state_path=tmp_path / "state.json")
+
+    processor.process_event(_event("beforeSubmitPrompt", prompt="Retry this export"))
     result = processor.process_event(_event("stop", status="cancelled"))
 
     assert result.emitted is False
-    assert json.loads((tmp_path / "state.json").read_text()) == {}
+    state = json.loads((tmp_path / "state.json").read_text())
+    assert state["gen_def456"]["prompt"] == "Retry this export"
 
 
 def test_unknown_event_is_ignored(tmp_path, monkeypatch):

--- a/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_translator.py
@@ -191,7 +191,9 @@ def _completion_prompt(request_json: Mapping[str, Any]) -> str:
     return _string_content(inputs)
 
 
-def _response_output(response_data: Mapping[str, Any], stream_events: Sequence[Any]) -> Any:
+def _response_output(
+    response_data: Mapping[str, Any], stream_events: Sequence[Any]
+) -> Any:
     if stream_events:
         text = _stream_answer(stream_events=stream_events)
         if text:
@@ -219,6 +221,25 @@ def _metadata_usage(response_data: Mapping[str, Any]) -> Mapping[str, Any]:
     if isinstance(data, Mapping):
         return data
     return {}
+
+
+def _response_model(response_data: Mapping[str, Any]) -> str | None:
+    """Return a model only when Dify includes one in its response payload."""
+    candidates = [response_data.get("model")]
+    metadata = response_data.get(METADATA_KEY)
+    if isinstance(metadata, Mapping):
+        candidates.append(metadata.get("model"))
+        usage = metadata.get(USAGE_KEY)
+        if isinstance(usage, Mapping):
+            candidates.append(usage.get("model"))
+    data = response_data.get(DATA_KEY)
+    if isinstance(data, Mapping):
+        candidates.append(data.get("model"))
+
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return None
 
 
 def _stream_answer(stream_events: Sequence[Any]) -> str:
@@ -290,7 +311,9 @@ def _apply_response_metadata(
         MODE_KEY,
         STATUS_KEY,
     ):
-        _set_metadata(attributes=attributes, key=f"dify.{key}", value=response_data.get(key))
+        _set_metadata(
+            attributes=attributes, key=f"dify.{key}", value=response_data.get(key)
+        )
 
     data = response_data.get(DATA_KEY)
     if isinstance(data, Mapping):
@@ -348,7 +371,9 @@ def _apply_usage(
     if total_tokens is not None:
         attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = total_tokens
 
-    _set_metadata(attributes=attributes, key=f"dify.{LATENCY_KEY}", value=usage.get(LATENCY_KEY))
+    _set_metadata(
+        attributes=attributes, key=f"dify.{LATENCY_KEY}", value=usage.get(LATENCY_KEY)
+    )
 
 
 def _apply_llm_content(
@@ -356,6 +381,8 @@ def _apply_llm_content(
     *,
     endpoint: str,
     request_json: Mapping[str, Any],
+    response_data: Mapping[str, Any],
+    usage: Mapping[str, Any],
     output: Any,
 ) -> None:
     kind = _endpoint_kind(endpoint)
@@ -367,6 +394,17 @@ def _apply_llm_content(
     # even for text-style Dify completion apps, which return answer-shaped
     # message payloads rather than raw completion choices.
     attributes[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+    model = _response_model(response_data=response_data)
+    if model is None:
+        usage_model = usage.get("model")
+        if isinstance(usage_model, str) and usage_model.strip():
+            model = usage_model.strip()
+    if model is None:
+        request_model = request_json.get("model")
+        if isinstance(request_model, str) and request_model.strip():
+            model = request_model.strip()
+    if model is not None:
+        attributes[SpanAttributes.LLM_REQUEST_MODEL] = model
 
     prompt_content = (
         _string_content(request_json.get(QUERY_KEY))
@@ -397,9 +435,16 @@ def _apply_respan_params(
         or current_workflow_name
     )
     if workflow_name:
-        attributes.setdefault(SpanAttributes.TRACELOOP_WORKFLOW_NAME, str(workflow_name))
-    if respan_params.get("workflow_name") and "trace_group_identifier" not in respan_params:
-        attributes.setdefault(RESPAN_TRACE_GROUP_ID, str(respan_params["workflow_name"]))
+        attributes.setdefault(
+            SpanAttributes.TRACELOOP_WORKFLOW_NAME, str(workflow_name)
+        )
+    if (
+        respan_params.get("workflow_name")
+        and "trace_group_identifier" not in respan_params
+    ):
+        attributes.setdefault(
+            RESPAN_TRACE_GROUP_ID, str(respan_params["workflow_name"])
+        )
 
     for key, value in respan_params.items():
         if key in {
@@ -450,7 +495,11 @@ def build_dify_span_data(
     request_params_mapping = _to_mapping(request_params) or {}
     response_data = _response_json(response)
     stream_events = list(stream_events or [])
-    output = str(error) if error is not None else _response_output(response_data, stream_events)
+    output = (
+        str(error)
+        if error is not None
+        else _response_output(response_data, stream_events)
+    )
     default_span_name = _default_span_name(endpoint=endpoint)
 
     attributes: dict[str, Any] = {
@@ -493,6 +542,8 @@ def build_dify_span_data(
             attributes=attributes,
             endpoint=endpoint,
             request_json=request_json_mapping,
+            response_data=response_data,
+            usage=usage,
             output=output,
         )
 

--- a/python-sdks/instrumentations/respan-instrumentation-dify/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/tests/test_instrumentation.py
@@ -111,6 +111,41 @@ def test_build_completion_span_data_uses_inputs_query():
     assert not OFF_CONTRACT_ALIASES.intersection(attrs)
 
 
+def test_build_chat_span_data_maps_only_provider_exposed_model():
+    _, attrs = build_dify_span_data(
+        method="POST",
+        endpoint="/chat-messages",
+        request_json={"query": "Hi", "user": "user-123"},
+        response=FakeResponse(
+            {
+                "answer": "Hello",
+                "metadata": {
+                    "usage": {
+                        "model": "anthropic/claude-sonnet-4",
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                    }
+                },
+            }
+        ),
+    )
+
+    assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "anthropic/claude-sonnet-4"
+    assert "model" not in attrs
+
+
+def test_build_chat_span_data_does_not_invent_missing_model():
+    _, attrs = build_dify_span_data(
+        method="POST",
+        endpoint="/chat-messages",
+        request_json={"query": "Hi", "user": "user-123"},
+        response=FakeResponse({"answer": "Hello", "metadata": {"usage": {}}}),
+    )
+
+    assert SpanAttributes.LLM_REQUEST_MODEL not in attrs
+    assert "model" not in attrs
+
+
 def test_build_workflow_span_data_sets_workflow_log_type_without_llm_aliases():
     _, attrs = build_dify_span_data(
         method="POST",
@@ -131,7 +166,9 @@ def test_build_workflow_span_data_sets_workflow_log_type_without_llm_aliases():
 
     assert attrs[RESPAN_LOG_TYPE] == "workflow"
     assert SpanAttributes.LLM_REQUEST_TYPE not in attrs
-    assert attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == '{"result":"Short summary."}'
+    assert (
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == '{"result":"Short summary."}'
+    )
     assert attrs[f"{RESPAN_METADATA}.dify.workflow_run_id"] == "run-123"
     assert attrs[f"{RESPAN_METADATA}.dify.total_tokens"] == "42"
     assert not OFF_CONTRACT_ALIASES.intersection(attrs)
@@ -149,6 +186,7 @@ def test_streaming_events_accumulate_answer_and_usage():
                 "event": "message_end",
                 "metadata": {
                     "usage": {
+                        "model": "dify/stream-model",
                         "prompt_tokens": 1,
                         "completion_tokens": 1,
                         "total_tokens": 2,
@@ -161,6 +199,7 @@ def test_streaming_events_accumulate_answer_and_usage():
     assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "Hello"
     assert attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == "Hello"
     assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 2
+    assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "dify/stream-model"
     assert not OFF_CONTRACT_ALIASES.intersection(attrs)
 
 

--- a/python-sdks/instrumentations/respan-instrumentation-dspy/src/respan_instrumentation_dspy/_utils.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dspy/src/respan_instrumentation_dspy/_utils.py
@@ -7,12 +7,12 @@ from collections.abc import Mapping
 from typing import Any
 
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+from respan_sdk.utils.serialization import serialize_value
 
 from respan_instrumentation_dspy._constants import (
     ANTHROPIC_PROVIDER_PREFIX,
     AZURE_PROVIDER_PREFIX,
     BEDROCK_PROVIDER_PREFIX,
-    CHAT_MODEL_TYPE,
     COMPLETION_TOKENS_KEY,
     DSPY_PROVIDER_NAME,
     DSPY_USAGE_INPUT_TOKENS_ATTR,
@@ -24,12 +24,9 @@ from respan_instrumentation_dspy._constants import (
     OPENAI_PROVIDER_PREFIX,
     OUTPUT_TOKENS_KEY,
     PROMPT_TOKENS_KEY,
-    RESPONSES_MODEL_TYPE,
-    TEXT_MODEL_TYPE,
     TOTAL_TOKENS_KEY,
     USER_ROLE,
 )
-from respan_sdk.utils.serialization import serialize_value
 
 
 def safe_json(value: Any) -> str:
@@ -143,11 +140,8 @@ def extract_provider_name(model_name: Any) -> str:
 
 
 def request_type_from_model_type(model_type: Any) -> str:
-    """Map DSPy model types to the Respan LLM request type value."""
-    if model_type == TEXT_MODEL_TYPE:
-        return LLMRequestTypeValues.COMPLETION.value
-    if model_type in {CHAT_MODEL_TYPE, RESPONSES_MODEL_TYPE}:
-        return LLMRequestTypeValues.CHAT.value
+    """Return the canonical request type for every DSPy LLM surface."""
+    del model_type
     return LLMRequestTypeValues.CHAT.value
 
 
@@ -206,9 +200,7 @@ def add_lm_request_attributes(
     instance_kwargs = getattr(instance, "kwargs", None)
     request_kwargs = inputs.get("kwargs")
 
-    attributes[SpanAttributes.LLM_SYSTEM] = extract_provider_name(
-        model_name=model_name
-    )
+    attributes[SpanAttributes.LLM_SYSTEM] = extract_provider_name(model_name=model_name)
     if isinstance(model_name, str) and model_name:
         attributes[SpanAttributes.LLM_REQUEST_MODEL] = model_name
     attributes[SpanAttributes.LLM_REQUEST_TYPE] = request_type_from_model_type(

--- a/python-sdks/instrumentations/respan-instrumentation-dspy/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dspy/tests/test_instrumentation.py
@@ -4,19 +4,19 @@ import logging
 import sys
 from types import ModuleType, SimpleNamespace
 
-from opentelemetry.semconv_ai import SpanAttributes
-
 import respan_instrumentation_dspy._callback
+from opentelemetry.semconv_ai import SpanAttributes
 from respan_instrumentation_dspy import DSPyInstrumentor
+from respan_instrumentation_dspy._callback import DSPyInstrumentationCallback
 from respan_instrumentation_dspy._constants import (
     DSPY_USAGE_INPUT_TOKENS_ATTR,
     DSPY_USAGE_OUTPUT_TOKENS_ATTR,
 )
-from respan_instrumentation_dspy._callback import DSPyInstrumentationCallback
 from respan_instrumentation_dspy._utils import (
     add_lm_usage_attributes,
     extract_provider_name,
     normalize_messages,
+    request_type_from_model_type,
     safe_json,
 )
 
@@ -38,6 +38,10 @@ _OFF_CONTRACT_ALIAS_KEYS = (
 def _assert_no_off_contract_aliases(attributes):
     for off_contract_key in _OFF_CONTRACT_ALIAS_KEYS:
         assert off_contract_key not in attributes
+
+
+def test_text_model_uses_canonical_chat_request_type():
+    assert request_type_from_model_type("text") == "chat"
 
 
 def _install_fake_dspy(monkeypatch, callbacks=None):

--- a/python-sdks/instrumentations/respan-instrumentation-dspy/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dspy/tests/test_instrumentation.py
@@ -20,7 +20,6 @@ from respan_instrumentation_dspy._utils import (
     safe_json,
 )
 
-
 _OFF_CONTRACT_ALIAS_KEYS = (
     "tools",
     "tool_calls",
@@ -277,10 +276,7 @@ def test_tool_callback_emits_tool_span(monkeypatch):
         "name": "lookup_order",
         "arguments": {"order_id": "ord_123"},
     }
-    assert (
-        attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
-        == '{"status": "shipped"}'
-    )
+    assert attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == '{"status": "shipped"}'
     assert SpanAttributes.TRACELOOP_SPAN_KIND not in attributes
     _assert_no_off_contract_aliases(attributes=attributes)
 
@@ -327,6 +323,7 @@ def test_react_module_callback_emits_agent_span(monkeypatch):
     assert attributes["respan.entity.log_type"] == "agent"
     assert attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "ReAct"
     assert SpanAttributes.TRACELOOP_SPAN_KIND not in attributes
+    assert not any(key.startswith(("gen_ai.", "llm.")) for key in attributes)
     _assert_no_off_contract_aliases(attributes=attributes)
 
 


### PR DESCRIPTION
## Summary

- emit connected failed Cursor agent roots on cancellation and retain state when terminal export fails
- map only provider-exposed Dify models, including terminal streaming usage, without inventing model or cost aliases
- lock DSPy agent/module spans to the common-only contract
- add one patch release intent for all three instrumentations

## Validation

- [x] Cursor SDK: 6 passed
- [x] Dify: 8 passed
- [x] DSPy: 16 passed, 1 opt-in live test skipped
- [x] clean wheels built for all three packages
- [x] release inventory and release-intent validation passed
- [x] corresponding examples: 15/15 completed under `otel2-fix-py-group-12-20260816T142858Z`
- [x] Respan MCP: 15/15 trace trees and 77/77 full records inspected; counts and parent links match, no duplicates/orphans/blank critical content
- [x] expected Cursor cancellation is the only failed record (`499`)

- [x] Contribution re-audit against every current document under `contribution/` passed after `f9c9a0e`: every DSPy LLM surface now uses canonical `llm.request.type=chat`, including text-completion models.
- [x] Fresh correction validation: Cursor SDK 6 passed, Dify 8 passed, DSPy 16 passed / 1 skipped; DSPy wheel, release inventory/intents, formatting/import, and diff checks passed; marker `otel2-pr-contract-corrections-20260818T133300Z` produced 1 connected DSPy trace / 5 full records, all inspected.

## External follow-ups

- Dify completion still projects as chat and operation-specific entity names still render as generic task/workflow nodes. The emitted attributes follow the contribution contract, so those remain backend presentation issues.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/59
