### PR TITLE
fix(instrumentation-py): repair Mirascope, Mistral, and Ollama OTel 2.x spans

### DIFF
--- a/.release-intents/20260817-mirascope-mistral-ollama-otel2.json
+++ b/.release-intents/20260817-mirascope-mistral-ollama-otel2.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair Mirascope, Mistral, and Ollama OTel 2.x span semantics, lifecycle, streaming, tools, errors, and coverage",
+  "packages": {
+    "respan-instrumentation-mirascope": "patch",
+    "respan-instrumentation-mistralai": "patch",
+    "respan-instrumentation-ollama": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-mirascope/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-mirascope/README.md
@@ -3,7 +3,9 @@
 This package traces Mirascope 2.x model calls, context-aware calls, sync and
 async streams, and toolkit execution. Model calls become canonical Respan chat
 spans; toolkit executions become canonical tool spans. Streaming spans finish
-when the underlying stream is consumed and preserve iterator errors.
+when the underlying stream is consumed, emit `llm.is_streaming=true`, and
+preserve real iterator errors without treating normal iterator completion as a
+failure.
 
 ```python
 from respan_instrumentation_mirascope import MirascopeInstrumentor
@@ -15,6 +17,11 @@ instrumentor.activate()
 `capture_content=False` omits messages, tool definitions, arguments, and model
 outputs while retaining models, providers, usage, status, and errors. Activation
 is reference-counted and safe to repeat.
+
+Mirascope `ToolCall.args` JSON text is decoded for tool-span input as
+`{"name": ..., "arguments": ...}`. Chat spans retain canonical request tool
+definitions and current-turn calls, while tool outputs store the executed
+function result rather than Mirascope's transport envelope.
 
 Do not combine this adapter with `mirascope.ops.instrument_llm()` unless you
 intentionally want two independent telemetry pipelines for each operation.

--- a/python-sdks/instrumentations/respan-instrumentation-mirascope/src/respan_instrumentation_mirascope/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-mirascope/src/respan_instrumentation_mirascope/_instrumentation.py
@@ -2,24 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import importlib
+import inspect
+import json
 import logging
 import threading
 import weakref
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 from opentelemetry import trace
+from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
+from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
 from opentelemetry.trace import Status, StatusCode
-from opentelemetry.semconv_ai import LLMRequestTypeValues
-from opentelemetry.semconv_ai import SpanAttributes
-
-from respan_instrumentation_mirascope._serialization import json_string, json_value
 from respan_sdk.constants import ERROR_MESSAGE_ATTR
 from respan_sdk.constants.llm_logging import LogMethodChoices
 from respan_sdk.constants.span_attributes import RESPAN_LOG_METHOD, RESPAN_LOG_TYPE
 from respan_tracing.core.tracer import RespanTracer
+
+from respan_instrumentation_mirascope._serialization import (
+    json_string,
+    json_value,
+    safe_exception_text,
+    safe_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +36,7 @@ MIRASCOPE_INSTRUMENTATION_NAME = "mirascope"
 _LOCK = threading.RLock()
 _REFCOUNT = 0
 _CAPTURE_CONTENT = True
-_PATCHES: list["_Patch"] = []
+_PATCHES: list[_Patch] = []
 
 _MODERN_INPUT_USAGE = getattr(
     SpanAttributes, "LLM_USAGE_INPUT_TOKENS", "gen_ai.usage.input_tokens"
@@ -63,7 +72,7 @@ def _is_respan_tracing_enabled() -> bool:
 
 
 def _model_identity(model: Any, response: Any = None) -> tuple[str, str]:
-    raw_model = str(
+    raw_model = safe_text(
         getattr(response, "model_id", None)
         or getattr(model, "model_id", None)
         or "unknown"
@@ -72,8 +81,12 @@ def _model_identity(model: Any, response: Any = None) -> tuple[str, str]:
         inferred_provider, model_name = raw_model.split("/", 1)
     else:
         inferred_provider, model_name = "unknown", raw_model
-    provider = str(getattr(response, "provider_id", None) or inferred_provider)
+    provider = safe_text(getattr(response, "provider_id", None) or inferred_provider)
     return provider, model_name
+
+
+def _chat_span_name(model: Any) -> str:
+    return safe_text(f"mirascope.{_model_identity(model)[1]}.chat")
 
 
 def _message_parts(value: Any) -> list[tuple[str, Any]]:
@@ -90,39 +103,145 @@ def _message_parts(value: Any) -> list[tuple[str, Any]]:
         if isinstance(item, dict):
             role = item.get("role", role)
             content = item.get("content", content)
-        messages.append((str(role or "user"), content if content is not None else item))
+        messages.append(
+            (safe_text(role or "user"), content if content is not None else item)
+        )
     return messages
 
 
 def _set_messages(span: Any, *, prefix: str, value: Any) -> None:
     for index, (role, content) in enumerate(_message_parts(value)):
+        normalized_content = json_value(content)
         span.set_attribute(f"{prefix}.{index}.role", role)
         span.set_attribute(
             f"{prefix}.{index}.content",
-            content if isinstance(content, str) else json_string(content),
+            normalized_content
+            if isinstance(normalized_content, str)
+            else json_string(normalized_content),
         )
 
 
 def _tool_definitions(value: Any) -> list[dict[str, Any]]:
     if value is None:
         return []
-    tools = value if isinstance(value, (list, tuple)) else [value]
+    toolkit_tools = getattr(value, "tools", None)
+    if toolkit_tools is not None:
+        value = toolkit_tools
+    tools = (
+        value
+        if isinstance(value, Sequence) and not isinstance(value, str | bytes)
+        else [value]
+    )
     definitions: list[dict[str, Any]] = []
     for tool in tools:
+        function: dict[str, Any] = {
+            "name": safe_text(
+                getattr(tool, "name", None)
+                or getattr(tool, "__name__", tool.__class__.__name__)
+            ),
+        }
+        description = getattr(tool, "description", None) or getattr(
+            tool, "__doc__", None
+        )
+        if description:
+            function["description"] = safe_text(description)
+        parameters = getattr(tool, "parameters", None) or getattr(tool, "schema", None)
+        if parameters is None and callable(tool):
+            properties: dict[str, Any] = {}
+            required: list[str] = []
+            try:
+                for parameter in inspect.signature(tool).parameters.values():
+                    if parameter.name in {"self", "cls"}:
+                        continue
+                    annotation = parameter.annotation
+                    type_name = (
+                        getattr(annotation, "__name__", None)
+                        if annotation is not inspect.Parameter.empty
+                        else None
+                    )
+                    json_type = {
+                        "bool": "boolean",
+                        "dict": "object",
+                        "float": "number",
+                        "int": "integer",
+                        "list": "array",
+                        "str": "string",
+                    }.get(type_name, "string")
+                    properties[parameter.name] = {"type": json_type}
+                    if parameter.default is inspect.Parameter.empty:
+                        required.append(parameter.name)
+                parameters = {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                    "additionalProperties": False,
+                }
+            except (TypeError, ValueError):
+                parameters = {}
+        if callable(getattr(parameters, "model_dump", None)):
+            parameters = parameters.model_dump(by_alias=True, exclude_none=True)
+        normalized_parameters = json_value(parameters or {})
+        if (
+            isinstance(normalized_parameters, dict)
+            and "properties" in normalized_parameters
+        ):
+            normalized_parameters.setdefault("type", "object")
+        function["parameters"] = normalized_parameters
         definitions.append(
             {
-                "name": getattr(tool, "name", None)
-                or getattr(tool, "__name__", tool.__class__.__name__),
-                "description": getattr(tool, "description", None)
-                or getattr(tool, "__doc__", None),
-                "parameters": json_value(
-                    getattr(tool, "schema", None)
-                    or getattr(tool, "parameters", None)
-                    or {}
-                ),
+                "type": "function",
+                "function": function,
             }
         )
     return definitions
+
+
+def _tool_arguments(value: Any) -> Any:
+    if not isinstance(value, str):
+        return json_value(value)
+    try:
+        return json_value(json.loads(value))
+    except (TypeError, ValueError):
+        return safe_text(value)
+
+
+def _tool_calls(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    calls = (
+        value
+        if isinstance(value, Sequence) and not isinstance(value, str | bytes)
+        else [value]
+    )
+    normalized: list[dict[str, Any]] = []
+    for call in calls:
+        function = getattr(call, "function", None)
+        name = safe_text(
+            getattr(call, "name", None)
+            or getattr(function, "name", None)
+            or "mirascope.tool"
+        )
+        arguments = getattr(call, "args", None)
+        if arguments is None:
+            arguments = getattr(call, "arguments", None)
+        parsed_arguments = _tool_arguments(arguments if arguments is not None else {})
+        normalized_call: dict[str, Any] = {
+            "type": "function",
+            "function": {
+                "name": name,
+                "arguments": json.dumps(
+                    parsed_arguments,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            },
+        }
+        call_id = getattr(call, "id", None) or getattr(call, "call_id", None)
+        if call_id:
+            normalized_call["id"] = safe_text(call_id)
+        normalized.append(normalized_call)
+    return normalized
 
 
 def _prepare_chat_span(
@@ -131,9 +250,10 @@ def _prepare_chat_span(
     model: Any,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
+    stream: bool = False,
 ) -> None:
     provider, model_name = _model_identity(model)
-    entity_name = f"mirascope.{model_name}"
+    entity_name = safe_text(f"mirascope.{model_name}")
     span.set_attribute(RESPAN_LOG_METHOD, LogMethodChoices.TRACING_INTEGRATION.value)
     span.set_attribute(RESPAN_LOG_TYPE, "chat")
     span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
@@ -141,11 +261,13 @@ def _prepare_chat_span(
     span.set_attribute(SpanAttributes.LLM_SYSTEM, provider)
     span.set_attribute(SpanAttributes.LLM_REQUEST_MODEL, model_name)
     span.set_attribute(SpanAttributes.LLM_REQUEST_TYPE, LLMRequestTypeValues.CHAT.value)
+    if stream:
+        span.set_attribute(SpanAttributes.LLM_IS_STREAMING, True)
     content = args[1] if len(args) > 1 else kwargs.get("content")
     if _CAPTURE_CONTENT:
         span.set_attribute(
             SpanAttributes.TRACELOOP_ENTITY_INPUT,
-            json_string({"content": content, "tools": kwargs.get("tools")}),
+            json_string({"content": content}),
         )
         _set_messages(span, prefix=SpanAttributes.LLM_PROMPTS, value=content)
         definitions = _tool_definitions(kwargs.get("tools"))
@@ -180,19 +302,33 @@ def _set_usage(span: Any, usage: Any) -> None:
 
 
 def _status_code(value: Any, *, default: int) -> int:
-    candidates = [
-        value,
-        getattr(value, "response", None),
-        getattr(value, "raw_response", None),
-    ]
-    for candidate in candidates:
+    pending = [value]
+    seen: set[int] = set()
+    while pending:
+        candidate = pending.pop(0)
+        if candidate is None or id(candidate) in seen:
+            continue
+        seen.add(id(candidate))
         for name in ("status_code", "status"):
             try:
                 code = getattr(candidate, name, None)
-                if isinstance(code, int):
+                if isinstance(code, int) and not isinstance(code, bool):
                     return code
-            except Exception:
+            except Exception:  # noqa: BLE001, S112 - vendor properties may raise
                 continue
+        for name in (
+            "response",
+            "raw_response",
+            "original_exception",
+            "tool_exception",
+            "__cause__",
+        ):
+            try:
+                nested = getattr(candidate, name, None)
+            except Exception:  # noqa: BLE001 - vendor exception properties may raise
+                nested = None
+            if nested is not None:
+                pending.append(nested)
     return default
 
 
@@ -208,19 +344,22 @@ def _finish_chat_span(span: Any, *, model: Any, response: Any) -> None:
     if callable(text_value):
         try:
             text_value = text_value()
-        except Exception:
+        except Exception:  # noqa: BLE001 - response helpers are vendor-controlled
             text_value = None
     output = text_value if text_value is not None else content
-    tool_calls = getattr(response, "tool_calls", None)
+    tool_calls = _tool_calls(getattr(response, "tool_calls", None))
     span.set_attribute(
         SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-        json_string({"content": content, "tool_calls": tool_calls}),
+        json_string({"content": output, "tool_calls": tool_calls}),
     )
     span.set_attribute(f"{SpanAttributes.LLM_COMPLETIONS}.0.role", "assistant")
     if output is not None:
+        normalized_output = json_value(output)
         span.set_attribute(
             f"{SpanAttributes.LLM_COMPLETIONS}.0.content",
-            output if isinstance(output, str) else json_string(output),
+            normalized_output
+            if isinstance(normalized_output, str)
+            else json_string(normalized_output),
         )
     if tool_calls:
         span.set_attribute(
@@ -233,7 +372,7 @@ def _record_error(span: Any, exc: BaseException) -> None:
     status_code = _status_code(exc, default=500)
     if status_code < 400:
         status_code = 500
-    message = str(exc)
+    message = safe_exception_text(exc)
     span.set_attribute("status_code", status_code)
     span.set_attribute(ERROR_MESSAGE_ATTR, message)
     span.set_attribute(
@@ -246,7 +385,14 @@ def _record_error(span: Any, exc: BaseException) -> None:
             }
         ),
     )
-    span.record_exception(exc)
+    span.add_event(
+        "exception",
+        attributes={
+            OTelSpanAttributes.EXCEPTION_TYPE: type(exc).__name__,
+            OTelSpanAttributes.EXCEPTION_MESSAGE: message,
+            OTelSpanAttributes.EXCEPTION_ESCAPED: True,
+        },
+    )
     span.set_status(Status(StatusCode.ERROR, message))
 
 
@@ -279,11 +425,26 @@ def _wrap_sync_iterator(source: Any, response: Any, state: _StreamSpanState) -> 
         try:
             while True:
                 try:
-                    with trace.use_span(state.span, end_on_exit=False):
+                    with trace.use_span(
+                        state.span,
+                        end_on_exit=False,
+                        record_exception=False,
+                        set_status_on_exception=False,
+                    ):
                         chunk = next(source)
                 except StopIteration:
                     break
                 yield chunk
+        except GeneratorExit:
+            close = getattr(source, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except BaseException as exc:
+                    state.fail(exc)
+                    raise
+            state.finish(response)
+            raise
         except BaseException as exc:
             state.fail(exc)
             raise
@@ -298,11 +459,29 @@ def _wrap_async_iterator(source: Any, response: Any, state: _StreamSpanState) ->
         try:
             while True:
                 try:
-                    with trace.use_span(state.span, end_on_exit=False):
+                    with trace.use_span(
+                        state.span,
+                        end_on_exit=False,
+                        record_exception=False,
+                        set_status_on_exception=False,
+                    ):
                         chunk = await source.__anext__()
                 except StopAsyncIteration:
                     break
                 yield chunk
+        except GeneratorExit:
+            aclose = getattr(source, "aclose", None)
+            close = getattr(source, "close", None)
+            try:
+                if callable(aclose):
+                    await aclose()
+                elif callable(close):
+                    close()
+            except BaseException as exc:
+                state.fail(exc)
+                raise
+            state.finish(response)
+            raise
         except BaseException as exc:
             state.fail(exc)
             raise
@@ -312,16 +491,59 @@ def _wrap_async_iterator(source: Any, response: Any, state: _StreamSpanState) ->
     return iterator()
 
 
+def _finalize_abandoned_sync_stream(source: Any, state: _StreamSpanState) -> None:
+    close = getattr(source, "close", None)
+    try:
+        if callable(close):
+            close()
+    except Exception as exc:  # noqa: BLE001 - provider close hooks are untrusted
+        state.fail(exc)
+    else:
+        state.finish()
+
+
+def _finalize_abandoned_async_stream(source: Any, state: _StreamSpanState) -> None:
+    async def close_source() -> None:
+        aclose = getattr(source, "aclose", None)
+        close = getattr(source, "close", None)
+        try:
+            if callable(aclose):
+                result = aclose()
+                if inspect.isawaitable(result):
+                    await result
+            elif callable(close):
+                close()
+        except Exception as exc:  # noqa: BLE001 - provider close hooks are untrusted
+            state.fail(exc)
+        else:
+            state.finish()
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        try:
+            asyncio.run(close_source())
+        except Exception as exc:  # noqa: BLE001 - provider close hooks are untrusted
+            state.fail(exc)
+    else:
+        loop.create_task(close_source())
+
+
 def _call_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(original)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         model = args[0]
         span = trace.get_tracer(MIRASCOPE_INSTRUMENTATION_NAME).start_span(
-            f"mirascope.{_model_identity(model)[1]}.chat"
+            _chat_span_name(model)
         )
         _prepare_chat_span(span, model=model, args=args, kwargs=kwargs)
         try:
-            with trace.use_span(span, end_on_exit=False):
+            with trace.use_span(
+                span,
+                end_on_exit=False,
+                record_exception=False,
+                set_status_on_exception=False,
+            ):
                 response = original(*args, **kwargs)
             _finish_chat_span(span, model=model, response=response)
             return response
@@ -339,11 +561,16 @@ def _async_call_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         model = args[0]
         span = trace.get_tracer(MIRASCOPE_INSTRUMENTATION_NAME).start_span(
-            f"mirascope.{_model_identity(model)[1]}.chat"
+            _chat_span_name(model)
         )
         _prepare_chat_span(span, model=model, args=args, kwargs=kwargs)
         try:
-            with trace.use_span(span, end_on_exit=False):
+            with trace.use_span(
+                span,
+                end_on_exit=False,
+                record_exception=False,
+                set_status_on_exception=False,
+            ):
                 response = await original(*args, **kwargs)
             _finish_chat_span(span, model=model, response=response)
             return response
@@ -361,11 +588,16 @@ def _stream_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         model = args[0]
         span = trace.get_tracer(MIRASCOPE_INSTRUMENTATION_NAME).start_span(
-            f"mirascope.{_model_identity(model)[1]}.chat"
+            _chat_span_name(model)
         )
-        _prepare_chat_span(span, model=model, args=args, kwargs=kwargs)
+        _prepare_chat_span(span, model=model, args=args, kwargs=kwargs, stream=True)
         try:
-            with trace.use_span(span, end_on_exit=False):
+            with trace.use_span(
+                span,
+                end_on_exit=False,
+                record_exception=False,
+                set_status_on_exception=False,
+            ):
                 response = original(*args, **kwargs)
         except BaseException as exc:
             _record_error(span, exc)
@@ -378,7 +610,12 @@ def _stream_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
             return response
         response._chunk_iterator = _wrap_sync_iterator(source, response, state)
         try:
-            state.finalizer = weakref.finalize(response, state.finish)
+            state.finalizer = weakref.finalize(
+                response,
+                _finalize_abandoned_sync_stream,
+                source,
+                state,
+            )
         except TypeError:
             pass
         return response
@@ -391,11 +628,16 @@ def _async_stream_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         model = args[0]
         span = trace.get_tracer(MIRASCOPE_INSTRUMENTATION_NAME).start_span(
-            f"mirascope.{_model_identity(model)[1]}.chat"
+            _chat_span_name(model)
         )
-        _prepare_chat_span(span, model=model, args=args, kwargs=kwargs)
+        _prepare_chat_span(span, model=model, args=args, kwargs=kwargs, stream=True)
         try:
-            with trace.use_span(span, end_on_exit=False):
+            with trace.use_span(
+                span,
+                end_on_exit=False,
+                record_exception=False,
+                set_status_on_exception=False,
+            ):
                 response = await original(*args, **kwargs)
         except BaseException as exc:
             _record_error(span, exc)
@@ -408,7 +650,12 @@ def _async_stream_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
             return response
         response._chunk_iterator = _wrap_async_iterator(source, response, state)
         try:
-            state.finalizer = weakref.finalize(response, state.finish)
+            state.finalizer = weakref.finalize(
+                response,
+                _finalize_abandoned_async_stream,
+                source,
+                state,
+            )
         except TypeError:
             pass
         return response
@@ -422,7 +669,7 @@ def _tool_call(args: tuple[Any, ...]) -> Any:
 
 def _tool_name(tool_call: Any) -> str:
     function = getattr(tool_call, "function", None)
-    return str(
+    return safe_text(
         getattr(tool_call, "name", None)
         or getattr(function, "name", None)
         or "mirascope.tool"
@@ -439,7 +686,40 @@ def _prepare_tool_span(span: Any, tool_call: Any) -> None:
         value = getattr(tool_call, "args", None)
         if value is None:
             value = getattr(tool_call, "arguments", tool_call)
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_INPUT, json_string(value))
+        span.set_attribute(
+            SpanAttributes.TRACELOOP_ENTITY_INPUT,
+            json_string({"name": name, "arguments": _tool_arguments(value)}),
+        )
+
+
+def _finish_tool_span(span: Any, result: Any) -> None:
+    error = getattr(result, "error", None)
+    output = getattr(result, "result", result)
+    if error is not None:
+        status_code = _status_code(error, default=500)
+        if status_code < 400:
+            status_code = 500
+        message = (
+            safe_exception_text(error)
+            if isinstance(error, BaseException)
+            else safe_text(error)
+        )
+        span.set_attribute("status_code", status_code)
+        span.set_attribute(ERROR_MESSAGE_ATTR, message)
+        if isinstance(error, BaseException):
+            span.add_event(
+                "exception",
+                attributes={
+                    OTelSpanAttributes.EXCEPTION_TYPE: type(error).__name__,
+                    OTelSpanAttributes.EXCEPTION_MESSAGE: message,
+                    OTelSpanAttributes.EXCEPTION_ESCAPED: False,
+                },
+            )
+        span.set_status(Status(StatusCode.ERROR, message))
+    else:
+        span.set_attribute("status_code", _status_code(result, default=200))
+    if _CAPTURE_CONTENT:
+        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_OUTPUT, json_string(output))
 
 
 def _tool_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
@@ -448,18 +728,18 @@ def _tool_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
         tool_call = kwargs.get("tool_call") or _tool_call(args)
         name = _tool_name(tool_call)
         tracer = trace.get_tracer(MIRASCOPE_INSTRUMENTATION_NAME)
-        with tracer.start_as_current_span(f"{name}.tool") as span:
+        with tracer.start_as_current_span(
+            safe_text(f"{name}.tool"),
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
             _prepare_tool_span(span, tool_call)
             try:
                 result = original(*args, **kwargs)
             except BaseException as exc:
                 _record_error(span, exc)
                 raise
-            span.set_attribute("status_code", _status_code(result, default=200))
-            if _CAPTURE_CONTENT:
-                span.set_attribute(
-                    SpanAttributes.TRACELOOP_ENTITY_OUTPUT, json_string(result)
-                )
+            _finish_tool_span(span, result)
             return result
 
     return wrapper
@@ -471,18 +751,18 @@ def _async_tool_wrapper(original: Callable[..., Any]) -> Callable[..., Any]:
         tool_call = kwargs.get("tool_call") or _tool_call(args)
         name = _tool_name(tool_call)
         tracer = trace.get_tracer(MIRASCOPE_INSTRUMENTATION_NAME)
-        with tracer.start_as_current_span(f"{name}.tool") as span:
+        with tracer.start_as_current_span(
+            safe_text(f"{name}.tool"),
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
             _prepare_tool_span(span, tool_call)
             try:
                 result = await original(*args, **kwargs)
             except BaseException as exc:
                 _record_error(span, exc)
                 raise
-            span.set_attribute("status_code", _status_code(result, default=200))
-            if _CAPTURE_CONTENT:
-                span.set_attribute(
-                    SpanAttributes.TRACELOOP_ENTITY_OUTPUT, json_string(result)
-                )
+            _finish_tool_span(span, result)
             return result
 
     return wrapper
@@ -499,26 +779,34 @@ def _patch(owner: Any, name: str, factory: Callable[[Any], Any]) -> None:
 
 
 def _install_patches() -> None:
-    models = importlib.import_module("mirascope.llm.models.models")
-    model = getattr(models, "Model")
-    for name in ("call", "context_call"):
-        _patch(model, name, _call_wrapper)
-    for name in ("call_async", "context_call_async"):
-        _patch(model, name, _async_call_wrapper)
-    for name in ("stream", "context_stream"):
-        _patch(model, name, _stream_wrapper)
-    for name in ("stream_async", "context_stream_async"):
-        _patch(model, name, _async_stream_wrapper)
+    first_new_patch = len(_PATCHES)
+    try:
+        models = importlib.import_module("mirascope.llm.models.models")
+        model = models.Model
+        for name in ("call", "context_call"):
+            _patch(model, name, _call_wrapper)
+        for name in ("call_async", "context_call_async"):
+            _patch(model, name, _async_call_wrapper)
+        for name in ("stream", "context_stream"):
+            _patch(model, name, _stream_wrapper)
+        for name in ("stream_async", "context_stream_async"):
+            _patch(model, name, _async_stream_wrapper)
 
-    toolkit_module = importlib.import_module("mirascope.llm.tools.toolkit")
-    for class_name in ("Toolkit", "ContextToolkit"):
-        owner = getattr(toolkit_module, class_name, None)
-        if owner is not None:
-            _patch(owner, "execute", _tool_wrapper)
-    for class_name in ("AsyncToolkit", "AsyncContextToolkit"):
-        owner = getattr(toolkit_module, class_name, None)
-        if owner is not None:
-            _patch(owner, "execute", _async_tool_wrapper)
+        toolkit_module = importlib.import_module("mirascope.llm.tools.toolkit")
+        for class_name in ("Toolkit", "ContextToolkit"):
+            owner = getattr(toolkit_module, class_name, None)
+            if owner is not None:
+                _patch(owner, "execute", _tool_wrapper)
+        for class_name in ("AsyncToolkit", "AsyncContextToolkit"):
+            owner = getattr(toolkit_module, class_name, None)
+            if owner is not None:
+                _patch(owner, "execute", _async_tool_wrapper)
+    except Exception:
+        for patch in reversed(_PATCHES[first_new_patch:]):
+            if getattr(patch.owner, patch.name, None) is patch.replacement:
+                setattr(patch.owner, patch.name, patch.original)
+        del _PATCHES[first_new_patch:]
+        raise
 
 
 def _remove_patches() -> None:
@@ -540,7 +828,7 @@ class MirascopeInstrumentor:
     def activate(self) -> None:
         global _CAPTURE_CONTENT, _REFCOUNT
 
-        if self._is_instrumented or not _is_respan_tracing_enabled():
+        if not _is_respan_tracing_enabled():
             return
         try:
             importlib.import_module("mirascope")
@@ -548,9 +836,17 @@ class MirascopeInstrumentor:
             logger.warning("Mirascope instrumentation unavailable: %s", exc)
             return
         with _LOCK:
+            if self._is_instrumented:
+                return
             if _REFCOUNT == 0:
+                previous_capture_content = _CAPTURE_CONTENT
                 _CAPTURE_CONTENT = self._capture_content
-                _install_patches()
+                try:
+                    _install_patches()
+                except Exception as exc:  # noqa: BLE001 - activation is best-effort
+                    _CAPTURE_CONTENT = previous_capture_content
+                    logger.warning("Mirascope instrumentation unavailable: %s", exc)
+                    return
             elif _CAPTURE_CONTENT != self._capture_content:
                 logger.warning(
                     "Mirascope is already instrumented; the first capture_content setting wins"
@@ -561,9 +857,9 @@ class MirascopeInstrumentor:
     def deactivate(self) -> None:
         global _REFCOUNT
 
-        if not self._is_instrumented:
-            return
         with _LOCK:
+            if not self._is_instrumented:
+                return
             self._is_instrumented = False
             _REFCOUNT = max(0, _REFCOUNT - 1)
             if _REFCOUNT == 0:

--- a/python-sdks/instrumentations/respan-instrumentation-mirascope/src/respan_instrumentation_mirascope/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-mirascope/src/respan_instrumentation_mirascope/_serialization.py
@@ -4,60 +4,160 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 from collections.abc import Mapping, Sequence
+from itertools import islice
 from typing import Any
+
+_MAX_DEPTH = 6
+_MAX_ITEMS = 50
+_MAX_STRING_LENGTH = 8_000
+_MAX_JSON_LENGTH = 16_000
+_REDACTED = "[REDACTED]"
+_SENSITIVE_KEYS = {
+    "api-key",
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "cookie",
+    "password",
+    "refresh_token",
+    "secret",
+    "set-cookie",
+    "token",
+}
+_SENSITIVE_TEXT_PATTERNS = (
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+"),
+    re.compile(
+        r"(?i)\b(api[-_ ]?key|authorization|cookie|password|refresh[-_ ]?token|"
+        r"secret|token)([\"']?\s*[:=]\s*[\"']?)([^\s,;\"'}]+)"
+    ),
+)
+
+
+def _bounded_string(value: str) -> str:
+    if len(value) <= _MAX_STRING_LENGTH:
+        return value
+    return f"{value[:_MAX_STRING_LENGTH]}...[truncated]"
+
+
+def safe_text(value: Any) -> str:
+    """Return bounded, redacted text without invoking arbitrary object reprs."""
+    if isinstance(value, str):
+        text = value
+    elif value is None:
+        return ""
+    elif isinstance(value, bool | int | float):
+        text = str(value)
+    elif isinstance(value, bytes):
+        return f"<bytes:{len(value)}>"
+    else:
+        return f"<{type(value).__name__}>"
+    text = _SENSITIVE_TEXT_PATTERNS[0].sub("Bearer [REDACTED]", text)
+    text = _SENSITIVE_TEXT_PATTERNS[1].sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]",
+        text,
+    )
+    return _bounded_string(text)
+
+
+def safe_exception_text(exc: BaseException) -> str:
+    """Render an exception message without invoking an overridden ``__str__``."""
+    try:
+        args = exc.args
+    except Exception:  # noqa: BLE001 - custom exceptions may override attributes
+        args = ()
+    values = args[:4] if isinstance(args, tuple) else ()
+    message = ": ".join(filter(None, (safe_text(value) for value in values)))
+    return _bounded_string(message or type(exc).__name__)
+
+
+def _safe_key(value: Any) -> str:
+    if isinstance(value, str | bool | int | float) or value is None:
+        return safe_text(value)
+    return f"<{type(value).__name__}>"
+
+
+def _is_sensitive_key(value: Any) -> bool:
+    key = _safe_key(value).strip().lower()
+    return key in _SENSITIVE_KEYS or key.endswith(
+        ("_api_key", "_password", "_secret", "_token")
+    )
 
 
 def json_value(value: Any, *, _depth: int = 0, _seen: set[int] | None = None) -> Any:
-    if value is None or isinstance(value, bool | int | float | str):
+    if value is None or isinstance(value, bool | int | float):
         return value
-    if _depth >= 6:
-        return repr(value)[:8_000]
+    if isinstance(value, str):
+        return safe_text(value)
+    if isinstance(value, bytes):
+        return f"<bytes:{len(value)}>"
+    if _depth >= _MAX_DEPTH:
+        return f"<{type(value).__name__}:max-depth>"
     seen = _seen if _seen is not None else set()
     if id(value) in seen:
         return "<cycle>"
     seen.add(id(value))
     try:
         if dataclasses.is_dataclass(value) and not isinstance(value, type):
-            value = dataclasses.asdict(value)
+            value = {
+                field.name: getattr(value, field.name)
+                for field in dataclasses.fields(value)
+            }
         elif callable(getattr(value, "model_dump", None)):
             value = value.model_dump()
         elif callable(getattr(value, "to_dict", None)):
             value = value.to_dict()
-        elif isinstance(value, Mapping):
-            value = dict(value)
-        elif isinstance(value, Sequence) and not isinstance(value, str | bytes):
-            value = list(value)
+        elif isinstance(value, Mapping | Sequence) and not isinstance(
+            value, str | bytes
+        ):
+            pass
+        elif callable(value):
+            return {
+                "name": safe_text(getattr(value, "__name__", value.__class__.__name__)),
+                "description": safe_text(getattr(value, "__doc__", "") or ""),
+            }
         elif hasattr(value, "__dict__"):
             value = {
                 key: item
                 for key, item in vars(value).items()
                 if not key.startswith("_")
             }
-        elif callable(value):
-            return {
-                "name": getattr(value, "__name__", value.__class__.__name__),
-                "description": getattr(value, "__doc__", None),
-            }
         else:
-            return repr(value)[:8_000]
+            return f"<{type(value).__name__}>"
 
         if isinstance(value, Mapping):
-            return {
-                str(key): json_value(item, _depth=_depth + 1, _seen=seen)
-                for key, item in list(value.items())[:50]
-            }
+            normalized: dict[str, Any] = {}
+            for key, item in islice(value.items(), _MAX_ITEMS):
+                normalized_key = _safe_key(key)
+                normalized[normalized_key] = (
+                    _REDACTED
+                    if _is_sensitive_key(normalized_key)
+                    else json_value(item, _depth=_depth + 1, _seen=seen)
+                )
+            return normalized
         if isinstance(value, Sequence) and not isinstance(value, str | bytes):
             return [
                 json_value(item, _depth=_depth + 1, _seen=seen)
-                for item in list(value)[:50]
+                for item in islice(value, _MAX_ITEMS)
             ]
         return value
-    except Exception:
-        return repr(value)[:8_000]
+    except Exception:  # noqa: BLE001 - serializer must tolerate arbitrary vendor values
+        return f"<{type(value).__name__}:unserializable>"
     finally:
         seen.discard(id(value))
 
 
 def json_string(value: Any) -> str:
-    return json.dumps(json_value(value), default=str, sort_keys=True)
+    encoded = json.dumps(json_value(value), ensure_ascii=False, sort_keys=True)
+    if len(encoded) <= _MAX_JSON_LENGTH:
+        return encoded
+    return json.dumps(
+        {
+            "preview": encoded[: _MAX_JSON_LENGTH - 200],
+            "truncated": True,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )

--- a/python-sdks/instrumentations/respan-instrumentation-mirascope/tests/test_backend_status_and_lifecycle.py
+++ b/python-sdks/instrumentations/respan-instrumentation-mirascope/tests/test_backend_status_and_lifecycle.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import pytest
+import respan_instrumentation_mirascope._instrumentation as instrumentation
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.semconv_ai import SpanAttributes
-
-import respan_instrumentation_mirascope._instrumentation as instrumentation
 from respan_instrumentation_mirascope import MirascopeInstrumentor
 
 
@@ -79,3 +80,107 @@ def test_lifecycle_is_reference_counted_and_idempotent(monkeypatch) -> None:
     assert removed == 0
     second.deactivate()
     assert removed == 1
+
+
+def test_same_instance_concurrent_lifecycle_changes_refcount_once(monkeypatch) -> None:
+    installed = 0
+    removed = 0
+
+    class BarrierLock:
+        def __init__(self) -> None:
+            self._barrier = threading.Barrier(2)
+            self._lock = threading.Lock()
+
+        def __enter__(self):
+            self._barrier.wait(timeout=5)
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            self._lock.release()
+
+    def install() -> None:
+        nonlocal installed
+        installed += 1
+
+    def remove() -> None:
+        nonlocal removed
+        removed += 1
+
+    monkeypatch.setattr(instrumentation, "_REFCOUNT", 0)
+    monkeypatch.setattr(instrumentation, "_LOCK", BarrierLock())
+    monkeypatch.setattr(instrumentation, "_install_patches", install)
+    monkeypatch.setattr(instrumentation, "_remove_patches", remove)
+    monkeypatch.setattr(instrumentation, "_is_respan_tracing_enabled", lambda: True)
+    monkeypatch.setattr(
+        instrumentation.importlib, "import_module", lambda name: object()
+    )
+    instrumentor = MirascopeInstrumentor()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(instrumentor.activate) for _ in range(2)]
+        for future in futures:
+            future.result(timeout=5)
+
+    assert installed == 1
+    assert instrumentation._REFCOUNT == 1
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(instrumentor.deactivate) for _ in range(2)]
+        for future in futures:
+            future.result(timeout=5)
+
+    assert removed == 1
+    assert instrumentation._REFCOUNT == 0
+
+
+def test_partial_first_install_rolls_back_every_new_patch(monkeypatch) -> None:
+    class Model:
+        def call(self):
+            return None
+
+        context_call = call
+        call_async = call
+        context_call_async = call
+        stream = call
+        context_stream = call
+        stream_async = call
+        context_stream_async = call
+
+    original_methods = {
+        name: getattr(Model, name)
+        for name in (
+            "call",
+            "context_call",
+            "call_async",
+            "context_call_async",
+            "stream",
+            "context_stream",
+            "stream_async",
+            "context_stream_async",
+        )
+    }
+
+    def import_module(name: str):
+        if name == "mirascope":
+            return object()
+        if name == "mirascope.llm.models.models":
+            return SimpleNamespace(Model=Model)
+        if name == "mirascope.llm.tools.toolkit":
+            raise RuntimeError("deterministic partial install failure")
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(instrumentation, "_REFCOUNT", 0)
+    monkeypatch.setattr(instrumentation, "_PATCHES", [])
+    monkeypatch.setattr(instrumentation, "_CAPTURE_CONTENT", True)
+    monkeypatch.setattr(instrumentation, "_is_respan_tracing_enabled", lambda: True)
+    monkeypatch.setattr(instrumentation.importlib, "import_module", import_module)
+    instrumentor = MirascopeInstrumentor(capture_content=False)
+
+    instrumentor.activate()
+
+    assert instrumentor._is_instrumented is False
+    assert instrumentation._REFCOUNT == 0
+    assert instrumentation._PATCHES == []
+    assert instrumentation._CAPTURE_CONTENT is True
+    assert {name: getattr(Model, name) for name in original_methods} == original_methods

--- a/python-sdks/instrumentations/respan-instrumentation-mirascope/tests/test_mirascope_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-mirascope/tests/test_mirascope_instrumentation.py
@@ -1,25 +1,28 @@
 from __future__ import annotations
 
+import asyncio
+import gc
 import json
 from types import SimpleNamespace
+from typing import ClassVar
 
 import pytest
+import respan_instrumentation_mirascope._instrumentation as instrumentation
+from mirascope import llm
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import StatusCode
-
-import respan_instrumentation_mirascope._instrumentation as instrumentation
 from respan_sdk.constants.span_attributes import RESPAN_LOG_METHOD, RESPAN_LOG_TYPE
 
 
-class Response:
+class FakeResponse:
     provider_id = "openai"
     model_id = "openai/gpt-4.1-mini"
     content = "Hello"
     text = "Hello"
-    tool_calls = []
+    tool_calls: ClassVar[list[object]] = []
     usage = SimpleNamespace(
         input_tokens=5,
         output_tokens=2,
@@ -46,7 +49,7 @@ def test_sync_call_has_canonical_chat_attributes(spans) -> None:
     model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
 
     def call(self, content, **kwargs):
-        return Response()
+        return FakeResponse()
 
     wrapped = instrumentation._call_wrapper(call)
     response = wrapped(model, "Say hello", tools=[lambda city: city])
@@ -60,7 +63,9 @@ def test_sync_call_has_canonical_chat_attributes(spans) -> None:
     assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "gpt-4.1-mini"
     assert attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"] == "Say hello"
     assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "Hello"
-    assert json.loads(attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["name"]
+    tool_definition = json.loads(attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])[0]
+    assert tool_definition["type"] == "function"
+    assert tool_definition["function"]["name"]
     assert attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 5
     assert attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 2
     assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 7
@@ -90,7 +95,7 @@ async def test_async_call_error_is_recorded_and_reraised(spans) -> None:
 
 def test_sync_stream_span_ends_after_consumption(spans) -> None:
     model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
-    response = Response()
+    response = FakeResponse()
     response._chunk_iterator = iter(["a", "b"])
 
     def stream(self, content, **kwargs):
@@ -106,7 +111,7 @@ def test_sync_stream_span_ends_after_consumption(spans) -> None:
 @pytest.mark.asyncio
 async def test_async_stream_error_marks_span(spans) -> None:
     model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
-    response = Response()
+    response = FakeResponse()
 
     async def chunks():
         yield "first"
@@ -131,22 +136,70 @@ async def test_async_stream_error_marks_span(spans) -> None:
     assert output["error"] == "RuntimeError"
 
 
-def test_tool_execution_uses_tool_contract_without_tool_calls(spans) -> None:
-    tool_call = SimpleNamespace(name="weather", args={"city": "Paris"})
-
-    def execute(self, call):
+def test_real_tool_execution_uses_tool_contract_without_transport_envelope(
+    spans,
+) -> None:
+    @llm.tool
+    def weather(city: str) -> dict[str, int]:
+        """Look up deterministic weather."""
+        assert city == "Paris"
         return {"temperature": 18}
 
-    wrapped = instrumentation._tool_wrapper(execute)
-    assert wrapped(object(), tool_call) == {"temperature": 18}
+    tool_call = llm.ToolCall(id="call-1", name="weather", args='{"city":"Paris"}')
+    toolkit = llm.Toolkit(tools=[weather])
+    wrapped = instrumentation._tool_wrapper(llm.Toolkit.execute)
+    result = wrapped(toolkit, tool_call)
+    assert result.result == {"temperature": 18}
     attrs = spans.get_finished_spans()[0].attributes
     assert attrs[RESPAN_LOG_TYPE] == "tool"
     assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] == "weather"
-    assert json.loads(attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {"city": "Paris"}
+    assert json.loads(attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "arguments": {"city": "Paris"},
+        "name": "weather",
+    }
     assert json.loads(attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
         "temperature": 18
     }
     assert not any(key.endswith("tool_calls") for key in attrs)
+
+
+def test_real_tool_error_keeps_result_and_marks_tool_span_failed(spans) -> None:
+    @llm.tool
+    def broken_tool(city: str) -> str:
+        """Raise a deterministic application error."""
+        raise ValueError(f"no weather for {city}")
+
+    tool_call = llm.ToolCall(
+        id="call-error",
+        name="broken_tool",
+        args='{"city":"Paris"}',
+    )
+    toolkit = llm.Toolkit(tools=[broken_tool])
+    result = instrumentation._tool_wrapper(llm.Toolkit.execute)(toolkit, tool_call)
+    assert result.error is not None
+
+    span = spans.get_finished_spans()[0]
+    assert span.status.status_code is StatusCode.ERROR
+    assert span.attributes["status_code"] == 500
+    assert span.attributes["error.message"] == "no weather for Paris"
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == (
+        "no weather for Paris"
+    )
+    assert [event.name for event in span.events] == ["exception"]
+
+
+def test_raised_tool_error_records_one_exception_event(spans) -> None:
+    tool_call = llm.ToolCall(id="call-error", name="broken_tool", args="{}")
+
+    def execute(self, call):
+        raise RuntimeError("tool transport failed")
+
+    with pytest.raises(RuntimeError, match="tool transport failed"):
+        instrumentation._tool_wrapper(execute)(object(), tool_call)
+
+    span = spans.get_finished_spans()[0]
+    assert span.status.status_code is StatusCode.ERROR
+    assert [event.name for event in span.events] == ["exception"]
 
 
 def test_capture_content_false_omits_messages_and_outputs(spans, monkeypatch) -> None:
@@ -154,7 +207,7 @@ def test_capture_content_false_omits_messages_and_outputs(spans, monkeypatch) ->
     model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
 
     def call(self, content, **kwargs):
-        return Response()
+        return FakeResponse()
 
     instrumentation._call_wrapper(call)(model, "secret")
     attrs = spans.get_finished_spans()[0].attributes
@@ -162,3 +215,518 @@ def test_capture_content_false_omits_messages_and_outputs(spans, monkeypatch) ->
     assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in attrs
     assert not any(key.startswith(SpanAttributes.LLM_PROMPTS) for key in attrs)
     assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 7
+
+
+def test_chat_prompt_completion_and_error_attributes_are_bounded(spans) -> None:
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+    response = FakeResponse()
+    response.content = "y" * 40_000
+    response.text = "y" * 40_000
+
+    instrumentation._call_wrapper(lambda self, content: response)(
+        model,
+        "x" * 40_000,
+    )
+    attrs = spans.get_finished_spans()[0].attributes
+    assert len(attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"]) < 8_100
+    assert len(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]) < 8_100
+
+    def fail(self, content):
+        raise RuntimeError("z" * 40_000)
+
+    with pytest.raises(RuntimeError):
+        instrumentation._call_wrapper(fail)(model, "fail")
+    error_attrs = spans.get_finished_spans()[-1].attributes
+    assert len(error_attrs["error.message"]) < 8_100
+
+
+def test_direct_model_provider_and_error_text_are_privacy_safe(spans) -> None:
+    class SecretText:
+        def __str__(self) -> str:
+            return "api_key=direct-attribute-secret"
+
+    model = SimpleNamespace(model_id=SecretText())
+    response = FakeResponse()
+    response.model_id = SecretText()
+    response.provider_id = SecretText()
+
+    instrumentation._call_wrapper(lambda self, content: response)(model, "hello")
+    serialized_attrs = json.dumps(dict(spans.get_finished_spans()[0].attributes))
+    assert "direct-attribute-secret" not in serialized_attrs
+    assert "<SecretText>" in serialized_attrs
+
+    def fail(self, content):
+        raise RuntimeError("Authorization: Bearer direct-error-secret")
+
+    with pytest.raises(RuntimeError):
+        instrumentation._call_wrapper(fail)(model, "fail")
+    error_span = spans.get_finished_spans()[-1]
+    assert "direct-error-secret" not in error_span.attributes["error.message"]
+    assert "[REDACTED]" in error_span.attributes["error.message"]
+
+
+def test_broken_exception_string_cannot_mask_or_leak_call_error(spans) -> None:
+    class BrokenStringError(RuntimeError):
+        stringify_calls = 0
+
+        def __str__(self) -> str:
+            type(self).stringify_calls += 1
+            raise AssertionError("secret-from-broken-exception-string")
+
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+
+    def fail(self, content):
+        raise BrokenStringError("api_key=provider-secret")
+
+    with pytest.raises(BrokenStringError):
+        instrumentation._call_wrapper(fail)(model, "fail")
+
+    span = spans.get_finished_spans()[0]
+    assert BrokenStringError.stringify_calls == 0
+    assert span.attributes["error.message"] == "api_key=[REDACTED]"
+    assert span.events[0].attributes["exception.message"] == "api_key=[REDACTED]"
+
+
+def test_broken_tool_error_string_is_never_invoked(spans) -> None:
+    class BrokenStringError(RuntimeError):
+        stringify_calls = 0
+
+        def __str__(self) -> str:
+            type(self).stringify_calls += 1
+            raise AssertionError("token-from-broken-tool-error")
+
+    tool_call = llm.ToolCall(id="call-error", name="broken_tool", args="{}")
+    result = SimpleNamespace(
+        error=BrokenStringError("token=tool-secret"),
+        result="tool failed",
+    )
+    returned = instrumentation._tool_wrapper(lambda self, call: result)(
+        object(), tool_call
+    )
+
+    assert returned is result
+    span = spans.get_finished_spans()[0]
+    assert BrokenStringError.stringify_calls == 0
+    assert span.attributes["error.message"] == "token=[REDACTED]"
+    assert span.events[0].attributes["exception.message"] == "token=[REDACTED]"
+
+
+def test_real_response_emits_current_turn_tool_call_and_request_definition(
+    spans,
+) -> None:
+    @llm.tool
+    def weather(city: str) -> dict[str, int]:
+        """Look up deterministic weather."""
+        return {"temperature": 18}
+
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+    tool_call = llm.ToolCall(id="call-1", name="weather", args='{"city":"Paris"}')
+    response = llm.Response(
+        raw={},
+        provider_id="openai",
+        model_id="openai/gpt-4.1-mini",
+        provider_model_name="gpt-4.1-mini",
+        params={},
+        tools=[weather],
+        input_messages=[llm.messages.user("Weather in Paris?")],
+        assistant_message=llm.messages.assistant(
+            [tool_call],
+            provider_id="openai",
+            model_id="openai/gpt-4.1-mini",
+        ),
+        finish_reason=None,
+        usage=llm.Usage(input_tokens=24, output_tokens=10),
+    )
+
+    def call(self, content, **kwargs):
+        return response
+
+    instrumentation._call_wrapper(call)(model, "Weather in Paris?", tools=[weather])
+    attrs = spans.get_finished_spans()[0].attributes
+    definitions = json.loads(attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])
+    calls = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])
+    assert definitions == [
+        {
+            "function": {
+                "description": "Look up deterministic weather.",
+                "name": "weather",
+                "parameters": {
+                    "additionalProperties": False,
+                    "properties": {"city": {"title": "City", "type": "string"}},
+                    "required": ["city"],
+                    "type": "object",
+                },
+            },
+            "type": "function",
+        }
+    ]
+    assert calls == [
+        {
+            "function": {
+                "arguments": '{"city":"Paris"}',
+                "name": "weather",
+            },
+            "id": "call-1",
+            "type": "function",
+        }
+    ]
+    assert json.loads(attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "content": "",
+        "tool_calls": calls,
+    }
+    assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 34
+    for alias in (
+        "tools",
+        "tool_calls",
+        "model",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_request_tokens",
+        "span_tools",
+        "has_tool_calls",
+    ):
+        assert alias not in attrs
+
+
+def test_real_sync_stream_sets_stream_flag_and_finishes_content_and_usage(
+    spans,
+) -> None:
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+    response = llm.StreamResponse(
+        provider_id="openai",
+        model_id="openai/gpt-4.1-mini",
+        provider_model_name="gpt-4.1-mini",
+        params={},
+        tools=None,
+        input_messages=[llm.messages.user("Stream a reply")],
+        chunk_iterator=iter(
+            [
+                llm.TextStartChunk(),
+                llm.TextChunk(delta="Mirascope streaming works."),
+                llm.TextEndChunk(),
+                llm.UsageDeltaChunk(input_tokens=12, output_tokens=6),
+            ]
+        ),
+    )
+
+    returned = instrumentation._stream_wrapper(lambda self, content: response)(
+        model, "Stream a reply"
+    )
+    assert list(returned.text_stream()) == ["Mirascope streaming works.", "\n"]
+    attrs = spans.get_finished_spans()[0].attributes
+    assert spans.get_finished_spans()[0].events == ()
+    assert attrs[SpanAttributes.LLM_IS_STREAMING] is True
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        "Mirascope streaming works."
+    )
+    assert attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 12
+    assert attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 6
+
+
+def test_real_sync_stream_close_finalizes_once_without_false_error(spans) -> None:
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+    source_closed = False
+
+    def chunks():
+        nonlocal source_closed
+        try:
+            yield llm.TextStartChunk()
+            yield llm.TextChunk(delta="Partial sync content.")
+            yield llm.TextEndChunk()
+        finally:
+            source_closed = True
+
+    response = llm.StreamResponse(
+        provider_id="openai",
+        model_id="openai/gpt-4.1-mini",
+        provider_model_name="gpt-4.1-mini",
+        params={},
+        tools=None,
+        input_messages=[llm.messages.user("Close sync stream")],
+        chunk_iterator=chunks(),
+    )
+
+    returned = instrumentation._stream_wrapper(lambda self, content: response)(
+        model, "Close sync stream"
+    )
+    chunk_stream = returned._chunk_iterator
+    assert next(chunk_stream).type == "text_start_chunk"
+    assert next(chunk_stream).delta == "Partial sync content."
+    chunk_stream.close()
+    chunk_stream.close()
+
+    exported = spans.get_finished_spans()
+    assert len(exported) == 1
+    assert exported[0].status.status_code is not StatusCode.ERROR
+    assert exported[0].events == ()
+    assert exported[0].attributes["status_code"] == 200
+    assert source_closed is True
+
+
+def test_abandoned_sync_stream_closes_source_and_finalizes_once(spans) -> None:
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+    source_closed = False
+
+    def stream(self, content):
+        nonlocal source_closed
+
+        class Chunks:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                return llm.TextStartChunk()
+
+            def close(self) -> None:
+                nonlocal source_closed
+                source_closed = True
+
+        return llm.StreamResponse(
+            provider_id="openai",
+            model_id="openai/gpt-4.1-mini",
+            provider_model_name="gpt-4.1-mini",
+            params={},
+            tools=None,
+            input_messages=[llm.messages.user("Abandon sync stream")],
+            chunk_iterator=Chunks(),
+        )
+
+    wrapped = instrumentation._stream_wrapper(stream)
+    returned = wrapped(model, "Abandon sync stream")
+    del returned
+    del wrapped
+    gc.collect()
+
+    exported = spans.get_finished_spans()
+    assert source_closed is True
+    assert len(exported) == 1
+    assert exported[0].status.status_code is not StatusCode.ERROR
+
+
+@pytest.mark.asyncio
+async def test_real_async_stream_sets_stream_flag_and_finishes_content(spans) -> None:
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+
+    async def chunks():
+        yield llm.TextStartChunk()
+        yield llm.TextChunk(delta="Async Mirascope stream.")
+        yield llm.TextEndChunk()
+        yield llm.UsageDeltaChunk(input_tokens=8, output_tokens=4)
+
+    response = llm.AsyncStreamResponse(
+        provider_id="openai",
+        model_id="openai/gpt-4.1-mini",
+        provider_model_name="gpt-4.1-mini",
+        params={},
+        tools=None,
+        input_messages=[llm.messages.user("Stream async")],
+        chunk_iterator=chunks(),
+    )
+
+    async def stream(self, content):
+        return response
+
+    returned = await instrumentation._async_stream_wrapper(stream)(
+        model, "Stream async"
+    )
+    collected = [part async for part in returned.text_stream()]
+    assert collected == ["Async Mirascope stream.", "\n"]
+    attrs = spans.get_finished_spans()[0].attributes
+    assert spans.get_finished_spans()[0].events == ()
+    assert attrs[SpanAttributes.LLM_IS_STREAMING] is True
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        "Async Mirascope stream."
+    )
+    assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 12
+
+
+@pytest.mark.asyncio
+async def test_real_async_stream_close_finalizes_once_without_false_error(
+    spans,
+) -> None:
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+    source_closed = False
+
+    async def chunks():
+        nonlocal source_closed
+        try:
+            yield llm.TextStartChunk()
+            yield llm.TextChunk(delta="Partial async content.")
+            yield llm.TextEndChunk()
+        finally:
+            source_closed = True
+
+    response = llm.AsyncStreamResponse(
+        provider_id="openai",
+        model_id="openai/gpt-4.1-mini",
+        provider_model_name="gpt-4.1-mini",
+        params={},
+        tools=None,
+        input_messages=[llm.messages.user("Close async stream")],
+        chunk_iterator=chunks(),
+    )
+
+    async def stream(self, content):
+        return response
+
+    returned = await instrumentation._async_stream_wrapper(stream)(
+        model, "Close async stream"
+    )
+    chunk_stream = returned._chunk_iterator
+    assert (await chunk_stream.__anext__()).type == "text_start_chunk"
+    assert (await chunk_stream.__anext__()).delta == "Partial async content."
+    await chunk_stream.aclose()
+    await chunk_stream.aclose()
+
+    exported = spans.get_finished_spans()
+    assert len(exported) == 1
+    assert exported[0].status.status_code is not StatusCode.ERROR
+    assert exported[0].events == ()
+    assert exported[0].attributes["status_code"] == 200
+    assert source_closed is True
+
+
+@pytest.mark.asyncio
+async def test_abandoned_async_stream_closes_source_and_finalizes_once(spans) -> None:
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+    source_closed = False
+
+    async def stream(self, content):
+        nonlocal source_closed
+
+        class Chunks:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                return llm.TextStartChunk()
+
+            async def aclose(self) -> None:
+                nonlocal source_closed
+                source_closed = True
+
+        return llm.AsyncStreamResponse(
+            provider_id="openai",
+            model_id="openai/gpt-4.1-mini",
+            provider_model_name="gpt-4.1-mini",
+            params={},
+            tools=None,
+            input_messages=[llm.messages.user("Abandon async stream")],
+            chunk_iterator=Chunks(),
+        )
+
+    wrapped = instrumentation._async_stream_wrapper(stream)
+    returned = await wrapped(model, "Abandon async stream")
+    del returned
+    del wrapped
+    gc.collect()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    exported = spans.get_finished_spans()
+    assert source_closed is True
+    assert len(exported) == 1
+    assert exported[0].status.status_code is not StatusCode.ERROR
+
+
+def test_activated_real_model_and_toolkit_export_exact_connected_spans(
+    monkeypatch,
+) -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(
+        instrumentation.trace,
+        "get_tracer",
+        lambda *args, **kwargs: provider.get_tracer("test.mirascope.activated"),
+    )
+    monkeypatch.setattr(instrumentation, "_is_respan_tracing_enabled", lambda: True)
+
+    @llm.tool
+    def weather(city: str) -> dict[str, int]:
+        """Return activated deterministic weather."""
+        return {"temperature": 18 if city == "Paris" else 0}
+
+    class ActivatedProvider:
+        id = "respan-activated"
+        default_scope = "respan-activated/"
+        client = None
+
+        def call(
+            self,
+            *,
+            model_id,
+            messages,
+            toolkit,
+            format=None,
+            **params,
+        ):
+            tool_call = llm.ToolCall(
+                id="activated-call-1",
+                name="weather",
+                args='{"city":"Paris"}',
+            )
+            return llm.Response(
+                raw={"fixture": "activated"},
+                provider_id=self.id,
+                model_id=model_id,
+                provider_model_name=model_id.split("/", 1)[-1],
+                params=params,
+                tools=toolkit,
+                format=format,
+                input_messages=messages,
+                assistant_message=llm.messages.assistant(
+                    [tool_call],
+                    provider_id=self.id,
+                    model_id=model_id,
+                ),
+                finish_reason=None,
+                usage=llm.Usage(input_tokens=9, output_tokens=3),
+            )
+
+    llm.register_provider(ActivatedProvider(), scope="respan-activated/")
+    model = llm.Model("respan-activated/model")
+    instrumentor = instrumentation.MirascopeInstrumentor()
+    instrumentor.activate()
+    instrumentor.activate()
+    try:
+        tracer = provider.get_tracer("test.mirascope.parent")
+        with tracer.start_as_current_span("activated.workflow") as parent:
+            response = model.call("Weather in Paris?", tools=[weather])
+            outputs = response.execute_tools()
+            assert outputs[0].result == {"temperature": 18}
+            parent_span_id = parent.get_span_context().span_id
+    finally:
+        instrumentor.deactivate()
+        instrumentor.deactivate()
+
+    exported = exporter.get_finished_spans()
+    assert len(exported) == 3
+    assert len({span.context.span_id for span in exported}) == 3
+    parent = next(span for span in exported if span.name == "activated.workflow")
+    children = [span for span in exported if span is not parent]
+    assert {span.attributes[RESPAN_LOG_TYPE] for span in children} == {"chat", "tool"}
+    assert {span.parent.span_id for span in children} == {parent_span_id}
+    assert all("traceloop.span.kind" not in span.attributes for span in children)
+
+
+def test_raised_chat_exception_natively_marks_enclosing_span_error(spans) -> None:
+    model = SimpleNamespace(model_id="openai/gpt-4.1-mini")
+
+    class ProviderError(RuntimeError):
+        status_code = 503
+
+    def call(self, content):
+        raise ProviderError("provider unavailable")
+
+    tracer = instrumentation.trace.get_tracer("test.mirascope.parent")
+    with pytest.raises(ProviderError), tracer.start_as_current_span("workflow"):
+        instrumentation._call_wrapper(call)(model, "fail")
+
+    exported = spans.get_finished_spans()
+    chat = next(span for span in exported if span.name.endswith(".chat"))
+    parent = next(span for span in exported if span.name == "workflow")
+    assert chat.status.status_code is StatusCode.ERROR
+    assert chat.attributes["status_code"] == 503
+    assert parent.status.status_code is StatusCode.ERROR
+    assert chat.parent.span_id == parent.context.span_id

--- a/python-sdks/instrumentations/respan-instrumentation-mirascope/tests/test_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-mirascope/tests/test_serialization.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping
+
+from respan_instrumentation_mirascope._serialization import json_string
+
+
+def test_serialization_redacts_secrets_and_bounds_large_values() -> None:
+    payload = {
+        "api_key": "do-not-export",
+        "nested": {"authorization": "Bearer do-not-export"},
+        "prompt": "x" * 40_000,
+    }
+
+    encoded = json_string(payload)
+
+    assert len(encoded) <= 16_000
+    assert "do-not-export" not in encoded
+    assert json.loads(encoded)
+
+
+def test_serialization_does_not_fall_back_to_object_repr() -> None:
+    class SecretRepr:
+        __slots__ = ()
+
+        def __repr__(self) -> str:
+            return "token-from-repr"
+
+    encoded = json_string({"value": SecretRepr()})
+
+    assert "token-from-repr" not in encoded
+    assert json.loads(encoded) == {"value": "<SecretRepr>"}
+
+
+def test_serialization_does_not_stringify_arbitrary_mapping_keys() -> None:
+    class SecretKey:
+        stringify_calls = 0
+
+        def __str__(self) -> str:
+            type(self).stringify_calls += 1
+            return "api_key=key-secret"
+
+    encoded = json_string({SecretKey(): "safe"})
+
+    assert SecretKey.stringify_calls == 0
+    assert "key-secret" not in encoded
+    assert json.loads(encoded) == {"<SecretKey>": "safe"}
+
+
+def test_serialization_redacts_secrets_embedded_in_direct_text() -> None:
+    encoded = json_string(
+        {
+            "message": "Authorization: Bearer direct-text-secret",
+            "query": "api_key=direct-query-secret",
+        }
+    )
+
+    assert "direct-text-secret" not in encoded
+    assert "direct-query-secret" not in encoded
+    assert encoded.count("[REDACTED]") >= 2
+
+
+def test_serialization_reads_only_the_bounded_mapping_prefix() -> None:
+    class CountingMapping(Mapping[str, int]):
+        def __init__(self) -> None:
+            self.iterated = 0
+
+        def __getitem__(self, key: str) -> int:
+            return int(key)
+
+        def __iter__(self) -> Iterator[str]:
+            for index in range(10_000):
+                self.iterated += 1
+                yield str(index)
+
+        def __len__(self) -> int:
+            return 10_000
+
+    value = CountingMapping()
+    encoded = json_string(value)
+
+    assert value.iterated == 50
+    assert len(json.loads(encoded)) == 50

--- a/python-sdks/instrumentations/respan-instrumentation-mistralai/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-mistralai/README.md
@@ -5,7 +5,12 @@ Trace the official `mistralai` Python SDK with Respan.
 This package wraps `openinference-instrumentation-mistralai` and registers
 Respan's OpenInference translator so Mistral AI spans are emitted with the
 canonical `traceloop.*`, `gen_ai.*`, `llm.*`, and `respan.*` fields expected by
-the Respan OTLP pipeline.
+the Respan OTLP pipeline. It covers synchronous and asynchronous chat,
+streaming content and usage, request tool definitions, current-turn tool calls,
+precise provider error status, and interrupted-stream finalization. Duplicate
+native Mistral SDK spans are suppressed only for the SDK's own instrumentation
+scope. Tested dependency support starts at `mistralai==2.9.3` and
+`openinference-instrumentation-mistralai==2.0.6`.
 
 ## Install
 
@@ -44,4 +49,8 @@ respan.shutdown()
 ```
 
 Any keyword arguments passed to `MistralAIInstrumentor(...)` are forwarded to the
-underlying OpenInference instrumentor.
+underlying OpenInference instrumentor. Multiple Respan Mistral instrumentor
+instances share one OpenInference delegate and one normalization processor;
+the final owner deactivates them. Shared instances must use identical keyword
+arguments. An activation with different arguments is rejected and remains
+inactive rather than silently inheriting another instance's configuration.

--- a/python-sdks/instrumentations/respan-instrumentation-mistralai/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-mistralai/pyproject.toml
@@ -14,8 +14,8 @@ python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.1"
 respan-instrumentation-openinference = ">=1.2.2"
-mistralai = ">=2.0.0"
-openinference-instrumentation-mistralai = ">=2.0.0"
+mistralai = ">=2.9.3,<3.0.0"
+openinference-instrumentation-mistralai = ">=2.0.6,<3.0.0"
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
 
 [tool.poetry.plugins."respan.instrumentations"]

--- a/python-sdks/instrumentations/respan-instrumentation-mistralai/src/respan_instrumentation_mistralai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-mistralai/src/respan_instrumentation_mistralai/_instrumentation.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+import math
+import re
+from collections.abc import Mapping, Sequence
+from threading import RLock
+from types import TracebackType
 from typing import Any
 
 from opentelemetry import trace
@@ -26,18 +31,46 @@ MISTRALAI_SDK_TRACER_NAME = "mistralai_sdk_tracer"
 _OFF_CONTRACT_ALIAS_KEYS = (
     RESPAN_SPAN_TOOLS,
     RESPAN_SPAN_TOOL_CALLS,
+    TLSpanAttributes.TRACELOOP_SPAN_KIND,
     "tools",
     "tool_calls",
     "model",
     "prompt_tokens",
     "completion_tokens",
     "total_request_tokens",
+    "span_tools",
+    "has_tool_calls",
+    "parallel_tool_calls",
 )
 _GEN_AI_MESSAGE_PREFIXES = (
     f"{TLSpanAttributes.LLM_PROMPTS}.",
     f"{TLSpanAttributes.LLM_COMPLETIONS}.",
 )
 _TOOL_CALLS_SUFFIX = ".tool_calls"
+_STATUS_CODE_PATTERN = re.compile(r"\bStatus\s+(?P<status>[1-5]\d{2})\b", re.IGNORECASE)
+_SECRET_KEY_PATTERN = re.compile(
+    r"(?:authorization|api[-_ ]?key|access[-_ ]?token|password|secret)",
+    re.IGNORECASE,
+)
+_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+[^\s,;]+")
+_INLINE_SECRET_PATTERN = re.compile(
+    r"(?i)\b(api[-_ ]?key|access[-_ ]?token|password|secret)"
+    r"\s*[:=]\s*[^\s,;]+"
+)
+_MAX_JSON_LENGTH = 16_384
+_MAX_SOURCE_JSON_LENGTH = 65_536
+_MAX_STRING_LENGTH = 4_096
+_MAX_COLLECTION_ITEMS = 64
+_MAX_JSON_DEPTH = 8
+_REDACTED = "[REDACTED]"
+_TRUNCATED = "[TRUNCATED]"
+_UNSUPPORTED = "[UNSUPPORTED]"
+_LIFECYCLE_LOCK = RLock()
+_SHARED_DELEGATE: OpenInferenceInstrumentor | None = None
+_SHARED_CLEANUP_PROCESSOR: _MistralAIOffContractAliasProcessor | None = None
+_SHARED_STREAM_GUARD_PATCH: tuple[Any, type, type] | None = None
+_SHARED_INSTRUMENTOR_KWARGS: dict[str, Any] | None = None
+_SHARED_REFCOUNT = 0
 
 
 def _load_openinference_mistralai_class() -> type:
@@ -61,14 +94,211 @@ def _is_gen_ai_tool_calls_attr(key: str) -> bool:
     return key.endswith(_TOOL_CALLS_SUFFIX) and key.startswith(_GEN_AI_MESSAGE_PREFIXES)
 
 
-def _safe_json_str(value: Any) -> str:
+def _bounded_redacted_text(value: str) -> str:
+    bounded = value[:_MAX_STRING_LENGTH]
+    if len(value) > _MAX_STRING_LENGTH:
+        bounded += _TRUNCATED
+    bounded = _BEARER_PATTERN.sub(f"Bearer {_REDACTED}", bounded)
+    return _INLINE_SECRET_PATTERN.sub(
+        lambda match: f"{match.group(1)}={_REDACTED}",
+        bounded,
+    )
+
+
+def _safe_scalar_text(value: Any) -> str | None:
     if isinstance(value, str):
+        return _bounded_redacted_text(value)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and math.isfinite(value):
+        return str(value)
+    return None
+
+
+def _safe_json_value(
+    value: Any,
+    *,
+    depth: int = 0,
+    key: str | None = None,
+) -> Any:
+    if key is not None and _SECRET_KEY_PATTERN.search(key):
+        return _REDACTED
+    if depth >= _MAX_JSON_DEPTH:
+        return _TRUNCATED
+    if value is None or isinstance(value, (bool, int)):
         return value
-    return json.dumps(value, default=str)
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return _bounded_redacted_text(value)
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        truncated = False
+        for index, (raw_key, item) in enumerate(value.items()):
+            if index >= _MAX_COLLECTION_ITEMS:
+                truncated = True
+                break
+            safe_key = _safe_scalar_text(raw_key)
+            if safe_key is None:
+                continue
+            result[safe_key] = _safe_json_value(
+                item,
+                depth=depth + 1,
+                key=safe_key,
+            )
+        if truncated:
+            result[_TRUNCATED] = True
+        return result
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        result = []
+        truncated = False
+        for index, item in enumerate(value):
+            if index >= _MAX_COLLECTION_ITEMS:
+                truncated = True
+                break
+            result.append(_safe_json_value(item, depth=depth + 1))
+        if truncated:
+            result.append(_TRUNCATED)
+        return result
+    return _UNSUPPORTED
+
+
+def _safe_json_str(value: Any) -> str:
+    candidate = value
+    if isinstance(value, str) and len(value) <= _MAX_SOURCE_JSON_LENGTH:
+        try:
+            candidate = json.loads(value)
+        except (TypeError, ValueError):
+            candidate = value
+
+    sanitized = _safe_json_value(candidate)
+    encoded = json.dumps(
+        sanitized,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    if len(encoded) <= _MAX_JSON_LENGTH:
+        return encoded
+
+    preview = encoded[: _MAX_JSON_LENGTH // 2]
+    return json.dumps(
+        {"preview": preview, "truncated": True},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _json_object(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, str) or not value or len(value) > _MAX_SOURCE_JSON_LENGTH:
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _normalize_tool_call(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+
+    normalized: dict[str, Any] = {}
+    tool_call_id = value.get("id")
+    if tool_call_id not in (None, "") and (safe_id := _safe_scalar_text(tool_call_id)):
+        normalized["id"] = safe_id
+
+    tool_type = value.get("type")
+    if tool_type not in (None, "") and (safe_type := _safe_scalar_text(tool_type)):
+        normalized["type"] = safe_type
+
+    function = value.get("function")
+    if isinstance(function, dict):
+        normalized_function: dict[str, Any] = {}
+        function_name = function.get("name")
+        if function_name not in (None, "") and (
+            safe_name := _safe_scalar_text(function_name)
+        ):
+            normalized_function["name"] = safe_name
+        arguments = function.get("arguments")
+        if arguments is not None:
+            normalized_function["arguments"] = _safe_json_str(arguments)
+        if normalized_function:
+            normalized["function"] = normalized_function
+
+    if "function" in normalized and "type" not in normalized:
+        normalized["type"] = "function"
+    return normalized or None
+
+
+def _current_turn_tool_calls(
+    output_payload: dict[str, Any],
+) -> dict[int, list[dict[str, Any]]]:
+    response_payload = output_payload.get("data", output_payload)
+    if not isinstance(response_payload, dict):
+        return {}
+    choices = response_payload.get("choices")
+    if not isinstance(choices, list):
+        return {}
+
+    result: dict[int, list[dict[str, Any]]] = {}
+    for fallback_index, choice in enumerate(choices):
+        if not isinstance(choice, dict):
+            continue
+        choice_index = choice.get("index", fallback_index)
+        if not isinstance(choice_index, int):
+            choice_index = fallback_index
+        message = choice.get("message") or choice.get("delta")
+        if not isinstance(message, dict):
+            continue
+        raw_calls = message.get("tool_calls")
+        if not isinstance(raw_calls, list):
+            continue
+        calls = [
+            normalized
+            for raw_call in raw_calls
+            if (normalized := _normalize_tool_call(raw_call)) is not None
+        ]
+        if calls:
+            result[choice_index] = calls
+    return result
+
+
+def _exception_details(span: ReadableSpan) -> tuple[str | None, str | None]:
+    for event in reversed(tuple(getattr(span, "events", ()) or ())):
+        if getattr(event, "name", None) != "exception":
+            continue
+        attrs = dict(getattr(event, "attributes", {}) or {})
+        error_type = attrs.get("exception.type")
+        error_message = attrs.get("exception.message")
+        return (
+            safe_error_type.rsplit(".", 1)[-1]
+            if (safe_error_type := _safe_scalar_text(error_type))
+            else None,
+            _safe_scalar_text(error_message),
+        )
+    return None, None
+
+
+def _error_status_code(attrs: dict[str, Any], error_message: str | None) -> int | None:
+    for key in ("http.response.status_code", "http.status_code", "status_code"):
+        value = attrs.get(key)
+        if isinstance(value, int) and 100 <= value <= 599:
+            return value
+        if isinstance(value, str) and value.isdigit() and 100 <= int(value) <= 599:
+            return int(value)
+    if error_message and (match := _STATUS_CODE_PATTERN.search(error_message)):
+        return int(match.group("status"))
+    return None
 
 
 class _MistralAIOffContractAliasProcessor(SpanProcessor):
-    """Clean Mistral spans before the Respan exporter sees them."""
+    """Normalize Mistral spans before the Respan exporter sees them."""
 
     def on_start(self, span: Any, parent_context: Any = None) -> None:
         pass
@@ -93,9 +323,61 @@ class _MistralAIOffContractAliasProcessor(SpanProcessor):
         for key in _OFF_CONTRACT_ALIAS_KEYS:
             attrs.pop(key, None)
 
+        raw_input = attrs.get(TLSpanAttributes.TRACELOOP_ENTITY_INPUT)
+        request_payload = _json_object(raw_input)
+        if raw_input is not None:
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json_str(raw_input)
+        if request_payload is not None:
+            stream = request_payload.get("stream")
+            if isinstance(stream, bool):
+                attrs[TLSpanAttributes.LLM_IS_STREAMING] = stream
+
+            tools = request_payload.get("tools")
+            if isinstance(tools, list) and tools:
+                attrs[TLSpanAttributes.LLM_REQUEST_FUNCTIONS] = _safe_json_str(tools)
+
+        raw_output = attrs.get(TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT)
+        output_payload = _json_object(raw_output)
+        if raw_output is not None:
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json_str(raw_output)
+        if output_payload is not None:
+            for choice_index, tool_calls in _current_turn_tool_calls(
+                output_payload
+            ).items():
+                attrs[
+                    f"{TLSpanAttributes.LLM_COMPLETIONS}.{choice_index}.tool_calls"
+                ] = _safe_json_str(tool_calls)
+
         for key, value in list(attrs.items()):
             if _is_gen_ai_tool_calls_attr(key):
                 attrs[key] = _safe_json_str(value)
+        request_functions = attrs.get(TLSpanAttributes.LLM_REQUEST_FUNCTIONS)
+        if request_functions is not None:
+            attrs[TLSpanAttributes.LLM_REQUEST_FUNCTIONS] = _safe_json_str(
+                request_functions
+            )
+
+        status = getattr(span, "status", None)
+        status_code = getattr(status, "status_code", None)
+        if status_code is trace.StatusCode.ERROR:
+            error_type, error_message = _exception_details(span)
+            provider_status = _error_status_code(attrs, error_message)
+            effective_status = provider_status or 500
+            attrs["status_code"] = effective_status
+            bounded_error = {
+                "error": error_type or "MistralAIError",
+                "message": (
+                    f"Mistral request failed with status {provider_status}"
+                    if provider_status is not None
+                    else "Mistral request failed"
+                ),
+                "status": "error",
+                "status_code": effective_status,
+            }
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json_str(
+                bounded_error
+            )
+            attrs["error.message"] = bounded_error["message"]
 
         span._attributes = attrs
 
@@ -117,13 +399,206 @@ def _active_span_processors() -> tuple[Any, Any]:
     return active_span_processor, processors
 
 
+def _stream_status(exception: BaseException | None) -> trace.Status:
+    if exception is None or isinstance(exception, GeneratorExit):
+        return trace.Status(status_code=trace.StatusCode.OK)
+    return trace.Status(
+        status_code=trace.StatusCode.ERROR,
+        description=f"{type(exception).__name__}: Mistral stream interrupted",
+    )
+
+
+def _finish_guarded_stream(stream: Any, exception: BaseException | None = None) -> None:
+    if getattr(stream, "_self_is_finished", False):
+        return
+    if exception is not None and not isinstance(exception, GeneratorExit):
+        with_span = getattr(stream, "_self_with_span", None)
+        if with_span is not None:
+            with_span.record_exception(exception)
+    try:
+        stream._finish_tracing(status=_stream_status(exception))
+    except Exception:
+        logger.exception("Failed to finalize guarded Mistral stream")
+
+
+async def _close_async_stream_source(
+    source: Any,
+    exception: BaseException | None,
+) -> None:
+    try:
+        exit_method = getattr(source, "__aexit__", None)
+        if callable(exit_method):
+            await exit_method(
+                type(exception) if exception is not None else None,
+                exception,
+                exception.__traceback__ if exception is not None else None,
+            )
+            return
+        close_method = getattr(source, "aclose", None)
+        if callable(close_method):
+            await close_method()
+    except BaseException:
+        logger.debug(
+            "Failed to close guarded Mistral async stream",
+            exc_info=True,
+        )
+
+
+def _install_stream_guards() -> tuple[Any, type, type]:
+    chat_wrapper = importlib.import_module(
+        f"{OPENINFERENCE_MISTRALAI_MODULE}._chat_wrapper"
+    )
+    original_sync_stream = chat_wrapper._Stream
+    original_async_stream = chat_wrapper._AsyncStream
+
+    class _RespanMistralSyncStream(original_sync_stream):
+        def __next__(self) -> Any:
+            try:
+                return super().__next__()
+            except GeneratorExit as exception:
+                _finish_guarded_stream(self, exception)
+                raise
+            except BaseException as exception:
+                _finish_guarded_stream(self, exception)
+                raise
+
+        def __enter__(self) -> Any:
+            enter_method = getattr(self.__wrapped__, "__enter__", None)
+            if callable(enter_method):
+                enter_method()
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> Any:
+            raised: BaseException | None = None
+            try:
+                exit_method = getattr(self.__wrapped__, "__exit__", None)
+                if callable(exit_method):
+                    return exit_method(exc_type, exc_value, traceback)
+                return None
+            except BaseException as exception:
+                raised = exception
+                raise
+            finally:
+                _finish_guarded_stream(self, raised or exc_value)
+
+        def close(self) -> None:
+            raised: BaseException | None = None
+            try:
+                exit_method = getattr(self.__wrapped__, "__exit__", None)
+                if callable(exit_method):
+                    exit_method(None, None, None)
+                    return
+                close_method = getattr(self.__wrapped__, "close", None)
+                if callable(close_method):
+                    close_method()
+            except BaseException as exception:
+                raised = exception
+                raise
+            finally:
+                _finish_guarded_stream(self, raised)
+
+        def __del__(self) -> None:
+            if getattr(self, "_self_is_finished", True):
+                return
+            try:
+                self.close()
+            except BaseException:
+                logger.debug(
+                    "Failed to close abandoned Mistral stream",
+                    exc_info=True,
+                )
+
+        def throw(self, *args: Any) -> Any:
+            target = self.__wrapped__
+            throw_method = getattr(target, "throw", None)
+            if not callable(throw_method):
+                throw_method = getattr(
+                    getattr(target, "generator", None), "throw", None
+                )
+            if not callable(throw_method):
+                raise TypeError("Mistral stream does not support throw")
+            try:
+                result = throw_method(*args)
+            except GeneratorExit as exception:
+                _finish_guarded_stream(self, exception)
+                raise
+            except BaseException as exception:
+                _finish_guarded_stream(self, exception)
+                raise
+            self._process_chunk(result)
+            return result
+
+    class _RespanMistralAsyncStream(original_async_stream):
+        async def stream_async_with_accumulator(self) -> Any:
+            async def generator() -> Any:
+                source = None
+                interruption: BaseException | None = None
+                try:
+                    source = await self.stream
+                    async for event in source:
+                        self._process_chunk(event)
+                        choices = getattr(getattr(event, "data", None), "choices", ())
+                        if choices and choices[0].finish_reason is not None:
+                            self._finish_tracing()
+                        yield event
+                except GeneratorExit as exception:
+                    interruption = exception
+                    raise
+                except BaseException as exception:
+                    interruption = exception
+                    _finish_guarded_stream(self, exception)
+                    raise
+                finally:
+                    _finish_guarded_stream(self, interruption)
+                    if source is not None:
+                        await _close_async_stream_source(source, interruption)
+
+            return generator()
+
+    chat_wrapper._Stream = _RespanMistralSyncStream
+    chat_wrapper._AsyncStream = _RespanMistralAsyncStream
+    return chat_wrapper, original_sync_stream, original_async_stream
+
+
+def _restore_stream_guards(patch: tuple[Any, type, type] | None) -> None:
+    if patch is None:
+        return
+    chat_wrapper, original_sync_stream, original_async_stream = patch
+    chat_wrapper._Stream = original_sync_stream
+    chat_wrapper._AsyncStream = original_async_stream
+
+
+def _instrumentor_kwargs_match(
+    left: Mapping[str, Any],
+    right: Mapping[str, Any] | None,
+) -> bool:
+    if right is None or left.keys() != right.keys():
+        return False
+    for key, left_value in left.items():
+        right_value = right[key]
+        if left_value is right_value:
+            continue
+        try:
+            matches = left_value == right_value
+        except (TypeError, ValueError):
+            return False
+        if not isinstance(matches, bool) or not matches:
+            return False
+    return True
+
+
 class MistralAIInstrumentor:
     """Respan instrumentor for the official Mistral AI Python SDK."""
 
     name = MISTRALAI_INSTRUMENTATION_NAME
 
     def __init__(self, **instrumentor_kwargs: Any) -> None:
-        self._instrumentor_kwargs = instrumentor_kwargs
+        self._instrumentor_kwargs = dict(instrumentor_kwargs)
         self._delegate = None
         self._cleanup_processor = None
         self._is_instrumented = False
@@ -137,6 +612,12 @@ class MistralAIInstrumentor:
 
     def activate(self) -> None:
         """Instrument Mistral AI via OpenInference and Respan's translator."""
+        global _SHARED_CLEANUP_PROCESSOR
+        global _SHARED_DELEGATE
+        global _SHARED_INSTRUMENTOR_KWARGS
+        global _SHARED_REFCOUNT
+        global _SHARED_STREAM_GUARD_PATCH
+
         if self._is_instrumented:
             return
 
@@ -155,35 +636,80 @@ class MistralAIInstrumentor:
             )
             return
 
-        try:
-            self._delegate = OpenInferenceInstrumentor(
-                mistralai_instrumentor_class,
-                **self._instrumentor_kwargs,
-            )
-            self._delegate.activate()
-            self._register_cleanup_processor()
-            self._is_instrumented = True
-            logger.info("Mistral AI instrumentation activated")
-        except Exception:
-            if self._delegate is not None:
-                try:
-                    self._delegate.deactivate()
-                except Exception:
-                    logger.exception("Failed to clean up Mistral AI instrumentation")
-            self._delegate = None
-            self._cleanup_processor = None
-            self._is_instrumented = False
-            logger.exception("Failed to activate Mistral AI instrumentation")
+        with _LIFECYCLE_LOCK:
+            if self._is_instrumented:
+                return
+            if _SHARED_REFCOUNT:
+                if not _instrumentor_kwargs_match(
+                    self._instrumentor_kwargs,
+                    _SHARED_INSTRUMENTOR_KWARGS,
+                ):
+                    logger.warning(
+                        "Mistral AI instrumentation activation rejected because "
+                        "an active instance uses different configuration"
+                    )
+                    return
+                self._delegate = _SHARED_DELEGATE
+                self._cleanup_processor = _SHARED_CLEANUP_PROCESSOR
+                self._is_instrumented = True
+                _SHARED_REFCOUNT += 1
+                logger.info(
+                    "Mistral AI instrumentation activation shared (%d owners)",
+                    _SHARED_REFCOUNT,
+                )
+                return
 
-    def _register_cleanup_processor(self) -> None:
+            delegate = None
+            cleanup_processor = None
+            stream_guard_patch = None
+            try:
+                delegate = OpenInferenceInstrumentor(
+                    mistralai_instrumentor_class,
+                    **self._instrumentor_kwargs,
+                )
+                delegate.activate()
+                stream_guard_patch = _install_stream_guards()
+                cleanup_processor = self._register_cleanup_processor()
+                if cleanup_processor is None:
+                    raise RuntimeError(
+                        "Mistral AI cleanup processor could not be registered"
+                    )
+                _SHARED_DELEGATE = delegate
+                _SHARED_CLEANUP_PROCESSOR = cleanup_processor
+                _SHARED_STREAM_GUARD_PATCH = stream_guard_patch
+                _SHARED_INSTRUMENTOR_KWARGS = dict(self._instrumentor_kwargs)
+                _SHARED_REFCOUNT = 1
+                self._delegate = delegate
+                self._cleanup_processor = cleanup_processor
+                self._is_instrumented = True
+                logger.info("Mistral AI instrumentation activated")
+            except Exception:
+                if cleanup_processor is not None:
+                    self._unregister_cleanup_processor(cleanup_processor)
+                _restore_stream_guards(stream_guard_patch)
+                if delegate is not None:
+                    try:
+                        delegate.deactivate()
+                    except Exception:
+                        logger.exception(
+                            "Failed to clean up Mistral AI instrumentation"
+                        )
+                self._delegate = None
+                self._cleanup_processor = None
+                self._is_instrumented = False
+                logger.exception("Failed to activate Mistral AI instrumentation")
+
+    def _register_cleanup_processor(
+        self,
+    ) -> _MistralAIOffContractAliasProcessor | None:
         translator_getter = getattr(OpenInferenceInstrumentor, "_get_translator", None)
         if translator_getter is None:
-            return
+            return None
 
         translator = translator_getter()
         active_span_processor, processors = _active_span_processors()
         if active_span_processor is None or processors is None:
-            return
+            return None
 
         cleanup_processor = _MistralAIOffContractAliasProcessor()
         rebuilt_processors = []
@@ -199,10 +725,14 @@ class MistralAIInstrumentor:
 
         if inserted:
             active_span_processor._span_processors = tuple(rebuilt_processors)
-            self._cleanup_processor = cleanup_processor
+            return cleanup_processor
+        return None
 
-    def _unregister_cleanup_processor(self) -> None:
-        if self._cleanup_processor is None:
+    @staticmethod
+    def _unregister_cleanup_processor(
+        cleanup_processor: _MistralAIOffContractAliasProcessor | None,
+    ) -> None:
+        if cleanup_processor is None:
             return
 
         active_span_processor, processors = _active_span_processors()
@@ -210,18 +740,46 @@ class MistralAIInstrumentor:
             active_span_processor._span_processors = tuple(
                 processor
                 for processor in processors
-                if processor is not self._cleanup_processor
+                if processor is not cleanup_processor
             )
-        self._cleanup_processor = None
 
     def deactivate(self) -> None:
         """Deactivate the instrumentation."""
-        self._unregister_cleanup_processor()
-        if self._is_instrumented and self._delegate is not None:
-            try:
-                self._delegate.deactivate()
-            except Exception:
-                logger.exception("Failed to deactivate Mistral AI instrumentation")
-        self._delegate = None
-        self._is_instrumented = False
-        logger.info("Mistral AI instrumentation deactivated")
+        global _SHARED_CLEANUP_PROCESSOR
+        global _SHARED_DELEGATE
+        global _SHARED_INSTRUMENTOR_KWARGS
+        global _SHARED_REFCOUNT
+        global _SHARED_STREAM_GUARD_PATCH
+
+        with _LIFECYCLE_LOCK:
+            if not self._is_instrumented:
+                return
+
+            self._is_instrumented = False
+            _SHARED_REFCOUNT = max(0, _SHARED_REFCOUNT - 1)
+            if _SHARED_REFCOUNT:
+                self._delegate = None
+                self._cleanup_processor = None
+                logger.info(
+                    "Mistral AI instrumentation remains active (%d owners)",
+                    _SHARED_REFCOUNT,
+                )
+                return
+
+            cleanup_processor = _SHARED_CLEANUP_PROCESSOR
+            delegate = _SHARED_DELEGATE
+            self._unregister_cleanup_processor(cleanup_processor)
+            _restore_stream_guards(_SHARED_STREAM_GUARD_PATCH)
+            if delegate is not None:
+                try:
+                    delegate.deactivate()
+                except Exception:
+                    logger.exception("Failed to deactivate Mistral AI instrumentation")
+
+            _SHARED_CLEANUP_PROCESSOR = None
+            _SHARED_DELEGATE = None
+            _SHARED_STREAM_GUARD_PATCH = None
+            _SHARED_INSTRUMENTOR_KWARGS = None
+            self._delegate = None
+            self._cleanup_processor = None
+            logger.info("Mistral AI instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-mistralai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-mistralai/tests/test_instrumentation.py
@@ -1,12 +1,13 @@
 import json
 import logging
 import sys
+import threading
 from types import ModuleType, SimpleNamespace
+from typing import ClassVar
 
 import pytest
-
-from respan_instrumentation_mistralai import MistralAIInstrumentor
-from respan_instrumentation_mistralai import _instrumentation
+from opentelemetry import trace
+from respan_instrumentation_mistralai import MistralAIInstrumentor, _instrumentation
 from respan_instrumentation_mistralai._instrumentation import (
     MISTRALAI_SDK_TRACER_NAME,
     OPENINFERENCE_MISTRALAI_MODULE,
@@ -20,11 +21,13 @@ from respan_tracing.core.tracer import RespanTracer
 
 
 def _install_fake_modules(monkeypatch):
+    translator = object()
+
     class FakeMistralAIInstrumentor:
         pass
 
     class FakeOpenInferenceInstrumentor:
-        created = []
+        created: ClassVar[list] = []
 
         def __init__(self, instrumentor_class, **kwargs):
             self.instrumentor_class = instrumentor_class
@@ -38,6 +41,10 @@ def _install_fake_modules(monkeypatch):
 
         def deactivate(self):
             self.is_deactivated = True
+
+        @classmethod
+        def _get_translator(cls):
+            return translator
 
     openinference_module = ModuleType("openinference")
     openinference_instrumentation_module = ModuleType("openinference.instrumentation")
@@ -62,16 +69,35 @@ def _install_fake_modules(monkeypatch):
         "OpenInferenceInstrumentor",
         FakeOpenInferenceInstrumentor,
     )
+    active_span_processor = SimpleNamespace(_span_processors=(translator,))
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: SimpleNamespace(_active_span_processor=active_span_processor),
+    )
+    monkeypatch.setattr(
+        _instrumentation,
+        "_install_stream_guards",
+        lambda: (SimpleNamespace(), object, object),
+    )
+    monkeypatch.setattr(_instrumentation, "_restore_stream_guards", lambda _patch: None)
 
     return SimpleNamespace(
         mistralai_instrumentor_class=FakeMistralAIInstrumentor,
         openinference_instrumentor_class=FakeOpenInferenceInstrumentor,
+        translator=translator,
+        active_span_processor=active_span_processor,
     )
 
 
 @pytest.fixture(autouse=True)
-def reset_tracer():
+def reset_tracer(monkeypatch):
     RespanTracer.reset_instance()
+    monkeypatch.setattr(_instrumentation, "_SHARED_DELEGATE", None)
+    monkeypatch.setattr(_instrumentation, "_SHARED_CLEANUP_PROCESSOR", None)
+    monkeypatch.setattr(_instrumentation, "_SHARED_STREAM_GUARD_PATCH", None)
+    monkeypatch.setattr(_instrumentation, "_SHARED_INSTRUMENTOR_KWARGS", None)
+    monkeypatch.setattr(_instrumentation, "_SHARED_REFCOUNT", 0)
     yield
     RespanTracer.reset_instance()
 
@@ -187,8 +213,40 @@ def test_cleanup_processor_removes_mistralai_off_contract_aliases():
             "completion_tokens": 5,
             "total_request_tokens": 15,
             "llm.request.functions": "[]",
+            "traceloop.span.kind": "chat",
+            "traceloop.entity.input": json.dumps(
+                {
+                    "api_key": "raw-input-secret",
+                    "messages": [
+                        {
+                            "content": "Bearer raw-input-token" + ("x" * 20_000),
+                            "role": "user",
+                        }
+                    ],
+                    "stream": False,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {"name": "lookup", "parameters": {}},
+                        }
+                    ],
+                }
+            ),
+            "traceloop.entity.output": json.dumps(
+                {
+                    "authorization": {"nested": "raw-output-secret"},
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"tool_calls": tool_calls},
+                        }
+                    ],
+                }
+            ),
             "gen_ai.completion.0.tool_calls": tool_calls,
         },
+        status=trace.Status(trace.StatusCode.OK),
+        events=(),
     )
 
     _instrumentation._MistralAIOffContractAliasProcessor().on_end(span)
@@ -202,15 +260,33 @@ def test_cleanup_processor_removes_mistralai_off_contract_aliases():
         "prompt_tokens",
         "completion_tokens",
         "total_request_tokens",
+        "traceloop.span.kind",
     ):
         assert key not in span._attributes
-    assert span._attributes["llm.request.functions"] == "[]"
+    assert json.loads(span._attributes["llm.request.functions"]) == [
+        {
+            "type": "function",
+            "function": {"name": "lookup", "parameters": {}},
+        }
+    ]
+    assert span._attributes["llm.is_streaming"] is False
     assert json.loads(span._attributes["gen_ai.completion.0.tool_calls"]) == tool_calls
+    safe_input = span._attributes["traceloop.entity.input"]
+    safe_output = span._attributes["traceloop.entity.output"]
+    assert len(safe_input) <= _instrumentation._MAX_JSON_LENGTH
+    assert len(safe_output) <= _instrumentation._MAX_JSON_LENGTH
+    assert json.loads(safe_input)["api_key"] == "[REDACTED]"
+    assert json.loads(safe_output)["authorization"] == "[REDACTED]"
+    assert "raw-input-secret" not in safe_input
+    assert "raw-input-token" not in safe_input
+    assert "raw-output-secret" not in safe_output
 
 
 def test_cleanup_processor_ignores_non_mistralai_spans():
     span = SimpleNamespace(
-        instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.other"),
+        instrumentation_scope=SimpleNamespace(
+            name="openinference.instrumentation.other"
+        ),
         _attributes={
             "tools": [],
             "gen_ai.completion.0.tool_calls": [],
@@ -238,13 +314,254 @@ def test_cleanup_processor_drops_native_mistral_sdk_spans_from_respan_export():
     assert span._attributes["gen_ai.system"] == "mistralai"
 
 
+def test_cleanup_processor_does_not_mutate_unrelated_sdk_span():
+    span = SimpleNamespace(
+        instrumentation_scope=SimpleNamespace(name="unrelated_sdk_tracer"),
+        _attributes={"gen_ai.system": "other"},
+    )
+
+    _instrumentation._MistralAIOffContractAliasProcessor().on_end(span)
+
+    assert span._attributes == {"gen_ai.system": "other"}
+
+
+def test_cleanup_processor_preserves_precise_native_error_status():
+    unsafe_value = "api_key=should-not-survive-" + ("x" * 20_000)
+    span = SimpleNamespace(
+        instrumentation_scope=SimpleNamespace(name=OPENINFERENCE_MISTRALAI_MODULE),
+        _attributes={
+            "traceloop.span.kind": "chat",
+            "traceloop.entity.input": json.dumps(
+                {"model": "mistral-small-latest", "stream": False}
+            ),
+            "traceloop.entity.output": unsafe_value,
+            "error.message": unsafe_value,
+        },
+        status=trace.Status(
+            trace.StatusCode.ERROR,
+            'SDKError: Status 401. Body: {"request_id":"do-not-copy"}',
+        ),
+        events=(
+            SimpleNamespace(
+                name="exception",
+                attributes={
+                    "exception.type": "mistralai.client.errors.sdkerror.SDKError",
+                    "exception.message": (
+                        "API error occurred: Status 401. Body: "
+                        '{"request_id":"do-not-copy"}'
+                    ),
+                },
+            ),
+        ),
+    )
+
+    _instrumentation._MistralAIOffContractAliasProcessor().on_end(span)
+
+    assert span._attributes["status_code"] == 401
+    assert span._attributes["error.message"] == "Mistral request failed with status 401"
+    assert json.loads(span._attributes["traceloop.entity.output"]) == {
+        "error": "SDKError",
+        "message": "Mistral request failed with status 401",
+        "status": "error",
+        "status_code": 401,
+    }
+    assert "request_id" not in span._attributes["traceloop.entity.output"]
+    assert "should-not-survive" not in span._attributes["traceloop.entity.output"]
+    assert "should-not-survive" not in span._attributes["error.message"]
+    assert "traceloop.span.kind" not in span._attributes
+
+
+def test_safe_json_is_bounded_redacted_and_never_uses_arbitrary_repr():
+    class UnsafeRepresentation:
+        def __str__(self):
+            raise AssertionError("arbitrary __str__ must not be called")
+
+    encoded = _instrumentation._safe_json_str(
+        {
+            "api_key": "secret-value",
+            "authorization": "Bearer top-secret",
+            "content": "Bearer another-secret " + ("z" * 40_000),
+            "parameters": {"properties": {"api_key": {"type": "string"}}},
+            "unsupported": UnsafeRepresentation(),
+        }
+    )
+    payload = json.loads(encoded)
+
+    assert len(encoded) <= _instrumentation._MAX_JSON_LENGTH
+    assert "secret-value" not in encoded
+    assert "top-secret" not in encoded
+    assert "another-secret" not in encoded
+    assert payload["api_key"] == "[REDACTED]"
+    assert payload["authorization"] == "[REDACTED]"
+    assert payload["parameters"]["properties"]["api_key"] == "[REDACTED]"
+    assert payload["unsupported"] == "[UNSUPPORTED]"
+
+
+def test_concurrent_activation_of_same_instance_has_one_shared_owner(monkeypatch):
+    fake = _install_fake_modules(monkeypatch)
+    activation_entered = threading.Event()
+    second_reached_lock = threading.Event()
+    release_activation = threading.Event()
+    load_lock = threading.Lock()
+    load_count = 0
+
+    def tracked_load():
+        nonlocal load_count
+        with load_lock:
+            load_count += 1
+            if load_count == 2:
+                second_reached_lock.set()
+        return fake.mistralai_instrumentor_class
+
+    monkeypatch.setattr(
+        _instrumentation,
+        "_load_openinference_mistralai_class",
+        tracked_load,
+    )
+
+    def slow_activate(delegate):
+        delegate.is_activated = True
+        activation_entered.set()
+        assert release_activation.wait(timeout=5)
+
+    monkeypatch.setattr(
+        fake.openinference_instrumentor_class,
+        "activate",
+        slow_activate,
+    )
+    instrumentor = MistralAIInstrumentor()
+
+    first = threading.Thread(target=instrumentor.activate)
+    second = threading.Thread(target=instrumentor.activate)
+    first.start()
+    assert activation_entered.wait(timeout=5)
+    second.start()
+    assert second_reached_lock.wait(timeout=5)
+    release_activation.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert len(fake.openinference_instrumentor_class.created) == 1
+    assert instrumentor._is_instrumented is True
+    assert _instrumentation._SHARED_REFCOUNT == 1
+
+    instrumentor.deactivate()
+    assert _instrumentation._SHARED_REFCOUNT == 0
+
+
+def test_two_instances_share_cleanup_and_delegate_lifecycle(monkeypatch):
+    fake = _install_fake_modules(monkeypatch)
+    translator = object()
+    exporter = object()
+
+    class FakeOpenInferenceInstrumentor(fake.openinference_instrumentor_class):
+        created: ClassVar[list] = []
+
+        @classmethod
+        def _get_translator(cls):
+            return translator
+
+    active_span_processor = SimpleNamespace(_span_processors=(translator, exporter))
+    tracer_provider = SimpleNamespace(_active_span_processor=active_span_processor)
+    monkeypatch.setattr(
+        _instrumentation,
+        "OpenInferenceInstrumentor",
+        FakeOpenInferenceInstrumentor,
+    )
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: tracer_provider,
+    )
+
+    first = MistralAIInstrumentor()
+    second = MistralAIInstrumentor()
+    first.activate()
+    first.activate()
+    second.activate()
+
+    assert len(FakeOpenInferenceInstrumentor.created) == 1
+    assert _instrumentation._SHARED_REFCOUNT == 2
+    assert (
+        sum(
+            isinstance(
+                processor,
+                _instrumentation._MistralAIOffContractAliasProcessor,
+            )
+            for processor in active_span_processor._span_processors
+        )
+        == 1
+    )
+
+    delegate = FakeOpenInferenceInstrumentor.created[0]
+    first.deactivate()
+    first.deactivate()
+    assert delegate.is_deactivated is False
+    assert _instrumentation._SHARED_REFCOUNT == 1
+
+    second.deactivate()
+    assert delegate.is_deactivated is True
+    assert active_span_processor._span_processors == (translator, exporter)
+    assert _instrumentation._SHARED_REFCOUNT == 0
+
+
+def test_second_instance_with_different_kwargs_is_rejected(monkeypatch, caplog):
+    fake = _install_fake_modules(monkeypatch)
+    first = MistralAIInstrumentor(trace_content=False)
+    second = MistralAIInstrumentor(trace_content=True)
+
+    first.activate()
+    with caplog.at_level(logging.WARNING):
+        second.activate()
+
+    assert len(fake.openinference_instrumentor_class.created) == 1
+    assert first._is_instrumented is True
+    assert second._is_instrumented is False
+    assert _instrumentation._SHARED_REFCOUNT == 1
+    assert "active instance uses different configuration" in caplog.text
+
+    second.deactivate()
+    first.deactivate()
+
+
+def test_activation_rolls_back_when_cleanup_registration_fails(
+    monkeypatch,
+    caplog,
+):
+    fake = _install_fake_modules(monkeypatch)
+    restored = []
+    monkeypatch.setattr(
+        MistralAIInstrumentor,
+        "_register_cleanup_processor",
+        lambda _self: None,
+    )
+    monkeypatch.setattr(
+        _instrumentation,
+        "_restore_stream_guards",
+        lambda patch: restored.append(patch),
+    )
+    instrumentor = MistralAIInstrumentor()
+
+    with caplog.at_level(logging.ERROR):
+        instrumentor.activate()
+
+    delegate = fake.openinference_instrumentor_class.created[0]
+    assert delegate.is_deactivated is True
+    assert instrumentor._is_instrumented is False
+    assert _instrumentation._SHARED_REFCOUNT == 0
+    assert len(restored) == 1
+    assert "cleanup processor could not be registered" in caplog.text
+
+
 def test_activate_places_cleanup_after_openinference_translator(monkeypatch):
     fake = _install_fake_modules(monkeypatch)
     translator = object()
     exporter = object()
 
     class FakeOpenInferenceInstrumentor(fake.openinference_instrumentor_class):
-        created = []
+        created: ClassVar[list] = []
 
         @classmethod
         def _get_translator(cls):

--- a/python-sdks/instrumentations/respan-instrumentation-mistralai/tests/test_real_sdk_spans.py
+++ b/python-sdks/instrumentations/respan-instrumentation-mistralai/tests/test_real_sdk_spans.py
@@ -1,0 +1,555 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+import respan_instrumentation_mistralai._instrumentation as instrumentation
+from mistralai.client import Mistral
+from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_instrumentation_mistralai import MistralAIInstrumentor
+from respan_instrumentation_openinference import OpenInferenceInstrumentor
+from respan_tracing.constants.tracing import SAMPLE_RATE_ATTR
+
+MODEL = "mistral-small-latest"
+TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Return deterministic weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+OFF_CONTRACT_ALIASES = {
+    "traceloop.span.kind",
+    "respan.span.tools",
+    "respan.span.tool_calls",
+    "tools",
+    "tool_calls",
+    "model",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_request_tokens",
+    "span_tools",
+    "has_tool_calls",
+    "parallel_tool_calls",
+}
+
+
+def _completion_response(
+    *,
+    content: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    message: dict[str, Any] = {"role": "assistant", "content": content}
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    return {
+        "id": "cmpl_deterministic",
+        "object": "chat.completion",
+        "model": MODEL,
+        "created": 1_710_000_000,
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": "tool_calls" if tool_calls else "stop",
+            }
+        ],
+    }
+
+
+def _stream_body(
+    *,
+    first: str,
+    second: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+) -> str:
+    chunks = [
+        {
+            "id": "stream_deterministic",
+            "object": "chat.completion.chunk",
+            "model": MODEL,
+            "created": 1_710_000_000,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": first},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "stream_deterministic",
+            "object": "chat.completion.chunk",
+            "model": MODEL,
+            "created": 1_710_000_000,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": second},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        },
+    ]
+    return "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks) + (
+        "data: [DONE]\n\n"
+    )
+
+
+def _sync_client(handler: Callable[[httpx.Request], httpx.Response]) -> Mistral:
+    return Mistral(
+        api_key="test-secret-key",
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+
+def _async_client(handler: Callable[[httpx.Request], httpx.Response]) -> Mistral:
+    async def async_handler(request: httpx.Request) -> httpx.Response:
+        return handler(request)
+
+    return Mistral(
+        api_key="test-secret-key",
+        async_client=httpx.AsyncClient(transport=httpx.MockTransport(async_handler)),
+    )
+
+
+def _mistral_spans(spans: tuple[ReadableSpan, ...]) -> list[ReadableSpan]:
+    return [
+        span
+        for span in spans
+        if span.instrumentation_scope.name
+        == instrumentation.OPENINFERENCE_MISTRALAI_MODULE
+    ]
+
+
+def test_current_sdk_exports_complete_canonical_spans(monkeypatch) -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(trace, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_translator_registered", False)
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_translator", None)
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_active_span_processors", [])
+    monkeypatch.setattr(instrumentation, "_SHARED_DELEGATE", None)
+    monkeypatch.setattr(instrumentation, "_SHARED_CLEANUP_PROCESSOR", None)
+    monkeypatch.setattr(instrumentation, "_SHARED_STREAM_GUARD_PATCH", None)
+    monkeypatch.setattr(instrumentation, "_SHARED_INSTRUMENTOR_KWARGS", None)
+    monkeypatch.setattr(instrumentation, "_SHARED_REFCOUNT", 0)
+
+    instrumentor = MistralAIInstrumentor()
+    instrumentor.activate()
+    parent_tracer = provider.get_tracer("test.mistralai.parents")
+    parent_ids: set[int] = set()
+
+    def sync_handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        prompt = payload["messages"][-1]["content"]
+        if prompt == "sync stream":
+            return httpx.Response(
+                200,
+                content=_stream_body(
+                    first="sync ",
+                    second="complete",
+                    prompt_tokens=11,
+                    completion_tokens=3,
+                ),
+                headers={"content-type": "text/event-stream"},
+                request=request,
+            )
+        if prompt == "weather in Paris":
+            return httpx.Response(
+                200,
+                json=_completion_response(
+                    content="",
+                    prompt_tokens=13,
+                    completion_tokens=5,
+                    tool_calls=[
+                        {
+                            "id": "call_weather_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Paris"}',
+                            },
+                        }
+                    ],
+                ),
+                request=request,
+            )
+        if prompt == "provider failure":
+            return httpx.Response(
+                401,
+                json={"message": "invalid api key", "request_id": "request_123"},
+                request=request,
+            )
+        if prompt == "application failure":
+            raise RuntimeError("deterministic Mistral transport failure")
+        return httpx.Response(
+            200,
+            json=_completion_response(
+                content="sync complete",
+                prompt_tokens=7,
+                completion_tokens=2,
+            ),
+            request=request,
+        )
+
+    def async_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=_stream_body(
+                first="async ",
+                second="complete",
+                prompt_tokens=17,
+                completion_tokens=4,
+            ),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    with _sync_client(sync_handler) as client:
+        with parent_tracer.start_as_current_span("root.sync") as parent:
+            parent_ids.add(parent.get_span_context().span_id)
+            response = client.chat.complete(
+                model=MODEL,
+                messages=[{"role": "user", "content": "sync complete"}],
+            )
+            assert response.choices[0].message.content == "sync complete"
+
+        with parent_tracer.start_as_current_span("root.sync-stream") as parent:
+            parent_ids.add(parent.get_span_context().span_id)
+            chunks = client.chat.stream(
+                model=MODEL,
+                messages=[{"role": "user", "content": "sync stream"}],
+            )
+            assert "".join(
+                event.data.choices[0].delta.content or "" for event in chunks
+            ) == ("sync complete")
+
+        with parent_tracer.start_as_current_span("root.tool") as parent:
+            parent_ids.add(parent.get_span_context().span_id)
+            tool_response = client.chat.complete(
+                model=MODEL,
+                messages=[{"role": "user", "content": "weather in Paris"}],
+                tools=[TOOL],
+                tool_choice="auto",
+            )
+            assert tool_response.choices[0].message.tool_calls[0].id == "call_weather_1"
+
+        with (
+            pytest.raises(Exception, match="Status 401"),
+            parent_tracer.start_as_current_span("root.provider-error") as parent,
+        ):
+            parent_ids.add(parent.get_span_context().span_id)
+            client.chat.complete(
+                model=MODEL,
+                messages=[{"role": "user", "content": "provider failure"}],
+            )
+
+        with (
+            pytest.raises(RuntimeError, match="deterministic Mistral"),
+            parent_tracer.start_as_current_span("root.application-error") as parent,
+        ):
+            parent_ids.add(parent.get_span_context().span_id)
+            client.chat.complete(
+                model=MODEL,
+                messages=[{"role": "user", "content": "application failure"}],
+            )
+
+    async def run_async_stream() -> None:
+        async with _async_client(async_handler) as client:
+            with parent_tracer.start_as_current_span("root.async-stream") as parent:
+                parent_ids.add(parent.get_span_context().span_id)
+                chunks = await client.chat.stream_async(
+                    model=MODEL,
+                    messages=[{"role": "user", "content": "async stream"}],
+                )
+                content = ""
+                async for event in chunks:
+                    content += event.data.choices[0].delta.content or ""
+                assert content == "async complete"
+
+    asyncio.run(run_async_stream())
+
+    instrumentor.deactivate()
+    provider.force_flush()
+
+    finished = exporter.get_finished_spans()
+    mistral_spans = _mistral_spans(finished)
+    assert len(mistral_spans) == 6
+    assert len({span.context.span_id for span in mistral_spans}) == 6
+    assert {span.parent.span_id for span in mistral_spans} == parent_ids
+
+    parent_spans = {
+        span.name: span
+        for span in finished
+        if span.instrumentation_scope.name == "test.mistralai.parents"
+    }
+    assert parent_spans["root.provider-error"].status.status_code is (
+        trace.StatusCode.ERROR
+    )
+    assert parent_spans["root.application-error"].status.status_code is (
+        trace.StatusCode.ERROR
+    )
+
+    by_prompt = {
+        span.attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"]: span
+        for span in mistral_spans
+    }
+    sync_span = by_prompt["sync complete"]
+    assert sync_span.attributes[SpanAttributes.LLM_IS_STREAMING] is False
+    assert sync_span.attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        "sync complete"
+    )
+    assert sync_span.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 7
+    assert sync_span.attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 2
+
+    for prompt, content, prompt_tokens, completion_tokens in (
+        ("sync stream", "sync complete", 11, 3),
+        ("async stream", "async complete", 17, 4),
+    ):
+        span = by_prompt[prompt]
+        assert span.attributes[SpanAttributes.LLM_IS_STREAMING] is True
+        assert span.attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == content
+        assert span.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == prompt_tokens
+        assert span.attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == (
+            completion_tokens
+        )
+        assert span.attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == (
+            prompt_tokens + completion_tokens
+        )
+
+    tool_span = by_prompt["weather in Paris"]
+    assert json.loads(tool_span.attributes[SpanAttributes.LLM_REQUEST_FUNCTIONS]) == [
+        TOOL
+    ]
+    assert json.loads(
+        tool_span.attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]
+    ) == [
+        {
+            "id": "call_weather_1",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"city":"Paris"}',
+            },
+        }
+    ]
+
+    error_span = by_prompt["provider failure"]
+    assert error_span.status.status_code is trace.StatusCode.ERROR
+    assert error_span.attributes["status_code"] == 401
+    assert json.loads(
+        error_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    ) == {
+        "error": "SDKError",
+        "message": "Mistral request failed with status 401",
+        "status": "error",
+        "status_code": 401,
+    }
+
+    application_error_span = by_prompt["application failure"]
+    assert application_error_span.status.status_code is trace.StatusCode.ERROR
+    assert application_error_span.attributes["status_code"] == 500
+    assert json.loads(
+        application_error_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    ) == {
+        "error": "RuntimeError",
+        "message": "Mistral request failed",
+        "status": "error",
+        "status_code": 500,
+    }
+
+    for span in mistral_spans:
+        attrs = dict(span.attributes)
+        assert OFF_CONTRACT_ALIASES.isdisjoint(attrs)
+        serialized_attrs = json.dumps(attrs, default=str)
+        assert "test-secret-key" not in serialized_attrs
+        assert "authorization" not in serialized_attrs.lower()
+
+    native_sdk_spans = [
+        span
+        for span in finished
+        if span.instrumentation_scope.name == instrumentation.MISTRALAI_SDK_TRACER_NAME
+    ]
+    assert all(span.attributes[SAMPLE_RATE_ATTR] == 0 for span in native_sdk_spans)
+
+
+def test_current_sdk_finalizes_interrupted_streams(monkeypatch) -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(trace, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_translator_registered", False)
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_translator", None)
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_active_span_processors", [])
+    monkeypatch.setattr(instrumentation, "_SHARED_DELEGATE", None)
+    monkeypatch.setattr(instrumentation, "_SHARED_CLEANUP_PROCESSOR", None)
+    monkeypatch.setattr(instrumentation, "_SHARED_STREAM_GUARD_PATCH", None)
+    monkeypatch.setattr(instrumentation, "_SHARED_INSTRUMENTOR_KWARGS", None)
+    monkeypatch.setattr(instrumentation, "_SHARED_REFCOUNT", 0)
+
+    instrumentor = MistralAIInstrumentor()
+    instrumentor.activate()
+
+    def sync_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=_stream_body(
+                first="partial ",
+                second="content",
+                prompt_tokens=5,
+                completion_tokens=2,
+            ),
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+
+    with _sync_client(sync_handler) as client:
+        early_stream = client.chat.stream(
+            model=MODEL,
+            messages=[{"role": "user", "content": "sync early close"}],
+        )
+        assert next(early_stream).data.choices[0].delta.content == "partial "
+        early_stream.close()
+
+        with (
+            pytest.raises(GeneratorExit),
+            client.chat.stream(
+                model=MODEL,
+                messages=[{"role": "user", "content": "sync generator exit"}],
+            ) as generator_exit_stream,
+        ):
+            assert (
+                next(generator_exit_stream).data.choices[0].delta.content == "partial "
+            )
+            raise GeneratorExit
+
+    class BlockingAsyncStream(httpx.AsyncByteStream):
+        def __init__(self) -> None:
+            self.closed = False
+            self.close_calls = 0
+            self.wait_forever = asyncio.Event()
+
+        async def __aiter__(self):
+            partial = {
+                "id": "stream_cancelled",
+                "object": "chat.completion.chunk",
+                "model": MODEL,
+                "created": 1_710_000_000,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "partial "},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            yield f"data: {json.dumps(partial)}\n\n".encode()
+            await self.wait_forever.wait()
+
+        async def aclose(self) -> None:
+            self.closed = True
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise asyncio.CancelledError("source cleanup cancellation")
+
+    blocking_stream: BlockingAsyncStream | None = None
+
+    def async_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal blocking_stream
+        payload = json.loads(request.content)
+        prompt = payload["messages"][-1]["content"]
+        if prompt == "async cancellation":
+            blocking_stream = BlockingAsyncStream()
+            return httpx.Response(
+                200,
+                stream=blocking_stream,
+                headers={"content-type": "text/event-stream"},
+                request=request,
+            )
+        return sync_handler(request)
+
+    async def run_async_interruptions() -> None:
+        async with _async_client(async_handler) as client:
+            early_stream = await client.chat.stream_async(
+                model=MODEL,
+                messages=[{"role": "user", "content": "async early close"}],
+            )
+            first = await anext(early_stream)
+            assert first.data.choices[0].delta.content == "partial "
+            await early_stream.aclose()
+
+            cancelled_stream = await client.chat.stream_async(
+                model=MODEL,
+                messages=[{"role": "user", "content": "async cancellation"}],
+            )
+            first = await anext(cancelled_stream)
+            assert first.data.choices[0].delta.content == "partial "
+            pending = asyncio.create_task(anext(cancelled_stream))
+            await asyncio.sleep(0)
+            pending.cancel("original stream cancellation")
+            with pytest.raises(
+                asyncio.CancelledError,
+                match="original stream cancellation",
+            ):
+                await pending
+
+    asyncio.run(run_async_interruptions())
+    instrumentor.deactivate()
+    provider.force_flush()
+
+    assert blocking_stream is not None
+    assert blocking_stream.closed is True
+    spans = _mistral_spans(exporter.get_finished_spans())
+    assert len(spans) == 4
+    by_prompt = {
+        span.attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"]: span
+        for span in spans
+    }
+    for prompt in (
+        "sync early close",
+        "sync generator exit",
+        "async early close",
+    ):
+        span = by_prompt[prompt]
+        assert span.status.status_code is trace.StatusCode.OK
+        assert span.attributes[SpanAttributes.LLM_IS_STREAMING] is True
+
+    cancelled_span = by_prompt["async cancellation"]
+    assert cancelled_span.status.status_code is trace.StatusCode.ERROR
+    assert cancelled_span.attributes["status_code"] == 500
+    assert json.loads(
+        cancelled_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    ) == {
+        "error": "CancelledError",
+        "message": "Mistral request failed",
+        "status": "error",
+        "status_code": 500,
+    }

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/README.md
@@ -2,6 +2,8 @@
 
 Respan instrumentation plugin for [Ollama](https://ollama.com/). It instruments the official Ollama Python client and emits chat, completion, and embedding spans into the Respan tracing pipeline.
 
+Chat spans include canonical request tool definitions and only the tool calls emitted by the current response turn. Streamed calls are marked with `llm.is_streaming`, and provider HTTP failures retain their explicit status code.
+
 ## Configuration
 
 ### 1. Install

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_instrumentation.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import importlib
 import inspect
 import logging
+import threading
 import time
-from collections.abc import AsyncIterator, Iterator
-from typing import Any, Callable
+from collections.abc import AsyncIterator, Callable, Iterator
+from typing import Any
+
+from respan_tracing.core.tracer import RespanTracer
 
 from respan_instrumentation_ollama._constants import (
     ASYNC_CLIENT_CLASS_NAME,
@@ -21,11 +24,15 @@ from respan_instrumentation_ollama._constants import (
     STREAM_KEY,
 )
 from respan_instrumentation_ollama._otel_emitter import (
+    _current_trace_parent_ids,
     emit_chat_span,
     emit_embedding_span,
     emit_generate_span,
 )
-from respan_tracing.core.tracer import RespanTracer
+from respan_instrumentation_ollama._translator import (
+    StreamResponseAccumulator,
+    bounded_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +44,27 @@ _original_sync_embed = None
 _original_async_embed = None
 _original_sync_embeddings = None
 _original_async_embeddings = None
+
+
+def _error_status_code(exc: BaseException) -> int:
+    """Return an explicit provider status without guessing from error text."""
+    response = getattr(exc, "response", None)
+    for value in (
+        getattr(exc, "status_code", None),
+        getattr(response, "status_code", None),
+        getattr(response, "status", None),
+    ):
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 400:
+            return value
+    return 500
+
+
+def _error_message(exc: BaseException) -> str:
+    try:
+        message = str(exc)
+    except Exception:  # noqa: BLE001 - broken vendor exceptions must not escape
+        message = ""
+    return bounded_text(message or type(exc).__name__)
 
 
 def _get_module_attr(module_path: str, attr_name: str) -> Any:
@@ -72,32 +100,63 @@ def _request_kwargs_from_call(
     }
 
 
+def _close_sync_iterator(iterator: Any) -> None:
+    close = getattr(iterator, "close", None)
+    if not callable(close):
+        return
+    try:
+        close()
+    except BaseException:
+        logger.debug("Failed to close Ollama stream iterator", exc_info=True)
+
+
+async def _close_async_iterator(async_iterator: Any) -> None:
+    close = getattr(async_iterator, "aclose", None)
+    if not callable(close):
+        return
+    try:
+        await close()
+    except BaseException:
+        logger.debug("Failed to close Ollama async stream iterator", exc_info=True)
+
+
 def _instrument_sync_stream(
     *,
     iterator: Iterator[Any],
     emit_span: Callable[..., None],
     request_kwargs: dict[str, Any],
     start_ns: int,
+    parent_ids: tuple[str | None, str | None],
 ) -> Iterator[Any]:
-    chunks: list[Any] = []
+    captured = StreamResponseAccumulator()
+    error_message: str | None = None
+    status_code = 200
+    close_source = False
     try:
         for chunk in iterator:
-            chunks.append(chunk)
+            try:
+                captured.append(chunk)
+            except Exception:  # instrumentation must never break provider iteration
+                logger.debug("Failed to capture Ollama stream chunk", exc_info=True)
             yield chunk
-    except Exception as exc:
-        emit_span(
-            request_kwargs=request_kwargs,
-            response_or_chunks=chunks,
-            start_ns=start_ns,
-            error_message=str(exc),
-            status_code=500,
-        )
+    except GeneratorExit:
+        close_source = True
         raise
-    else:
+    except BaseException as exc:
+        close_source = True
+        error_message = _error_message(exc)
+        status_code = _error_status_code(exc)
+        raise
+    finally:
+        if close_source:
+            _close_sync_iterator(iterator)
         emit_span(
             request_kwargs=request_kwargs,
-            response_or_chunks=chunks,
+            response_or_chunks=captured.response(),
             start_ns=start_ns,
+            error_message=error_message,
+            status_code=status_code,
+            parent_ids=parent_ids,
         )
 
 
@@ -107,26 +166,39 @@ async def _instrument_async_stream(
     emit_span: Callable[..., None],
     request_kwargs: dict[str, Any],
     start_ns: int,
+    parent_ids: tuple[str | None, str | None],
 ) -> AsyncIterator[Any]:
-    chunks: list[Any] = []
+    captured = StreamResponseAccumulator()
+    error_message: str | None = None
+    status_code = 200
+    close_source = False
     try:
         async for chunk in async_iterator:
-            chunks.append(chunk)
+            try:
+                captured.append(chunk)
+            except Exception:  # instrumentation must never break provider iteration
+                logger.debug(
+                    "Failed to capture Ollama async stream chunk", exc_info=True
+                )
             yield chunk
-    except Exception as exc:
-        emit_span(
-            request_kwargs=request_kwargs,
-            response_or_chunks=chunks,
-            start_ns=start_ns,
-            error_message=str(exc),
-            status_code=500,
-        )
+    except GeneratorExit:
+        close_source = True
         raise
-    else:
+    except BaseException as exc:
+        close_source = True
+        error_message = _error_message(exc)
+        status_code = _error_status_code(exc)
+        raise
+    finally:
+        if close_source:
+            await _close_async_iterator(async_iterator)
         emit_span(
             request_kwargs=request_kwargs,
-            response_or_chunks=chunks,
+            response_or_chunks=captured.response(),
             start_ns=start_ns,
+            error_message=error_message,
+            status_code=status_code,
+            parent_ids=parent_ids,
         )
 
 
@@ -138,14 +210,16 @@ def _wrap_sync_llm_call(
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         request_kwargs = _request_kwargs_from_call(original, self, args, kwargs)
         start_ns = time.time_ns()
+        parent_ids = _current_trace_parent_ids()
         try:
             response = original(self, *args, **kwargs)
         except Exception as exc:
             emit_span(
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=_error_message(exc),
+                status_code=_error_status_code(exc),
+                parent_ids=parent_ids,
             )
             raise
 
@@ -155,12 +229,14 @@ def _wrap_sync_llm_call(
                 emit_span=emit_span,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
+                parent_ids=parent_ids,
             )
 
         emit_span(
             request_kwargs=request_kwargs,
             response_or_chunks=response,
             start_ns=start_ns,
+            parent_ids=parent_ids,
         )
         return response
 
@@ -175,14 +251,16 @@ def _wrap_async_llm_call(
     async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         request_kwargs = _request_kwargs_from_call(original, self, args, kwargs)
         start_ns = time.time_ns()
+        parent_ids = _current_trace_parent_ids()
         try:
             response = await original(self, *args, **kwargs)
         except Exception as exc:
             emit_span(
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=_error_message(exc),
+                status_code=_error_status_code(exc),
+                parent_ids=parent_ids,
             )
             raise
 
@@ -192,12 +270,14 @@ def _wrap_async_llm_call(
                 emit_span=emit_span,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
+                parent_ids=parent_ids,
             )
 
         emit_span(
             request_kwargs=request_kwargs,
             response_or_chunks=response,
             start_ns=start_ns,
+            parent_ids=parent_ids,
         )
         return response
 
@@ -212,15 +292,17 @@ def _wrap_sync_embedding_call(
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         request_kwargs = _request_kwargs_from_call(original, self, args, kwargs)
         start_ns = time.time_ns()
+        parent_ids = _current_trace_parent_ids()
         try:
             response = original(self, *args, **kwargs)
         except Exception as exc:
             emit_embedding_span(
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=_error_message(exc),
+                status_code=_error_status_code(exc),
                 method_name=method_name,
+                parent_ids=parent_ids,
             )
             raise
 
@@ -229,6 +311,7 @@ def _wrap_sync_embedding_call(
             response=response,
             start_ns=start_ns,
             method_name=method_name,
+            parent_ids=parent_ids,
         )
         return response
 
@@ -243,15 +326,17 @@ def _wrap_async_embedding_call(
     async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         request_kwargs = _request_kwargs_from_call(original, self, args, kwargs)
         start_ns = time.time_ns()
+        parent_ids = _current_trace_parent_ids()
         try:
             response = await original(self, *args, **kwargs)
         except Exception as exc:
             emit_embedding_span(
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=_error_message(exc),
+                status_code=_error_status_code(exc),
                 method_name=method_name,
+                parent_ids=parent_ids,
             )
             raise
 
@@ -260,6 +345,7 @@ def _wrap_async_embedding_call(
             response=response,
             start_ns=start_ns,
             method_name=method_name,
+            parent_ids=parent_ids,
         )
         return response
 
@@ -270,6 +356,9 @@ class OllamaInstrumentor:
     """Respan instrumentor for the official Ollama Python SDK."""
 
     name = OLLAMA_INSTRUMENTATION_NAME
+    _lifecycle_lock = threading.RLock()
+    _patches_applied = False
+    _activation_count = 0
 
     def __init__(self) -> None:
         self._is_instrumented = False
@@ -283,11 +372,16 @@ class OllamaInstrumentor:
 
     def activate(self) -> None:
         """Monkey-patch Ollama client generation and embedding methods."""
+        with type(self)._lifecycle_lock:
+            self._activate_locked()
+
+    def _activate_locked(self) -> None:
         global _original_sync_chat, _original_async_chat
         global _original_sync_generate, _original_async_generate
         global _original_sync_embed, _original_async_embed
         global _original_sync_embeddings, _original_async_embeddings
 
+        cls = type(self)
         if self._is_instrumented:
             return
 
@@ -295,6 +389,11 @@ class OllamaInstrumentor:
             logger.info(
                 "Ollama instrumentation skipped because Respan tracing is disabled"
             )
+            return
+
+        if cls._patches_applied:
+            cls._activation_count += 1
+            self._is_instrumented = True
             return
 
         try:
@@ -315,7 +414,7 @@ class OllamaInstrumentor:
                 exc,
             )
             return
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - plugin activation is best-effort
             logger.warning("Failed to activate Ollama instrumentation: %s", exc)
             return
 
@@ -419,22 +518,40 @@ class OllamaInstrumentor:
                 )
         except Exception:
             logger.exception("Failed to patch Ollama client methods")
-            self.deactivate()
+            self._is_instrumented = True
+            cls._patches_applied = True
+            cls._activation_count = 1
+            self._deactivate_locked()
             return
 
         self._is_instrumented = True
+        cls._patches_applied = True
+        cls._activation_count = 1
         logger.info("Ollama instrumentation activated")
 
     def deactivate(self) -> None:
         """Restore Ollama client methods."""
+        with type(self)._lifecycle_lock:
+            self._deactivate_locked()
+
+    def _deactivate_locked(self) -> None:
         global _original_sync_chat, _original_async_chat
         global _original_sync_generate, _original_async_generate
         global _original_sync_embed, _original_async_embed
         global _original_sync_embeddings, _original_async_embeddings
 
+        cls = type(self)
+        if not self._is_instrumented:
+            return
+
+        self._is_instrumented = False
+        cls._activation_count = max(cls._activation_count - 1, 0)
+        if cls._activation_count:
+            return
+
         try:
             Client, AsyncClient = _load_client_classes()
-        except Exception:
+        except Exception:  # noqa: BLE001 - teardown must clear local state
             Client = AsyncClient = None
 
         if Client is not None:
@@ -469,5 +586,6 @@ class OllamaInstrumentor:
         _original_async_embed = None
         _original_sync_embeddings = None
         _original_async_embeddings = None
-        self._is_instrumented = False
+        cls._patches_applied = False
+        cls._activation_count = 0
         logger.info("Ollama instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_otel_emitter.py
@@ -12,6 +12,16 @@ from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+)
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 from respan_instrumentation_ollama._constants import (
     ASSISTANT_ROLE,
@@ -30,11 +40,13 @@ from respan_instrumentation_ollama._constants import (
     PROMPT_EVAL_COUNT_KEY,
     PROMPT_KEY,
     ROLE_KEY,
+    STREAM_KEY,
     SYSTEM_KEY,
     TOOLS_KEY,
     USER_ROLE,
 )
 from respan_instrumentation_ollama._translator import (
+    bounded_text,
     extract_chat_tool_calls,
     extract_model,
     extract_usage,
@@ -49,16 +61,6 @@ from respan_instrumentation_ollama._translator import (
     safe_json,
     to_json_attr,
 )
-from respan_sdk.constants.llm_logging import (
-    LOG_TYPE_CHAT,
-    LOG_TYPE_EMBEDDING,
-)
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
-from respan_sdk.utils.data_processing.id_processing import (
-    format_span_id,
-    format_trace_id,
-)
-from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +69,7 @@ def _current_trace_parent_ids() -> tuple[str | None, str | None]:
     try:
         current_span = trace.get_current_span()
         span_context = current_span.get_span_context()
-    except Exception:
+    except Exception:  # noqa: BLE001 - invalid ambient context means no parent
         return None, None
 
     trace_id = getattr(span_context, "trace_id", 0) or 0
@@ -87,7 +89,7 @@ def _base_attrs(*, span_name: str, log_type: str, request_type: str) -> dict[str
     }
     workflow_name = context_api.get_value(SpanAttributes.TRACELOOP_ENTITY_NAME)
     if workflow_name:
-        attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = workflow_name
+        attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = to_json_attr(workflow_name)
     return attrs
 
 
@@ -122,6 +124,11 @@ def _set_usage_attrs(attrs: dict[str, Any], response_or_chunks: Any) -> None:
         )
 
 
+def _set_streaming_attr(attrs: dict[str, Any], request_kwargs: dict[str, Any]) -> None:
+    if request_kwargs.get(STREAM_KEY) is True:
+        attrs[SpanAttributes.LLM_IS_STREAMING] = True
+
+
 def _set_prompt_attrs(attrs: dict[str, Any], messages: list[dict[str, Any]]) -> None:
     for index, message in enumerate(messages):
         role = message.get(ROLE_KEY)
@@ -129,7 +136,7 @@ def _set_prompt_attrs(attrs: dict[str, Any], messages: list[dict[str, Any]]) -> 
         tool_calls = message.get("tool_calls")
         prefix = f"{SpanAttributes.LLM_PROMPTS}.{index}"
         if role is not None:
-            attrs[f"{prefix}.role"] = str(role)
+            attrs[f"{prefix}.role"] = to_json_attr(role)
         if content is not None:
             attrs[f"{prefix}.content"] = to_json_attr(content)
         if tool_calls:
@@ -144,8 +151,8 @@ def _set_completion_attrs(
     tool_calls: list[dict[str, Any]] | None = None,
 ) -> None:
     prefix = f"{SpanAttributes.LLM_COMPLETIONS}.0"
-    attrs[f"{prefix}.role"] = role or ASSISTANT_ROLE
-    attrs[f"{prefix}.content"] = content
+    attrs[f"{prefix}.role"] = to_json_attr(role or ASSISTANT_ROLE)
+    attrs[f"{prefix}.content"] = to_json_attr(content)
     if tool_calls:
         attrs[f"{prefix}.tool_calls"] = safe_json(tool_calls)
 
@@ -171,6 +178,7 @@ def build_chat_attrs(
         request_kwargs=request_kwargs,
         response_or_chunks=response_or_chunks,
     )
+    _set_streaming_attr(attrs, request_kwargs)
 
     messages = normalize_chat_messages(request_kwargs.get(MESSAGES_KEY))
     attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = format_chat_input(
@@ -213,6 +221,7 @@ def build_generate_attrs(
         request_kwargs=request_kwargs,
         response_or_chunks=response_or_chunks,
     )
+    _set_streaming_attr(attrs, request_kwargs)
 
     messages = normalize_generate_messages(
         prompt=request_kwargs.get(PROMPT_KEY),
@@ -271,11 +280,15 @@ def _emit_span(
     start_ns: int,
     error_message: str | None = None,
     status_code: int = 200,
+    parent_ids: tuple[str | None, str | None] | None = None,
 ) -> None:
     if error_message:
+        error_message = bounded_text(error_message)
         attrs["error.message"] = error_message
         attrs.setdefault("status_code", status_code if status_code >= 400 else 500)
-    trace_id, parent_id = _current_trace_parent_ids()
+    trace_id, parent_id = (
+        parent_ids if parent_ids is not None else _current_trace_parent_ids()
+    )
     span = build_readable_span(
         name=span_name,
         trace_id=trace_id,
@@ -296,6 +309,7 @@ def emit_chat_span(
     response_or_chunks: Any = None,
     error_message: str | None = None,
     status_code: int = 200,
+    parent_ids: tuple[str | None, str | None] | None = None,
 ) -> None:
     try:
         attrs = build_chat_attrs(
@@ -308,6 +322,7 @@ def emit_chat_span(
             start_ns=start_ns,
             error_message=error_message,
             status_code=status_code,
+            parent_ids=parent_ids,
         )
     except Exception:
         logger.debug("Failed to emit Ollama chat span", exc_info=True)
@@ -320,6 +335,7 @@ def emit_generate_span(
     response_or_chunks: Any = None,
     error_message: str | None = None,
     status_code: int = 200,
+    parent_ids: tuple[str | None, str | None] | None = None,
 ) -> None:
     try:
         attrs = build_generate_attrs(
@@ -332,6 +348,7 @@ def emit_generate_span(
             start_ns=start_ns,
             error_message=error_message,
             status_code=status_code,
+            parent_ids=parent_ids,
         )
     except Exception:
         logger.debug("Failed to emit Ollama generate span", exc_info=True)
@@ -345,6 +362,7 @@ def emit_embedding_span(
     error_message: str | None = None,
     status_code: int = 200,
     method_name: str = EMBED_METHOD_NAME,
+    parent_ids: tuple[str | None, str | None] | None = None,
 ) -> None:
     try:
         attrs = build_embedding_attrs(
@@ -358,6 +376,7 @@ def emit_embedding_span(
             start_ns=start_ns,
             error_message=error_message,
             status_code=status_code,
+            parent_ids=parent_ids,
         )
     except Exception:
         logger.debug("Failed to emit Ollama embedding span", exc_info=True)

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/src/respan_instrumentation_ollama/_translator.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
 import json
-from typing import Any, Iterable
+import math
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
 
 from respan_instrumentation_ollama._constants import (
     ARGUMENTS_KEY,
@@ -32,20 +36,174 @@ from respan_instrumentation_ollama._constants import (
     TYPE_KEY,
     USER_ROLE,
 )
-from respan_sdk.utils.serialization import serialize_value
+
+_MAX_DEPTH = 6
+_MAX_ITEMS = 50
+_MAX_STRING_LENGTH = 8_000
+_MAX_JSON_LENGTH = 16_000
+_REDACTED = "[REDACTED]"
+_SENSITIVE_KEYS = {
+    "api-key",
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "cookie",
+    "password",
+    "refresh_token",
+    "secret",
+    "set-cookie",
+    "token",
+}
+_SENSITIVE_TEXT_PATTERN = re.compile(
+    r"(?i)\b(authorization|api[-_ ]?key|password|secret|token)\b"
+    r"\s*[:=]\s*(?:bearer\s+)?[^\s,;]+|\bbearer\s+[^\s,;]+"
+)
+
+
+def bounded_text(value: str, *, limit: int = _MAX_STRING_LENGTH) -> str:
+    """Bound direct string attributes and redact obvious credential fragments."""
+    redacted = _SENSITIVE_TEXT_PATTERN.sub(_REDACTED, value)
+    if len(redacted) <= limit:
+        return redacted
+    marker = "...[truncated]"
+    return f"{redacted[: max(limit - len(marker), 0)]}{marker}"
+
+
+def _is_sensitive_key(value: Any) -> bool:
+    key = value.strip().lower() if isinstance(value, str) else ""
+    return bool(key) and (
+        key in _SENSITIVE_KEYS
+        or key.endswith(("_api_key", "_password", "_secret", "_token"))
+    )
+
+
+def _safe_key(value: Any) -> str:
+    if isinstance(value, str):
+        return bounded_text(value, limit=256)
+    if isinstance(value, bool | int | float):
+        return str(value)
+    return f"<{type(value).__name__}>"
+
+
+def _json_value(
+    value: Any,
+    *,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> Any:
+    """Return a bounded JSON value without falling back to arbitrary reprs."""
+    if value is None or isinstance(value, bool | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, str):
+        return bounded_text(value)
+    if isinstance(value, bytes):
+        return f"<bytes:{len(value)}>"
+    if depth >= _MAX_DEPTH:
+        return f"<{type(value).__name__}:max-depth>"
+
+    active = seen if seen is not None else set()
+    object_id = id(value)
+    if object_id in active:
+        return "<cycle>"
+    active.add(object_id)
+    try:
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            value = dataclasses.asdict(value)
+        elif callable(getattr(value, "model_dump", None)):
+            try:
+                value = value.model_dump(exclude_none=True, by_alias=False)
+            except TypeError:
+                value = value.model_dump()
+        elif callable(getattr(value, "to_dict", None)):
+            value = value.to_dict()
+        elif isinstance(value, Mapping):
+            value = dict(value)
+        elif (
+            isinstance(value, Sequence)
+            and not isinstance(value, str | bytes)
+            or isinstance(value, set | frozenset)
+        ):
+            value = list(value)
+        elif callable(value):
+            return {
+                NAME_KEY: bounded_text(
+                    getattr(value, "__name__", value.__class__.__name__),
+                    limit=256,
+                )
+            }
+        elif hasattr(value, "__dict__"):
+            value = {
+                key: item
+                for key, item in vars(value).items()
+                if isinstance(key, str) and not key.startswith("_")
+            }
+        else:
+            return f"<{type(value).__name__}>"
+
+        if isinstance(value, Mapping):
+            result: dict[str, Any] = {}
+            for key, item in list(value.items())[:_MAX_ITEMS]:
+                safe_key = _safe_key(key)
+                result[safe_key] = (
+                    _REDACTED
+                    if _is_sensitive_key(key)
+                    else _json_value(item, depth=depth + 1, seen=active)
+                )
+            if len(value) > _MAX_ITEMS:
+                result["_respan_truncated_items"] = len(value) - _MAX_ITEMS
+            return result
+        if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+            result = [
+                _json_value(item, depth=depth + 1, seen=active)
+                for item in list(value)[:_MAX_ITEMS]
+            ]
+            if len(value) > _MAX_ITEMS:
+                result.append({"_respan_truncated_items": len(value) - _MAX_ITEMS})
+            return result
+        return value
+    except Exception:  # noqa: BLE001 - vendor values must not break app calls
+        return f"<{type(value).__name__}:unserializable>"
+    finally:
+        active.discard(object_id)
 
 
 def safe_json(value: Any) -> str:
-    """JSON-encode values after applying the SDK serializer."""
-    try:
-        return json.dumps(serialize_value(value=value), default=str)
-    except Exception:
-        return str(value)
+    """JSON-encode a bounded, redacted value without arbitrary repr fallback."""
+    encoded = json.dumps(_json_value(value), ensure_ascii=False, sort_keys=True)
+    if len(encoded) <= _MAX_JSON_LENGTH:
+        return encoded
+
+    # JSON escaping can expand a preview (quotes, backslashes, and control
+    # characters), so choose the largest prefix whose *encoded* wrapper still
+    # respects the configured limit.
+    low = 0
+    high = min(len(encoded), _MAX_JSON_LENGTH)
+    bounded = json.dumps(
+        {"preview": "", "truncated": True},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = json.dumps(
+            {"preview": encoded[:midpoint], "truncated": True},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        if len(candidate) <= _MAX_JSON_LENGTH:
+            bounded = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return bounded
 
 
 def to_json_attr(value: Any) -> str:
     if isinstance(value, str):
-        return value
+        return bounded_text(value)
     return safe_json(value=value)
 
 
@@ -58,36 +216,115 @@ def _field(value: Any, name: str, default: Any = None) -> Any:
     if callable(getter):
         try:
             return getter(name, default)
-        except Exception:
-            pass
+        except Exception:  # noqa: BLE001 - fall back to attribute access
+            return getattr(value, name, default)
     return getattr(value, name, default)
 
 
+class StreamResponseAccumulator:
+    """Retain only bounded output plus terminal fields needed for span emission."""
+
+    def __init__(self) -> None:
+        self._message_seen = False
+        self._message_role = "assistant"
+        self._message_content = ""
+        self._message_content_truncated = False
+        self._response_seen = False
+        self._response_content = ""
+        self._response_content_truncated = False
+        self._tool_calls: list[dict[str, Any]] = []
+        self._tool_call_signatures: set[str] = set()
+        self._model: Any = None
+        self._prompt_tokens: int | None = None
+        self._completion_tokens: int | None = None
+
+    @staticmethod
+    def _append_content(
+        current: str, value: Any, *, truncated: bool
+    ) -> tuple[str, bool]:
+        if truncated or value is None or (isinstance(value, str) and not value):
+            return current, truncated
+        next_part = _stringify_content(value)
+        combined = current + next_part
+        if len(combined) <= _MAX_STRING_LENGTH:
+            return combined, False
+        marker = "...[truncated]"
+        return f"{combined[: _MAX_STRING_LENGTH - len(marker)]}{marker}", True
+
+    def append(self, chunk: Any) -> None:
+        model = _field(chunk, MODEL_KEY)
+        if model is not None:
+            self._model = _json_value(model)
+
+        prompt_tokens = _field(chunk, PROMPT_EVAL_COUNT_KEY)
+        if isinstance(prompt_tokens, int) and not isinstance(prompt_tokens, bool):
+            self._prompt_tokens = prompt_tokens
+        completion_tokens = _field(chunk, EVAL_COUNT_KEY)
+        if isinstance(completion_tokens, int) and not isinstance(
+            completion_tokens, bool
+        ):
+            self._completion_tokens = completion_tokens
+
+        message = _field(chunk, MESSAGE_KEY)
+        if message is not None:
+            self._message_seen = True
+            role = _field(message, ROLE_KEY)
+            if role:
+                self._message_role = to_json_attr(role)
+            self._message_content, self._message_content_truncated = (
+                self._append_content(
+                    self._message_content,
+                    _field(message, CONTENT_KEY),
+                    truncated=self._message_content_truncated,
+                )
+            )
+            for tool_call in normalize_tool_calls(_field(message, TOOL_CALLS_KEY)):
+                if len(self._tool_calls) >= _MAX_ITEMS:
+                    break
+                signature = safe_json(tool_call)
+                if signature not in self._tool_call_signatures:
+                    self._tool_call_signatures.add(signature)
+                    self._tool_calls.append(tool_call)
+
+        response = _field(chunk, RESPONSE_KEY)
+        if response is not None:
+            self._response_seen = True
+            self._response_content, self._response_content_truncated = (
+                self._append_content(
+                    self._response_content,
+                    response,
+                    truncated=self._response_content_truncated,
+                )
+            )
+
+    def response(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if self._model is not None:
+            result[MODEL_KEY] = _json_value(self._model)
+        if self._message_seen:
+            message: dict[str, Any] = {
+                ROLE_KEY: self._message_role,
+                CONTENT_KEY: self._message_content,
+            }
+            if self._tool_calls:
+                message[TOOL_CALLS_KEY] = list(self._tool_calls)
+            result[MESSAGE_KEY] = message
+        if self._response_seen:
+            result[RESPONSE_KEY] = self._response_content
+        if self._prompt_tokens is not None:
+            result[PROMPT_EVAL_COUNT_KEY] = self._prompt_tokens
+        if self._completion_tokens is not None:
+            result[EVAL_COUNT_KEY] = self._completion_tokens
+        return result
+
+
 def _dump_value(value: Any) -> Any:
-    if value is None:
-        return None
-    if isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, dict):
-        return {
-            str(key): _dump_value(nested_value)
-            for key, nested_value in value.items()
-            if nested_value is not None
-        }
-    if isinstance(value, (list, tuple, set)):
-        return [_dump_value(item) for item in value if item is not None]
-    model_dump = getattr(value, "model_dump", None)
-    if callable(model_dump):
-        try:
-            return model_dump(exclude_none=True, by_alias=False)
-        except TypeError:
-            return model_dump()
-    return serialize_value(value=value)
+    return _json_value(value)
 
 
 def _stringify_content(value: Any) -> str:
     if isinstance(value, str):
-        return value
+        return bounded_text(value)
     return safe_json(value=value)
 
 
@@ -98,9 +335,9 @@ def normalize_chat_messages(messages: Any) -> list[dict[str, Any]]:
         messages = [messages]
 
     normalized_messages: list[dict[str, Any]] = []
-    for message in messages:
+    for message in messages[:_MAX_ITEMS]:
         role = _field(message, ROLE_KEY, USER_ROLE) or USER_ROLE
-        normalized: dict[str, Any] = {ROLE_KEY: str(role)}
+        normalized: dict[str, Any] = {ROLE_KEY: to_json_attr(role)}
 
         content = _field(message, CONTENT_KEY)
         if content is not None:
@@ -108,7 +345,7 @@ def normalize_chat_messages(messages: Any) -> list[dict[str, Any]]:
 
         tool_name = _field(message, TOOL_NAME_KEY)
         if tool_name is not None:
-            normalized[TOOL_NAME_KEY] = str(tool_name)
+            normalized[TOOL_NAME_KEY] = to_json_attr(tool_name)
 
         tool_calls = normalize_tool_calls(_field(message, TOOL_CALLS_KEY))
         if tool_calls:
@@ -169,8 +406,8 @@ def format_chat_output(response_or_chunks: Any) -> str:
         message = _field(response, MESSAGE_KEY)
         content = _field(message, CONTENT_KEY)
         if content:
-            parts.append(str(content))
-    return "".join(parts)
+            parts.append(_stringify_content(content))
+    return bounded_text("".join(parts))
 
 
 def format_generate_output(response_or_chunks: Any) -> str:
@@ -178,8 +415,8 @@ def format_generate_output(response_or_chunks: Any) -> str:
     for response in _iter_responses(response_or_chunks):
         content = _field(response, RESPONSE_KEY)
         if content:
-            parts.append(str(content))
-    return "".join(parts)
+            parts.append(_stringify_content(content))
+    return bounded_text("".join(parts))
 
 
 def normalize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
@@ -189,13 +426,13 @@ def normalize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
         tool_calls = [tool_calls]
 
     normalized_calls: list[dict[str, Any]] = []
-    for tool_call in tool_calls:
+    for tool_call in tool_calls[:_MAX_ITEMS]:
         function = _field(tool_call, FUNCTION_KEY)
         name = _field(function, NAME_KEY) or _field(tool_call, NAME_KEY)
         if not name:
             continue
 
-        normalized_function: dict[str, Any] = {NAME_KEY: str(name)}
+        normalized_function: dict[str, Any] = {NAME_KEY: to_json_attr(name)}
         arguments = _field(function, ARGUMENTS_KEY)
         if arguments is None:
             arguments = _field(tool_call, ARGUMENTS_KEY)
@@ -208,7 +445,7 @@ def normalize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
         }
         call_id = _field(tool_call, ID_KEY)
         if call_id:
-            normalized[ID_KEY] = str(call_id)
+            normalized[ID_KEY] = to_json_attr(call_id)
         normalized_calls.append(normalized)
     return normalized_calls
 
@@ -245,11 +482,14 @@ def _annotation_to_json_schema(annotation: Any) -> dict[str, Any]:
 
 def _callable_tool_definition(tool: Any) -> dict[str, Any]:
     function: dict[str, Any] = {
-        NAME_KEY: getattr(tool, "__name__", tool.__class__.__name__),
+        NAME_KEY: bounded_text(
+            getattr(tool, "__name__", tool.__class__.__name__),
+            limit=256,
+        ),
     }
     doc = inspect.getdoc(tool)
     if doc:
-        function[DESCRIPTION_KEY] = doc
+        function[DESCRIPTION_KEY] = bounded_text(doc)
 
     try:
         signature = inspect.signature(tool)
@@ -259,7 +499,7 @@ def _callable_tool_definition(tool: Any) -> dict[str, Any]:
     if signature is not None:
         properties: dict[str, Any] = {}
         required: list[str] = []
-        for param_name, parameter in signature.parameters.items():
+        for param_name, parameter in list(signature.parameters.items())[:_MAX_ITEMS]:
             if param_name in {"self", "cls"}:
                 continue
             properties[param_name] = _annotation_to_json_schema(parameter.annotation)
@@ -310,7 +550,7 @@ def normalize_tools(tools: Any) -> list[dict[str, Any]]:
         tools = [tools]
 
     normalized_tools: list[dict[str, Any]] = []
-    for tool in tools:
+    for tool in tools[:_MAX_ITEMS]:
         if callable(tool):
             normalized_tools.append(_callable_tool_definition(tool))
             continue
@@ -342,11 +582,11 @@ def extract_model(
 ) -> str | None:
     model = request_kwargs.get(MODEL_KEY)
     if model:
-        return str(model)
+        return to_json_attr(model)
     response = _last_response(response_or_chunks)
     response_model = _field(response, MODEL_KEY)
     if response_model:
-        return str(response_model)
+        return to_json_attr(response_model)
     return None
 
 

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/tests/test_instrumentation.py
@@ -8,13 +8,13 @@ from typing import Any
 
 import pytest
 from opentelemetry import context as context_api
+from opentelemetry import trace
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
-
-from respan_instrumentation_ollama import OllamaInstrumentor
-from respan_instrumentation_ollama import _instrumentation
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from respan_instrumentation_ollama import OllamaInstrumentor, _instrumentation
 from respan_instrumentation_ollama._constants import (
     ASYNC_CLIENT_CLASS_NAME,
     CHAT_METHOD_NAME,
@@ -89,6 +89,8 @@ def reset_instrumentation_globals() -> None:
     _instrumentation._original_async_embed = None
     _instrumentation._original_sync_embeddings = None
     _instrumentation._original_async_embeddings = None
+    OllamaInstrumentor._patches_applied = False
+    OllamaInstrumentor._activation_count = 0
 
 
 @pytest.fixture()
@@ -193,7 +195,7 @@ def fake_ollama(monkeypatch: pytest.MonkeyPatch) -> tuple[type[Any], type[Any]]:
     client_module = ModuleType(OLLAMA_CLIENT_MODULE)
     setattr(client_module, CLIENT_CLASS_NAME, Client)
     setattr(client_module, ASYNC_CLIENT_CLASS_NAME, AsyncClient)
-    setattr(ollama_module, "_client", client_module)
+    ollama_module._client = client_module
 
     monkeypatch.setitem(sys.modules, "ollama", ollama_module)
     monkeypatch.setitem(sys.modules, OLLAMA_CLIENT_MODULE, client_module)
@@ -286,8 +288,129 @@ def test_generate_stream_emits_one_span_after_iterator_is_consumed(
     assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "Hello world."
     assert attrs[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 2
     assert attrs[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 3
+    assert attrs[SpanAttributes.LLM_IS_STREAMING] is True
     _assert_no_off_contract_aliases(attrs)
 
+    instrumentor.deactivate()
+
+
+def test_sync_stream_early_close_emits_once_with_call_time_parent(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ollama: tuple[type[Any], type[Any]],
+    captured_spans: list[Any],
+) -> None:
+    Client, _ = fake_ollama
+
+    class CloseAwareIterator:
+        def __init__(self) -> None:
+            self._chunks = iter(
+                [
+                    _generate_response(model="llama3.2", response="Hello "),
+                    _generate_response(model="llama3.2", response="world."),
+                ]
+            )
+            self.close_count = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._chunks)
+
+        def close(self) -> None:
+            self.close_count += 1
+
+    source = CloseAwareIterator()
+
+    def generate(
+        self: Any,
+        model: str = "",
+        prompt: str | None = None,
+        *,
+        system: str | None = None,
+        stream: bool = False,
+    ) -> Any:
+        return source
+
+    monkeypatch.setattr(Client, GENERATE_METHOD_NAME, generate)
+    instrumentor = OllamaInstrumentor()
+    instrumentor.activate()
+    call_parent = SpanContext(
+        trace_id=int("1" * 32, 16),
+        span_id=int("2" * 16, 16),
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    close_parent = SpanContext(
+        trace_id=int("3" * 32, 16),
+        span_id=int("4" * 16, 16),
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+
+    with trace.use_span(NonRecordingSpan(call_parent), end_on_exit=False):
+        stream = Client().generate(
+            model="llama3.2",
+            prompt="Say hello",
+            stream=True,
+        )
+    assert next(stream).response == "Hello "
+    with trace.use_span(NonRecordingSpan(close_parent), end_on_exit=False):
+        stream.close()
+        stream.close()
+
+    assert len(captured_spans) == 1
+    span = captured_spans[0]
+    assert span.context.trace_id == call_parent.trace_id
+    assert span.parent is not None
+    assert span.parent.span_id == call_parent.span_id
+    assert span._attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == ("Hello ")
+    assert source.close_count == 1
+    instrumentor.deactivate()
+
+
+def test_long_stream_retention_is_bounded_and_keeps_terminal_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ollama: tuple[type[Any], type[Any]],
+    captured_spans: list[Any],
+) -> None:
+    Client, _ = fake_ollama
+
+    def long_generate(
+        self: Any,
+        model: str = "",
+        prompt: str | None = None,
+        *,
+        system: str | None = None,
+        stream: bool = False,
+    ) -> Any:
+        def chunks():
+            for _ in range(100):
+                yield _generate_response(model=model, response="x" * 200)
+            yield _generate_response(
+                model=model,
+                response="",
+                prompt_tokens=123,
+                completion_tokens=456,
+            )
+
+        return chunks()
+
+    monkeypatch.setattr(Client, GENERATE_METHOD_NAME, long_generate)
+    instrumentor = OllamaInstrumentor()
+    instrumentor.activate()
+
+    assert len(
+        list(Client().generate(model="llama3.2", prompt="long", stream=True))
+    ) == (101)
+
+    assert len(captured_spans) == 1
+    attrs = captured_spans[0]._attributes
+    output = attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]
+    assert len(output) <= 8_000
+    assert output.endswith("...[truncated]")
+    assert attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 123
+    assert attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 456
     instrumentor.deactivate()
 
 
@@ -326,6 +449,82 @@ def test_async_methods_emit_spans(
             == "Async stream."
         )
 
+        instrumentor.deactivate()
+
+    asyncio.run(run())
+
+
+def test_async_stream_cancellation_emits_once_with_call_time_parent(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ollama: tuple[type[Any], type[Any]],
+    captured_spans: list[Any],
+) -> None:
+    async def run() -> None:
+        _, AsyncClient = fake_ollama
+
+        class CloseAwareAsyncIterator:
+            def __init__(self) -> None:
+                self._first = True
+                self.close_count = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._first:
+                    self._first = False
+                    return _chat_response(model="llama3.2", content="first")
+                await asyncio.Event().wait()
+                raise StopAsyncIteration
+
+            async def aclose(self) -> None:
+                self.close_count += 1
+                raise asyncio.CancelledError
+
+        source = CloseAwareAsyncIterator()
+
+        async def blocking_chat(
+            self: Any,
+            model: str = "",
+            messages: list[dict[str, Any]] | None = None,
+            *,
+            tools: list[Any] | None = None,
+            stream: bool = False,
+        ) -> Any:
+            return source
+
+        monkeypatch.setattr(AsyncClient, CHAT_METHOD_NAME, blocking_chat)
+        instrumentor = OllamaInstrumentor()
+        instrumentor.activate()
+        call_parent = SpanContext(
+            trace_id=int("5" * 32, 16),
+            span_id=int("6" * 16, 16),
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+
+        with trace.use_span(NonRecordingSpan(call_parent), end_on_exit=False):
+            stream = await AsyncClient().chat(
+                model="llama3.2",
+                messages=[{"role": "user", "content": "Stream"}],
+                stream=True,
+            )
+        assert (await anext(stream)).message.content == "first"
+        pending = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        await stream.aclose()
+
+        assert len(captured_spans) == 1
+        span = captured_spans[0]
+        assert span.context.trace_id == call_parent.trace_id
+        assert span.parent is not None
+        assert span.parent.span_id == call_parent.span_id
+        assert span.status.status_code.name == "ERROR"
+        assert span._attributes["error.message"] == "CancelledError"
+        assert source.close_count == 1
         instrumentor.deactivate()
 
     asyncio.run(run())
@@ -391,6 +590,41 @@ def test_error_path_emits_failed_span(
     instrumentor.deactivate()
 
 
+def test_error_path_preserves_explicit_provider_status(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_ollama: tuple[type[Any], type[Any]],
+    captured_spans: list[Any],
+) -> None:
+    Client, _ = fake_ollama
+
+    class ProviderError(RuntimeError):
+        status_code = 503
+
+    def raise_error(
+        self: Any,
+        model: str = "",
+        messages: list[dict[str, Any]] | None = None,
+        *,
+        tools: list[Any] | None = None,
+        stream: bool = False,
+    ) -> Any:
+        raise ProviderError("provider overloaded")
+
+    monkeypatch.setattr(Client, CHAT_METHOD_NAME, raise_error)
+    instrumentor = OllamaInstrumentor()
+    instrumentor.activate()
+
+    with pytest.raises(ProviderError, match="provider overloaded"):
+        Client().chat(model="llama3.2", messages=[{"role": "user", "content": "fail"}])
+
+    assert len(captured_spans) == 1
+    span = captured_spans[0]
+    assert span.status.status_code.name == "ERROR"
+    assert span._attributes["status_code"] == 503
+
+    instrumentor.deactivate()
+
+
 def test_deactivate_restores_original_methods(
     fake_ollama: tuple[type[Any], type[Any]],
 ) -> None:
@@ -412,6 +646,32 @@ def test_deactivate_restores_original_methods(
     assert getattr(Client, GENERATE_METHOD_NAME) is original_sync_generate
     assert getattr(Client, EMBED_METHOD_NAME) is original_sync_embed
     assert getattr(AsyncClient, CHAT_METHOD_NAME) is original_async_chat
+
+
+def test_multiple_instrumentors_keep_process_patch_until_last_deactivate(
+    fake_ollama: tuple[type[Any], type[Any]],
+) -> None:
+    Client, _ = fake_ollama
+    original_sync_chat = getattr(Client, CHAT_METHOD_NAME)
+    first = OllamaInstrumentor()
+    second = OllamaInstrumentor()
+
+    first.activate()
+    patched_sync_chat = getattr(Client, CHAT_METHOD_NAME)
+    second.activate()
+
+    assert patched_sync_chat is not original_sync_chat
+    assert getattr(Client, CHAT_METHOD_NAME) is patched_sync_chat
+    assert OllamaInstrumentor._activation_count == 2
+
+    first.deactivate()
+    assert getattr(Client, CHAT_METHOD_NAME) is patched_sync_chat
+    assert second._is_instrumented is True
+    assert OllamaInstrumentor._activation_count == 1
+
+    second.deactivate()
+    assert getattr(Client, CHAT_METHOD_NAME) is original_sync_chat
+    assert OllamaInstrumentor._activation_count == 0
 
 
 def test_active_workflow_name_is_attached_to_synthetic_span() -> None:

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/tests/test_real_client.py
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/tests/test_real_client.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import Any
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from opentelemetry.trace.status import StatusCode
+from respan_instrumentation_ollama import OllamaInstrumentor
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+
+MODEL = "llama3.2"
+PRIVATE_HEADER = "Bearer ollama-test-private-value"
+
+
+def get_weather(city: str) -> str:
+    """Return deterministic weather for a city."""
+    return f"Sunny in {city}"
+
+
+class _OllamaCompatibilityHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("content-length", "0") or "0")
+        payload = json.loads(self.rfile.read(content_length) or b"{}")
+
+        if self.path == "/api/chat":
+            self._chat(payload)
+            return
+        if self.path == "/api/generate":
+            self._generate(payload)
+            return
+        if self.path in {"/api/embed", "/api/embeddings"}:
+            self._write_json(
+                {
+                    "model": payload.get("model") or MODEL,
+                    "embeddings": [[0.1, 0.2, 0.3]],
+                    "embedding": [0.1, 0.2, 0.3],
+                    "prompt_eval_count": 4,
+                    "done": True,
+                }
+            )
+            return
+        self._write_json({"error": "not found"}, status_code=404)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+    def _chat(self, payload: dict[str, Any]) -> None:
+        messages = payload.get("messages") or []
+        if any(
+            "force failure" in str(message.get("content", ""))
+            for message in messages
+            if isinstance(message, dict)
+        ):
+            self._write_json({"error": "compat provider unavailable"}, status_code=503)
+            return
+
+        if any(
+            message.get("role") == "tool"
+            for message in messages
+            if isinstance(message, dict)
+        ):
+            message = {
+                "role": "assistant",
+                "content": "The weather in Tokyo is sunny.",
+            }
+        elif payload.get("tools"):
+            message = {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"city": "Tokyo"},
+                        },
+                    }
+                ],
+            }
+        else:
+            message = {"role": "assistant", "content": "Tracing works."}
+
+        self._write_json(
+            {
+                "model": payload.get("model") or MODEL,
+                "created_at": "2026-08-17T00:00:00Z",
+                "message": message,
+                "done": True,
+                "prompt_eval_count": 9,
+                "eval_count": 7,
+            }
+        )
+
+    def _generate(self, payload: dict[str, Any]) -> None:
+        if payload.get("stream"):
+            self.send_response(200)
+            self.send_header("content-type", "application/x-ndjson")
+            self.end_headers()
+            for chunk in (
+                {
+                    "model": payload.get("model") or MODEL,
+                    "response": "Streaming ",
+                    "done": False,
+                },
+                {
+                    "model": payload.get("model") or MODEL,
+                    "response": "works.",
+                    "done": True,
+                    "prompt_eval_count": 6,
+                    "eval_count": 5,
+                },
+            ):
+                self.wfile.write(json.dumps(chunk).encode() + b"\n")
+            return
+        self._write_json(
+            {
+                "model": payload.get("model") or MODEL,
+                "response": "Generation works.",
+                "done": True,
+                "prompt_eval_count": 6,
+                "eval_count": 5,
+            }
+        )
+
+    def _write_json(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status_code)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture()
+def ollama_compat_server() -> Iterator[str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OllamaCompatibilityHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_current_ollama_client_exports_complete_connected_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    ollama_compat_server: str,
+) -> None:
+    ollama = pytest.importorskip("ollama")
+    captured_spans: list[Any] = []
+    monkeypatch.setattr(
+        "respan_instrumentation_ollama._otel_emitter.inject_span",
+        lambda span: captured_spans.append(span),
+    )
+
+    instrumentor = OllamaInstrumentor()
+    instrumentor.activate()
+    client = ollama.Client(
+        host=ollama_compat_server,
+        headers={"Authorization": PRIVATE_HEADER},
+    )
+    trace_id = int("1" * 32, 16)
+    parent_span_id = int("2" * 16, 16)
+    parent_context = SpanContext(
+        trace_id=trace_id,
+        span_id=parent_span_id,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+
+    try:
+        with trace.use_span(NonRecordingSpan(parent_context), end_on_exit=False):
+            chat_response = client.chat(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Say hello."}],
+            )
+            stream_chunks = list(
+                client.generate(
+                    model=MODEL,
+                    prompt="Stream a reply.",
+                    stream=True,
+                )
+            )
+            tool_response = client.chat(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Weather in Tokyo?"}],
+                tools=[get_weather],
+            )
+            tool_calls = tool_response.message.tool_calls or []
+            assert len(tool_calls) == 1
+            assistant_message = tool_response.message.model_dump(exclude_none=True)
+            tool_result = get_weather(**tool_calls[0].function.arguments)
+            final_response = client.chat(
+                model=MODEL,
+                messages=[
+                    {"role": "user", "content": "Weather in Tokyo?"},
+                    assistant_message,
+                    {
+                        "role": "tool",
+                        "tool_name": "get_weather",
+                        "content": tool_result,
+                    },
+                ],
+            )
+            embed_response = client.embed(model="nomic-embed-text", input="hello")
+            with pytest.raises(ollama.ResponseError) as error_info:
+                client.chat(
+                    model=MODEL,
+                    messages=[{"role": "user", "content": "force failure"}],
+                )
+    finally:
+        client.close()
+        instrumentor.deactivate()
+
+    assert chat_response.message.content == "Tracing works."
+    assert "".join(chunk.response for chunk in stream_chunks) == "Streaming works."
+    assert final_response.message.content == "The weather in Tokyo is sunny."
+    assert embed_response.prompt_eval_count == 4
+    assert error_info.value.status_code == 503
+    assert len(captured_spans) == 6
+
+    span_ids = {span.context.span_id for span in captured_spans}
+    assert len(span_ids) == len(captured_spans)
+    for span in captured_spans:
+        attrs = dict(span.attributes or {})
+        assert span.context.trace_id == trace_id
+        assert span.parent is not None
+        assert span.parent.span_id == parent_span_id
+        assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
+        assert PRIVATE_HEADER not in json.dumps(attrs, default=str)
+
+    chat_attrs = dict(captured_spans[0].attributes or {})
+    assert chat_attrs[RESPAN_LOG_TYPE] == "chat"
+    assert chat_attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"] == "Say hello."
+    assert chat_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "Tracing works."
+
+    stream_attrs = dict(captured_spans[1].attributes or {})
+    assert stream_attrs[SpanAttributes.LLM_IS_STREAMING] is True
+    assert stream_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        "Streaming works."
+    )
+    assert stream_attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 11
+
+    first_tool_attrs = dict(captured_spans[2].attributes or {})
+    definitions = json.loads(first_tool_attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])
+    current_calls = json.loads(
+        first_tool_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]
+    )
+    assert definitions[0]["function"]["name"] == "get_weather"
+    assert definitions[0]["function"]["parameters"]["properties"]["city"] == {
+        "type": "string"
+    }
+    assert current_calls == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"city": "Tokyo"}',
+            },
+        }
+    ]
+
+    final_tool_attrs = dict(captured_spans[3].attributes or {})
+    assert f"{SpanAttributes.LLM_PROMPTS}.1.tool_calls" in final_tool_attrs
+    assert f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls" not in final_tool_attrs
+
+    error_span = captured_spans[-1]
+    assert error_span.status.status_code is StatusCode.ERROR
+    assert error_span.attributes["status_code"] == 503
+    assert "compat provider unavailable" in error_span.attributes["error.message"]
+
+    banned_aliases = {
+        "respan.span.tools",
+        "respan.span.tool_calls",
+        "tools",
+        "tool_calls",
+        "model",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_request_tokens",
+        "span_tools",
+        "has_tool_calls",
+        "parallel_tool_calls",
+    }
+    for span in captured_spans:
+        assert banned_aliases.isdisjoint(span.attributes or {})

--- a/python-sdks/instrumentations/respan-instrumentation-ollama/tests/test_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-ollama/tests/test_translator.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_instrumentation_ollama._otel_emitter import build_chat_attrs
+from respan_instrumentation_ollama._translator import (
+    StreamResponseAccumulator,
+    safe_json,
+)
+
+
+class _SecretRepr:
+    def __repr__(self) -> str:
+        return "Bearer repr-secret-must-not-escape"
+
+    def __str__(self) -> str:
+        return "Bearer str-secret-must-not-escape"
+
+
+def test_safe_json_is_bounded_redacted_and_avoids_arbitrary_repr() -> None:
+    encoded = safe_json(
+        {
+            "Authorization": "Bearer mapping-secret-must-not-escape",
+            "nested": {"api_key": "key-secret-must-not-escape"},
+            "opaque": _SecretRepr(),
+            "long": "x" * 20_000,
+        }
+    )
+
+    parsed = json.loads(encoded)
+    assert len(encoded) <= 16_000
+    assert "mapping-secret-must-not-escape" not in encoded
+    assert "key-secret-must-not-escape" not in encoded
+    assert "repr-secret-must-not-escape" not in encoded
+    assert "str-secret-must-not-escape" not in encoded
+    assert parsed["Authorization"] == "[REDACTED]"
+    assert parsed["nested"]["api_key"] == "[REDACTED]"
+    assert parsed["opaque"] == {}
+    assert parsed["long"].endswith("...[truncated]")
+
+    escape_encoded = safe_json({"escape_heavy": '"\\\n' * 20_000})
+    assert len(escape_encoded) <= 16_000
+    assert json.loads(escape_encoded)["truncated"] is True
+
+
+def test_direct_prompt_and_completion_attributes_are_bounded_and_redacted() -> None:
+    secret = "do not expose Authorization: Bearer private-value "
+    response: dict[str, Any] = {
+        "model": "llama3.2",
+        "message": {"role": "assistant", "content": secret + "y" * 20_000},
+    }
+    attrs = build_chat_attrs(
+        request_kwargs={
+            "model": "llama3.2",
+            "messages": [{"role": "user", "content": secret + "x" * 20_000}],
+        },
+        response_or_chunks=response,
+    )
+
+    prompt = attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"]
+    completion = attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]
+    assert len(prompt) <= 8_000
+    assert len(completion) <= 8_000
+    assert "private-value" not in prompt
+    assert "private-value" not in completion
+    assert prompt.endswith("...[truncated]")
+    assert completion.endswith("...[truncated]")
+
+
+def test_stream_tool_call_retention_is_bounded_and_keeps_first_valid_calls() -> None:
+    captured = StreamResponseAccumulator()
+    for index in range(100):
+        captured.append(
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": f"tool_{index}",
+                                "arguments": {"index": index},
+                            }
+                        }
+                    ],
+                },
+                "prompt_eval_count": index,
+                "eval_count": index + 1,
+            }
+        )
+
+    response = captured.response()
+    calls = response["message"]["tool_calls"]
+    assert len(calls) == 50
+    assert calls[0]["function"]["name"] == "tool_0"
+    assert calls[-1]["function"]["name"] == "tool_49"
+    assert response["prompt_eval_count"] == 99
+    assert response["eval_count"] == 100


### PR DESCRIPTION
## Summary

- repair Mirascope 2.5 streaming, real tool argument/result translation, lifecycle ownership, privacy-safe bounded serialization, early-close handling, and current-runtime coverage
- repair Mistral 2.9.3/OpenInference 2.0.6 streaming finalization, lifecycle/refcounting, canonical tools, precise 401/500 errors, redaction, duplicate suppression, and tested dependency floors
- repair Ollama 0.6.2 lifecycle ownership, bounded incremental streaming, call-time parenting, cancellation/early-close cleanup, canonical tools, exact 503 errors, and privacy-safe serialization
- add one patch release intent for all three instrumentation packages

## Validation

- [x] focused package tests: Mirascope 30/30, Mistral 18/18, Ollama 16/16 (64/64)
- [x] all three wheels build successfully
- [x] release inventory, release intent, Ruff format/check, Python compilation, and diff checks pass
- [x] exact example marker: otel2-fix-py-group-19-20260817T152514Z
- [x] complete example processes: 18/18
- [x] The exact marker returned 19 traces and 42 records. Every tree and full record was inspected: one root per trace, matching list/tree/detail sets, exact parent links, 42 unique record IDs and 42 unique span IDs, meaningful bounded content, exact model/usage/stream data, connected tools, controlled failures, grouping, privacy, and no forbidden aliases.

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- native failed workflow roots are still projected as success/200 after ingestion even though in-memory exporter tests prove OTel ERROR
- canonical tool definitions/calls remain available in semantic metadata and completion messages while separate platform tool arrays remain empty
- Mirascope/Ollama canonical provider metadata does not populate platform provider_id
- aggregate instrumentation minimums currently reference unpublished package versions; this PR follows the contribution release-intent workflow and does not hand-edit package versions

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/67
