### PR TITLE
fix(instrumentation-py): repair Chroma, Hugging Face, and Instructor OTel 2.x spans

### DIFF
--- a/.release-intents/20260817-python-chroma-huggingface-instructor-tracing-fixes.json
+++ b/.release-intents/20260817-python-chroma-huggingface-instructor-tracing-fixes.json
@@ -1,0 +1,9 @@
+{
+  "summary": "Repair Chroma workflow serialization and preserve Hugging Face and Instructor content, tool calls, and exact usage in canonical trace attributes",
+  "packages": {
+    "respan-sdk": "patch",
+    "respan-tracing": "patch",
+    "respan-instrumentation-huggingface": "patch",
+    "respan-instrumentation-instructor": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-huggingface/src/respan_instrumentation_huggingface/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-huggingface/src/respan_instrumentation_huggingface/_instrumentation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import logging
 from typing import Any
 
@@ -11,6 +12,10 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanProcessor
 from opentelemetry.semconv_ai import LLMRequestTypeValues
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from respan_sdk.constants.llm_logging import LOG_TYPE_TEXT
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_tracing.core.tracer import RespanTracer
+
 from respan_instrumentation_huggingface._constants import (
     ASSISTANT_ROLE,
     HUGGINGFACE_GEN_AI_SYSTEM,
@@ -20,9 +25,6 @@ from respan_instrumentation_huggingface._constants import (
     TRANSFORMERS_TEXT_GENERATION_SPAN_NAME,
     USER_ROLE,
 )
-from respan_sdk.constants.llm_logging import LOG_TYPE_TEXT
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
-from respan_tracing.core.tracer import RespanTracer
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +103,18 @@ def _indexed_content_indices(attrs: dict[str, Any], prefix: str) -> set[str]:
     return indices
 
 
+def _indexed_contents(attrs: dict[str, Any], prefix: str) -> list[Any]:
+    def sort_key(index: str) -> tuple[int, int | str]:
+        if index.isdigit():
+            return (0, int(index))
+        return (1, index)
+
+    return [
+        attrs[f"{prefix}.{index}.content"]
+        for index in sorted(_indexed_content_indices(attrs, prefix), key=sort_key)
+    ]
+
+
 class HuggingFaceSpanContractProcessor(SpanProcessor):
     """Normalize upstream Transformers spans into Respan's span contract."""
 
@@ -135,6 +149,27 @@ class HuggingFaceSpanContractProcessor(SpanProcessor):
             attrs.setdefault(
                 f"{TLSpanAttributes.LLM_COMPLETIONS}.{index}.role",
                 ASSISTANT_ROLE,
+            )
+
+        prompts = _indexed_contents(attrs, TLSpanAttributes.LLM_PROMPTS)
+        completions = _indexed_contents(attrs, TLSpanAttributes.LLM_COMPLETIONS)
+        if prompts:
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = json.dumps(
+                prompts,
+                separators=(",", ":"),
+            )
+        if completions:
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json.dumps(
+                completions,
+                separators=(",", ":"),
+            )
+        if len(completions) > 1:
+            # Respan's chat projection renders completion index 0. Keep every
+            # indexed attribute and make that canonical content unambiguously
+            # preserve the full batch in prompt order.
+            attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"] = json.dumps(
+                completions,
+                separators=(",", ":"),
             )
 
         span._attributes = attrs

--- a/python-sdks/instrumentations/respan-instrumentation-huggingface/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-huggingface/tests/test_instrumentation.py
@@ -1,12 +1,11 @@
+import json
 import logging
 import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
-
-from respan_instrumentation_huggingface import HuggingFaceInstrumentor
-from respan_instrumentation_huggingface import _instrumentation
+from respan_instrumentation_huggingface import HuggingFaceInstrumentor, _instrumentation
 from respan_instrumentation_huggingface._constants import (
     HUGGINGFACE_GEN_AI_SYSTEM,
     TRANSFORMERS_MODULE,
@@ -232,6 +231,54 @@ def test_contract_processor_preserves_existing_roles():
 
     assert span._attributes[f"{TLSpanAttributes.LLM_PROMPTS}.0.role"] == "system"
     assert span._attributes[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.role"] == "model"
+
+
+def test_contract_processor_preserves_complete_indexed_batch_content():
+    processor = HuggingFaceSpanContractProcessor()
+    span = SimpleNamespace(
+        name=TRANSFORMERS_TEXT_GENERATION_SPAN_NAME,
+        instrumentation_scope=SimpleNamespace(name=TRANSFORMERS_SCOPE_NAME),
+        _attributes={
+            f"{TLSpanAttributes.LLM_PROMPTS}.0.content": "Batch prompt one:",
+            f"{TLSpanAttributes.LLM_PROMPTS}.1.content": "Batch prompt two:",
+            f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content": "First result",
+            f"{TLSpanAttributes.LLM_COMPLETIONS}.1.content": "Second result",
+        },
+    )
+
+    processor.on_end(span)
+
+    assert json.loads(span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_INPUT]) == [
+        "Batch prompt one:",
+        "Batch prompt two:",
+    ]
+    assert json.loads(span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == [
+        "First result",
+        "Second result",
+    ]
+    assert json.loads(
+        span._attributes[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"]
+    ) == ["First result", "Second result"]
+    assert (
+        span._attributes[f"{TLSpanAttributes.LLM_COMPLETIONS}.1.content"]
+        == "Second result"
+    )
+    assert span._attributes[f"{TLSpanAttributes.LLM_PROMPTS}.1.role"] == "user"
+    assert span._attributes[f"{TLSpanAttributes.LLM_COMPLETIONS}.1.role"] == "assistant"
+
+
+def test_contract_processor_does_not_recreate_redacted_content():
+    processor = HuggingFaceSpanContractProcessor()
+    span = SimpleNamespace(
+        name=TRANSFORMERS_TEXT_GENERATION_SPAN_NAME,
+        instrumentation_scope=SimpleNamespace(name=TRANSFORMERS_SCOPE_NAME),
+        _attributes={TLSpanAttributes.LLM_REQUEST_MODEL: "private-model"},
+    )
+
+    processor.on_end(span)
+
+    assert TLSpanAttributes.TRACELOOP_ENTITY_INPUT not in span._attributes
+    assert TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT not in span._attributes
 
 
 def test_contract_processor_ignores_non_transformers_spans():

--- a/python-sdks/instrumentations/respan-instrumentation-instructor/src/respan_instrumentation_instructor/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-instructor/src/respan_instrumentation_instructor/_instrumentation.py
@@ -21,9 +21,10 @@ from typing import (
 )
 
 from opentelemetry import trace
-from opentelemetry.semconv_ai import LLMRequestTypeValues
-from opentelemetry.semconv_ai import SpanAttributes
-
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
 from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
 from respan_sdk.constants.span_attributes import (
     GEN_AI_SYSTEM,
@@ -166,7 +167,8 @@ def _typed_dict_json_schema(response_model: Any) -> dict[str, Any]:
         annotations = getattr(response_model, "__annotations__", {})
     required_keys = getattr(response_model, "__required_keys__", frozenset())
     properties = {
-        field_name: _json_schema_for_annotation(field_type) | {
+        field_name: _json_schema_for_annotation(field_type)
+        | {
             "title": field_name.replace("_", " ").title(),
         }
         for field_name, field_type in annotations.items()
@@ -209,7 +211,9 @@ def _response_model_function_schema(response_model: Any) -> list[dict[str, Any]]
 
 
 def _request_function_schema(arguments: Mapping[str, Any]) -> Any | None:
-    response_model_schema = _response_model_function_schema(arguments.get("response_model"))
+    response_model_schema = _response_model_function_schema(
+        arguments.get("response_model")
+    )
     if response_model_schema is not None:
         return response_model_schema
 
@@ -410,9 +414,9 @@ def _build_span_attributes(
                     role
                 )
             if content is not None:
-                attributes[
-                    f"{SpanAttributes.LLM_PROMPTS}.{message_index}.content"
-                ] = _message_content_to_string(content)
+                attributes[f"{SpanAttributes.LLM_PROMPTS}.{message_index}.content"] = (
+                    _message_content_to_string(content)
+                )
             if tool_calls is not None:
                 attributes[
                     f"{SpanAttributes.LLM_PROMPTS}.{message_index}.tool_calls"
@@ -427,8 +431,152 @@ def _build_span_attributes(
     return attributes
 
 
-def _set_success_attributes(span: Any, result: Any) -> None:
-    output = _serialize_value_to_string(result)
+def _object_value(value: Any, key: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)
+
+
+def _looks_like_raw_response(value: Any) -> bool:
+    choices = _object_value(value, "choices")
+    return isinstance(choices, (list, tuple)) and bool(choices)
+
+
+def _raw_response_from_result(
+    result: Any,
+    captured_responses: list[Any] | None = None,
+) -> Any | None:
+    if captured_responses:
+        return captured_responses[-1]
+
+    if (
+        isinstance(result, tuple)
+        and len(result) > 1
+        and _looks_like_raw_response(result[1])
+    ):
+        return result[1]
+
+    raw_response = getattr(result, "_raw_response", None)
+    if raw_response is not None:
+        return raw_response
+
+    get_raw_response = getattr(result, "get_raw_response", None)
+    if callable(get_raw_response):
+        return get_raw_response()
+
+    if isinstance(result, (list, tuple)):
+        for item in reversed(result):
+            raw_response = getattr(item, "_raw_response", None)
+            if raw_response is not None:
+                return raw_response
+
+    return None
+
+
+def _parsed_result(result: Any, raw_response: Any | None = None) -> Any:
+    if (
+        isinstance(result, tuple)
+        and len(result) == 2
+        and (result[1] is raw_response or _looks_like_raw_response(result[1]))
+    ):
+        return result[0]
+    return result
+
+
+def _normalized_tool_calls(raw_response: Any) -> list[dict[str, Any]]:
+    choices = _object_value(raw_response, "choices")
+    if not isinstance(choices, (list, tuple)) or not choices:
+        return []
+
+    message = _object_value(choices[0], "message")
+    raw_tool_calls = _object_value(message, "tool_calls")
+    if not isinstance(raw_tool_calls, (list, tuple)):
+        return []
+
+    tool_calls: list[dict[str, Any]] = []
+    for raw_tool_call in raw_tool_calls:
+        function = _object_value(raw_tool_call, "function")
+        name = _object_value(function, "name")
+        arguments = _object_value(function, "arguments")
+        if name is None:
+            continue
+        tool_call: dict[str, Any] = {
+            "type": _object_value(raw_tool_call, "type") or "function",
+            "function": {
+                "name": str(name),
+                "arguments": "" if arguments is None else str(arguments),
+            },
+        }
+        tool_call_id = _object_value(raw_tool_call, "id")
+        if tool_call_id is not None:
+            tool_call["id"] = str(tool_call_id)
+        tool_calls.append(tool_call)
+    return tool_calls
+
+
+def _set_raw_response_attributes(span: Any, raw_response: Any) -> None:
+    if raw_response is None:
+        return
+
+    response_model = _object_value(raw_response, "model")
+    if response_model:
+        span.set_attribute(SpanAttributes.LLM_RESPONSE_MODEL, str(response_model))
+
+    choices = _object_value(raw_response, "choices")
+    if isinstance(choices, (list, tuple)) and choices:
+        finish_reason = _object_value(choices[0], "finish_reason")
+        if finish_reason:
+            span.set_attribute(
+                SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON,
+                str(finish_reason),
+            )
+
+    tool_calls = _normalized_tool_calls(raw_response)
+    if tool_calls:
+        span.set_attribute(
+            f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls",
+            _serialize_value_to_string(tool_calls),
+        )
+
+    usage = _object_value(raw_response, "usage")
+    if usage is None:
+        return
+
+    input_tokens = _object_value(usage, "input_tokens")
+    if input_tokens is None:
+        input_tokens = _object_value(usage, "prompt_tokens")
+    output_tokens = _object_value(usage, "output_tokens")
+    if output_tokens is None:
+        output_tokens = _object_value(usage, "completion_tokens")
+    total_tokens = _object_value(usage, "total_tokens")
+    if total_tokens is None and input_tokens is not None and output_tokens is not None:
+        total_tokens = int(input_tokens) + int(output_tokens)
+
+    if input_tokens is not None:
+        span.set_attribute(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, int(input_tokens))
+        span.set_attribute(SpanAttributes.LLM_USAGE_PROMPT_TOKENS, int(input_tokens))
+    if output_tokens is not None:
+        span.set_attribute(
+            GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS,
+            int(output_tokens),
+        )
+        span.set_attribute(
+            SpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
+            int(output_tokens),
+        )
+    if total_tokens is not None:
+        span.set_attribute(SpanAttributes.LLM_USAGE_TOTAL_TOKENS, int(total_tokens))
+
+
+def _set_success_attributes(
+    span: Any,
+    result: Any,
+    raw_response: Any | None = None,
+) -> None:
+    if raw_response is None:
+        raw_response = _raw_response_from_result(result)
+    parsed_result = _parsed_result(result, raw_response=raw_response)
+    output = _serialize_value_to_string(parsed_result)
     span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_OUTPUT, output)
     span.set_attribute(
         f"{SpanAttributes.LLM_COMPLETIONS}.0.role",
@@ -438,7 +586,29 @@ def _set_success_attributes(span: Any, result: Any) -> None:
         f"{SpanAttributes.LLM_COMPLETIONS}.0.content",
         output,
     )
+    _set_raw_response_attributes(span=span, raw_response=raw_response)
     span.set_status(trace.StatusCode.OK)
+
+
+def _with_completion_response_hook(
+    kwargs: Mapping[str, Any],
+    captured_responses: list[Any],
+) -> dict[str, Any]:
+    call_kwargs = dict(kwargs)
+    try:
+        hooks_module = importlib.import_module("instructor.core.hooks")
+        hooks = call_kwargs.get("hooks")
+        if hooks is None:
+            hooks = hooks_module.Hooks()
+        elif hasattr(hooks, "copy"):
+            hooks = hooks.copy()
+        else:
+            return call_kwargs
+        hooks.on("completion:response", captured_responses.append)
+        call_kwargs["hooks"] = hooks
+    except (AttributeError, ImportError, TypeError):
+        return call_kwargs
+    return call_kwargs
 
 
 def _set_error_status(span: Any, exception: Exception) -> None:
@@ -450,6 +620,7 @@ def _iter_with_span(
     iterator: Iterator[Any],
     span: Any,
     span_context: Any,
+    captured_responses: list[Any] | None = None,
 ) -> Iterator[Any]:
     output_items: list[Any] = []
     span_closed = False
@@ -463,12 +634,26 @@ def _iter_with_span(
         span_closed = True
         raise
     else:
-        _set_success_attributes(span=span, result=output_items)
+        _set_success_attributes(
+            span=span,
+            result=output_items,
+            raw_response=_raw_response_from_result(
+                output_items,
+                captured_responses=captured_responses,
+            ),
+        )
         span_context.__exit__(None, None, None)
         span_closed = True
     finally:
         if not span_closed:
-            _set_success_attributes(span=span, result=output_items)
+            _set_success_attributes(
+                span=span,
+                result=output_items,
+                raw_response=_raw_response_from_result(
+                    output_items,
+                    captured_responses=captured_responses,
+                ),
+            )
             span_context.__exit__(None, None, None)
 
 
@@ -476,6 +661,7 @@ async def _async_iter_with_span(
     async_iterator: AsyncIterator[Any],
     span: Any,
     span_context: Any,
+    captured_responses: list[Any] | None = None,
 ) -> AsyncIterator[Any]:
     output_items: list[Any] = []
     span_closed = False
@@ -489,12 +675,26 @@ async def _async_iter_with_span(
         span_closed = True
         raise
     else:
-        _set_success_attributes(span=span, result=output_items)
+        _set_success_attributes(
+            span=span,
+            result=output_items,
+            raw_response=_raw_response_from_result(
+                output_items,
+                captured_responses=captured_responses,
+            ),
+        )
         span_context.__exit__(None, None, None)
         span_closed = True
     finally:
         if not span_closed:
-            _set_success_attributes(span=span, result=output_items)
+            _set_success_attributes(
+                span=span,
+                result=output_items,
+                raw_response=_raw_response_from_result(
+                    output_items,
+                    captured_responses=captured_responses,
+                ),
+            )
             span_context.__exit__(None, None, None)
 
 
@@ -571,8 +771,13 @@ class InstructorInstrumentor:
                     mode=effective_mode,
                 )
                 span = span_context.__enter__()
+                captured_responses: list[Any] = []
+                call_kwargs = _with_completion_response_hook(
+                    kwargs=kwargs,
+                    captured_responses=captured_responses,
+                )
                 try:
-                    result = await original_create(*args, **kwargs)
+                    result = await original_create(*args, **call_kwargs)
                 except Exception as exception:
                     _set_error_status(span=span, exception=exception)
                     span_context.__exit__(
@@ -582,8 +787,20 @@ class InstructorInstrumentor:
                     )
                     raise
                 if isinstance(result, AsyncIterator):
-                    return _async_iter_with_span(result, span, span_context)
-                _set_success_attributes(span=span, result=result)
+                    return _async_iter_with_span(
+                        result,
+                        span,
+                        span_context,
+                        captured_responses=captured_responses,
+                    )
+                _set_success_attributes(
+                    span=span,
+                    result=result,
+                    raw_response=_raw_response_from_result(
+                        result,
+                        captured_responses=captured_responses,
+                    ),
+                )
                 span_context.__exit__(None, None, None)
                 return result
 
@@ -610,8 +827,13 @@ class InstructorInstrumentor:
                 mode=effective_mode,
             )
             span = span_context.__enter__()
+            captured_responses: list[Any] = []
+            call_kwargs = _with_completion_response_hook(
+                kwargs=kwargs,
+                captured_responses=captured_responses,
+            )
             try:
-                result = original_create(*args, **kwargs)
+                result = original_create(*args, **call_kwargs)
             except Exception as exception:
                 _set_error_status(span=span, exception=exception)
                 span_context.__exit__(
@@ -621,8 +843,20 @@ class InstructorInstrumentor:
                 )
                 raise
             if isinstance(result, Iterator):
-                return _iter_with_span(result, span, span_context)
-            _set_success_attributes(span=span, result=result)
+                return _iter_with_span(
+                    result,
+                    span,
+                    span_context,
+                    captured_responses=captured_responses,
+                )
+            _set_success_attributes(
+                span=span,
+                result=result,
+                raw_response=_raw_response_from_result(
+                    result,
+                    captured_responses=captured_responses,
+                ),
+            )
             span_context.__exit__(None, None, None)
             return result
 
@@ -762,6 +996,10 @@ class InstructorInstrumentor:
                     result = original_method(instance, *args, **kwargs)
                 finally:
                     INSTRUCTOR_CALL_CONTEXT.reset(token)
+                if isinstance(result, AsyncIterator) and operation_name.endswith(
+                    "create_iterable"
+                ):
+                    return _async_iter_with_call_context(result, context)
                 if isinstance(result, Iterator) and operation_name.endswith(
                     "create_iterable"
                 ):
@@ -776,19 +1014,52 @@ class InstructorInstrumentor:
             )
             if arguments.get("model") is None:
                 arguments["model"] = getattr(instance, "default_model", None)
-            with self._start_span(
+            span_context = self._start_span(
                 operation_name=operation_name,
                 arguments=arguments,
                 provider=_extract_provider_from_instance(instance) or _OPENAI_PROVIDER,
                 mode=getattr(instance, "mode", None),
-            ) as span:
-                try:
-                    result = original_method(instance, *args, **kwargs)
-                except Exception as exception:
-                    _set_error_status(span=span, exception=exception)
-                    raise
-                _set_success_attributes(span=span, result=result)
-                return result
+            )
+            span = span_context.__enter__()
+            captured_responses: list[Any] = []
+            call_kwargs = _with_completion_response_hook(
+                kwargs=kwargs,
+                captured_responses=captured_responses,
+            )
+            try:
+                result = original_method(instance, *args, **call_kwargs)
+            except Exception as exception:
+                _set_error_status(span=span, exception=exception)
+                span_context.__exit__(
+                    type(exception),
+                    exception,
+                    exception.__traceback__,
+                )
+                raise
+            if isinstance(result, AsyncIterator):
+                return _async_iter_with_span(
+                    result,
+                    span,
+                    span_context,
+                    captured_responses=captured_responses,
+                )
+            if isinstance(result, Iterator):
+                return _iter_with_span(
+                    result,
+                    span,
+                    span_context,
+                    captured_responses=captured_responses,
+                )
+            _set_success_attributes(
+                span=span,
+                result=result,
+                raw_response=_raw_response_from_result(
+                    result,
+                    captured_responses=captured_responses,
+                ),
+            )
+            span_context.__exit__(None, None, None)
+            return result
 
         return _mark_wrapped(wrapped_method)
 

--- a/python-sdks/instrumentations/respan-instrumentation-instructor/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-instructor/tests/test_instrumentation.py
@@ -1,16 +1,13 @@
 import asyncio
 import json
 import sys
-from types import ModuleType
-from types import SimpleNamespace
-from typing import Literal
-from typing import TypedDict
+from types import ModuleType, SimpleNamespace
+from typing import Literal, TypedDict
 
 import pytest
 from opentelemetry.semconv_ai import SpanAttributes
-
-from respan_instrumentation_instructor import InstructorInstrumentor
-from respan_instrumentation_instructor import _instrumentation
+from respan_instrumentation_instructor import InstructorInstrumentor, _instrumentation
+from respan_instrumentation_instructor._instrumentation import _set_success_attributes
 from respan_sdk.constants.span_attributes import (
     GEN_AI_SYSTEM,
     RESPAN_LOG_TYPE,
@@ -85,6 +82,34 @@ class FakeTracer:
         span = FakeSpan(name=name, attributes=attributes)
         self.spans.append(span)
         return FakeSpanContext(span=span)
+
+
+def _raw_tool_completion():
+    return SimpleNamespace(
+        model="gpt-4o-mini-2024-07-18",
+        usage=SimpleNamespace(
+            prompt_tokens=124,
+            completion_tokens=71,
+            total_tokens=195,
+        ),
+        choices=[
+            SimpleNamespace(
+                finish_reason="tool_calls",
+                message=SimpleNamespace(
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="call_release_note",
+                            type="function",
+                            function=SimpleNamespace(
+                                name="ReleaseNote",
+                                arguments='{"title":"Canonical tracing"}',
+                            ),
+                        )
+                    ]
+                ),
+            )
+        ],
+    )
 
 
 def _fake_create(**kwargs):
@@ -275,8 +300,7 @@ def test_patch_create_emits_native_respan_chat_span(monkeypatch):
     assert attributes[GEN_AI_SYSTEM] == "openai"
     assert attributes[f"{SpanAttributes.LLM_PROMPTS}.0.role"] == "user"
     assert (
-        attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"]
-        == "Extract Ada Lovelace."
+        attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"] == "Extract Ada Lovelace."
     )
     assert attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.role"] == "assistant"
     assert attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == '{"name":"Ada"}'
@@ -396,6 +420,61 @@ def test_patch_create_records_consumed_iterable_output(monkeypatch):
     )
 
 
+def test_success_attributes_extract_raw_tool_call_and_exact_usage():
+    span = FakeSpan(name="instructor.create_with_completion", attributes={})
+
+    _set_success_attributes(
+        span=span,
+        result=({"title": "Canonical tracing"}, _raw_tool_completion()),
+    )
+
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == (
+        '{"title":"Canonical tracing"}'
+    )
+    assert span.attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        '{"title":"Canonical tracing"}'
+    )
+    assert json.loads(
+        span.attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]
+    ) == [
+        {
+            "id": "call_release_note",
+            "type": "function",
+            "function": {
+                "name": "ReleaseNote",
+                "arguments": '{"title":"Canonical tracing"}',
+            },
+        }
+    ]
+    assert span.attributes["gen_ai.usage.input_tokens"] == 124
+    assert span.attributes["gen_ai.usage.output_tokens"] == 71
+    assert span.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 124
+    assert span.attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 71
+    assert span.attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 195
+    assert span.attributes[SpanAttributes.GEN_AI_RESPONSE_FINISH_REASON] == (
+        "tool_calls"
+    )
+    assert span.attributes[SpanAttributes.LLM_RESPONSE_MODEL] == (
+        "gpt-4o-mini-2024-07-18"
+    )
+    assert "tools" not in span.attributes
+    assert "tool_calls" not in span.attributes
+
+
+def test_success_attributes_preserve_structured_tuple_results():
+    span = FakeSpan(name="instructor.create", attributes={})
+
+    _set_success_attributes(
+        span=span,
+        result=({"name": "Ada"}, {"confidence": 0.99}),
+    )
+
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == [
+        {"name": "Ada"},
+        {"confidence": 0.99},
+    ]
+
+
 def test_instructor_create_uses_wrapped_create_fn_without_duplicate_span(monkeypatch):
     fake = _install_fake_instructor_modules(monkeypatch)
     tracer = _install_fake_tracer(monkeypatch)
@@ -413,9 +492,9 @@ def test_instructor_create_uses_wrapped_create_fn_without_duplicate_span(monkeyp
 
     assert len(tracer.spans) == 1
     assert tracer.spans[0].name == "instructor.create"
-    assert "UserResult" in tracer.spans[0].attributes[
-        SpanAttributes.LLM_REQUEST_FUNCTIONS
-    ]
+    assert (
+        "UserResult" in tracer.spans[0].attributes[SpanAttributes.LLM_REQUEST_FUNCTIONS]
+    )
 
 
 def test_create_iterable_preserves_method_context_for_wrapped_create_fn(monkeypatch):
@@ -441,6 +520,90 @@ def test_create_iterable_preserves_method_context_for_wrapped_create_fn(monkeypa
     schema = json.loads(functions)[0]["function"]["parameters"]
     assert schema["title"] == "TicketResult"
     assert schema["properties"]["priority"]["enum"] == ["low", "medium", "high"]
+
+
+def test_unwrapped_create_iterable_records_items_after_consumption(monkeypatch):
+    tracer = _install_fake_tracer(monkeypatch)
+
+    class StreamingClient:
+        provider = FakeProvider()
+        mode = FakeMode()
+        default_model = "gpt-4o-mini"
+        create_fn = staticmethod(_fake_create)
+
+        def create_iterable(self, messages, response_model, hooks=None, **kwargs):
+            return iter([{"task": "send checklist"}, {"task": "finish dashboard"}])
+
+    instrumentor = InstructorInstrumentor()
+    wrapped = instrumentor._wrap_instructor_method(
+        original_method=StreamingClient.create_iterable,
+        operation_name="instructor.create_iterable",
+    )
+
+    result = wrapped(
+        StreamingClient(),
+        messages=[{"role": "user", "content": "Extract action items."}],
+        response_model=TicketResult,
+    )
+
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in tracer.spans[0].attributes
+    assert list(result) == [
+        {"task": "send checklist"},
+        {"task": "finish dashboard"},
+    ]
+    assert json.loads(
+        tracer.spans[0].attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    ) == [
+        {"task": "send checklist"},
+        {"task": "finish dashboard"},
+    ]
+
+
+def test_unwrapped_async_create_iterable_records_items_after_consumption(monkeypatch):
+    tracer = _install_fake_tracer(monkeypatch)
+
+    class AsyncStreamingClient:
+        provider = FakeProvider()
+        mode = FakeMode()
+        default_model = "gpt-4o-mini"
+        create_fn = staticmethod(_fake_async_create)
+
+        async def create_iterable(
+            self,
+            messages,
+            response_model,
+            hooks=None,
+            **kwargs,
+        ):
+            yield {"task": "send checklist"}
+            yield {"task": "finish dashboard"}
+
+    instrumentor = InstructorInstrumentor()
+    wrapped = instrumentor._wrap_instructor_method(
+        original_method=AsyncStreamingClient.create_iterable,
+        operation_name="instructor.async_create_iterable",
+    )
+
+    async def consume():
+        return [
+            item
+            async for item in wrapped(
+                AsyncStreamingClient(),
+                messages=[{"role": "user", "content": "Extract action items."}],
+                response_model=TicketResult,
+            )
+        ]
+
+    assert asyncio.run(consume()) == [
+        {"task": "send checklist"},
+        {"task": "finish dashboard"},
+    ]
+    assert json.loads(
+        tracer.spans[0].attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    ) == [
+        {"task": "send checklist"},
+        {"task": "finish dashboard"},
+    ]
 
 
 def test_instructor_create_emits_span_for_unwrapped_create_fn(monkeypatch):
@@ -502,9 +665,10 @@ def test_patch_async_create_emits_span(monkeypatch):
 
     assert result.model_dump() == {"name": "Grace"}
     assert len(tracer.spans) == 1
-    assert tracer.spans[0].attributes[
-        f"{SpanAttributes.LLM_COMPLETIONS}.0.content"
-    ] == '{"name":"Grace"}'
+    assert (
+        tracer.spans[0].attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]
+        == '{"name":"Grace"}'
+    )
 
 
 def test_deactivate_restores_patches(monkeypatch):

--- a/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
+++ b/python-sdks/respan-sdk/src/respan_sdk/utils/serialization.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict, is_dataclass
 from datetime import date, datetime
 from typing import Any, Dict, List
 
@@ -7,7 +8,7 @@ def json_serial(obj):
 
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
-    raise TypeError ("Type %s not serializable" % type(obj))
+    raise TypeError("Type %s not serializable" % type(obj))
 
 
 def serialize_value(value: Any) -> Any:
@@ -18,8 +19,19 @@ def serialize_value(value: Any) -> Any:
     if isinstance(value, (str, int, float, bool)):
         return value
 
-    if isinstance(value, datetime):
+    if isinstance(value, (datetime, date)):
         return value.isoformat()
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return serialize_value(value=model_dump())
+
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        return serialize_value(value=tolist())
+
+    if is_dataclass(value) and not isinstance(value, type):
+        return serialize_value(value=asdict(value))
 
     if isinstance(value, dict):
         normalized: Dict[str, Any] = {}

--- a/python-sdks/respan-sdk/tests/test_serialization.py
+++ b/python-sdks/respan-sdk/tests/test_serialization.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from datetime import date
+
+from respan_sdk.utils.serialization import serialize_value
+
+
+class ArrayLike:
+    def tolist(self):
+        return [[0.1, 0.2], [0.3, 0.4]]
+
+
+class ModelLike:
+    def model_dump(self):
+        return {"name": "record", "vectors": ArrayLike()}
+
+
+@dataclass
+class Container:
+    created_on: date
+    result: ModelLike
+
+
+def test_serialize_value_normalizes_sdk_containers_and_array_values():
+    assert serialize_value(
+        Container(created_on=date(2026, 8, 17), result=ModelLike())
+    ) == {
+        "created_on": "2026-08-17",
+        "result": {
+            "name": "record",
+            "vectors": [[0.1, 0.2], [0.3, 0.4]],
+        },
+    }

--- a/python-sdks/respan-tracing/src/respan_tracing/decorators/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/decorators/base.py
@@ -1,21 +1,23 @@
-import json
 import inspect
+import json
+import os
 from functools import wraps
-from typing import Optional, TypeVar, Callable, Any, ParamSpec, Awaitable
+from typing import Any, Awaitable, Callable, Optional, ParamSpec, TypeVar
+
 from opentelemetry import context as context_api
-from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace.status import Status, StatusCode
 from respan_sdk import FilterParamDict
-from respan_tracing.constants.context_constants import (
-    ENABLE_CONTENT_TRACING_KEY
-)
+from respan_sdk.utils.serialization import serialize_value
+
+from respan_tracing.constants.context_constants import ENABLE_CONTENT_TRACING_KEY
 from respan_tracing.constants.generic_constants import LOGGER_NAME_DECORATORS
 from respan_tracing.utils.auto_flush import (
     flush_after_span,
     has_recording_parent_span,
 )
 from respan_tracing.utils.logging import get_respan_logger
-from respan_tracing.utils.span_setup import setup_span, cleanup_span, LinksParam
+from respan_tracing.utils.span_setup import LinksParam, cleanup_span, setup_span
 
 logger = get_respan_logger(LOGGER_NAME_DECORATORS)
 
@@ -32,7 +34,13 @@ def _is_json_size_valid(json_str: str) -> bool:
 
 def _should_send_prompts() -> bool:
     """Check if we should send prompt content in traces"""
-    return context_api.get_value(ENABLE_CONTENT_TRACING_KEY) is not False
+    if context_api.get_value(ENABLE_CONTENT_TRACING_KEY) is False:
+        return False
+
+    trace_content = os.getenv("TRACELOOP_TRACE_CONTENT")
+    if trace_content is None:
+        return True
+    return trace_content.strip().lower() not in {"0", "false", "no", "off"}
 
 
 def _is_async_method(fn):
@@ -75,23 +83,49 @@ def _handle_span_input(span, args, kwargs):
     """Handle entity input logging"""
     try:
         if _should_send_prompts():
-            json_input = json.dumps({"args": list(args), "kwargs": kwargs})
+            json_input = json.dumps(
+                {
+                    "args": [_serialize_input_value(value) for value in args],
+                    "kwargs": {
+                        str(key): _serialize_input_value(value)
+                        for key, value in kwargs.items()
+                    },
+                }
+            )
             if _is_json_size_valid(json_input):
                 span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_INPUT, json_input)
-    except (TypeError, ValueError) as e:
-        # Skip if serialization fails
-        pass
+    except (RecursionError, TypeError, ValueError) as error:
+        logger.debug("Skipping span input that could not be serialized: %s", error)
+
+
+def _serialize_input_value(value):
+    """Bound arbitrary runtime objects without traversing private client state."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(key): _serialize_input_value(nested_value)
+            for key, nested_value in value.items()
+        }
+    if isinstance(value, (list, tuple, set)):
+        return [_serialize_input_value(nested_value) for nested_value in value]
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return _serialize_input_value(model_dump())
+
+    return f"<{type(value).__name__}>"
+
 
 def _handle_span_output(span, result):
     """Handle entity output logging"""
     try:
         if _should_send_prompts():
-            json_output = json.dumps(result)
+            json_output = json.dumps(serialize_value(value=result))
             if _is_json_size_valid(json_output):
                 span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_OUTPUT, json_output)
-    except (TypeError, ValueError) as e:
-        # Skip if serialization fails
-        pass
+    except (RecursionError, TypeError, ValueError) as error:
+        logger.debug("Skipping span output that could not be serialized: %s", error)
 
 
 def _cleanup_span(span, ctx_token, *, is_root_boundary: bool = False):
@@ -99,8 +133,8 @@ def _cleanup_span(span, ctx_token, *, is_root_boundary: bool = False):
     cleanup_span(
         span,
         ctx_token,
-        entity_name_token=getattr(span, '_entity_name_token', None),
-        entity_path_token=getattr(span, '_entity_path_token', None),
+        entity_name_token=getattr(span, "_entity_name_token", None),
+        entity_path_token=getattr(span, "_entity_path_token", None),
     )
     flush_after_span(is_root_boundary)
 
@@ -118,7 +152,9 @@ def _handle_generator(span, ctx_token, generator, *, is_root_boundary: bool = Fa
         _cleanup_span(span, ctx_token, is_root_boundary=is_root_boundary)
 
 
-async def _ahandle_generator(span, ctx_token, async_generator, *, is_root_boundary: bool = False):
+async def _ahandle_generator(
+    span, ctx_token, async_generator, *, is_root_boundary: bool = False
+):
     """Handle async generator functions"""
     try:
         async for item in async_generator:
@@ -272,7 +308,9 @@ def _create_entity_method_decorator(
                         span.record_exception(e)
                         raise
                     finally:
-                        _cleanup_span(span, ctx_token, is_root_boundary=is_root_boundary)
+                        _cleanup_span(
+                            span, ctx_token, is_root_boundary=is_root_boundary
+                        )
 
                 return async_wrapper
         else:
@@ -312,7 +350,9 @@ def _create_entity_method_decorator(
                     raise
                 finally:
                     if not inspect.isgeneratorfunction(fn):
-                        _cleanup_span(span, ctx_token, is_root_boundary=is_root_boundary)
+                        _cleanup_span(
+                            span, ctx_token, is_root_boundary=is_root_boundary
+                        )
 
             return sync_wrapper
 

--- a/python-sdks/respan-tracing/tests/test_decorator_content_serialization.py
+++ b/python-sdks/respan-tracing/tests/test_decorator_content_serialization.py
@@ -1,0 +1,79 @@
+import json
+
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_tracing.decorators.base import (
+    _handle_span_input,
+    _handle_span_output,
+    _should_send_prompts,
+)
+
+
+class RecordingSpan:
+    def __init__(self):
+        self.attributes = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+
+class ChromaLikeResult:
+    def model_dump(self):
+        return {
+            "ids": ["doc-1", "doc-2"],
+            "embeddings": ArrayLike(),
+        }
+
+
+class ArrayLike:
+    def tolist(self):
+        return [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_span_output_serializes_nested_sdk_and_array_values(monkeypatch):
+    monkeypatch.delenv("TRACELOOP_TRACE_CONTENT", raising=False)
+    span = RecordingSpan()
+
+    _handle_span_output(
+        span,
+        {
+            "count": 2,
+            "peek": ChromaLikeResult(),
+        },
+    )
+
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "count": 2,
+        "peek": {
+            "ids": ["doc-1", "doc-2"],
+            "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+        },
+    }
+
+
+def test_trace_content_environment_disables_decorator_output(monkeypatch):
+    monkeypatch.setenv("TRACELOOP_TRACE_CONTENT", "false")
+    span = RecordingSpan()
+
+    assert _should_send_prompts() is False
+    _handle_span_output(span, {"secret": "must not be recorded"})
+
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in span.attributes
+
+
+def test_span_input_bounds_runtime_clients_without_serializing_private_state(
+    monkeypatch,
+):
+    class Client:
+        def __init__(self):
+            self.api_key = "must-not-leak"
+
+    monkeypatch.delenv("TRACELOOP_TRACE_CONTENT", raising=False)
+    span = RecordingSpan()
+
+    _handle_span_input(span, (Client(), "invoice extraction"), {})
+
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "args": ["<Client>", "invoice extraction"],
+        "kwargs": {},
+    }
+    assert "must-not-leak" not in span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]


### PR DESCRIPTION
## Summary

- restore Chroma workflow serialization through bounded SDK value normalization and end-to-end content privacy
- preserve complete Hugging Face batch content and validate a real local Transformers pipeline
- capture Instructor raw response schemas, calls, exact non-stream usage, and sync/async iterable results without SDK-object leakage
- add the required patch release intent for the four changed release-managed Python packages

## Validation

- [x] Chroma: 3 focused tests passed
- [x] Hugging Face: 10 focused tests passed
- [x] Instructor: 17 focused tests passed; 1 opt-in live test skipped
- [x] affected respan-tracing tests: 60 passed
- [x] affected respan-sdk tests: 7 passed
- [x] four changed package wheels built successfully
- [x] release inventory, release intents, formatting/import checks, and git diff checks passed
- [x] all 14 linked examples completed under marker `otel2-fix-py-group-15-20260817T084907Z`
- [x] Respan MCP: 14 connected traces and all 52 full records inspected; no errors, orphan parents, extra roots, or duplicates

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- Instructor emits canonical `llm.request.functions` and `gen_ai.completion.0.tool_calls`. The platform retains both in semantic content and sets `has_tool_calls=true`, but its separate top-level tool arrays and model projection remain incomplete. The instrumentation intentionally does not add contribution-contract-forbidden aliases.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/63
