### PR TITLE
fix(instrumentation-py): repair Groq, Guardrails, and Haystack OTel 2.x spans

### DIFF
--- a/.release-intents/20260817-groq-guardrails-haystack.json
+++ b/.release-intents/20260817-groq-guardrails-haystack.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair Groq streaming, Guardrails native span semantics, and Haystack activation compatibility",
+  "packages": {
+    "respan-instrumentation-groq": "patch",
+    "respan-instrumentation-guardrails": "patch",
+    "respan-instrumentation-haystack": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-groq/src/respan_instrumentation_groq/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-groq/src/respan_instrumentation_groq/_instrumentation.py
@@ -5,10 +5,17 @@ import logging
 from typing import Any
 
 from opentelemetry import trace
-
-from respan_instrumentation_groq._processor import GroqSpanProcessor
 from respan_instrumentation_openinference import OpenInferenceInstrumentor
 from respan_tracing.core.tracer import RespanTracer
+
+from respan_instrumentation_groq._processor import (
+    GroqInputSpanProcessor,
+    GroqSpanProcessor,
+)
+from respan_instrumentation_groq._streaming import (
+    patch_openinference_stream_wrappers,
+    restore_openinference_stream_wrappers,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +42,9 @@ class GroqInstrumentor:
     def __init__(self, **instrumentor_kwargs: Any) -> None:
         self._instrumentor_kwargs = instrumentor_kwargs
         self._delegate = None
+        self._input_processor: GroqInputSpanProcessor | None = None
         self._processor: GroqSpanProcessor | None = None
+        self._stream_wrapper_patch = None
         self._is_instrumented = False
 
     @staticmethod
@@ -46,7 +55,11 @@ class GroqInstrumentor:
         return bool(getattr(tracer, "is_enabled", True))
 
     @staticmethod
-    def _register_processor(tracer_provider: Any, processor: GroqSpanProcessor) -> None:
+    def _register_processors(
+        tracer_provider: Any,
+        input_processor: GroqInputSpanProcessor,
+        processor: GroqSpanProcessor,
+    ) -> None:
         active_span_processor = getattr(tracer_provider, "_active_span_processor", None)
         processors = (
             getattr(active_span_processor, "_span_processors", None)
@@ -55,28 +68,38 @@ class GroqInstrumentor:
         )
         if active_span_processor is None or processors is None:
             if hasattr(tracer_provider, "add_span_processor"):
+                tracer_provider.add_span_processor(input_processor)
                 tracer_provider.add_span_processor(processor)
             return
 
         remaining_processors = tuple(
             existing_processor
             for existing_processor in processors
-            if existing_processor is not processor
+            if existing_processor not in {input_processor, processor}
         )
         translator = getattr(OpenInferenceInstrumentor, "_translator", None)
 
         processor_chain = list(remaining_processors)
-        insert_index = 0
+        translator_index = None
         if translator is not None:
             for index, existing_processor in enumerate(processor_chain):
                 if existing_processor is translator:
-                    insert_index = index + 1
+                    translator_index = index
                     break
-        processor_chain.insert(insert_index, processor)
+        if translator_index is None:
+            processor_chain.insert(0, input_processor)
+            processor_chain.insert(1, processor)
+        else:
+            processor_chain.insert(translator_index, input_processor)
+            processor_chain.insert(translator_index + 2, processor)
         active_span_processor._span_processors = tuple(processor_chain)
 
     @staticmethod
-    def _unregister_processor(tracer_provider: Any, processor: GroqSpanProcessor) -> None:
+    def _unregister_processors(
+        tracer_provider: Any,
+        input_processor: GroqInputSpanProcessor | None,
+        processor: GroqSpanProcessor | None,
+    ) -> None:
         active_span_processor = getattr(tracer_provider, "_active_span_processor", None)
         processors = (
             getattr(active_span_processor, "_span_processors", None)
@@ -88,7 +111,7 @@ class GroqInstrumentor:
         active_span_processor._span_processors = tuple(
             existing_processor
             for existing_processor in processors
-            if existing_processor is not processor
+            if existing_processor not in {input_processor, processor}
         )
 
     def activate(self) -> None:
@@ -112,13 +135,19 @@ class GroqInstrumentor:
             return
 
         try:
+            self._stream_wrapper_patch = patch_openinference_stream_wrappers()
             self._delegate = OpenInferenceInstrumentor(
                 groq_instrumentor_class,
                 **self._instrumentor_kwargs,
             )
             self._delegate.activate()
+            self._input_processor = GroqInputSpanProcessor()
             self._processor = GroqSpanProcessor()
-            self._register_processor(trace.get_tracer_provider(), self._processor)
+            self._register_processors(
+                trace.get_tracer_provider(),
+                self._input_processor,
+                self._processor,
+            )
             self._is_instrumented = True
             logger.info("Groq instrumentation activated")
         except Exception:
@@ -128,20 +157,30 @@ class GroqInstrumentor:
                 except Exception:
                     logger.exception("Failed to clean up Groq instrumentation")
             self._delegate = None
+            self._input_processor = None
             self._processor = None
+            restore_openinference_stream_wrappers(self._stream_wrapper_patch)
+            self._stream_wrapper_patch = None
             self._is_instrumented = False
             logger.exception("Failed to activate Groq instrumentation")
 
     def deactivate(self) -> None:
         """Deactivate the instrumentation."""
-        if self._processor is not None:
-            self._unregister_processor(trace.get_tracer_provider(), self._processor)
+        if self._input_processor is not None or self._processor is not None:
+            self._unregister_processors(
+                trace.get_tracer_provider(),
+                self._input_processor,
+                self._processor,
+            )
         if self._is_instrumented and self._delegate is not None:
             try:
                 self._delegate.deactivate()
             except Exception:
                 logger.exception("Failed to deactivate Groq instrumentation")
         self._delegate = None
+        self._input_processor = None
         self._processor = None
+        restore_openinference_stream_wrappers(self._stream_wrapper_patch)
+        self._stream_wrapper_patch = None
         self._is_instrumented = False
         logger.info("Groq instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-groq/src/respan_instrumentation_groq/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-groq/src/respan_instrumentation_groq/_processor.py
@@ -6,6 +6,12 @@ import json
 from collections import defaultdict
 from typing import Any
 
+from openinference.semconv.trace import (
+    MessageAttributes as OIMessageAttributes,
+)
+from openinference.semconv.trace import (
+    SpanAttributes as OISpanAttributes,
+)
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
 
@@ -14,6 +20,7 @@ GEN_AI_PROMPT_PREFIX = f"{TLSpanAttributes.LLM_PROMPTS}."
 GEN_AI_COMPLETION_PREFIX = f"{TLSpanAttributes.LLM_COMPLETIONS}."
 GEN_AI_TOOL_CALLS_SUFFIX = ".tool_calls"
 GEN_AI_TOOL_CALLS_INDEX_FRAGMENT = ".tool_calls."
+OI_INPUT_MESSAGES_PREFIX = f"{OISpanAttributes.LLM_INPUT_MESSAGES}."
 
 _OFF_CONTRACT_ALIAS_ATTRIBUTES = frozenset(
     {
@@ -81,10 +88,9 @@ def _is_gen_ai_message_tool_call_key(key: str) -> bool:
 
 
 def _is_gen_ai_message_tool_call_aggregate_key(key: str) -> bool:
-    return (
-        key.startswith((GEN_AI_PROMPT_PREFIX, GEN_AI_COMPLETION_PREFIX))
-        and key.endswith(GEN_AI_TOOL_CALLS_SUFFIX)
-    )
+    return key.startswith(
+        (GEN_AI_PROMPT_PREFIX, GEN_AI_COMPLETION_PREFIX)
+    ) and key.endswith(GEN_AI_TOOL_CALLS_SUFFIX)
 
 
 def _structured_tool_calls(value: Any) -> Any:
@@ -143,22 +149,45 @@ def _normalize_gen_ai_tool_calls(attrs: Any) -> None:
 
     for aggregate_key, tool_calls_by_index in indexed_calls.items():
         if aggregate_key not in attrs:
-            attrs[aggregate_key] = [
-                tool_calls_by_index[index] for index in sorted(tool_calls_by_index)
-            ]
+            attrs[aggregate_key] = json.dumps(
+                [tool_calls_by_index[index] for index in sorted(tool_calls_by_index)],
+                default=str,
+                separators=(",", ":"),
+            )
 
     for key in tuple(attrs):
         if _is_gen_ai_message_tool_call_aggregate_key(key):
-            attrs[key] = _structured_tool_calls(attrs[key])
+            structured_tool_calls = _structured_tool_calls(attrs[key])
             message_key = key[: -len(GEN_AI_TOOL_CALLS_SUFFIX)]
             content_key = f"{message_key}.content"
             if attrs.get(content_key) in {None, ""}:
-                attrs[content_key] = _tool_calls_content(attrs[key]) or ""
+                attrs[content_key] = _tool_calls_content(structured_tool_calls) or ""
             role_key = f"{message_key}.role"
             if attrs.get(role_key) is None:
                 attrs[role_key] = "assistant"
+            attrs[key] = json.dumps(
+                structured_tool_calls,
+                default=str,
+                separators=(",", ":"),
+            )
         elif _is_gen_ai_message_tool_call_key(key):
             _drop_attribute(attrs, key)
+
+
+def _promote_tool_result_identity(attrs: Any) -> None:
+    """Retain OI tool-result identity before the shared translator strips it."""
+    for key, value in tuple(attrs.items()):
+        if not key.startswith(OI_INPUT_MESSAGES_PREFIX):
+            continue
+        suffix = key[len(OI_INPUT_MESSAGES_PREFIX) :]
+        index, separator, message_field = suffix.partition(".")
+        if separator != "." or not index.isdigit():
+            continue
+        target = f"{GEN_AI_PROMPT_PREFIX}{index}"
+        if message_field == OIMessageAttributes.MESSAGE_TOOL_CALL_ID:
+            attrs.setdefault(f"{target}.tool_call_id", value)
+        elif message_field == OIMessageAttributes.MESSAGE_NAME:
+            attrs.setdefault(f"{target}.name", value)
 
 
 def _is_groq_span(span: ReadableSpan, attrs: Any) -> bool:
@@ -187,3 +216,18 @@ class GroqSpanProcessor(SpanProcessor):
         for key in tuple(attrs):
             if key in _OFF_CONTRACT_ALIAS_ATTRIBUTES or _is_groq_omit(attrs[key]):
                 _drop_attribute(attrs, key)
+
+
+class GroqInputSpanProcessor(SpanProcessor):
+    """Promote Groq-only message fields before OpenInference translation."""
+
+    def on_start(self, span, parent_context=None) -> None:
+        return None
+
+    def on_end(self, span: ReadableSpan) -> None:
+        original_attrs = getattr(span, "_attributes", None)
+        if original_attrs is None or not _is_groq_span(span, original_attrs):
+            return
+        attrs = dict(original_attrs)
+        _promote_tool_result_identity(attrs)
+        span._attributes = attrs

--- a/python-sdks/instrumentations/respan-instrumentation-groq/src/respan_instrumentation_groq/_streaming.py
+++ b/python-sdks/instrumentations/respan-instrumentation-groq/src/respan_instrumentation_groq/_streaming.py
@@ -1,0 +1,491 @@
+"""OpenInference compatibility wrappers that keep Groq stream spans open."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Callable, Iterator, Mapping
+from inspect import signature
+from types import SimpleNamespace, TracebackType
+from typing import Any, Self
+
+import opentelemetry.context as context_api
+from opentelemetry import trace as trace_api
+from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+
+_PATCH_FLAG = "_respan_stream_wrappers_patched"
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _json_value(value: Any) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_value(item) for item in value]
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump(exclude_none=True)
+        except TypeError:
+            return model_dump()
+    return str(value)
+
+
+class _AssembledCompletion:
+    def __init__(self, *, model: str | None, usage: Any, choices: list[Any]) -> None:
+        self.model = model
+        self.usage = usage
+        self.choices = choices
+
+    def model_dump_json(self, **_: Any) -> str:
+        return json.dumps(
+            {
+                "model": self.model,
+                "choices": [
+                    {
+                        "index": choice.index,
+                        "finish_reason": choice.finish_reason,
+                        "message": {
+                            "role": choice.message.role,
+                            "content": choice.message.content,
+                            "tool_calls": _json_value(choice.message.tool_calls),
+                        },
+                    }
+                    for choice in self.choices
+                ],
+                "usage": _json_value(self.usage),
+            },
+            separators=(",", ":"),
+        )
+
+
+class _StreamAccumulator:
+    """Incrementally assemble Groq chat chunks without retaining every frame."""
+
+    def __init__(self) -> None:
+        self.model: str | None = None
+        self.usage: Any = None
+        self._choices: dict[int, dict[str, Any]] = {}
+
+    def add(self, chunk: Any) -> None:
+        model = _field(chunk, "model")
+        if model:
+            self.model = str(model)
+
+        usage = _field(chunk, "usage")
+        if usage is None:
+            usage = _field(_field(chunk, "x_groq"), "usage")
+        if usage is not None:
+            self.usage = usage
+
+        for choice in _field(chunk, "choices", []) or []:
+            index = int(_field(choice, "index", 0) or 0)
+            state = self._choices.setdefault(
+                index,
+                {
+                    "role": "assistant",
+                    "content": [],
+                    "finish_reason": None,
+                    "tool_calls": {},
+                },
+            )
+            delta = _field(choice, "delta")
+            role = _field(delta, "role")
+            if role:
+                state["role"] = str(role)
+            content = _field(delta, "content")
+            if content:
+                state["content"].append(str(content))
+            finish_reason = _field(choice, "finish_reason")
+            if finish_reason is not None:
+                state["finish_reason"] = str(finish_reason)
+
+            for tool_call in _field(delta, "tool_calls", []) or []:
+                tool_index = int(_field(tool_call, "index", 0) or 0)
+                tool_state = state["tool_calls"].setdefault(
+                    tool_index,
+                    {
+                        "id": None,
+                        "type": "function",
+                        "name": None,
+                        "arguments": [],
+                    },
+                )
+                tool_call_id = _field(tool_call, "id")
+                if tool_call_id:
+                    tool_state["id"] = str(tool_call_id)
+                tool_type = _field(tool_call, "type")
+                if tool_type:
+                    tool_state["type"] = str(tool_type)
+                function = _field(tool_call, "function")
+                function_name = _field(function, "name")
+                if function_name:
+                    tool_state["name"] = str(function_name)
+                arguments = _field(function, "arguments")
+                if arguments:
+                    tool_state["arguments"].append(str(arguments))
+
+    def completion(self) -> _AssembledCompletion:
+        choices: list[Any] = []
+        for index in sorted(self._choices):
+            state = self._choices[index]
+            tool_calls = [
+                SimpleNamespace(
+                    id=tool_state["id"],
+                    type=tool_state["type"],
+                    function=SimpleNamespace(
+                        name=tool_state["name"],
+                        arguments="".join(tool_state["arguments"]),
+                    ),
+                )
+                for _, tool_state in sorted(state["tool_calls"].items())
+            ]
+            choices.append(
+                SimpleNamespace(
+                    index=index,
+                    finish_reason=state["finish_reason"],
+                    message=SimpleNamespace(
+                        role=state["role"],
+                        content="".join(state["content"]),
+                        tool_calls=tool_calls,
+                        function_call=None,
+                    ),
+                )
+            )
+        if not choices:
+            choices.append(
+                SimpleNamespace(
+                    index=0,
+                    finish_reason=None,
+                    message=SimpleNamespace(
+                        role="assistant",
+                        content="",
+                        tool_calls=[],
+                        function_call=None,
+                    ),
+                )
+            )
+        return _AssembledCompletion(
+            model=self.model,
+            usage=self.usage,
+            choices=choices,
+        )
+
+
+class _SyncStreamProxy:
+    def __init__(
+        self, stream: Any, finish: Callable[[Any, BaseException | None], None]
+    ) -> None:
+        self._stream = stream
+        self._iterator = iter(stream)
+        self._finish_callback = finish
+        self._accumulator = _StreamAccumulator()
+        self._finished = False
+
+    def __iter__(self) -> Iterator[Any]:
+        return self
+
+    def __next__(self) -> Any:
+        try:
+            chunk = next(self._iterator)
+        except StopIteration:
+            self._finish(None)
+            raise
+        except BaseException as exc:
+            self._finish(exc)
+            raise
+        self._accumulator.add(chunk)
+        return chunk
+
+    def _finish(self, error: BaseException | None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        self._finish_callback(self._accumulator.completion(), error)
+
+    def close(self) -> Any:
+        try:
+            close = getattr(self._stream, "close", None)
+            return close() if callable(close) else None
+        finally:
+            self._finish(None)
+
+    def __enter__(self) -> Self:
+        enter = getattr(self._stream, "__enter__", None)
+        if callable(enter):
+            enter()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Any:
+        try:
+            exit_method = getattr(self._stream, "__exit__", None)
+            return (
+                exit_method(exc_type, exc, traceback)
+                if callable(exit_method)
+                else False
+            )
+        finally:
+            self._finish(exc)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+class _AsyncStreamProxy:
+    def __init__(
+        self, stream: Any, finish: Callable[[Any, BaseException | None], None]
+    ) -> None:
+        self._stream = stream
+        self._iterator = stream.__aiter__()
+        self._finish_callback = finish
+        self._accumulator = _StreamAccumulator()
+        self._finished = False
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            chunk = await self._iterator.__anext__()
+        except StopAsyncIteration:
+            self._finish(None)
+            raise
+        except BaseException as exc:
+            self._finish(exc)
+            raise
+        self._accumulator.add(chunk)
+        return chunk
+
+    def _finish(self, error: BaseException | None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        self._finish_callback(self._accumulator.completion(), error)
+
+    async def aclose(self) -> Any:
+        try:
+            close = getattr(self._stream, "close", None)
+            if not callable(close):
+                close = getattr(self._stream, "aclose", None)
+            result = close() if callable(close) else None
+            if hasattr(result, "__await__"):
+                return await result
+            return result
+        finally:
+            self._finish(None)
+
+    async def __aenter__(self) -> Self:
+        enter = getattr(self._stream, "__aenter__", None)
+        if callable(enter):
+            result = enter()
+            if hasattr(result, "__await__"):
+                await result
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Any:
+        try:
+            exit_method = getattr(self._stream, "__aexit__", None)
+            result = (
+                exit_method(exc_type, exc, traceback)
+                if callable(exit_method)
+                else False
+            )
+            if hasattr(result, "__await__"):
+                return await result
+            return result
+        finally:
+            self._finish(exc)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+def _finish_stream(
+    *,
+    wrappers_module: Any,
+    with_span: Any,
+    response_extractor: Any,
+    request_parameters: Mapping[str, Any],
+    completion: Any,
+    error: BaseException | None,
+) -> None:
+    status = trace_api.Status(status_code=trace_api.StatusCode.OK)
+    if error is not None:
+        with_span.record_exception(error)
+        status = trace_api.Status(
+            status_code=trace_api.StatusCode.ERROR,
+            description=f"{type(error).__name__}: {error}",
+        )
+    wrappers_module._finish_tracing(
+        status=status,
+        with_span=with_span,
+        attributes=response_extractor.get_attributes(response=completion),
+        extra_attributes=response_extractor.get_extra_attributes(
+            response=completion,
+            request_parameters=request_parameters,
+        ),
+    )
+
+
+def _stream_requested(request_parameters: Mapping[str, Any], response: Any) -> bool:
+    return bool(request_parameters.get("stream")) or type(response).__name__ in {
+        "Stream",
+        "AsyncStream",
+    }
+
+
+def patch_openinference_stream_wrappers() -> tuple[Any, type, type] | None:
+    """Replace upstream wrappers with stream-aware subclasses before activation."""
+    wrappers_module = __import__(
+        "openinference.instrumentation.groq._wrappers",
+        fromlist=["_CompletionsWrapper", "_AsyncCompletionsWrapper"],
+    )
+    if getattr(wrappers_module, _PATCH_FLAG, False):
+        return None
+
+    original_sync = wrappers_module._CompletionsWrapper
+    original_async = wrappers_module._AsyncCompletionsWrapper
+
+    class RespanCompletionsWrapper(original_sync):
+        def __call__(
+            self,
+            wrapped: Any,
+            instance: Any,
+            args: tuple[Any, ...],
+            kwargs: Mapping[str, Any],
+        ) -> Any:
+            if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+                return wrapped(*args, **kwargs)
+            request_parameters = wrappers_module._parse_args(
+                signature(wrapped), *args, **kwargs
+            )
+            with self._start_as_current_span(
+                span_name="Completions",
+                attributes=self._request_extractor.get_attributes_from_request(
+                    request_parameters
+                ),
+                context_attributes=wrappers_module.get_attributes_from_context(),
+                extra_attributes=self._request_extractor.get_extra_attributes_from_request(
+                    request_parameters
+                ),
+            ) as with_span:
+                try:
+                    response = wrapped(*args, **kwargs)
+                except Exception as exc:
+                    with_span.record_exception(exc)
+                    with_span.finish_tracing(
+                        status=trace_api.Status(
+                            status_code=trace_api.StatusCode.ERROR,
+                            description=f"{type(exc).__name__}: {exc}",
+                        )
+                    )
+                    raise
+                if _stream_requested(request_parameters, response):
+                    with_span.set_attributes({TLSpanAttributes.LLM_IS_STREAMING: True})
+                    return _SyncStreamProxy(
+                        response,
+                        lambda completion, error: _finish_stream(
+                            wrappers_module=wrappers_module,
+                            with_span=with_span,
+                            response_extractor=self._response_extractor,
+                            request_parameters=request_parameters,
+                            completion=completion,
+                            error=error,
+                        ),
+                    )
+                _finish_stream(
+                    wrappers_module=wrappers_module,
+                    with_span=with_span,
+                    response_extractor=self._response_extractor,
+                    request_parameters=request_parameters,
+                    completion=response,
+                    error=None,
+                )
+                return response
+
+    class RespanAsyncCompletionsWrapper(original_async):
+        async def __call__(
+            self,
+            wrapped: Any,
+            instance: Any,
+            args: tuple[Any, ...],
+            kwargs: Mapping[str, Any],
+        ) -> Any:
+            if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+                return await wrapped(*args, **kwargs)
+            request_parameters = wrappers_module._parse_args(
+                signature(wrapped), *args, **kwargs
+            )
+            with self._start_as_current_span(
+                span_name="AsyncCompletions",
+                attributes=self._request_extractor.get_attributes_from_request(
+                    request_parameters
+                ),
+                context_attributes=wrappers_module.get_attributes_from_context(),
+                extra_attributes=self._request_extractor.get_extra_attributes_from_request(
+                    request_parameters
+                ),
+            ) as with_span:
+                try:
+                    response = await wrapped(*args, **kwargs)
+                except Exception as exc:
+                    with_span.record_exception(exc)
+                    with_span.finish_tracing(
+                        status=trace_api.Status(
+                            status_code=trace_api.StatusCode.ERROR,
+                            description=f"{type(exc).__name__}: {exc}",
+                        )
+                    )
+                    raise
+                if _stream_requested(request_parameters, response):
+                    with_span.set_attributes({TLSpanAttributes.LLM_IS_STREAMING: True})
+                    return _AsyncStreamProxy(
+                        response,
+                        lambda completion, error: _finish_stream(
+                            wrappers_module=wrappers_module,
+                            with_span=with_span,
+                            response_extractor=self._response_extractor,
+                            request_parameters=request_parameters,
+                            completion=completion,
+                            error=error,
+                        ),
+                    )
+                _finish_stream(
+                    wrappers_module=wrappers_module,
+                    with_span=with_span,
+                    response_extractor=self._response_extractor,
+                    request_parameters=request_parameters,
+                    completion=response,
+                    error=None,
+                )
+                return response
+
+    wrappers_module._CompletionsWrapper = RespanCompletionsWrapper
+    wrappers_module._AsyncCompletionsWrapper = RespanAsyncCompletionsWrapper
+    setattr(wrappers_module, _PATCH_FLAG, True)
+    return wrappers_module, original_sync, original_async
+
+
+def restore_openinference_stream_wrappers(patch: tuple[Any, type, type] | None) -> None:
+    if patch is None:
+        return
+    wrappers_module, original_sync, original_async = patch
+    wrappers_module._CompletionsWrapper = original_sync
+    wrappers_module._AsyncCompletionsWrapper = original_async
+    setattr(wrappers_module, _PATCH_FLAG, False)

--- a/python-sdks/instrumentations/respan-instrumentation-groq/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-groq/tests/test_instrumentation.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
+import asyncio
+import json
 import types
 from pathlib import Path
 from types import SimpleNamespace
+from typing import ClassVar
 
 import pytest
-
 import respan_instrumentation_groq._instrumentation as groq_instrumentation
+from opentelemetry.attributes import BoundedAttributes
 from respan_instrumentation_groq import GroqInstrumentor
-from respan_instrumentation_groq._processor import GroqSpanProcessor
-
+from respan_instrumentation_groq._processor import (
+    GroqInputSpanProcessor,
+    GroqSpanProcessor,
+)
+from respan_instrumentation_groq._streaming import (
+    _AsyncStreamProxy,
+    _SyncStreamProxy,
+)
 
 _TRANSLATOR = object()
 
@@ -20,7 +29,7 @@ class FakeOpenInferenceGroqInstrumentor:
 
 class FakeDelegate:
     _translator = _TRANSLATOR
-    instances: list["FakeDelegate"] = []
+    instances: ClassVar[list[FakeDelegate]] = []
 
     def __init__(self, instrumentor_class: type, **kwargs) -> None:
         self.instrumentor_class = instrumentor_class
@@ -108,10 +117,12 @@ def test_activate_delegates_to_openinference_groq(monkeypatch) -> None:
     assert delegate.activated is True
 
     processors = provider._active_span_processor._span_processors
-    assert processors[0] is _TRANSLATOR
-    assert processors[1] is instrumentor._processor
-    assert isinstance(processors[1], GroqSpanProcessor)
-    assert processors[2:] == ("export-processor",)
+    assert processors[0] is instrumentor._input_processor
+    assert isinstance(processors[0], GroqInputSpanProcessor)
+    assert processors[1] is _TRANSLATOR
+    assert processors[2] is instrumentor._processor
+    assert isinstance(processors[2], GroqSpanProcessor)
+    assert processors[3:] == ("export-processor",)
 
 
 def test_activate_is_idempotent(monkeypatch) -> None:
@@ -123,10 +134,13 @@ def test_activate_is_idempotent(monkeypatch) -> None:
     instrumentor.activate()
 
     assert len(FakeDelegate.instances) == 1
-    assert sum(
-        isinstance(processor, GroqSpanProcessor)
-        for processor in provider._active_span_processor._span_processors
-    ) == 1
+    assert (
+        sum(
+            isinstance(processor, GroqSpanProcessor)
+            for processor in provider._active_span_processor._span_processors
+        )
+        == 1
+    )
 
 
 def test_activate_skips_when_respan_tracing_is_disabled(monkeypatch) -> None:
@@ -176,6 +190,7 @@ def test_deactivate_unregisters_processor_and_delegate(monkeypatch) -> None:
 
     assert instrumentor._is_instrumented is False
     assert instrumentor._delegate is None
+    assert instrumentor._input_processor is None
     assert instrumentor._processor is None
     assert FakeDelegate.instances[0].deactivated is True
     assert processor not in provider._active_span_processor._span_processors
@@ -187,7 +202,9 @@ def test_deactivate_unregisters_processor_and_delegate(monkeypatch) -> None:
 
 def test_processor_strips_groq_aliases_and_omit_values() -> None:
     span = SimpleNamespace(
-        instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.groq"),
+        instrumentation_scope=SimpleNamespace(
+            name="openinference.instrumentation.groq"
+        ),
         _attributes={
             "gen_ai.request.model": "gpt-4.1-nano",
             "llm.request.functions": "[]",
@@ -226,7 +243,9 @@ def test_processor_normalizes_tool_call_attrs_for_backend() -> None:
         }
     ]
     span = SimpleNamespace(
-        instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.groq"),
+        instrumentation_scope=SimpleNamespace(
+            name="openinference.instrumentation.groq"
+        ),
         _attributes={
             "gen_ai.completion.0.role": "assistant",
             "gen_ai.completion.0.tool_calls": completion_tool_calls,
@@ -242,13 +261,18 @@ def test_processor_normalizes_tool_call_attrs_for_backend() -> None:
 
     GroqSpanProcessor().on_end(span)
 
-    assert span._attributes["gen_ai.completion.0.tool_calls"] == completion_tool_calls
+    assert (
+        json.loads(span._attributes["gen_ai.completion.0.tool_calls"])
+        == completion_tool_calls
+    )
     assert (
         span._attributes["gen_ai.completion.0.content"]
         == 'Tool call: get_weather({"city":"Tokyo"})'
     )
     assert span._attributes["gen_ai.completion.0.role"] == "assistant"
-    assert span._attributes["gen_ai.prompt.1.tool_calls"] == prompt_tool_calls
+    assert (
+        json.loads(span._attributes["gen_ai.prompt.1.tool_calls"]) == prompt_tool_calls
+    )
     assert (
         span._attributes["gen_ai.prompt.1.content"]
         == 'Tool call: get_weather({"city":"Paris"})'
@@ -280,6 +304,122 @@ def test_processor_detects_groq_omit_without_scope() -> None:
     GroqSpanProcessor().on_end(span)
 
     assert span._attributes == {"gen_ai.request.model": "gpt-4.1-nano"}
+
+
+def test_input_processor_preserves_tool_result_id_and_name() -> None:
+    span = SimpleNamespace(
+        instrumentation_scope=SimpleNamespace(
+            name="openinference.instrumentation.groq"
+        ),
+        _attributes={
+            "llm.input_messages.2.message.role": "tool",
+            "llm.input_messages.2.message.name": "get_weather",
+            "llm.input_messages.2.message.tool_call_id": "call_weather_1",
+        },
+    )
+
+    GroqInputSpanProcessor().on_end(span)
+
+    assert span._attributes["gen_ai.prompt.2.name"] == "get_weather"
+    assert span._attributes["gen_ai.prompt.2.tool_call_id"] == "call_weather_1"
+
+
+def test_input_processor_copies_immutable_otel_attributes_before_promotion() -> None:
+    span = SimpleNamespace(
+        instrumentation_scope=SimpleNamespace(
+            name="openinference.instrumentation.groq"
+        ),
+        _attributes=BoundedAttributes(
+            attributes={
+                "llm.input_messages.2.message.role": "tool",
+                "llm.input_messages.2.message.name": "get_weather",
+                "llm.input_messages.2.message.tool_call_id": "call_weather_1",
+            },
+            immutable=True,
+        ),
+    )
+
+    GroqInputSpanProcessor().on_end(span)
+
+    assert isinstance(span._attributes, dict)
+    assert span._attributes["gen_ai.prompt.2.name"] == "get_weather"
+    assert span._attributes["gen_ai.prompt.2.tool_call_id"] == "call_weather_1"
+
+
+def _stream_chunks():
+    usage = SimpleNamespace(prompt_tokens=8, completion_tokens=3, total_tokens=11)
+    return [
+        SimpleNamespace(
+            model="llama-3.1-8b-instant",
+            usage=None,
+            x_groq=None,
+            choices=[
+                SimpleNamespace(
+                    index=0,
+                    finish_reason=None,
+                    delta=SimpleNamespace(
+                        role="assistant",
+                        content="hello ",
+                        tool_calls=None,
+                    ),
+                )
+            ],
+        ),
+        SimpleNamespace(
+            model="llama-3.1-8b-instant",
+            usage=usage,
+            x_groq=None,
+            choices=[
+                SimpleNamespace(
+                    index=0,
+                    finish_reason="stop",
+                    delta=SimpleNamespace(
+                        role=None,
+                        content="world",
+                        tool_calls=None,
+                    ),
+                )
+            ],
+        ),
+    ]
+
+
+def test_sync_stream_proxy_finalizes_with_assembled_content_and_usage() -> None:
+    finished = []
+    proxy = _SyncStreamProxy(
+        iter(_stream_chunks()),
+        lambda completion, error: finished.append((completion, error)),
+    )
+
+    assert len(list(proxy)) == 2
+    assert len(finished) == 1
+    completion, error = finished[0]
+    assert error is None
+    assert completion.model == "llama-3.1-8b-instant"
+    assert completion.usage.total_tokens == 11
+    assert completion.choices[0].message.content == "hello world"
+    assert "object at 0x" not in completion.model_dump_json()
+
+
+def test_async_stream_proxy_finalizes_with_assembled_content_and_usage() -> None:
+    finished = []
+
+    async def stream():
+        for chunk in _stream_chunks():
+            yield chunk
+
+    async def consume() -> list[object]:
+        proxy = _AsyncStreamProxy(
+            stream(),
+            lambda completion, error: finished.append((completion, error)),
+        )
+        return [chunk async for chunk in proxy]
+
+    assert len(asyncio.run(consume())) == 2
+    completion, error = finished[0]
+    assert error is None
+    assert completion.choices[0].message.content == "hello world"
+    assert completion.usage.prompt_tokens == 8
 
 
 def test_wrapper_does_not_define_semconv_constants() -> None:

--- a/python-sdks/instrumentations/respan-instrumentation-guardrails/src/respan_instrumentation_guardrails/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-guardrails/src/respan_instrumentation_guardrails/_instrumentation.py
@@ -1,18 +1,14 @@
 """Guardrails AI instrumentation plugin for Respan."""
 
 import ast
-import functools
 import importlib
 import json
 import logging
-from collections.abc import Callable
 from typing import Any
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
-from opentelemetry.trace import Status, StatusCode
-
 from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_GUARDRAIL
 from respan_sdk.constants.span_attributes import (
     LLM_REQUEST_MODEL,
@@ -22,6 +18,7 @@ from respan_sdk.constants.span_attributes import (
     RESPAN_LOG_TYPE,
 )
 from respan_tracing.core.tracer import RespanTracer
+from respan_tracing.utils.span_factory import read_propagated_attributes
 
 logger = logging.getLogger(__name__)
 
@@ -29,15 +26,10 @@ GUARDRAILS_INSTRUMENTATION_NAME = "guardrails"
 GUARDRAILS_RUNTIME_MODULE = "guardrails"
 GUARDRAILS_GUARD_CLASS = "Guard"
 
-_GUARD_METHODS = ("__call__", "parse", "validate")
-_METHOD_LABELS = {
-    "__call__": "call",
-    "parse": "parse",
-    "validate": "validate",
-}
-_RESPAN_WRAPPED_ATTRIBUTE = "_respan_guardrails_wrapped"
 _GUARDRAILS_SPAN_TYPE = "type"
 _GUARDRAILS_SPAN_TYPE_PREFIX = "guardrails/"
+_GUARDRAILS_GUARD_TYPE = "guardrails/guard"
+_GUARDRAILS_STEP_TYPE = "guardrails/guard/step"
 _GUARDRAILS_LLM_CALL_TYPE = "guardrails/guard/step/call"
 _GUARDRAILS_INPUT_VALUE = "input.value"
 _GUARDRAILS_OUTPUT_VALUE = "output.value"
@@ -55,25 +47,6 @@ _LLM_USAGE_TOTAL_TOKENS = SpanAttributes.LLM_USAGE_TOTAL_TOKENS
 def _load_guardrails_guard_class() -> type:
     guardrails_module = importlib.import_module(GUARDRAILS_RUNTIME_MODULE)
     return getattr(guardrails_module, GUARDRAILS_GUARD_CLASS)
-
-
-def _json_safe(value: Any) -> Any:
-    if value is None or isinstance(value, str | int | float | bool):
-        return value
-    if isinstance(value, dict):
-        return {
-            str(item_key): _json_safe(item_value)
-            for item_key, item_value in value.items()
-        }
-    if isinstance(value, list | tuple | set):
-        return [_json_safe(item) for item in value]
-    if hasattr(value, "model_dump"):
-        return value.model_dump(mode="json")
-    return repr(value)
-
-
-def _json_string(value: Any) -> str:
-    return json.dumps(_json_safe(value), default=repr)
 
 
 def _parse_invocation_parameters(value: Any) -> dict[str, Any]:
@@ -111,7 +84,7 @@ def _translate_guardrails_message_attrs(
         if not key.startswith(source_prefix):
             continue
 
-        suffix = key[len(source_prefix):]
+        suffix = key[len(source_prefix) :]
         parts = suffix.split(".", 2)
         if len(parts) != 3 or not parts[0].isdigit() or parts[1] != "message":
             continue
@@ -133,106 +106,76 @@ def _has_guardrails_llm_attrs(attrs: dict[str, Any]) -> bool:
     if attrs.get(_GUARDRAILS_LLM_TOKEN_COUNT_TOTAL) is not None:
         return True
     return any(
-        key.startswith(_GUARDRAILS_LLM_INPUT_MESSAGES_PREFIX)
-        or key.startswith(_GUARDRAILS_LLM_OUTPUT_MESSAGES_PREFIX)
+        key.startswith(
+            (
+                _GUARDRAILS_LLM_INPUT_MESSAGES_PREFIX,
+                _GUARDRAILS_LLM_OUTPUT_MESSAGES_PREFIX,
+            )
+        )
         for key in attrs
     )
 
 
-def _result_payload(result: Any) -> dict[str, Any]:
-    payload: dict[str, Any] = {"result": repr(result)}
-    for attribute_name in (
-        "validation_passed",
-        "validated_output",
-        "raw_llm_output",
-        "error",
-    ):
-        if hasattr(result, attribute_name):
-            payload[attribute_name] = getattr(result, attribute_name)
-    return payload
-
-
-def _span_input_payload(
-    method_label: str,
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-) -> dict[str, Any]:
-    return {
-        "method": method_label,
-        "args": [_json_safe(argument) for argument in args],
-        "kwargs": {
-            str(argument_name): _json_safe(argument_value)
-            for argument_name, argument_value in kwargs.items()
-        },
-    }
-
-
-def _set_guardrail_span_attributes(
-    span: trace.Span,
-    span_name: str,
-    input_payload: dict[str, Any],
-) -> None:
-    span.set_attribute(RESPAN_LOG_TYPE, LOG_TYPE_GUARDRAIL)
-    span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, span_name)
-    span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, "")
-    span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_INPUT, _json_string(input_payload))
-
-
-def _build_guard_method_wrapper(
-    method_name: str,
-    original_method: Callable[..., Any],
-) -> Callable[..., Any]:
-    method_label = _METHOD_LABELS[method_name]
-    span_name = f"guardrails.{method_label}"
-
-    @functools.wraps(original_method)
-    def wrapped_method(guard_instance: Any, *args: Any, **kwargs: Any) -> Any:
-        tracer = trace.get_tracer(__name__)
-        input_payload = _span_input_payload(
-            method_label=method_label,
-            args=args,
-            kwargs=kwargs,
-        )
-
-        with tracer.start_as_current_span(span_name) as span:
-            _set_guardrail_span_attributes(
-                span=span,
-                span_name=span_name,
-                input_payload=input_payload,
-            )
-            try:
-                result = original_method(guard_instance, *args, **kwargs)
-            except Exception as exc:
-                span.record_exception(exc)
-                span.set_status(Status(StatusCode.ERROR, str(exc)))
-                span.set_attribute(
-                    SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                    _json_string(
-                        {
-                            "error_type": type(exc).__name__,
-                            "error": str(exc),
-                        }
-                    ),
-                )
-                raise
-
-            span.set_attribute(
-                SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                _json_string(_result_payload(result)),
-            )
-            return result
-
-    setattr(wrapped_method, _RESPAN_WRAPPED_ATTRIBUTE, True)
-    return wrapped_method
+def _guardrails_operation_name(guardrails_type: str, span_name: str) -> str:
+    if guardrails_type == _GUARDRAILS_GUARD_TYPE:
+        return "guardrails.guard"
+    if guardrails_type == _GUARDRAILS_STEP_TYPE:
+        return "guardrails.step"
+    if guardrails_type == _GUARDRAILS_LLM_CALL_TYPE:
+        return "guardrails.call"
+    if guardrails_type.endswith("/validator"):
+        return "guardrails.validator"
+    return f"guardrails.{span_name}"
 
 
 class GuardrailsSpanProcessor(SpanProcessor):
     """Normalize Guardrails internal OTEL spans for the Respan backend."""
 
+    def __init__(self) -> None:
+        self._propagated_by_trace: dict[int, dict[str, Any]] = {}
+        self._active_spans_by_trace: dict[int, int] = {}
+
+    @staticmethod
+    def _trace_id(span: Any) -> int | None:
+        get_span_context = getattr(span, "get_span_context", None)
+        if not callable(get_span_context):
+            return None
+        return getattr(get_span_context(), "trace_id", None)
+
     def on_start(self, span: Any, parent_context: Any = None) -> None:
-        pass
+        del parent_context
+        trace_id = self._trace_id(span)
+        if trace_id is not None:
+            self._active_spans_by_trace[trace_id] = (
+                self._active_spans_by_trace.get(trace_id, 0) + 1
+            )
+
+        propagated = read_propagated_attributes()
+        if propagated and trace_id is not None:
+            cached = self._propagated_by_trace.setdefault(trace_id, {})
+            cached.update(propagated)
+        elif trace_id is not None:
+            propagated = self._propagated_by_trace.get(trace_id, {})
+
+        for key, value in propagated.items():
+            attributes = getattr(span, "attributes", None) or {}
+            if attributes.get(key) is None:
+                span.set_attribute(key, value)
 
     def on_end(self, span: ReadableSpan) -> None:
+        trace_id = self._trace_id(span)
+        try:
+            self._normalize_span(span)
+        finally:
+            if trace_id is not None:
+                remaining = self._active_spans_by_trace.get(trace_id, 1) - 1
+                if remaining <= 0:
+                    self._active_spans_by_trace.pop(trace_id, None)
+                    self._propagated_by_trace.pop(trace_id, None)
+                else:
+                    self._active_spans_by_trace[trace_id] = remaining
+
+    def _normalize_span(self, span: ReadableSpan) -> None:
         original_attrs = getattr(span, "_attributes", None)
         if original_attrs is None:
             return
@@ -247,7 +190,7 @@ class GuardrailsSpanProcessor(SpanProcessor):
 
         attrs.setdefault(
             SpanAttributes.TRACELOOP_ENTITY_NAME,
-            f"guardrails.{span.name}",
+            _guardrails_operation_name(guardrails_type, span.name),
         )
         attrs.setdefault(SpanAttributes.TRACELOOP_ENTITY_PATH, "")
 
@@ -259,16 +202,24 @@ class GuardrailsSpanProcessor(SpanProcessor):
         if output_value is not None:
             attrs.setdefault(SpanAttributes.TRACELOOP_ENTITY_OUTPUT, str(output_value))
 
-        if guardrails_type != _GUARDRAILS_LLM_CALL_TYPE or not _has_guardrails_llm_attrs(
-            attrs
+        if (
+            guardrails_type != _GUARDRAILS_LLM_CALL_TYPE
+            or not _has_guardrails_llm_attrs(attrs)
         ):
             attrs.setdefault(RESPAN_LOG_TYPE, LOG_TYPE_GUARDRAIL)
-            attrs.setdefault(SpanAttributes.TRACELOOP_SPAN_KIND, LOG_TYPE_GUARDRAIL)
+            attrs.pop(SpanAttributes.TRACELOOP_SPAN_KIND, None)
+            if guardrails_type == _GUARDRAILS_GUARD_TYPE:
+                token_consumption = _int_value(attrs.get("token_consumption"))
+                if (
+                    not token_consumption
+                    and attrs.get("number_of_llm_calls") is not None
+                ):
+                    attrs["number_of_llm_calls"] = 0
             span._attributes = attrs
             return
 
         attrs[RESPAN_LOG_TYPE] = LOG_TYPE_CHAT
-        attrs.setdefault(SpanAttributes.TRACELOOP_SPAN_KIND, LOG_TYPE_CHAT)
+        attrs.pop(SpanAttributes.TRACELOOP_SPAN_KIND, None)
         attrs.setdefault(LLM_REQUEST_TYPE, LLMRequestTypeValues.CHAT.value)
 
         invocation_parameters = _parse_invocation_parameters(
@@ -314,7 +265,8 @@ class GuardrailsSpanProcessor(SpanProcessor):
         span._attributes = attrs
 
     def shutdown(self) -> None:
-        pass
+        self._propagated_by_trace.clear()
+        self._active_spans_by_trace.clear()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return True
@@ -323,8 +275,8 @@ class GuardrailsSpanProcessor(SpanProcessor):
 class GuardrailsInstrumentor:
     """Respan instrumentor for Guardrails AI.
 
-    Wraps the stable public ``Guard`` execution methods and emits Respan
-    ``guardrail`` spans into the active OpenTelemetry pipeline.
+    Normalizes Guardrails' native OTEL spans into the Respan contract without
+    adding a duplicate public-method wrapper span.
     """
 
     name = GUARDRAILS_INSTRUMENTATION_NAME
@@ -333,8 +285,11 @@ class GuardrailsInstrumentor:
 
     def __init__(self) -> None:
         self._guard_class: type | None = None
-        self._original_methods: dict[str, Callable[..., Any]] = {}
         self._is_instrumented = False
+
+    @property
+    def is_instrumented(self) -> bool:
+        return self._is_instrumented
 
     @staticmethod
     def _is_respan_tracing_enabled() -> bool:
@@ -342,24 +297,6 @@ class GuardrailsInstrumentor:
         if tracer is None:
             return True
         return bool(getattr(tracer, "is_enabled", True))
-
-    def _instrument_guard_class(self, guard_class: type) -> None:
-        for method_name in _GUARD_METHODS:
-            original_method = getattr(guard_class, method_name, None)
-            if original_method is None:
-                continue
-            if getattr(original_method, _RESPAN_WRAPPED_ATTRIBUTE, False):
-                continue
-
-            self._original_methods[method_name] = original_method
-            setattr(
-                guard_class,
-                method_name,
-                _build_guard_method_wrapper(
-                    method_name=method_name,
-                    original_method=original_method,
-                ),
-            )
 
     @classmethod
     def _register_span_processor(cls) -> None:
@@ -434,20 +371,12 @@ class GuardrailsInstrumentor:
 
         self._guard_class = guard_class
         self._register_span_processor()
-        self._instrument_guard_class(guard_class=guard_class)
         self._is_instrumented = True
         logger.info("Guardrails instrumentation activated")
 
     def deactivate(self) -> None:
         """Restore original Guardrails methods."""
-        if self._guard_class is not None:
-            for method_name, original_method in self._original_methods.items():
-                current_method = getattr(self._guard_class, method_name, None)
-                if getattr(current_method, _RESPAN_WRAPPED_ATTRIBUTE, False):
-                    setattr(self._guard_class, method_name, original_method)
-
         self._guard_class = None
-        self._original_methods.clear()
         self._remove_span_processor()
         self._is_instrumented = False
         logger.info("Guardrails instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-guardrails/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-guardrails/tests/test_instrumentation.py
@@ -2,11 +2,9 @@ import logging
 import sys
 from types import ModuleType, SimpleNamespace
 
-from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
 import pytest
-
-from respan_instrumentation_guardrails import GuardrailsInstrumentor
-from respan_instrumentation_guardrails import _instrumentation
+from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+from respan_instrumentation_guardrails import GuardrailsInstrumentor, _instrumentation
 from respan_instrumentation_guardrails._instrumentation import (
     GUARDRAILS_RUNTIME_MODULE,
     GuardrailsSpanProcessor,
@@ -23,11 +21,12 @@ from respan_tracing.core.tracer import RespanTracer
 
 
 class FakeSpan:
-    def __init__(self, name):
+    def __init__(self, name, *, trace_id=None):
         self.name = name
         self.attributes = {}
         self.exceptions = []
         self.status = None
+        self._trace_id = trace_id
 
     def __enter__(self):
         return self
@@ -44,6 +43,9 @@ class FakeSpan:
     def set_status(self, status):
         self.status = status
 
+    def get_span_context(self):
+        return SimpleNamespace(trace_id=self._trace_id)
+
 
 class FakeTracer:
     def __init__(self):
@@ -56,9 +58,13 @@ class FakeTracer:
 
 
 class FakeReadableSpan:
-    def __init__(self, name, attributes):
+    def __init__(self, name, attributes, *, trace_id=None):
         self.name = name
         self._attributes = dict(attributes)
+        self._trace_id = trace_id
+
+    def get_span_context(self):
+        return SimpleNamespace(trace_id=self._trace_id)
 
 
 def _install_fake_guardrails(monkeypatch):
@@ -97,10 +103,9 @@ def reset_tracer():
     RespanTracer.reset_instance()
 
 
-def test_parse_emits_guardrail_span(monkeypatch):
+def test_activate_uses_native_guardrails_spans_without_wrapping(monkeypatch):
     fake_guard_class = _install_fake_guardrails(monkeypatch)
-    fake_tracer = FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: fake_tracer)
+    original_parse = fake_guard_class.parse
 
     instrumentor = GuardrailsInstrumentor()
     instrumentor.activate()
@@ -110,63 +115,81 @@ def test_parse_emits_guardrail_span(monkeypatch):
         num_reasks=0,
     )
 
-    span = fake_tracer.spans[0]
     assert result.validation_passed is True
-    assert span.name == "guardrails.parse"
-    assert span.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_GUARDRAIL
-    assert span.attributes["traceloop.entity.name"] == "guardrails.parse"
-    assert '"method": "parse"' in span.attributes["traceloop.entity.input"]
-    assert '"validation_passed": true' in span.attributes["traceloop.entity.output"]
+    assert fake_guard_class.parse is original_parse
+    assert instrumentor.is_instrumented is True
 
 
-def test_call_and_validate_are_wrapped(monkeypatch):
+def test_call_and_validate_are_not_wrapped(monkeypatch):
     fake_guard_class = _install_fake_guardrails(monkeypatch)
-    fake_tracer = FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: fake_tracer)
+    original_call = fake_guard_class.__call__
+    original_validate = fake_guard_class.validate
 
     instrumentor = GuardrailsInstrumentor()
     instrumentor.activate()
 
-    fake_guard = fake_guard_class()
-    fake_guard(model="gpt-4o-mini", messages=[])
-    fake_guard.validate("known output")
-
-    assert [span.name for span in fake_tracer.spans] == [
-        "guardrails.call",
-        "guardrails.validate",
-    ]
+    assert fake_guard_class.__call__ is original_call
+    assert fake_guard_class.validate is original_validate
 
 
-def test_exception_records_span_error(monkeypatch):
-    class FailingGuard:
-        def parse(self, *args, **kwargs):
-            raise ValueError("invalid output")
+def test_span_processor_bridges_propagated_context_on_start(monkeypatch):
+    monkeypatch.setattr(
+        _instrumentation,
+        "read_propagated_attributes",
+        lambda: {
+            "respan.customer_params.customer_identifier": "customer-1",
+            "respan.threads.thread_identifier": "thread-1",
+            "respan.metadata.run_id": "marker-1",
+        },
+    )
+    span = FakeSpan("step")
 
-    guardrails_module = ModuleType(GUARDRAILS_RUNTIME_MODULE)
-    guardrails_module.Guard = FailingGuard
-    monkeypatch.setitem(sys.modules, GUARDRAILS_RUNTIME_MODULE, guardrails_module)
+    GuardrailsSpanProcessor().on_start(span)
 
-    fake_tracer = FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: fake_tracer)
-
-    instrumentor = GuardrailsInstrumentor()
-    instrumentor.activate()
-
-    with pytest.raises(ValueError, match="invalid output"):
-        FailingGuard().parse(llm_output="bad")
-
-    span = fake_tracer.spans[0]
-    assert isinstance(span.exceptions[0], ValueError)
-    assert '"error_type": "ValueError"' in span.attributes["traceloop.entity.output"]
+    assert span.attributes["respan.customer_params.customer_identifier"] == "customer-1"
+    assert span.attributes["respan.threads.thread_identifier"] == "thread-1"
+    assert span.attributes["respan.metadata.run_id"] == "marker-1"
 
 
-def test_deactivate_restores_original_methods(monkeypatch):
+def test_span_processor_reuses_trace_context_when_nested_runtime_loses_it(
+    monkeypatch,
+):
+    propagated = {
+        "respan.customer_params.customer_identifier": "customer-1",
+        "respan.threads.thread_identifier": "thread-1",
+        "respan.metadata.run_id": "marker-1",
+    }
+    current = {"value": propagated}
+    monkeypatch.setattr(
+        _instrumentation,
+        "read_propagated_attributes",
+        lambda: current["value"],
+    )
+    processor = GuardrailsSpanProcessor()
+    root = FakeSpan("workflow", trace_id=123)
+    child = FakeSpan("step", trace_id=123)
+
+    processor.on_start(root)
+    current["value"] = {}
+    processor.on_start(child)
+
+    assert child.attributes == propagated
+
+    processor.on_end(
+        FakeReadableSpan("step", {"type": "guardrails/guard/step"}, trace_id=123)
+    )
+    processor.on_end(FakeReadableSpan("workflow", {}, trace_id=123))
+    assert processor._propagated_by_trace == {}
+    assert processor._active_spans_by_trace == {}
+
+
+def test_deactivate_leaves_native_methods_unchanged(monkeypatch):
     fake_guard_class = _install_fake_guardrails(monkeypatch)
     original_parse = fake_guard_class.parse
 
     instrumentor = GuardrailsInstrumentor()
     instrumentor.activate()
-    assert fake_guard_class.parse is not original_parse
+    assert fake_guard_class.parse is original_parse
 
     instrumentor.deactivate()
     assert fake_guard_class.parse is original_parse
@@ -231,7 +254,7 @@ def test_span_processor_translates_guardrails_llm_call_span():
     GuardrailsSpanProcessor().on_end(span)
 
     assert span._attributes[RESPAN_LOG_TYPE] == LOG_TYPE_CHAT
-    assert span._attributes[SpanAttributes.TRACELOOP_SPAN_KIND] == LOG_TYPE_CHAT
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in span._attributes
     assert span._attributes[LLM_REQUEST_TYPE] == LLMRequestTypeValues.CHAT.value
     assert span._attributes[LLM_REQUEST_MODEL] == "gpt-4o"
     assert span._attributes[SpanAttributes.LLM_REQUEST_TEMPERATURE] == 0
@@ -244,7 +267,9 @@ def test_span_processor_translates_guardrails_llm_call_span():
     assert span._attributes["gen_ai.completion.0.content"] == '{"ok": true}'
     assert span._attributes["traceloop.entity.name"] == "guardrails.call"
     assert span._attributes["traceloop.entity.input"] == '{"messages": []}'
-    assert span._attributes["traceloop.entity.output"] == '{"output": "{\\"ok\\": true}"}'
+    assert (
+        span._attributes["traceloop.entity.output"] == '{"output": "{\\"ok\\": true}"}'
+    )
 
 
 def test_span_processor_marks_guardrails_non_llm_span_as_guardrail():
@@ -260,7 +285,7 @@ def test_span_processor_marks_guardrails_non_llm_span_as_guardrail():
     GuardrailsSpanProcessor().on_end(span)
 
     assert span._attributes[RESPAN_LOG_TYPE] == LOG_TYPE_GUARDRAIL
-    assert span._attributes[SpanAttributes.TRACELOOP_SPAN_KIND] == LOG_TYPE_GUARDRAIL
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in span._attributes
     assert span._attributes["traceloop.entity.name"] == "guardrails.guard"
     assert span._attributes["traceloop.entity.input"] == "input"
     assert span._attributes["traceloop.entity.output"] == "output"
@@ -279,10 +304,25 @@ def test_span_processor_keeps_local_validation_step_call_as_guardrail():
     GuardrailsSpanProcessor().on_end(span)
 
     assert span._attributes[RESPAN_LOG_TYPE] == LOG_TYPE_GUARDRAIL
-    assert span._attributes[SpanAttributes.TRACELOOP_SPAN_KIND] == LOG_TYPE_GUARDRAIL
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in span._attributes
     assert LLM_REQUEST_TYPE not in span._attributes
     assert LLM_USAGE_PROMPT_TOKENS not in span._attributes
     assert span._attributes["traceloop.entity.name"] == "guardrails.call"
+
+
+def test_span_processor_corrects_local_guard_llm_call_count() -> None:
+    span = FakeReadableSpan(
+        name="guard",
+        attributes={
+            "type": "guardrails/guard",
+            "token_consumption": 0,
+            "number_of_llm_calls": 1,
+        },
+    )
+
+    GuardrailsSpanProcessor().on_end(span)
+
+    assert span._attributes["number_of_llm_calls"] == 0
 
 
 def test_span_processor_ignores_unrelated_span():

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/pyproject.toml
@@ -15,8 +15,8 @@ respan-sdk = ">=2.5.0"
 respan-tracing = "^2.17.0"
 respan-instrumentation-openinference = ">=1.2.2"
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
-haystack-ai = ">=2.0.0"
-openinference-instrumentation-haystack = ">=0.1.20"
+haystack-ai = ">=2.0.0,<3.0.0"
+openinference-instrumentation-haystack = ">=0.1.36,<0.2.0"
 
 [tool.poetry.plugins."respan.instrumentations"]
 haystack = "respan_instrumentation_haystack:HaystackInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_constants.py
@@ -3,7 +3,6 @@
 from opentelemetry.semconv_ai import SpanAttributes
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
 
-
 HAYSTACK_INSTRUMENTATION_NAME = "haystack"
 
 HAYSTACK_ASYNC_PIPELINE_MODULE = "haystack.core.pipeline.async_pipeline"
@@ -49,6 +48,9 @@ HAYSTACK_PIPELINE_SPAN_NAMES = frozenset(
 )
 
 OPENINFERENCE_HAYSTACK_MODULE = "openinference.instrumentation.haystack"
+OPENINFERENCE_HAYSTACK_WRAPPERS_MODULE = (
+    "openinference.instrumentation.haystack._wrappers"
+)
 OPENINFERENCE_HAYSTACK_INSTRUMENTOR_CLASS_NAME = "HaystackInstrumentor"
 OPENINFERENCE_TRANSLATOR_CLASS_NAME = "OpenInferenceTranslator"
 

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/src/respan_instrumentation_haystack/_instrumentation.py
@@ -8,8 +8,12 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from opentelemetry import trace
-from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_instrumentation_openinference import OpenInferenceInstrumentor
+from respan_sdk.utils.data_processing.id_processing import format_span_id
+from respan_tracing.core.tracer import RespanTracer
+
 from respan_instrumentation_haystack._constants import (
     HAYSTACK_ASYNC_PIPELINE_CLASS_NAME,
     HAYSTACK_ASYNC_PIPELINE_MODULE,
@@ -28,16 +32,14 @@ from respan_instrumentation_haystack._constants import (
     HAYSTACK_RUN_COMPONENT_ASYNC_METHOD_NAME,
     HAYSTACK_RUN_COMPONENT_METHOD_NAME,
     HAYSTACK_RUN_METHOD_NAME,
-    OPENINFERENCE_HAYSTACK_MODULE,
     OPENINFERENCE_HAYSTACK_INSTRUMENTOR_CLASS_NAME,
+    OPENINFERENCE_HAYSTACK_MODULE,
+    OPENINFERENCE_HAYSTACK_WRAPPERS_MODULE,
     OPENINFERENCE_TRANSLATOR_CLASS_NAME,
     RESPAN_HAYSTACK_COMPONENT_CONTEXT_VAR_NAME,
     RESPAN_HAYSTACK_MAIN_COMPONENT_PATCH_FLAG,
     RESPAN_HAYSTACK_PIPELINE_CONTEXT_VAR_NAME,
 )
-from respan_sdk.utils.data_processing.id_processing import format_span_id
-from respan_instrumentation_openinference import OpenInferenceInstrumentor
-from respan_tracing.core.tracer import RespanTracer
 
 logger = logging.getLogger(__name__)
 
@@ -131,11 +133,7 @@ def _patch_main_component_wrapping() -> None:
 
     def compatible_wrap_function_wrapper(module: Any, name: str, wrapper: Any) -> Any:
         try:
-            return original_wrap_function_wrapper(
-                module=module,
-                name=name,
-                wrapper=wrapper,
-            )
+            return original_wrap_function_wrapper(module, name, wrapper)
         except AttributeError:
             if not isinstance(module, str):
                 raise
@@ -148,14 +146,84 @@ def _patch_main_component_wrapping() -> None:
                 raise
 
             _, _, method_name = name.partition(".")
-            return original_wrap_function_wrapper(
-                module=component_class,
-                name=method_name,
-                wrapper=wrapper,
-            )
+            return original_wrap_function_wrapper(component_class, method_name, wrapper)
 
     haystack_module.wrap_function_wrapper = compatible_wrap_function_wrapper
     setattr(haystack_module, RESPAN_HAYSTACK_MAIN_COMPONENT_PATCH_FLAG, True)
+
+
+def _patch_late_component_registration(delegate: Any) -> tuple[Any, Any, Any] | None:
+    """Wrap components imported after OpenInference activation.
+
+    OpenInference wraps the component registry only once during activation.
+    Haystack applications commonly initialize tracing before importing their
+    components, so later direct ``component.run()`` calls otherwise disappear.
+    """
+    openinference_instrumentor = getattr(delegate, "_instrumentor", None)
+    tracer = getattr(openinference_instrumentor, "_tracer", None)
+    sync_originals = getattr(
+        openinference_instrumentor,
+        "_original_component_run_methods",
+        None,
+    )
+    async_originals = getattr(
+        openinference_instrumentor,
+        "_original_component_run_async_methods",
+        None,
+    )
+    if (
+        tracer is None
+        or not isinstance(sync_originals, dict)
+        or not isinstance(async_originals, dict)
+    ):
+        return None
+
+    component_module = importlib.import_module(HAYSTACK_COMPONENT_MODULE)
+    haystack_module = importlib.import_module(OPENINFERENCE_HAYSTACK_MODULE)
+    wrappers_module = importlib.import_module(OPENINFERENCE_HAYSTACK_WRAPPERS_MODULE)
+    component_decorator = getattr(
+        component_module,
+        HAYSTACK_COMPONENT_DECORATOR_ATTRIBUTE,
+    )
+    original_component = component_decorator._component
+    wrap_function_wrapper = haystack_module.wrap_function_wrapper
+
+    def wrap_registered_component(component_class: type[Any]) -> None:
+        run_method = getattr(component_class, "run", None)
+        if callable(run_method) and component_class not in sync_originals:
+            sync_originals[component_class] = run_method
+            wrap_function_wrapper(
+                component_class,
+                "run",
+                wrappers_module._ComponentRunWrapper(tracer=tracer),
+            )
+
+        run_async_method = getattr(component_class, "run_async", None)
+        if callable(run_async_method) and component_class not in async_originals:
+            async_originals[component_class] = run_async_method
+            wrap_function_wrapper(
+                component_class,
+                "run_async",
+                wrappers_module._AsyncComponentRunWrapper(tracer=tracer),
+            )
+
+    def component_with_late_wrapping(component_class: type[Any]) -> type[Any]:
+        registered_component = original_component(component_class)
+        wrap_registered_component(registered_component)
+        return registered_component
+
+    component_decorator._component = component_with_late_wrapping
+    return component_decorator, original_component, component_with_late_wrapping
+
+
+def _restore_late_component_registration(
+    patch: tuple[Any, Any, Any] | None,
+) -> None:
+    if patch is None:
+        return
+    component_decorator, original_component, patched_component = patch
+    if getattr(component_decorator, "_component", None) is patched_component:
+        component_decorator._component = original_component
 
 
 def _patch_pipeline_context_wrapping() -> None:
@@ -182,34 +250,34 @@ def _patch_pipeline_context_wrapping() -> None:
     pipeline_class = getattr(pipeline_module, HAYSTACK_PIPELINE_CLASS_NAME)
 
     wrap_function_wrapper(
-        module=pipeline_class,
-        name=HAYSTACK_RUN_METHOD_NAME,
-        wrapper=_pipeline_run_context_wrapper,
+        pipeline_class,
+        HAYSTACK_RUN_METHOD_NAME,
+        _pipeline_run_context_wrapper,
     )
     wrap_function_wrapper(
-        module=async_pipeline_class,
-        name=HAYSTACK_RUN_METHOD_NAME,
-        wrapper=_pipeline_run_context_wrapper,
+        async_pipeline_class,
+        HAYSTACK_RUN_METHOD_NAME,
+        _pipeline_run_context_wrapper,
     )
     wrap_function_wrapper(
-        module=async_pipeline_class,
-        name=HAYSTACK_RUN_ASYNC_METHOD_NAME,
-        wrapper=_async_pipeline_run_context_wrapper,
+        async_pipeline_class,
+        HAYSTACK_RUN_ASYNC_METHOD_NAME,
+        _async_pipeline_run_context_wrapper,
     )
     wrap_function_wrapper(
-        module=async_pipeline_class,
-        name=HAYSTACK_RUN_ASYNC_GENERATOR_METHOD_NAME,
-        wrapper=_async_pipeline_run_async_generator_context_wrapper,
+        async_pipeline_class,
+        HAYSTACK_RUN_ASYNC_GENERATOR_METHOD_NAME,
+        _async_pipeline_run_async_generator_context_wrapper,
     )
     wrap_function_wrapper(
-        module=pipeline_class,
-        name=HAYSTACK_RUN_COMPONENT_METHOD_NAME,
-        wrapper=_component_run_context_wrapper,
+        pipeline_class,
+        HAYSTACK_RUN_COMPONENT_METHOD_NAME,
+        _component_run_context_wrapper,
     )
     wrap_function_wrapper(
-        module=async_pipeline_class,
-        name=HAYSTACK_RUN_COMPONENT_ASYNC_METHOD_NAME,
-        wrapper=_async_component_run_context_wrapper,
+        async_pipeline_class,
+        HAYSTACK_RUN_COMPONENT_ASYNC_METHOD_NAME,
+        _async_component_run_context_wrapper,
     )
     _PIPELINE_CONTEXT_PATCH_APPLIED = True
 
@@ -382,7 +450,9 @@ def _message_content(value: Any) -> str:
     return str(value)
 
 
-def _normalize_haystack_message(value: Any, *, fallback_role: str) -> dict[str, Any] | None:
+def _normalize_haystack_message(
+    value: Any, *, fallback_role: str
+) -> dict[str, Any] | None:
     if isinstance(value, str):
         return {"role": fallback_role, "content": value}
 
@@ -633,7 +703,7 @@ class _HaystackParentSpanProcessor(SpanProcessor):
 
         try:
             predecessors = tuple(graph.predecessors(component_context.component_name))
-        except Exception:
+        except Exception:  # noqa: BLE001
             return None
 
         candidates: list[tuple[int, str]] = []
@@ -705,12 +775,10 @@ def _register_haystack_parent_processor(
             insert_index = index + 1
             break
 
-    active_span_processor._span_processors = tuple(
-        [
-            *remaining_processors[:insert_index],
-            processor,
-            *remaining_processors[insert_index:],
-        ]
+    active_span_processor._span_processors = (
+        *remaining_processors[:insert_index],
+        processor,
+        *remaining_processors[insert_index:],
     )
 
 
@@ -754,8 +822,14 @@ class HaystackInstrumentor:
     def __init__(self, **instrumentor_kwargs: Any) -> None:
         self._instrumentor_kwargs = instrumentor_kwargs
         self._delegate = None
+        self._late_component_patch = None
         self._parent_processor = _HaystackParentSpanProcessor()
         self._is_instrumented = False
+
+    @property
+    def is_instrumented(self) -> bool:
+        """Whether the upstream instrumentor and Respan processor are active."""
+        return self._is_instrumented
 
     @staticmethod
     def _is_respan_tracing_enabled() -> bool:
@@ -791,11 +865,16 @@ class HaystackInstrumentor:
                 **self._instrumentor_kwargs,
             )
             self._delegate.activate()
+            self._late_component_patch = _patch_late_component_registration(
+                self._delegate
+            )
             _patch_pipeline_context_wrapping()
             _register_haystack_parent_processor(self._parent_processor)
             self._is_instrumented = True
             logger.info("Haystack instrumentation activated")
         except Exception:
+            _restore_late_component_registration(self._late_component_patch)
+            self._late_component_patch = None
             _remove_haystack_parent_processor(self._parent_processor)
             if self._delegate is not None:
                 try:
@@ -812,10 +891,13 @@ class HaystackInstrumentor:
         if self._is_instrumented and self._delegate is not None:
             try:
                 _remove_haystack_parent_processor(self._parent_processor)
+                _restore_late_component_registration(self._late_component_patch)
+                self._late_component_patch = None
                 self._delegate.deactivate()
             except Exception:
                 logger.exception("Failed to deactivate Haystack instrumentation")
         self._parent_processor.shutdown()
         self._delegate = None
+        self._late_component_patch = None
         self._is_instrumented = False
         logger.info("Haystack instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-haystack/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-haystack/tests/test_instrumentation.py
@@ -2,13 +2,12 @@ import json
 import logging
 import sys
 from types import ModuleType, SimpleNamespace
+from typing import ClassVar
 
 import pytest
-
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.semconv_ai import SpanAttributes
-from respan_instrumentation_haystack import HaystackInstrumentor
-from respan_instrumentation_haystack import _instrumentation
+from respan_instrumentation_haystack import HaystackInstrumentor, _instrumentation
 from respan_instrumentation_haystack._constants import (
     HAYSTACK_ASYNC_PIPELINE_CLASS_NAME,
     HAYSTACK_ASYNC_PIPELINE_MODULE,
@@ -23,6 +22,7 @@ from respan_instrumentation_haystack._constants import (
     HAYSTACK_PIPELINE_RUN_METHOD_SPAN_NAME,
     HAYSTACK_PIPELINE_RUN_SPAN_NAME,
     OPENINFERENCE_HAYSTACK_MODULE,
+    OPENINFERENCE_HAYSTACK_WRAPPERS_MODULE,
 )
 from respan_instrumentation_haystack._instrumentation import (
     _HaystackParentSpanProcessor,
@@ -39,7 +39,7 @@ def _install_fake_modules(monkeypatch):
         pass
 
     class FakeOpenInferenceInstrumentor:
-        created = []
+        created: ClassVar[list[object]] = []
 
         def __init__(self, instrumentor_class, **kwargs):
             self.instrumentor_class = instrumentor_class
@@ -131,9 +131,9 @@ def test_patch_main_component_wrapping_falls_back_to_registered_class(monkeypatc
 
     calls = []
 
-    def fake_wrap_function_wrapper(module, name, wrapper):
-        calls.append((module, name, wrapper))
-        if module == "__main__":
+    def fake_wrap_function_wrapper(target, name, wrapper):
+        calls.append((target, name, wrapper))
+        if target == "__main__":
             raise AttributeError("module '__main__' has no attribute")
         return "wrapped"
 
@@ -166,6 +166,74 @@ def test_patch_main_component_wrapping_falls_back_to_registered_class(monkeypatc
         ("__main__", "FakeMainComponent.run", "wrapper"),
         (FakeMainComponent, "run", "wrapper"),
     ]
+
+
+def test_patch_late_component_registration_wraps_direct_components(monkeypatch):
+    class FakeComponentDecorator:
+        def _component(self, component_class):
+            return component_class
+
+    class FakeSyncWrapper:
+        def __init__(self, tracer):
+            self.tracer = tracer
+
+    class FakeAsyncWrapper:
+        def __init__(self, tracer):
+            self.tracer = tracer
+
+    component_decorator = FakeComponentDecorator()
+    component_module = ModuleType(HAYSTACK_COMPONENT_MODULE)
+    component_module.component = component_decorator
+    wrapped_methods = []
+
+    def fake_wrap_function_wrapper(target, name, wrapper):
+        wrapped_methods.append((target, name, wrapper))
+
+    haystack_module = ModuleType(OPENINFERENCE_HAYSTACK_MODULE)
+    haystack_module.wrap_function_wrapper = fake_wrap_function_wrapper
+    wrappers_module = ModuleType(OPENINFERENCE_HAYSTACK_WRAPPERS_MODULE)
+    wrappers_module._ComponentRunWrapper = FakeSyncWrapper
+    wrappers_module._AsyncComponentRunWrapper = FakeAsyncWrapper
+    monkeypatch.setitem(sys.modules, HAYSTACK_COMPONENT_MODULE, component_module)
+    monkeypatch.setitem(sys.modules, OPENINFERENCE_HAYSTACK_MODULE, haystack_module)
+    monkeypatch.setitem(
+        sys.modules,
+        OPENINFERENCE_HAYSTACK_WRAPPERS_MODULE,
+        wrappers_module,
+    )
+
+    tracer = object()
+    openinference_instrumentor = SimpleNamespace(
+        _tracer=tracer,
+        _original_component_run_methods={},
+        _original_component_run_async_methods={},
+    )
+    delegate = SimpleNamespace(_instrumentor=openinference_instrumentor)
+    original_component = component_decorator._component
+
+    patch = _instrumentation._patch_late_component_registration(delegate)
+
+    class LateComponent:
+        def run(self):
+            return {"sync": True}
+
+        async def run_async(self):
+            return {"async": True}
+
+    registered = component_decorator._component(LateComponent)
+
+    assert registered is LateComponent
+    assert openinference_instrumentor._original_component_run_methods[registered]
+    assert openinference_instrumentor._original_component_run_async_methods[registered]
+    assert [(target, name) for target, name, _ in wrapped_methods] == [
+        (LateComponent, "run"),
+        (LateComponent, "run_async"),
+    ]
+    assert all(wrapper.tracer is tracer for _, _, wrapper in wrapped_methods)
+
+    _instrumentation._restore_late_component_registration(patch)
+
+    assert component_decorator._component == original_component
 
 
 class _FakeSpanContext:
@@ -676,6 +744,7 @@ def test_activate_uses_openinference_haystack(monkeypatch):
     assert delegate.kwargs == {}
     assert delegate.is_activated is True
     assert instrumentor._is_instrumented is True
+    assert instrumentor.is_instrumented is True
 
     instrumentor.deactivate()
 
@@ -707,8 +776,8 @@ def test_reactivate_does_not_duplicate_pipeline_context_wrappers(monkeypatch):
 
     wrapped_methods = []
 
-    def fake_wrap_function_wrapper(*, module, name, wrapper):
-        wrapped_methods.append((module, name, wrapper))
+    def fake_wrap_function_wrapper(target, name, wrapper):
+        wrapped_methods.append((target, name, wrapper))
 
     openinference_haystack_module = sys.modules[OPENINFERENCE_HAYSTACK_MODULE]
     openinference_haystack_module.wrap_function_wrapper = fake_wrap_function_wrapper


### PR DESCRIPTION
## Summary

- repair Groq sync/async stream finalization, canonical streaming content/usage, and tool-result identity
- repair Guardrails native span context, operation naming, local LLM counts, and duplicate wrapper behavior
- repair Haystack OpenInference activation, late-import direct components, canonical content, and tested dependency bounds
- add focused regressions and one patch release intent for all three packages

**Why.**

The OTel compatibility audit found incomplete Groq streams/tool history, Guardrails context loss and indistinguishable native operations, and Haystack activation/direct-component gaps against the current supported dependencies.

**Impact.**

Groq, Guardrails, and Haystack traces now retain connected, operation-specific trees with meaningful content, correct model/token data where applicable, exact propagated context, and no duplicate substitute spans.

## Validation

- [x] focused tests: Groq 15/15, Guardrails 12/12, Haystack 22/22 with one optional skip
- [x] Black and Ruff pass
- [x] all three wheels build and pass fresh Python 3.12 dependency-resolution, `pip check`, and import validation
- [x] release inventory and release intents validate
- [x] all 52 linked examples passed
- [x] Respan MCP inspected 52 trees and all 210 full records under `otel2-fix-py-group-14-20260817T035735Z`; parentage, content, types, usage, errors, grouping, and duplicates pass

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- None documented.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/62
