### PR TITLE
fix(instrumentation-py): repair OpenAI, OpenAI Agents, and OpenInference OTel 2.x spans

### DIFF
--- a/.release-intents/20260818-openai-agents-openinference-otel2.json
+++ b/.release-intents/20260818-openai-agents-openinference-otel2.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair OpenAI, OpenAI Agents, and OpenInference OTel 2.x span semantics, lifecycle, errors, tools, parsing, and example coverage.",
+  "packages": {
+    "respan-instrumentation-openai": "patch",
+    "respan-instrumentation-openai-agents": "patch",
+    "respan-instrumentation-openinference": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/README.md
@@ -1,6 +1,6 @@
 # respan-instrumentation-openai-agents
 
-Respan instrumentation plugin for the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python). Captures agent traces, tool calls, handoffs, and LLM generations via the OTEL pipeline.
+Respan instrumentation plugin for the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python). Captures current `0.20.x` agent, task, turn, tool, handoff, guardrail, Responses, Chat Completions, and streaming spans through the OTEL pipeline.
 
 ## Configuration
 
@@ -15,9 +15,9 @@ pip install respan-instrumentation-openai-agents
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `RESPAN_API_KEY` | Yes | Your Respan API key. Authenticates both proxy and tracing. |
-| `RESPAN_BASE_URL` | No | Defaults to `https://api.respan.ai`. |
+| `RESPAN_BASE_URL` | No | Defaults to `https://api.respan.ai/api`. |
 
-All vendor-specific variables (e.g. `OPENAI_API_KEY`) are derived from these in your application code.
+`OPENAI_API_KEY` is required when your application calls OpenAI directly. A compatible OpenAI gateway can instead be configured through the Agents SDK's normal custom-client APIs. Hosted Responses tools such as Web Search, File Search, and Computer Use require a Responses-capable OpenAI credential and endpoint; this instrumentation does not convert those tools to Chat Completions.
 
 ## Quickstart
 
@@ -31,10 +31,10 @@ from respan import Respan
 from respan_instrumentation_openai_agents import OpenAIAgentsInstrumentor
 
 respan_api_key = os.environ["RESPAN_API_KEY"]
-respan_base_url = os.getenv("RESPAN_BASE_URL", "https://api.respan.ai")
+respan_base_url = os.getenv("RESPAN_BASE_URL", "https://api.respan.ai/api")
 
 os.environ["OPENAI_API_KEY"] = respan_api_key
-os.environ["OPENAI_BASE_URL"] = f"{respan_base_url}/api/openai"
+os.environ["OPENAI_BASE_URL"] = respan_base_url
 
 respan = Respan(
     api_key=respan_api_key,
@@ -44,13 +44,19 @@ respan = Respan(
 
 agent = Agent(name="Assistant", instructions="You are a helpful assistant.")
 
+
 async def main():
-    result = await Runner.run(agent, "Hello!")
-    print(result.final_output)
+    try:
+        result = await Runner.run(agent, "Hello!")
+        print(result.final_output)
+    finally:
+        respan.flush()
+
 
 asyncio.run(main())
-respan.flush()
 ```
+
+Instrumentation activation is process-wide and reference-counted. Repeated `Respan` instances share one Agents tracing processor, and the SDK's previous processors are restored after the final deactivation. Auto-emitted spans use canonical JSON attributes, never `traceloop.span.kind` or the deprecated top-level tool aliases.
 
 ### 4. View Dashboard
 

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/pyproject.toml
@@ -13,8 +13,8 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = ">=2.3.0"
 respan-sdk = ">=2.5.0"
-openai-agents = ">=0.3.1"
-opentelemetry-semantic-conventions-ai = ">=0.4.1"
+openai-agents = ">=0.20.0,<0.21.0"
+opentelemetry-semantic-conventions-ai = ">=0.5.1,<0.6.0"
 
 [tool.poetry.plugins."respan.instrumentations"]
 openai-agents = "respan_instrumentation_openai_agents:OpenAIAgentsInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/__init__.py
@@ -1,6 +1,8 @@
 """Respan instrumentation plugin for the OpenAI Agents SDK."""
 
-from respan_instrumentation_openai_agents._instrumentation import OpenAIAgentsInstrumentor
+from respan_instrumentation_openai_agents._instrumentation import (
+    OpenAIAgentsInstrumentor,
+)
 
 __all__ = [
     "OpenAIAgentsInstrumentor",

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_instrumentation.py
@@ -1,75 +1,296 @@
 """OpenAI Agents SDK instrumentation plugin for Respan."""
 
+from __future__ import annotations
+
+import contextvars
+import functools
 import logging
-from typing import Any, Optional
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import AsyncIterator, Mapping
+from typing import Any
 
 from agents.tracing.processor_interface import TracingProcessor
+from agents.tracing.span_data import AgentSpanData
 from agents.tracing.spans import Span
 from agents.tracing.traces import Trace
+from opentelemetry import trace as otel_trace
 
 from respan_instrumentation_openai_agents._otel_emitter import emit_sdk_item
 
 logger = logging.getLogger(__name__)
 
+_MAX_SEEN_ITEMS = 8_192
+_STREAMING: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "respan_openai_agents_streaming", default=False
+)
+_STREAM_PATCH_LOCK = threading.RLock()
+_STREAM_ORIGINALS: dict[tuple[type[Any], str], Any] = {}
+
+
+def _stream_patch_targets() -> tuple[type[Any], ...]:
+    targets: list[type[Any]] = []
+    try:
+        from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
+
+        targets.append(OpenAIChatCompletionsModel)
+    except ImportError:
+        pass
+    try:
+        from agents.models.openai_responses import OpenAIResponsesModel
+
+        targets.append(OpenAIResponsesModel)
+    except ImportError:
+        pass
+    return tuple(targets)
+
+
+def _wrap_stream_method(original: Any) -> Any:
+    @functools.wraps(original)
+    def wrapped(*args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        source = original(*args, **kwargs)
+
+        async def iterate() -> AsyncIterator[Any]:
+            token = _STREAMING.set(True)
+            active_error: BaseException | None = None
+            try:
+                async for item in source:
+                    yield item
+            except BaseException as exc:
+                if not isinstance(exc, GeneratorExit):
+                    active_error = exc
+                raise
+            finally:
+                try:
+                    close = getattr(source, "aclose", None)
+                    if callable(close):
+                        await close()
+                except BaseException:
+                    if active_error is None:
+                        raise
+                    logger.debug(
+                        "Failed to close OpenAI Agents streaming source",
+                        exc_info=True,
+                    )
+                finally:
+                    _STREAMING.reset(token)
+
+        return iterate()
+
+    wrapped.__respan_openai_agents_stream_patch__ = True
+    return wrapped
+
+
+def _install_stream_patches() -> None:
+    """Mark native OpenAI model streaming spans without changing SDK output."""
+    with _STREAM_PATCH_LOCK:
+        for target in _stream_patch_targets():
+            key = (target, "stream_response")
+            if key in _STREAM_ORIGINALS:
+                continue
+            original = getattr(target, "stream_response", None)
+            if not callable(original):
+                continue
+            wrapped = _wrap_stream_method(original)
+            target.stream_response = wrapped
+            _STREAM_ORIGINALS[key] = (original, wrapped)
+
+
+def _remove_stream_patches() -> None:
+    with _STREAM_PATCH_LOCK:
+        for (target, name), (original, wrapped) in tuple(_STREAM_ORIGINALS.items()):
+            if getattr(target, name, None) is wrapped:
+                setattr(target, name, original)
+            _STREAM_ORIGINALS.pop((target, name), None)
+
 
 class _RespanTracingProcessor(TracingProcessor):
-    """OpenAI Agents SDK TracingProcessor that emits spans into the OTEL pipeline."""
+    """Convert completed OpenAI Agents items into the active OTEL pipeline."""
+
+    def __init__(self, *, metadata: Mapping[str, Any] | None = None) -> None:
+        self._metadata = dict(metadata or {})
+        self._lock = threading.RLock()
+        self._seen: OrderedDict[tuple[str, str], None] = OrderedDict()
+        self._open_spans: dict[tuple[str, str], Span[Any]] = {}
+        self._trace_starts: dict[str, int] = {}
+
+    def _mark_once(self, kind: str, identifier: str) -> bool:
+        key = (kind, identifier)
+        with self._lock:
+            if key in self._seen:
+                return False
+            self._seen[key] = None
+            self._seen.move_to_end(key)
+            while len(self._seen) > _MAX_SEEN_ITEMS:
+                self._seen.popitem(last=False)
+        return True
+
+    def _agent_context(self, span: Span[Any]) -> dict[str, Any]:
+        trace_id = span.trace_id
+        parent_id = span.parent_id
+        with self._lock:
+            for _ in range(32):
+                if not parent_id:
+                    break
+                parent = self._open_spans.get((trace_id, parent_id))
+                if parent is None:
+                    break
+                data = parent.span_data
+                if isinstance(data, AgentSpanData):
+                    return {
+                        "handoffs": tuple(data.handoffs or ()),
+                        "output_type": data.output_type,
+                        "tools": tuple(data.tools or ()),
+                    }
+                parent_id = parent.parent_id
+        return {}
 
     def on_trace_start(self, trace: Trace) -> None:
-        pass
+        with self._lock:
+            self._trace_starts.setdefault(trace.trace_id, time.time_ns())
 
     def on_trace_end(self, trace: Trace) -> None:
-        emit_sdk_item(trace)
+        end_ns = time.time_ns()
+        with self._lock:
+            start_ns = self._trace_starts.pop(trace.trace_id, end_ns)
+        if not self._mark_once("trace", trace.trace_id):
+            return
+        emit_sdk_item(
+            trace,
+            extra_metadata=self._metadata,
+            trace_start_ns=start_ns,
+            trace_end_ns=end_ns,
+        )
+        with self._lock:
+            stale = [key for key in self._open_spans if key[0] == trace.trace_id]
+            for key in stale:
+                self._open_spans.pop(key, None)
 
     def on_span_start(self, span: Span[Any]) -> None:
-        pass
+        with self._lock:
+            self._open_spans[(span.trace_id, span.span_id)] = span
 
     def on_span_end(self, span: Span[Any]) -> None:
-        emit_sdk_item(span)
+        if not self._mark_once("span", f"{span.trace_id}:{span.span_id}"):
+            return
+        agent_context = self._agent_context(span)
+        emit_sdk_item(
+            span,
+            extra_metadata=self._metadata,
+            agent_context=agent_context,
+            is_streaming=_STREAMING.get(),
+        )
+        with self._lock:
+            self._open_spans.pop((span.trace_id, span.span_id), None)
 
     def shutdown(self) -> None:
-        pass
+        self.force_flush()
+        with self._lock:
+            self._open_spans.clear()
+            self._trace_starts.clear()
+            self._seen.clear()
 
     def force_flush(self) -> None:
-        pass
+        force_flush = getattr(otel_trace.get_tracer_provider(), "force_flush", None)
+        if callable(force_flush):
+            try:
+                force_flush()
+            except Exception:
+                logger.exception("Failed to flush OpenAI Agents OTEL spans")
+
+
+_LIFECYCLE_LOCK = threading.RLock()
+_SHARED_PROCESSOR: _RespanTracingProcessor | None = None
+_ACTIVATION_COUNT = 0
+_PREVIOUS_PROCESSORS: tuple[TracingProcessor, ...] = ()
+
+
+def _current_processors() -> tuple[TracingProcessor, ...]:
+    from agents.tracing import get_trace_provider
+
+    provider = get_trace_provider()
+    multi = getattr(provider, "_multi_processor", None)
+    processors = getattr(multi, "_processors", ())
+    return tuple(processors) if processors is not None else ()
 
 
 class OpenAIAgentsInstrumentor:
-    """Respan instrumentor for the OpenAI Agents SDK.
-
-    Registers a ``TracingProcessor`` that converts OpenAI Agents SDK
-    traces/spans to OTEL ``ReadableSpan`` objects and injects them into
-    the single OTEL pipeline (``TracerProvider`` → ``RespanSpanExporter``
-    → ``/v2/traces``).
-
-    Usage::
-
-        from respan import Respan
-        from respan_instrumentation_openai_agents import OpenAIAgentsInstrumentor
-
-        respan = Respan(instrumentations=[OpenAIAgentsInstrumentor()])
-    """
+    """Install one ref-counted OpenAI Agents tracing processor per process."""
 
     name = "openai-agents"
 
     def __init__(self) -> None:
-        self._processor: Optional[_RespanTracingProcessor] = None
+        self._processor: _RespanTracingProcessor | None = None
+        self._is_active = False
 
     def activate(self) -> None:
-        """Register the tracing processor with the OpenAI Agents SDK.
+        """Replace the OpenAI tracing backend while preserving it for deactivation."""
+        global _ACTIVATION_COUNT, _PREVIOUS_PROCESSORS, _SHARED_PROCESSOR
 
-        Replaces the default OpenAI backend processor so traces are only
-        sent to Respan, not to OpenAI's tracing endpoint.
-        """
-        from agents.tracing import set_trace_processors
+        with _LIFECYCLE_LOCK:
+            if self._is_active:
+                return
+            if _ACTIVATION_COUNT:
+                _ACTIVATION_COUNT += 1
+                self._processor = _SHARED_PROCESSOR
+                self._is_active = True
+                return
 
-        self._processor = _RespanTracingProcessor()
-        set_trace_processors([self._processor])
-        logger.info("OpenAI Agents SDK instrumentation activated")
+            from agents.tracing import set_trace_processors
+
+            previous = _current_processors()
+            processor = _RespanTracingProcessor()
+            try:
+                _install_stream_patches()
+                set_trace_processors([processor])
+            except Exception:
+                _remove_stream_patches()
+                try:
+                    set_trace_processors(list(previous))
+                except Exception:
+                    logger.exception("Failed to roll back OpenAI Agents processors")
+                logger.exception("Failed to activate OpenAI Agents instrumentation")
+                return
+
+            _PREVIOUS_PROCESSORS = previous
+            _SHARED_PROCESSOR = processor
+            _ACTIVATION_COUNT = 1
+            self._processor = processor
+            self._is_active = True
+            logger.info("OpenAI Agents SDK instrumentation activated")
 
     def deactivate(self) -> None:
-        """Deactivate the instrumentation."""
-        self._processor = None
-        logger.info("OpenAI Agents SDK instrumentation deactivated")
+        """Release this activation and restore the prior SDK processors last."""
+        global _ACTIVATION_COUNT, _PREVIOUS_PROCESSORS, _SHARED_PROCESSOR
 
+        with _LIFECYCLE_LOCK:
+            if not self._is_active:
+                return
+            self._is_active = False
+            self._processor = None
+            _ACTIVATION_COUNT -= 1
+            if _ACTIVATION_COUNT:
+                return
 
+            from agents.tracing import set_trace_processors
+
+            processor = _SHARED_PROCESSOR
+            current = _current_processors()
+            replacement_items: list[TracingProcessor] = []
+            for item in (*_PREVIOUS_PROCESSORS, *current):
+                if item is processor:
+                    continue
+                if any(existing is item for existing in replacement_items):
+                    continue
+                replacement_items.append(item)
+            replacement = tuple(replacement_items)
+            try:
+                set_trace_processors(list(replacement))
+            finally:
+                _remove_stream_patches()
+                if processor is not None:
+                    processor.shutdown()
+                _SHARED_PROCESSOR = None
+                _PREVIOUS_PROCESSORS = ()
+                logger.info("OpenAI Agents SDK instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_otel_emitter.py
@@ -1,22 +1,11 @@
-"""Emit OpenAI Agents SDK spans as OTEL ReadableSpan objects.
+"""Translate current OpenAI Agents SDK trace items into canonical OTEL spans."""
 
-Each per-type emitter converts an OpenAI Agents SDK Trace/Span into a
-``ReadableSpan`` with ``traceloop.*`` and ``gen_ai.*`` attributes, then
-injects it into the OTEL pipeline via ``inject_span()``.
+from __future__ import annotations
 
-Attribute mapping follows the same conventions as decorator-based
-``traceloop.entity.*`` fields and auto-instrumented LLM spans
-(``llm.request.type``, ``gen_ai.*``). Auto-emitted spans do not set
-``traceloop.span.kind``.
-
-**Critical:** ALL child spans must have a non-empty
-``traceloop.entity.path`` to prevent accidental root-span promotion
-by ``is_root_span_candidate()``.
-"""
-
-import json
 import logging
-from typing import Any, Dict, Union
+import math
+from collections.abc import Mapping
+from typing import Any
 
 from agents.tracing.span_data import (
     AgentSpanData,
@@ -31,9 +20,11 @@ from agents.tracing.span_data import (
 )
 from agents.tracing.spans import Span, SpanImpl
 from agents.tracing.traces import Trace
-
-from opentelemetry.semconv_ai import SpanAttributes, LLMRequestTypeValues
-
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
+from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
 from respan_sdk.constants.llm_logging import (
     LOG_TYPE_AGENT,
     LOG_TYPE_CHAT,
@@ -45,16 +36,28 @@ from respan_sdk.constants.llm_logging import (
     LOG_TYPE_WORKFLOW,
 )
 from respan_sdk.constants.span_attributes import (
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    RESPAN_INTERNAL_SPAN_NAME_KIND,
     RESPAN_LOG_TYPE,
+    RESPAN_METADATA,
     RESPAN_METADATA_AGENT_NAME,
     RESPAN_METADATA_FROM_AGENT,
     RESPAN_METADATA_GUARDRAIL_NAME,
     RESPAN_METADATA_TO_AGENT,
     RESPAN_METADATA_TRIGGERED,
+    RESPAN_TRACE_GROUP_ID,
 )
-from respan_sdk.utils.serialization import serialize_value
 from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
+from respan_instrumentation_openai_agents._serialization import (
+    error_status_code,
+    flatten_metadata_attributes,
+    json_string,
+    json_value,
+    parse_json_string,
+    safe_error_message,
+    safe_text,
+)
 from respan_instrumentation_openai_agents._utils import (
     _format_input_messages,
     _format_output,
@@ -64,519 +67,573 @@ from respan_instrumentation_openai_agents._utils import (
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _resolve_timestamps(item: SpanImpl):
-    """Extract start/end nanoseconds from an SDK span's ISO timestamps."""
+def _resolve_timestamps(item: SpanImpl) -> tuple[int | None, int | None]:
     start_ns = end_ns = None
     if item.started_at:
         try:
             start_ns = int(_parse_ts(item.started_at).timestamp() * 1e9)
-        except Exception:
+        except (TypeError, ValueError, OverflowError):
             pass
     if item.ended_at:
         try:
             end_ns = int(_parse_ts(item.ended_at).timestamp() * 1e9)
-        except Exception:
+        except (TypeError, ValueError, OverflowError):
             pass
     return start_ns, end_ns
 
 
 def _base_attrs(
-    span_kind: str,
+    *,
     entity_name: str,
     entity_path: str,
     log_type: str,
-) -> Dict[str, Any]:
-    """Build the common attribute dict shared by all emitters."""
-    return {
-        SpanAttributes.TRACELOOP_ENTITY_NAME: entity_name,
-        SpanAttributes.TRACELOOP_ENTITY_PATH: entity_path,
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    normalized_name = safe_text(entity_name, default="unknown")
+    normalized_path = safe_text(entity_path)
+    attrs: dict[str, Any] = {
+        SpanAttributes.TRACELOOP_ENTITY_NAME: normalized_name,
+        SpanAttributes.TRACELOOP_ENTITY_PATH: normalized_path,
         RESPAN_LOG_TYPE: log_type,
     }
+    if metadata:
+        attrs[RESPAN_METADATA] = json_string(metadata)
+        for key, value in flatten_metadata_attributes(metadata).items():
+            attrs[f"{RESPAN_METADATA}.{key}"] = value
+    return attrs
 
 
-def _llm_base_attrs(
-    entity_name: str,
-    entity_path: str,
-    log_type: str,
-) -> Dict[str, Any]:
-    """Common attrs for an LLM span — deliberately WITHOUT a span kind.
-
-    Stamping ``traceloop.span.kind="task"`` on the LLM span makes the
-    backend file it as a generic task, so ``total_cost``/``total_tokens``
-    never roll up ($0). Omitting the kind (the span stays processable via
-    its ``traceloop.entity.path``) lets the backend classify it as a
-    ``chat`` LLM call off ``llm.request.type``/``gen_ai.system``.
-    """
-    return {
-        SpanAttributes.TRACELOOP_ENTITY_NAME: entity_name,
-        SpanAttributes.TRACELOOP_ENTITY_PATH: entity_path,
-        RESPAN_LOG_TYPE: log_type,
-    }
-
-
-def _safe_json(obj: Any) -> str:
-    """JSON-encode *obj*, falling back to str() on failure."""
-    try:
-        return json.dumps(obj, default=str)
-    except Exception:
-        return str(obj)
-
-
-def _set_json_structured_attr(attrs: Dict[str, Any], key: str, value: Any) -> None:
-    """Store structured values as JSON strings for OTEL attribute safety."""
-    if value:
-        attrs[key] = _safe_json(value)
+def _item_metadata(
+    item: Any, extra_metadata: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    trace_metadata = getattr(item, "trace_metadata", None)
+    if isinstance(trace_metadata, Mapping):
+        metadata.update(trace_metadata)
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    return metadata
 
 
 def _set_message_attrs(
-    attrs: Dict[str, Any],
-    prefix: str,
-    messages: list[dict[str, Any]],
+    attrs: dict[str, Any], prefix: str, messages: list[dict[str, Any]]
 ) -> None:
-    """Set indexed GenAI message attributes from normalized chat messages."""
-    for index, message in enumerate(messages):
+    for index, message in enumerate(messages[:50]):
         message_prefix = f"{prefix}.{index}"
         role = message.get("role")
         content = message.get("content")
         tool_calls = message.get("tool_calls")
         if role is not None:
-            attrs[f"{message_prefix}.role"] = str(role)
+            attrs[f"{message_prefix}.role"] = safe_text(
+                role, default="unknown", limit=64
+            )
         if content is not None:
             attrs[f"{message_prefix}.content"] = (
-                content if isinstance(content, str) else _safe_json(content)
+                safe_text(content, limit=4_000)
+                if isinstance(content, str)
+                else json_string(content)
             )
-        _set_json_structured_attr(attrs, f"{message_prefix}.tool_calls", tool_calls)
+        if tool_calls:
+            attrs[f"{message_prefix}.tool_calls"] = json_string(tool_calls)
 
 
 def _set_completion_attrs(
-    attrs: Dict[str, Any],
-    *,
-    content: str,
-    tool_calls: list[dict[str, Any]] | None = None,
+    attrs: dict[str, Any], *, content: str, tool_calls: list[dict[str, Any]]
 ) -> None:
-    completion_prefix = f"{SpanAttributes.LLM_COMPLETIONS}.0"
-    attrs[f"{completion_prefix}.role"] = "assistant"
-    attrs[f"{completion_prefix}.content"] = content
-    _set_json_structured_attr(
-        attrs,
-        f"{completion_prefix}.tool_calls",
-        tool_calls,
-    )
+    prefix = f"{SpanAttributes.LLM_COMPLETIONS}.0"
+    attrs[f"{prefix}.role"] = "assistant"
+    attrs[f"{prefix}.content"] = safe_text(content, limit=4_000)
+    if tool_calls:
+        attrs[f"{prefix}.tool_calls"] = json_string(tool_calls)
 
 
-def _extract_tools(tools: list) -> list:
-    """Convert Response API tool definitions to Chat Completions format."""
+def _get_field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    try:
+        return getattr(value, name, default)
+    except Exception:  # noqa: BLE001 - SDK objects may implement hostile descriptors.
+        return default
+
+
+def _tool_definition(tool: Any) -> dict[str, Any] | None:
+    dumped = json_value(tool)
+    if isinstance(dumped, str):
+        return {"type": "function", "function": {"name": dumped}}
+    if not isinstance(dumped, Mapping):
+        return None
+    tool_type = safe_text(dumped.get("type"), default="function", limit=64)
+    function = dumped.get("function")
+    if isinstance(function, Mapping):
+        name = function.get("name")
+        if not name:
+            return None
+        normalized = {"name": safe_text(name, default="unknown")}
+        for key in ("description", "parameters"):
+            if function.get(key) is not None:
+                normalized[key] = function[key]
+        return {"type": tool_type, "function": normalized}
+
+    name = dumped.get("name")
+    if not name:
+        return dict(dumped)
+    normalized = {"name": safe_text(name, default="unknown")}
+    for key in ("description", "parameters"):
+        if dumped.get(key) is not None:
+            normalized[key] = dumped[key]
+    return {"type": tool_type, "function": normalized}
+
+
+def _extract_tools(tools: Any) -> list[dict[str, Any]]:
+    if not tools:
+        return []
+    if isinstance(tools, str) or not isinstance(tools, (list, tuple)):
+        tools = [tools]
     result = []
-    for tool in tools:
-        tool_dict = serialize_value(tool)
-        if not isinstance(tool_dict, dict):
+    for tool in tools[:50]:
+        definition = _tool_definition(tool)
+        if definition is not None:
+            result.append(definition)
+    return result
+
+
+def _normalize_tool_call(value: Any) -> dict[str, Any] | None:
+    dumped = json_value(value)
+    if not isinstance(dumped, Mapping):
+        return None
+    function = dumped.get("function")
+    if isinstance(function, Mapping):
+        name = function.get("name")
+        arguments = function.get("arguments", {})
+    else:
+        name = dumped.get("name")
+        arguments = dumped.get("arguments", {})
+    if not name:
+        return None
+    normalized: dict[str, Any] = {
+        "type": "function",
+        "function": {
+            "name": safe_text(name, default="unknown"),
+            "arguments": (
+                arguments if isinstance(arguments, str) else json_string(arguments)
+            ),
+        },
+    }
+    call_id = dumped.get("call_id") or dumped.get("id")
+    if call_id:
+        normalized["id"] = safe_text(call_id, limit=256)
+    return normalized
+
+
+def _extract_tool_calls(output: Any) -> list[dict[str, Any]]:
+    dumped = json_value(output)
+    items = dumped if isinstance(dumped, list) else [dumped]
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in items[:50]:
+        if not isinstance(item, Mapping):
             continue
-        tool_type = tool_dict.get("type", "")
-        if tool_type == "function":
-            func = {
-                "name": tool_dict.get("name", ""),
-            }
-            desc = tool_dict.get("description")
-            if desc:
-                func["description"] = desc
-            params = tool_dict.get("parameters")
-            if params:
-                func["parameters"] = params
-            result.append({"type": "function", "function": func})
-        else:
-            result.append(tool_dict)
+        candidates: list[Any] = []
+        if item.get("type") == "function_call":
+            candidates.append(item)
+        nested = item.get("tool_calls")
+        if isinstance(nested, list):
+            candidates.extend(nested)
+        for candidate in candidates:
+            normalized = _normalize_tool_call(candidate)
+            if normalized is None:
+                continue
+            signature = json_string(normalized)
+            if signature in seen:
+                continue
+            seen.add(signature)
+            result.append(normalized)
     return result
 
 
-def _extract_tool_calls(output: list) -> list:
-    """Extract function tool calls from Response API output items."""
-    result = []
-    for item in output:
-        item_dict = serialize_value(item)
-        if isinstance(item_dict, dict) and item_dict.get("type") == "function_call":
-            result.append({
-                "id": item_dict.get("call_id", ""),
-                "type": "function",
-                "function": {
-                    "name": item_dict.get("name", ""),
-                    "arguments": item_dict.get("arguments", ""),
-                },
-            })
-    return result
+def _usage_value(usage: Any, *names: str) -> int | None:
+    for name in names:
+        value = _get_field(usage, name)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int) and value >= 0:
+            return int(value)
+        if isinstance(value, float) and math.isfinite(value) and value >= 0:
+            return int(value)
+    return None
 
 
-# ---------------------------------------------------------------------------
-# Per-type emitters
-# ---------------------------------------------------------------------------
+def _set_usage(attrs: dict[str, Any], usage: Any) -> None:
+    if not usage:
+        return
+    input_tokens = _usage_value(usage, "input_tokens", "prompt_tokens")
+    output_tokens = _usage_value(usage, "output_tokens", "completion_tokens")
+    total_tokens = _usage_value(usage, "total_tokens")
+    if input_tokens is not None:
+        attrs[GEN_AI_USAGE_INPUT_TOKENS] = input_tokens
+        attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = input_tokens
+    if output_tokens is not None:
+        attrs[GEN_AI_USAGE_OUTPUT_TOKENS] = output_tokens
+        attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = output_tokens
+    if total_tokens is None and input_tokens is not None and output_tokens is not None:
+        total_tokens = input_tokens + output_tokens
+    if total_tokens is not None:
+        attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = total_tokens
 
 
-def emit_trace(trace_obj: Trace) -> None:
-    """Emit a Trace (root workflow span)."""
-    attrs = _base_attrs(
-        span_kind="workflow",
-        entity_name=trace_obj.name or "trace",
-        entity_path="",  # root — no parent path
-        log_type=LOG_TYPE_WORKFLOW,
-    )
-    attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = trace_obj.name or "trace"
-
-    span = build_readable_span(
-        name=f"{trace_obj.name}.workflow",
-        trace_id=trace_obj.trace_id,
-        span_id=trace_obj.trace_id,  # root span uses trace_id as span_id
-        attributes=attrs,
-    )
-    inject_span(span)
+def _agent_tools(agent_context: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    return _extract_tools(agent_context.get("tools")) if agent_context else []
 
 
-def emit_agent(item: SpanImpl, span_data: AgentSpanData) -> None:
-    """Emit an AgentSpanData span."""
+def _is_streaming(
+    span_data: Any, explicit: bool, agent_context: Mapping[str, Any] | None
+) -> bool:
+    if explicit:
+        return True
+    model_config = _get_field(span_data, "model_config")
+    if isinstance(model_config, Mapping) and model_config.get("stream") is True:
+        return True
+    return bool(agent_context and agent_context.get("is_streaming"))
+
+
+def _build_item_span(
+    item: SpanImpl,
+    *,
+    name: str,
+    attributes: dict[str, Any],
+) -> Any:
     start_ns, end_ns = _resolve_timestamps(item)
-    name = span_data.name or "agent"
+    error = item.error
+    message = safe_error_message(error)
+    status_code = error_status_code(error) if error else 200
+    if message:
+        attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_string(
+            {"error": {"message": message, "status_code": status_code}}
+        )
+    return build_readable_span(
+        name=safe_text(name, default="span"),
+        trace_id=item.trace_id,
+        span_id=item.span_id,
+        parent_id=item.parent_id or item.trace_id,
+        start_time_ns=start_ns,
+        end_time_ns=end_ns,
+        attributes=attributes,
+        status_code=status_code,
+        error_message=message,
+    )
+
+
+def emit_trace(
+    trace_obj: Trace,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    start_ns: int | None = None,
+    end_ns: int | None = None,
+) -> None:
+    name = safe_text(trace_obj.name, default="trace")
+    metadata: dict[str, Any] = {}
+    trace_metadata = getattr(trace_obj, "metadata", None)
+    if isinstance(trace_metadata, Mapping):
+        metadata.update(trace_metadata)
+    if extra_metadata:
+        metadata.update(extra_metadata)
     attrs = _base_attrs(
-        span_kind="agent",
+        entity_name=name, entity_path="", log_type=LOG_TYPE_WORKFLOW, metadata=metadata
+    )
+    attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = name
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_string({"workflow_name": name})
+    group_id = getattr(trace_obj, "group_id", None)
+    if group_id:
+        attrs[RESPAN_TRACE_GROUP_ID] = safe_text(group_id, limit=512)
+    inject_span(
+        build_readable_span(
+            name=f"{name}.workflow",
+            trace_id=trace_obj.trace_id,
+            span_id=trace_obj.trace_id,
+            start_time_ns=start_ns,
+            end_time_ns=end_ns,
+            attributes=attrs,
+        )
+    )
+
+
+def emit_agent(
+    item: SpanImpl,
+    span_data: AgentSpanData,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    **_: Any,
+) -> None:
+    name = safe_text(span_data.name, default="agent")
+    attrs = _base_attrs(
         entity_name=name,
         entity_path=name,
         log_type=LOG_TYPE_AGENT,
+        metadata=_item_metadata(item, extra_metadata),
     )
     attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] = name
     attrs[RESPAN_METADATA_AGENT_NAME] = name
-
-    span = build_readable_span(
-        name=f"{name}.agent",
-        trace_id=item.trace_id,
-        span_id=item.span_id,
-        parent_id=item.parent_id or item.trace_id,
-        start_time_ns=start_ns,
-        end_time_ns=end_ns,
-        attributes=attrs,
-        status_code=400 if item.error else 200,
-        error_message=str(item.error) if item.error else None,
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_string(
+        {
+            "handoffs": span_data.handoffs or [],
+            "name": name,
+            "output_type": span_data.output_type,
+            "tools": span_data.tools or [],
+        }
     )
-    inject_span(span)
+    inject_span(_build_item_span(item, name=f"{name}.agent", attributes=attrs))
 
 
-def emit_response(item: SpanImpl, span_data: ResponseSpanData) -> None:
-    """Emit a ResponseSpanData span (the actual LLM call)."""
-    start_ns, end_ns = _resolve_timestamps(item)
-    attrs = _llm_base_attrs(
-        entity_name="response",
-        entity_path="response",
+def _llm_attrs(
+    item: SpanImpl,
+    *,
+    entity_name: str,
+    extra_metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    attrs = _base_attrs(
+        entity_name=entity_name,
+        entity_path=entity_name,
         log_type=LOG_TYPE_CHAT,
+        metadata=_item_metadata(item, extra_metadata),
     )
     attrs[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
     attrs[SpanAttributes.LLM_SYSTEM] = "openai"
+    return attrs
 
-    # Input
-    input_msgs = _format_input_messages(span_data.input)
-    if input_msgs:
-        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(input_msgs)
-        _set_message_attrs(attrs, SpanAttributes.LLM_PROMPTS, input_msgs)
 
-    # Response data
-    resp = span_data.response
-    if resp:
-        model = getattr(resp, "model", None) or ""
-        if model:
-            attrs[SpanAttributes.LLM_REQUEST_MODEL] = model
+def _set_llm_content(
+    attrs: dict[str, Any], *, input_value: Any, output_value: Any
+) -> None:
+    messages = _format_input_messages(input_value)
+    if messages:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_string(messages)
+        _set_message_attrs(attrs, SpanAttributes.LLM_PROMPTS, messages)
+    tool_calls = _extract_tool_calls(output_value)
+    output = _format_output(output_value)
+    if output_value is not None:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_string(
+            {"content": output, "tool_calls": tool_calls}
+        )
+        _set_completion_attrs(attrs, content=output, tool_calls=tool_calls)
 
-        if hasattr(resp, "output") and resp.output:
-            output = _format_output(resp.output)
-            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = output
 
-            tool_calls = _extract_tool_calls(resp.output)
-            _set_completion_attrs(attrs, content=output, tool_calls=tool_calls)
-
-        if hasattr(resp, "tools") and resp.tools:
-            tools_list = _extract_tools(resp.tools)
-            _set_json_structured_attr(
-                attrs,
-                SpanAttributes.LLM_REQUEST_FUNCTIONS,
-                tools_list,
-            )
-
-        usage = getattr(resp, "usage", None)
-        if usage:
-            attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = (
-                getattr(usage, "input_tokens", 0) or 0
-            )
-            attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = (
-                getattr(usage, "output_tokens", 0) or 0
-            )
-
-    span = build_readable_span(
-        name="openai.chat",
-        trace_id=item.trace_id,
-        span_id=item.span_id,
-        parent_id=item.parent_id or item.trace_id,
-        start_time_ns=start_ns,
-        end_time_ns=end_ns,
-        attributes=attrs,
-        status_code=400 if item.error else 200,
-        error_message=str(item.error) if item.error else None,
+def emit_response(
+    item: SpanImpl,
+    span_data: ResponseSpanData,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    agent_context: Mapping[str, Any] | None = None,
+    is_streaming: bool = False,
+) -> None:
+    attrs = _llm_attrs(item, entity_name="response", extra_metadata=extra_metadata)
+    response = span_data.response
+    output = _get_field(response, "output") if response is not None else None
+    _set_llm_content(attrs, input_value=span_data.input, output_value=output)
+    model = _get_field(response, "model")
+    if model:
+        attrs[SpanAttributes.LLM_REQUEST_MODEL] = safe_text(model)
+        attrs[SpanAttributes.LLM_RESPONSE_MODEL] = safe_text(model)
+    tools = _extract_tools(_get_field(response, "tools")) or _agent_tools(agent_context)
+    if tools:
+        attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS] = json_string(tools)
+    _set_usage(attrs, _get_field(span_data, "usage") or _get_field(response, "usage"))
+    attrs[SpanAttributes.LLM_IS_STREAMING] = _is_streaming(
+        span_data, is_streaming, agent_context
     )
-    inject_span(span)
+    inject_span(_build_item_span(item, name="openai.chat", attributes=attrs))
 
 
-def emit_function(item: SpanImpl, span_data: FunctionSpanData) -> None:
-    """Emit a FunctionSpanData span (tool call)."""
-    start_ns, end_ns = _resolve_timestamps(item)
-    name = span_data.name or "function"
+def emit_generation(
+    item: SpanImpl,
+    span_data: GenerationSpanData,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    agent_context: Mapping[str, Any] | None = None,
+    is_streaming: bool = False,
+) -> None:
+    attrs = _llm_attrs(item, entity_name="generation", extra_metadata=extra_metadata)
+    if span_data.model:
+        attrs[SpanAttributes.LLM_REQUEST_MODEL] = safe_text(span_data.model)
+        attrs[SpanAttributes.LLM_RESPONSE_MODEL] = safe_text(span_data.model)
+    _set_llm_content(attrs, input_value=span_data.input, output_value=span_data.output)
+    tools = _agent_tools(agent_context)
+    if tools:
+        attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS] = json_string(tools)
+    _set_usage(attrs, span_data.usage)
+    attrs[SpanAttributes.LLM_IS_STREAMING] = _is_streaming(
+        span_data, is_streaming, agent_context
+    )
+    inject_span(_build_item_span(item, name="openai.chat", attributes=attrs))
+
+
+def emit_function(
+    item: SpanImpl,
+    span_data: FunctionSpanData,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    **_: Any,
+) -> None:
+    name = safe_text(span_data.name, default="function")
     attrs = _base_attrs(
-        span_kind="tool",
         entity_name=name,
         entity_path=name,
         log_type=LOG_TYPE_TOOL,
+        metadata=_item_metadata(item, extra_metadata),
     )
-
-    input_str = serialize_value(span_data.input) or ""
-    if not isinstance(input_str, str):
-        input_str = json.dumps(input_str, default=str)
-    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(
-        [{"role": "tool", "content": input_str}]
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_string(
+        {"arguments": parse_json_string(span_data.input), "name": name}
     )
-
-    output_str = serialize_value(span_data.output) or ""
-    if not isinstance(output_str, str):
-        output_str = json.dumps(output_str, default=str)
-    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json(
-        {"role": "tool", "content": output_str}
-    )
-
-    span = build_readable_span(
-        name=f"{name}.tool",
-        trace_id=item.trace_id,
-        span_id=item.span_id,
-        parent_id=item.parent_id or item.trace_id,
-        start_time_ns=start_ns,
-        end_time_ns=end_ns,
-        attributes=attrs,
-        status_code=400 if item.error else 200,
-        error_message=str(item.error) if item.error else None,
-    )
-    inject_span(span)
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_string(span_data.output)
+    inject_span(_build_item_span(item, name=f"{name}.tool", attributes=attrs))
 
 
-def emit_generation(item: SpanImpl, span_data: GenerationSpanData) -> None:
-    """Emit a GenerationSpanData span."""
-    start_ns, end_ns = _resolve_timestamps(item)
-    attrs = _llm_base_attrs(
-        entity_name="generation",
-        entity_path="generation",
-        log_type=LOG_TYPE_CHAT,
-    )
-    attrs[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
-    attrs[SpanAttributes.LLM_SYSTEM] = "openai"
-
-    if span_data.model:
-        attrs[SpanAttributes.LLM_REQUEST_MODEL] = span_data.model
-
-    input_msgs = _format_input_messages(span_data.input)
-    if input_msgs:
-        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(input_msgs)
-        _set_message_attrs(attrs, SpanAttributes.LLM_PROMPTS, input_msgs)
-
-    output = _format_output(span_data.output)
-    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = output
-    _set_completion_attrs(
-        attrs,
-        content=output,
-        tool_calls=_extract_tool_calls(span_data.output or []),
-    )
-
-    if span_data.usage:
-        u = span_data.usage
-        attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = (
-            u.get("prompt_tokens") or u.get("input_tokens") or 0
-        )
-        attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = (
-            u.get("completion_tokens") or u.get("output_tokens") or 0
-        )
-
-    span = build_readable_span(
-        name="openai.chat",
-        trace_id=item.trace_id,
-        span_id=item.span_id,
-        parent_id=item.parent_id or item.trace_id,
-        start_time_ns=start_ns,
-        end_time_ns=end_ns,
-        attributes=attrs,
-        status_code=400 if item.error else 200,
-        error_message=str(item.error) if item.error else None,
-    )
-    inject_span(span)
-
-
-def emit_handoff(item: SpanImpl, span_data: HandoffSpanData) -> None:
-    """Emit a HandoffSpanData span."""
-    start_ns, end_ns = _resolve_timestamps(item)
-    from_agent = span_data.from_agent or ""
-    to_agent = span_data.to_agent or ""
+def emit_handoff(
+    item: SpanImpl,
+    span_data: HandoffSpanData,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    **_: Any,
+) -> None:
+    from_agent = safe_text(span_data.from_agent, default="unknown")
+    to_agent = safe_text(span_data.to_agent, default="unknown")
     attrs = _base_attrs(
-        span_kind="task",
         entity_name="handoff",
         entity_path="handoff",
         log_type=LOG_TYPE_HANDOFF,
+        metadata=_item_metadata(item, extra_metadata),
     )
-    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(from_agent)
-    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json(to_agent)
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_string(
+        {"from_agent": from_agent}
+    )
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_string({"to_agent": to_agent})
     attrs[RESPAN_METADATA_FROM_AGENT] = from_agent
     attrs[RESPAN_METADATA_TO_AGENT] = to_agent
-
-    span = build_readable_span(
-        name="handoff.task",
-        trace_id=item.trace_id,
-        span_id=item.span_id,
-        parent_id=item.parent_id or item.trace_id,
-        start_time_ns=start_ns,
-        end_time_ns=end_ns,
-        attributes=attrs,
-        status_code=400 if item.error else 200,
-        error_message=str(item.error) if item.error else None,
-    )
-    inject_span(span)
+    attrs[RESPAN_INTERNAL_SPAN_NAME_KIND] = "handoff"
+    attrs[RESPAN_INTERNAL_SPAN_NAME_DETAIL] = f"{from_agent}_to_{to_agent}"
+    inject_span(_build_item_span(item, name="handoff.task", attributes=attrs))
 
 
-def emit_guardrail(item: SpanImpl, span_data: GuardrailSpanData) -> None:
-    """Emit a GuardrailSpanData span."""
-    start_ns, end_ns = _resolve_timestamps(item)
-    name = f"guardrail:{span_data.name}"
+def emit_guardrail(
+    item: SpanImpl,
+    span_data: GuardrailSpanData,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    **_: Any,
+) -> None:
+    name = safe_text(span_data.name, default="guardrail")
     attrs = _base_attrs(
-        span_kind="task",
         entity_name=name,
         entity_path=name,
         log_type=LOG_TYPE_GUARDRAIL,
+        metadata=_item_metadata(item, extra_metadata),
     )
-    attrs[RESPAN_METADATA_GUARDRAIL_NAME] = span_data.name
-    attrs[RESPAN_METADATA_TRIGGERED] = str(span_data.triggered)
-
-    span = build_readable_span(
-        name=f"{name}.task",
-        trace_id=item.trace_id,
-        span_id=item.span_id,
-        parent_id=item.parent_id or item.trace_id,
-        start_time_ns=start_ns,
-        end_time_ns=end_ns,
-        attributes=attrs,
-        status_code=400 if item.error else 200,
-        error_message=str(item.error) if item.error else None,
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_string({"name": name})
+    attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_string(
+        {"triggered": bool(span_data.triggered)}
     )
-    inject_span(span)
+    attrs[RESPAN_METADATA_GUARDRAIL_NAME] = name
+    attrs[RESPAN_METADATA_TRIGGERED] = bool(span_data.triggered)
+    inject_span(_build_item_span(item, name=f"{name}.task", attributes=attrs))
 
 
-def emit_custom(item: SpanImpl, span_data: CustomSpanData) -> None:
-    """Emit a CustomSpanData span."""
-    start_ns, end_ns = _resolve_timestamps(item)
-    name = span_data.name or "custom"
+def emit_custom(
+    item: SpanImpl,
+    span_data: CustomSpanData,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    **_: Any,
+) -> None:
+    name = safe_text(span_data.name, default="custom")
+    metadata = _item_metadata(item, extra_metadata)
     attrs = _base_attrs(
-        span_kind="task",
         entity_name=name,
         entity_path=name,
         log_type=LOG_TYPE_CUSTOM,
+        metadata=metadata,
     )
     data = span_data.data or {}
-    for k, v in data.items():
-        if k in ("model",):
-            attrs[SpanAttributes.LLM_REQUEST_MODEL] = v
-        elif k == "prompt_tokens":
-            attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = v
-        elif k == "completion_tokens":
-            attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = v
-        elif k == "input":
-            attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json(v)
-        elif k == "output":
-            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json(v)
-        else:
-            attrs[f"respan.metadata.{k}"] = str(v)
-
-    span = build_readable_span(
-        name=f"{name}.task",
-        trace_id=item.trace_id,
-        span_id=item.span_id,
-        parent_id=item.parent_id or item.trace_id,
-        start_time_ns=start_ns,
-        end_time_ns=end_ns,
-        attributes=attrs,
-        status_code=400 if item.error else 200,
-        error_message=str(item.error) if item.error else None,
-    )
-    inject_span(span)
+    if data.get("model"):
+        attrs[SpanAttributes.LLM_REQUEST_MODEL] = safe_text(data["model"])
+    _set_usage(attrs, data)
+    if "input" in data:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_string(data["input"])
+    if "output" in data:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_string(data["output"])
+    excluded = {
+        "completion_tokens",
+        "input",
+        "input_tokens",
+        "model",
+        "output",
+        "output_tokens",
+        "prompt_tokens",
+        "total_tokens",
+    }
+    remaining = {key: value for key, value in data.items() if key not in excluded}
+    if remaining:
+        attrs[RESPAN_METADATA] = json_string({**metadata, **remaining})
+    inject_span(_build_item_span(item, name=f"{name}.task", attributes=attrs))
 
 
 def _emit_structural(
     item: SpanImpl,
     span_data: Any,
+    *,
     name: str,
     log_type: str,
-    agent_name: str = None,
+    input_value: Mapping[str, Any],
+    extra_metadata: Mapping[str, Any] | None,
 ) -> None:
-    """Emit a structural parent span (Task/Turn).
-
-    These are the SDK's tree scaffolding — one ``TaskSpanData`` per
-    ``Runner.run`` and one ``TurnSpanData`` per agent-loop turn. Without
-    them the agent/LLM/tool children orphan onto the trace root and the
-    backend renders the trace **flat**. Emitting them with the SDK's real
-    ``span_id``/``parent_id`` re-nests the tree.
-    """
-    start_ns, end_ns = _resolve_timestamps(item)
     attrs = _base_attrs(
-        span_kind="task",
         entity_name=name,
         entity_path=name,
         log_type=log_type,
+        metadata=_item_metadata(item, extra_metadata),
     )
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_string(input_value)
+    agent_name = getattr(span_data, "agent_name", None)
     if agent_name:
-        attrs[RESPAN_METADATA_AGENT_NAME] = agent_name
-
-    usage = getattr(span_data, "usage", None) or {}
-    if usage:
-        attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = (
-            usage.get("prompt_tokens") or usage.get("input_tokens") or 0
-        )
-        attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = (
-            usage.get("completion_tokens") or usage.get("output_tokens") or 0
-        )
-
-    span = build_readable_span(
-        name=f"{name}.task",
-        trace_id=item.trace_id,
-        span_id=item.span_id,
-        parent_id=item.parent_id or item.trace_id,
-        start_time_ns=start_ns,
-        end_time_ns=end_ns,
-        attributes=attrs,
-        status_code=400 if item.error else 200,
-        error_message=str(item.error) if item.error else None,
-    )
-    inject_span(span)
+        attrs[RESPAN_METADATA_AGENT_NAME] = safe_text(agent_name)
+    _set_usage(attrs, getattr(span_data, "usage", None))
+    inject_span(_build_item_span(item, name=f"{name}.task", attributes=attrs))
 
 
-def emit_task(item: SpanImpl, span_data: TaskSpanData) -> None:
-    """Emit a TaskSpanData span (one top-level Runner run)."""
-    _emit_structural(
-        item, span_data, span_data.name or "agent-run", LOG_TYPE_WORKFLOW
-    )
-
-
-def emit_turn(item: SpanImpl, span_data: TurnSpanData) -> None:
-    """Emit a TurnSpanData span (one agent-loop turn)."""
+def emit_task(
+    item: SpanImpl,
+    span_data: TaskSpanData,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    **_: Any,
+) -> None:
+    name = safe_text(span_data.name, default="agent-run")
     _emit_structural(
         item,
         span_data,
-        f"turn-{span_data.turn}",
-        LOG_TYPE_TASK,
-        span_data.agent_name,
+        name=name,
+        log_type=LOG_TYPE_WORKFLOW,
+        input_value={"name": name},
+        extra_metadata=extra_metadata,
     )
 
 
-# ---------------------------------------------------------------------------
-# Dispatcher
-# ---------------------------------------------------------------------------
+def emit_turn(
+    item: SpanImpl,
+    span_data: TurnSpanData,
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    **_: Any,
+) -> None:
+    turn = safe_text(span_data.turn, default="unknown", limit=64)
+    name = f"turn-{turn}"
+    _emit_structural(
+        item,
+        span_data,
+        name=name,
+        log_type=LOG_TYPE_TASK,
+        input_value={"agent_name": span_data.agent_name, "turn": span_data.turn},
+        extra_metadata=extra_metadata,
+    )
+
 
 _EMITTERS = {
     ResponseSpanData: emit_response,
@@ -591,21 +648,40 @@ _EMITTERS = {
 }
 
 
-def emit_sdk_item(item: Union[Trace, Span[Any]]) -> None:
-    """Convert an OpenAI Agents SDK Trace or Span and inject into OTEL pipeline."""
+def emit_sdk_item(
+    item: Trace | Span[Any],
+    *,
+    extra_metadata: Mapping[str, Any] | None = None,
+    agent_context: Mapping[str, Any] | None = None,
+    is_streaming: bool = False,
+    trace_start_ns: int | None = None,
+    trace_end_ns: int | None = None,
+) -> bool:
+    """Convert one completed SDK item and inject it into the OTEL pipeline."""
     if isinstance(item, Trace):
-        emit_trace(item)
-        return
-
-    if isinstance(item, SpanImpl):
-        emitter = _EMITTERS.get(type(item.span_data))
-        if emitter is None:
-            logger.warning("Unknown span data type: %s", type(item.span_data).__name__)
-            return
-        try:
-            emitter(item, item.span_data)
-        except Exception:
-            logger.exception("Error emitting %s", type(item.span_data).__name__)
-        return
-
-    logger.debug("Skipping unsupported item type: %s", type(item).__name__)
+        emit_trace(
+            item,
+            extra_metadata=extra_metadata,
+            start_ns=trace_start_ns,
+            end_ns=trace_end_ns,
+        )
+        return True
+    if not isinstance(item, SpanImpl):
+        logger.debug("Skipping unsupported item type: %s", type(item).__name__)
+        return False
+    emitter = _EMITTERS.get(type(item.span_data))
+    if emitter is None:
+        logger.warning("Unknown span data type: %s", type(item.span_data).__name__)
+        return False
+    try:
+        emitter(
+            item,
+            item.span_data,
+            extra_metadata=extra_metadata,
+            agent_context=agent_context,
+            is_streaming=is_streaming,
+        )
+    except Exception:
+        logger.exception("Error emitting %s", type(item.span_data).__name__)
+        return False
+    return True

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_serialization.py
@@ -1,0 +1,356 @@
+"""Bounded, redacting serializers for OpenAI Agents trace payloads."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from typing import Any
+
+MAX_ATTRIBUTE_BYTES = 16_000
+_MAX_COLLECTION_ITEMS = 50
+_MAX_DEPTH = 6
+_MAX_STRING_CHARS = 4_000
+_MAX_FLATTENED_METADATA_KEY_CHARS = 128
+_REDACTED = "[REDACTED]"
+
+_SENSITIVE_KEYS = {
+    "apikey",
+    "authorization",
+    "authtoken",
+    "clientsecret",
+    "cookie",
+    "credential",
+    "credentials",
+    "password",
+    "passwd",
+    "privatekey",
+    "refreshtoken",
+    "secret",
+    "sessioncookie",
+    "sessiontoken",
+    "token",
+}
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b"),
+)
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)\b(api[_-]?key|authorization|password|secret|session[_-]?token|token)"
+    r"(\s*[:=]\s*)([^\s,;]+)"
+)
+
+
+def _redact_text(value: str) -> str:
+    redacted = value
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub(_REDACTED, redacted)
+    redacted = _SECRET_ASSIGNMENT.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}{_REDACTED}", redacted
+    )
+    if len(redacted) <= _MAX_STRING_CHARS:
+        return redacted
+    return f"{redacted[:_MAX_STRING_CHARS]}...[truncated]"
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    normalized = re.sub(r"[^a-z0-9]", "", key.lower())
+    if normalized in _SENSITIVE_KEYS:
+        return True
+    return normalized.endswith(
+        ("accesstoken", "authtoken", "idtoken", "refreshtoken", "secretkey")
+    )
+
+
+def _safe_key_text(key: Any) -> str:
+    if isinstance(key, str):
+        return _redact_text(key)
+    if key is None:
+        return "null"
+    if isinstance(key, bool):
+        return "true" if key else "false"
+    if isinstance(key, int):
+        return str(key)
+    if isinstance(key, float) and math.isfinite(key):
+        return str(key)
+    return f"<{type(key).__name__}>"
+
+
+def safe_text(value: Any, *, default: str = "", limit: int = 512) -> str:
+    """Return a bounded, redacted scalar without invoking custom string hooks."""
+    if isinstance(value, str):
+        return _redact_text(value)[:limit]
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return ("true" if value else "false")[:limit]
+    if isinstance(value, int):
+        return str(value)[:limit]
+    if isinstance(value, float) and math.isfinite(value):
+        return str(value)[:limit]
+    return f"<{type(value).__name__}>"[:limit]
+
+
+def _public_object_fields(value: Any) -> Mapping[str, Any] | None:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        try:
+            return {
+                field.name: getattr(value, field.name)
+                for field in dataclasses.fields(value)
+            }
+        except Exception:  # noqa: BLE001 - dataclass fields can execute user code.
+            return None
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        for kwargs in (
+            {"mode": "json", "exclude_none": True},
+            {"exclude_none": True},
+            {},
+        ):
+            try:
+                dumped = model_dump(**kwargs)
+            except (TypeError, ValueError):
+                continue
+            except Exception:  # noqa: BLE001 - Pydantic hooks can execute user code.
+                return None
+            if isinstance(dumped, Mapping):
+                return dumped
+
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        try:
+            dumped = to_dict()
+        except Exception:  # noqa: BLE001 - SDK conversion hooks are untrusted.
+            return None
+        if isinstance(dumped, Mapping):
+            return dumped
+
+    try:
+        fields = vars(value)
+    except (TypeError, ValueError):
+        return None
+    except Exception:  # noqa: BLE001 - custom __dict__ descriptors are untrusted.
+        return None
+    if isinstance(fields, Mapping):
+        return {
+            key: item
+            for key, item in fields.items()
+            if not (isinstance(key, str) and key.startswith("_"))
+        }
+    return None
+
+
+def json_value(
+    value: Any,
+    *,
+    _depth: int = 0,
+    _seen: set[int] | None = None,
+) -> Any:
+    """Convert a value to bounded JSON data without arbitrary ``str``/``repr`` calls."""
+    if value is None or isinstance(value, bool | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return _redact_text(value)
+    if isinstance(value, bytes | bytearray | memoryview):
+        return f"<{type(value).__name__}:{len(value)} bytes>"
+    if _depth >= _MAX_DEPTH:
+        return f"<{type(value).__name__}:max-depth>"
+
+    seen = _seen if _seen is not None else set()
+    object_id = id(value)
+    if object_id in seen:
+        return "<cycle>"
+    seen.add(object_id)
+    try:
+        mapping: Mapping[Any, Any] | None = None
+        sequence: Sequence[Any] | None = None
+        if isinstance(value, Mapping):
+            mapping = value
+        elif isinstance(value, Sequence) and not isinstance(
+            value, str | bytes | bytearray
+        ):
+            sequence = value
+        else:
+            mapping = _public_object_fields(value)
+
+        if mapping is not None:
+            result: dict[str, Any] = {}
+            for index, (key, item) in enumerate(mapping.items()):
+                if index >= _MAX_COLLECTION_ITEMS:
+                    result["__truncated_items__"] = True
+                    break
+                key_text = _safe_key_text(key)
+                result[key_text] = (
+                    _REDACTED
+                    if _is_sensitive_key(key)
+                    else json_value(item, _depth=_depth + 1, _seen=seen)
+                )
+            return result
+
+        if sequence is not None:
+            items = list(islice(iter(sequence), _MAX_COLLECTION_ITEMS + 1))
+            result = [
+                json_value(item, _depth=_depth + 1, _seen=seen)
+                for item in items[:_MAX_COLLECTION_ITEMS]
+            ]
+            if len(items) > _MAX_COLLECTION_ITEMS:
+                result.append("<truncated:more items>")
+            return result
+
+        return f"<{type(value).__name__}>"
+    except Exception:  # noqa: BLE001 - serializer must not break agent execution.
+        return f"<{type(value).__name__}:unserializable>"
+    finally:
+        seen.discard(object_id)
+
+
+def json_string(value: Any) -> str:
+    """Return valid, redacted JSON bounded to the OTel attribute budget."""
+    normalized = json_value(value)
+    encoded = json.dumps(
+        normalized,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    encoded_bytes = len(encoded.encode("utf-8"))
+    if encoded_bytes <= MAX_ATTRIBUTE_BYTES:
+        return encoded
+
+    preview = encoded[: MAX_ATTRIBUTE_BYTES // 2]
+    while (
+        len(
+            json.dumps(
+                {
+                    "original_bytes": encoded_bytes,
+                    "preview": preview,
+                    "truncated": True,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        )
+        > MAX_ATTRIBUTE_BYTES
+    ):
+        preview = preview[: max(0, len(preview) - 256)]
+    return json.dumps(
+        {
+            "original_bytes": encoded_bytes,
+            "preview": preview,
+            "truncated": True,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def flatten_metadata_attributes(metadata: Mapping[Any, Any]) -> dict[str, str]:
+    """Return bounded, redacted top-level metadata fields for live ingestion.
+
+    The canonical aggregate JSON remains authoritative. These scalar aliases mirror
+    the tracing SDK's supported ``respan.metadata.<key>`` wire format so metadata
+    stays queryable while backends migrate to merging the aggregate field directly.
+    """
+    flattened: dict[str, str] = {}
+    try:
+        for index, (key, value) in enumerate(metadata.items()):
+            if index >= _MAX_COLLECTION_ITEMS:
+                break
+            if value is None:
+                continue
+            key_text = _safe_key_text(key).strip()
+            if not key_text:
+                continue
+            key_text = re.sub(r"[\x00-\x1f\x7f]", "_", key_text)
+            key_text = key_text[:_MAX_FLATTENED_METADATA_KEY_CHARS]
+            if not key_text or key_text in flattened:
+                continue
+            flattened[key_text] = (
+                _REDACTED
+                if _is_sensitive_key(key)
+                else (
+                    safe_text(value, limit=_MAX_STRING_CHARS)
+                    if isinstance(value, str)
+                    else json_string(value)
+                )
+            )
+    except Exception:  # noqa: BLE001 - untrusted mappings must not break tracing.
+        return flattened
+    return flattened
+
+
+def parse_json_string(value: Any) -> Any:
+    """Decode SDK JSON strings while retaining ordinary text as text."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def safe_error_message(error: Any) -> str | None:
+    """Render an SDK error without invoking arbitrary exception string methods."""
+    if error is None:
+        return None
+    if isinstance(error, Mapping):
+        message = error.get("message") or error.get("error")
+        if isinstance(message, str):
+            return _redact_text(message)
+        return json_string(error)
+    if isinstance(error, str):
+        return _redact_text(error)
+    return type(error).__name__
+
+
+def error_status_code(error: Any, *, default: int = 500) -> int:
+    """Extract a provider/application HTTP status from an Agents SDK error."""
+    candidates: list[Any] = [error]
+    if isinstance(error, Mapping):
+        candidates.extend(
+            (error.get("data"), error.get("response"), error.get("cause"))
+        )
+    else:
+        for name in ("data", "response", "cause", "__cause__"):
+            try:
+                candidates.append(getattr(error, name, None))
+            except Exception:  # noqa: BLE001, S112 - inspect next safe candidate.
+                continue
+
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if isinstance(candidate, Mapping):
+            values = (
+                candidate.get("status_code"),
+                candidate.get("status"),
+                candidate.get("http_status"),
+                candidate.get("code"),
+            )
+        else:
+            values = []
+            for name in ("status_code", "status", "http_status", "code"):
+                try:
+                    values.append(getattr(candidate, name, None))
+                except Exception:  # noqa: BLE001, S112 - inspect next safe field.
+                    continue
+        for value in values:
+            if isinstance(value, int) and 400 <= value <= 599:
+                return value
+            if isinstance(value, str) and value.isdigit():
+                parsed = int(value)
+                if 400 <= parsed <= 599:
+                    return parsed
+
+    return default

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/src/respan_instrumentation_openai_agents/_utils.py
@@ -1,13 +1,12 @@
 """Shared utility functions for span data serialization and formatting."""
 
-import json
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
-from respan_sdk.utils.serialization import serialize_value
+from respan_instrumentation_openai_agents._serialization import json_string, json_value
 
 
-def _responses_api_item_to_message(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def _responses_api_item_to_message(item: dict[str, Any]) -> dict[str, Any] | None:
     """Convert a single Responses API input/output item to a chat message dict."""
     item_type = item.get("type", "")
 
@@ -27,7 +26,7 @@ def _responses_api_item_to_message(item: Dict[str, Any]) -> Optional[Dict[str, A
                 elif bt == "input_file":
                     text_parts.append("[file]")
                 else:
-                    text_parts.append(block.get("text", str(block)))
+                    text_parts.append(block.get("text", json_string(block)))
             elif isinstance(block, str):
                 text_parts.append(block)
         return {"role": role, "content": "\n".join(text_parts)}
@@ -36,14 +35,16 @@ def _responses_api_item_to_message(item: Dict[str, Any]) -> Optional[Dict[str, A
         return {
             "role": "assistant",
             "content": "",
-            "tool_calls": [{
-                "id": item.get("call_id", ""),
-                "type": "function",
-                "function": {
-                    "name": item.get("name", ""),
-                    "arguments": item.get("arguments", ""),
-                },
-            }],
+            "tool_calls": [
+                {
+                    "id": item.get("call_id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": item.get("name", ""),
+                        "arguments": item.get("arguments", ""),
+                    },
+                }
+            ],
         }
 
     if item_type == "function_call_output":
@@ -56,15 +57,14 @@ def _responses_api_item_to_message(item: Dict[str, Any]) -> Optional[Dict[str, A
     return None
 
 
-def _format_input_messages(raw_input: Any) -> List[Dict[str, Any]]:
+def _format_input_messages(raw_input: Any) -> list[dict[str, Any]]:
     """Wrap raw input into proper ``[{"role": ..., "content": ...}]`` format."""
-    serialized = serialize_value(raw_input)
+    serialized = json_value(raw_input)
     if serialized is None:
         return []
     if isinstance(serialized, list):
         has_responses_api_items = any(
-            isinstance(item, dict) and "type" in item
-            for item in serialized
+            isinstance(item, dict) and "type" in item for item in serialized
         )
         if has_responses_api_items:
             messages = []
@@ -84,8 +84,8 @@ def _format_input_messages(raw_input: Any) -> List[Dict[str, Any]]:
     if isinstance(serialized, str):
         return [{"role": "user", "content": serialized}]
     if isinstance(serialized, dict):
-        return [{"role": "user", "content": json.dumps(serialized, default=str)}]
-    return [{"role": "user", "content": str(serialized)}]
+        return [{"role": "user", "content": json_string(serialized)}]
+    return [{"role": "user", "content": json_string(serialized)}]
 
 
 def _format_output(resp_output: Any) -> str:
@@ -96,7 +96,7 @@ def _format_output(resp_output: Any) -> str:
     they are extracted separately via ``_extract_tool_calls`` and stored
     as their own span attribute.
     """
-    serialized = serialize_value(resp_output)
+    serialized = json_value(resp_output)
     if not serialized:
         return ""
 
@@ -104,18 +104,22 @@ def _format_output(resp_output: Any) -> str:
         return serialized
 
     if isinstance(serialized, dict):
+        if serialized.get("type") in ("function_call", "function_call_output"):
+            return ""
+        if serialized.get("tool_calls") and serialized.get("content") is None:
+            return ""
         content = serialized.get("content")
         if content is None:
-            return json.dumps(serialized, default=str)
+            return json_string(serialized)
         if isinstance(content, str):
             return content
-        return json.dumps(content, default=str)
+        return json_string(content)
 
     if isinstance(serialized, list):
-        text_parts: List[str] = []
+        text_parts: list[str] = []
         for item in serialized:
             if not isinstance(item, dict):
-                text_parts.append(str(item))
+                text_parts.append(json_string(item))
                 continue
             item_type = item.get("type", "")
             if item_type in ("function_call", "function_call_output"):
@@ -139,12 +143,14 @@ def _format_output(resp_output: Any) -> str:
             if "content" in item:
                 content = item["content"]
                 if content is not None:
-                    text_parts.append(str(content))
+                    text_parts.append(
+                        content if isinstance(content, str) else json_string(content)
+                    )
                 continue
-            text_parts.append(str(item))
+            text_parts.append(json_string(item))
         return "\n".join(text_parts) if text_parts else ""
 
-    return str(serialized)
+    return json_string(serialized)
 
 
 def _parse_ts(ts: str) -> datetime:

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/tests/test_instrumentation.py
@@ -1,0 +1,231 @@
+"""Lifecycle and streaming tests for the OpenAI Agents instrumentor."""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+from agents.tracing import (
+    agent_span,
+    generation_span,
+    set_trace_processors,
+    task_span,
+    trace,
+    turn_span,
+)
+from agents.tracing.processor_interface import TracingProcessor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from respan_sdk.constants.span_attributes import RESPAN_METADATA
+
+from respan_instrumentation_openai_agents import _instrumentation
+from respan_instrumentation_openai_agents._instrumentation import (
+    OpenAIAgentsInstrumentor,
+    _RespanTracingProcessor,
+)
+
+
+class _SentinelProcessor(TracingProcessor):
+    def on_trace_start(self, trace: Any) -> None:
+        pass
+
+    def on_trace_end(self, trace: Any) -> None:
+        pass
+
+    def on_span_start(self, span: Any) -> None:
+        pass
+
+    def on_span_end(self, span: Any) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _restore_processors():
+    previous = _instrumentation._current_processors()
+    yield
+    for _ in range(100):
+        if not _instrumentation._ACTIVATION_COUNT:
+            break
+        active = OpenAIAgentsInstrumentor()
+        active._is_active = True
+        active.deactivate()
+    set_trace_processors(list(previous))
+    _instrumentation._remove_stream_patches()
+
+
+def test_repeated_activation_is_ref_counted_and_restores_previous_processor():
+    sentinel = _SentinelProcessor()
+    set_trace_processors([sentinel])
+    first = OpenAIAgentsInstrumentor()
+    second = OpenAIAgentsInstrumentor()
+
+    first.activate()
+    first.activate()
+    second.activate()
+
+    current = _instrumentation._current_processors()
+    assert len(current) == 1
+    assert current[0] is first._processor is second._processor
+    assert _instrumentation._ACTIVATION_COUNT == 2
+
+    first.deactivate()
+    assert _instrumentation._current_processors() == current
+    second.deactivate()
+    assert _instrumentation._current_processors() == (sentinel,)
+    assert _instrumentation._ACTIVATION_COUNT == 0
+
+
+def test_concurrent_instances_share_one_processor_and_restore_cleanly():
+    sentinel = _SentinelProcessor()
+    set_trace_processors([sentinel])
+    instances = [OpenAIAgentsInstrumentor() for _ in range(16)]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda item: item.activate(), instances))
+
+    current = _instrumentation._current_processors()
+    assert len(current) == 1
+    assert len({id(item._processor) for item in instances}) == 1
+    assert _instrumentation._ACTIVATION_COUNT == len(instances)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda item: item.deactivate(), instances))
+
+    assert _instrumentation._current_processors() == (sentinel,)
+    assert _instrumentation._ACTIVATION_COUNT == 0
+
+
+def test_deactivation_merges_preserved_and_late_processors():
+    original = _SentinelProcessor()
+    late = _SentinelProcessor()
+    set_trace_processors([original])
+    instrumentor = OpenAIAgentsInstrumentor()
+
+    instrumentor.activate()
+    shared = instrumentor._processor
+    set_trace_processors([shared, late])
+    instrumentor.deactivate()
+
+    assert _instrumentation._current_processors() == (original, late)
+
+
+def test_real_otel_provider_receives_complete_agents_trace(monkeypatch):
+    """Exercise the actual SDK processor -> OTEL provider delivery boundary."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(
+        _instrumentation.otel_trace,
+        "get_tracer_provider",
+        lambda: provider,
+    )
+    processor = _RespanTracingProcessor(
+        metadata={"example_run_id": "otel-delivery-marker"}
+    )
+    set_trace_processors([processor])
+
+    try:
+        with (
+            trace("delivery"),
+            task_span("delivery task"),
+            agent_span("Delivery Agent"),
+            turn_span(1, "Delivery Agent"),
+            generation_span(
+                input=[{"role": "user", "content": "Hello"}],
+                output=[{"role": "assistant", "content": "Hi"}],
+                model="gpt-4o-mini",
+                usage={"input_tokens": 1, "output_tokens": 1},
+            ),
+        ):
+            pass
+        processor.force_flush()
+        spans = exporter.get_finished_spans()
+    finally:
+        processor.shutdown()
+        provider.shutdown()
+
+    assert {span.name for span in spans} == {
+        "Delivery Agent.agent",
+        "delivery task.task",
+        "delivery.workflow",
+        "openai.chat",
+        "turn-1.task",
+    }
+    assert len({span.get_span_context().trace_id for span in spans}) == 1
+    assert all(
+        json.loads(span.attributes[RESPAN_METADATA])["example_run_id"]
+        == "otel-delivery-marker"
+        for span in spans
+    )
+    assert all(
+        span.attributes[f"{RESPAN_METADATA}.example_run_id"] == "otel-delivery-marker"
+        for span in spans
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_wrapper_marks_only_the_wrapped_async_iterator():
+    observations: list[bool] = []
+    source_closed = False
+
+    async def original():
+        nonlocal source_closed
+        observations.append(_instrumentation._STREAMING.get())
+        try:
+            yield "chunk"
+            observations.append(_instrumentation._STREAMING.get())
+        finally:
+            source_closed = True
+
+    wrapped = _instrumentation._wrap_stream_method(original)
+    assert [chunk async for chunk in wrapped()] == ["chunk"]
+    assert observations == [True, True]
+    assert source_closed is True
+    assert _instrumentation._STREAMING.get() is False
+
+
+@pytest.mark.asyncio
+async def test_stream_wrapper_closes_source_on_early_close():
+    source_closed = False
+
+    async def original():
+        nonlocal source_closed
+        try:
+            yield "first"
+            yield "second"
+        finally:
+            source_closed = True
+
+    iterator = _instrumentation._wrap_stream_method(original)()
+    assert await anext(iterator) == "first"
+    await iterator.aclose()
+
+    assert source_closed is True
+    assert _instrumentation._STREAMING.get() is False
+
+
+@pytest.mark.asyncio
+async def test_stream_wrapper_surfaces_source_close_error_without_context_leak():
+    async def original():
+        try:
+            yield "first"
+        finally:
+            raise RuntimeError("source close failed")
+
+    iterator = _instrumentation._wrap_stream_method(original)()
+    assert await anext(iterator) == "first"
+    with pytest.raises(RuntimeError, match="source close failed"):
+        await iterator.aclose()
+
+    assert _instrumentation._STREAMING.get() is False

--- a/python-sdks/instrumentations/respan-instrumentation-openai-agents/tests/test_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai-agents/tests/test_otel_emitter.py
@@ -1,52 +1,89 @@
-"""Unit tests for OpenAI Agents OTEL emitter contract attrs."""
+"""Contract tests for current OpenAI Agents SDK span translation."""
+
+from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from types import SimpleNamespace
 
+import pytest
+from agents import Agent, RunConfig, Runner, function_tool
+from agents.items import ModelResponse
+from agents.models.interface import Model
+from agents.tracing import (
+    SpanError,
+    agent_span,
+    function_span,
+    generation_span,
+    guardrail_span,
+    handoff_span,
+    set_trace_processors,
+    task_span,
+    trace,
+    turn_span,
+)
+from agents.usage import Usage
+from openai.types.responses import (
+    Response,
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+from openai.types.responses.response_completed_event import ResponseCompletedEvent
+from openai.types.responses.response_created_event import ResponseCreatedEvent
+from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
 from opentelemetry.semconv_ai import SpanAttributes
-
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from opentelemetry.trace.status import StatusCode
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE, RESPAN_METADATA
 
 from respan_instrumentation_openai_agents import _otel_emitter
-
+from respan_instrumentation_openai_agents._instrumentation import (
+    _RespanTracingProcessor,
+    _wrap_stream_method,
+)
+from respan_instrumentation_openai_agents._serialization import (
+    MAX_ATTRIBUTE_BYTES,
+    error_status_code,
+    flatten_metadata_attributes,
+    json_string,
+)
 
 _BANNED_ALIASES = {
+    "completion_tokens",
+    "has_tool_calls",
+    "model",
+    "parallel_tool_calls",
+    "prompt_tokens",
+    "respan.span.handoffs",
     "respan.span.tool_calls",
     "respan.span.tools",
-    "respan.span.handoffs",
+    "span_tools",
     "tool_calls",
     "tools",
-    "span_tools",
-    "has_tool_calls",
-    "parallel_tool_calls",
+    "total_request_tokens",
 }
 
 
-def _make_span_item() -> SimpleNamespace:
+def _make_span_item(*, error=None) -> SimpleNamespace:
     return SimpleNamespace(
         trace_id="trace_123",
         span_id="span_456",
         parent_id=None,
         started_at=None,
         ended_at=None,
-        error=None,
+        error=error,
+        trace_metadata={"tenant": "example"},
     )
 
 
-def _capture_attrs(monkeypatch):
-    captured = {}
-
-    def _fake_build_readable_span(**kwargs):
-        captured.update(kwargs)
-        return kwargs
-
-    monkeypatch.setattr(_otel_emitter, "build_readable_span", _fake_build_readable_span)
-    monkeypatch.setattr(_otel_emitter, "inject_span", lambda span: None)
+def _capture_spans(monkeypatch):
+    captured = []
+    monkeypatch.setattr(_otel_emitter, "inject_span", captured.append)
     return captured
 
 
-def test_emit_response_uses_chat_contract_tool_attrs(monkeypatch):
-    captured = _capture_attrs(monkeypatch)
+def test_emit_response_uses_complete_chat_contract(monkeypatch):
+    captured = _capture_spans(monkeypatch)
     response = SimpleNamespace(
         model="gpt-4o",
         output=[
@@ -65,15 +102,39 @@ def test_emit_response_uses_chat_contract_tool_attrs(monkeypatch):
                 "parameters": {"type": "object"},
             }
         ],
-        usage=SimpleNamespace(input_tokens=12, output_tokens=4),
+        usage=SimpleNamespace(input_tokens=12, output_tokens=4, total_tokens=16),
     )
-    span_data = SimpleNamespace(response=response, input="What is the weather in NYC?")
+    span_data = SimpleNamespace(
+        response=response,
+        input="What is the weather in NYC?",
+        usage=None,
+    )
 
-    _otel_emitter.emit_response(_make_span_item(), span_data)
+    _otel_emitter.emit_response(
+        _make_span_item(),
+        span_data,
+        extra_metadata={"example_run_id": "marker"},
+        is_streaming=True,
+    )
 
-    attrs = captured["attributes"]
+    span = captured[0]
+    attrs = span.attributes
     assert attrs[RESPAN_LOG_TYPE] == "chat"
     assert attrs[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
+    assert attrs[SpanAttributes.LLM_SYSTEM] == "openai"
+    assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "gpt-4o"
+    assert attrs[SpanAttributes.LLM_IS_STREAMING] is True
+    assert attrs["gen_ai.usage.input_tokens"] == 12
+    assert attrs["gen_ai.usage.output_tokens"] == 4
+    assert attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 12
+    assert attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 4
+    assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 16
+    assert json.loads(attrs[RESPAN_METADATA]) == {
+        "example_run_id": "marker",
+        "tenant": "example",
+    }
+    assert attrs[f"{RESPAN_METADATA}.example_run_id"] == "marker"
+    assert attrs[f"{RESPAN_METADATA}.tenant"] == "example"
     assert json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]) == [
         {
             "id": "call_1",
@@ -94,39 +155,585 @@ def test_emit_response_uses_chat_contract_tool_attrs(monkeypatch):
             },
         }
     ]
-    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.role"] == "assistant"
     assert _BANNED_ALIASES.isdisjoint(attrs)
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
 
 
-def test_emit_generation_extracts_tool_calls(monkeypatch):
-    captured = _capture_attrs(monkeypatch)
+def test_emit_generation_handles_chat_completion_tool_shape(monkeypatch):
+    captured = _capture_spans(monkeypatch)
     span_data = SimpleNamespace(
         input=[{"role": "user", "content": "Use the tool"}],
         output=[
             {
-                "type": "function_call",
-                "call_id": "call_2",
-                "name": "search_docs",
-                "arguments": '{"query":"otel"}',
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {
+                            "name": "search_docs",
+                            "arguments": '{"query":"otel"}',
+                        },
+                    }
+                ],
             }
         ],
         model="gpt-4o",
-        usage={"prompt_tokens": 8, "completion_tokens": 2},
+        model_config={"stream": False},
+        usage={"input_tokens": 8, "output_tokens": 2, "total_tokens": 10},
     )
 
-    _otel_emitter.emit_generation(_make_span_item(), span_data)
+    _otel_emitter.emit_generation(
+        _make_span_item(),
+        span_data,
+        agent_context={"tools": ["search_docs"]},
+    )
 
-    attrs = captured["attributes"]
-    assert attrs[RESPAN_LOG_TYPE] == "chat"
-    assert attrs[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
-    assert json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]) == [
-        {
-            "id": "call_2",
-            "type": "function",
-            "function": {
-                "name": "search_docs",
-                "arguments": '{"query":"otel"}',
-            },
-        }
+    attrs = captured[0].attributes
+    tool_calls = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])
+    assert tool_calls[0]["id"] == "call_2"
+    assert tool_calls[0]["function"]["name"] == "search_docs"
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == ""
+    assert json.loads(attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS]) == [
+        {"type": "function", "function": {"name": "search_docs"}}
     ]
+    assert attrs[SpanAttributes.LLM_IS_STREAMING] is False
     assert _BANNED_ALIASES.isdisjoint(attrs)
+
+
+def test_tool_agent_handoff_and_guardrail_are_structured(monkeypatch):
+    captured = _capture_spans(monkeypatch)
+    item = _make_span_item()
+
+    _otel_emitter.emit_function(
+        item,
+        SimpleNamespace(name="weather", input='{"city":"Tokyo"}', output="sunny"),
+    )
+    _otel_emitter.emit_agent(
+        item,
+        SimpleNamespace(
+            name="Triage",
+            tools=["weather"],
+            handoffs=["Spanish"],
+            output_type="Answer",
+        ),
+    )
+    _otel_emitter.emit_handoff(
+        item, SimpleNamespace(from_agent="Triage", to_agent="Spanish")
+    )
+    _otel_emitter.emit_guardrail(
+        item, SimpleNamespace(name="safe_input", triggered=True)
+    )
+
+    tool, agent, handoff, guardrail = captured
+    assert json.loads(tool.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "arguments": {"city": "Tokyo"},
+        "name": "weather",
+    }
+    assert (
+        json.loads(tool.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == "sunny"
+    )
+    assert json.loads(agent.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "handoffs": ["Spanish"],
+        "name": "Triage",
+        "output_type": "Answer",
+        "tools": ["weather"],
+    }
+    assert json.loads(handoff.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "from_agent": "Triage"
+    }
+    assert json.loads(handoff.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "to_agent": "Spanish"
+    }
+    assert json.loads(guardrail.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "triggered": True
+    }
+    for span in captured:
+        assert _BANNED_ALIASES.isdisjoint(span.attributes)
+        assert SpanAttributes.TRACELOOP_SPAN_KIND not in span.attributes
+
+
+def test_error_status_is_precise_bounded_and_redacted(monkeypatch):
+    captured = _capture_spans(monkeypatch)
+    error = {
+        "message": "401 denied for Bearer secret-token-value",
+        "data": {"status_code": 401, "api_key": "sk-super-secret-value"},
+    }
+
+    _otel_emitter.emit_agent(
+        _make_span_item(error=error),
+        SimpleNamespace(name="Agent", tools=[], handoffs=[], output_type=None),
+    )
+
+    span = captured[0]
+    assert span.status.status_code is StatusCode.ERROR
+    assert "401" in (span.status.description or "")
+    assert "secret-token-value" not in (span.status.description or "")
+    assert error_status_code(error) == 401
+    assert error_status_code({"message": "application exploded"}) == 500
+    assert error_status_code("cache status code: 404") == 500
+    assert error_status_code({"message": "cache status code: 404"}) == 500
+    assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "error": {"message": "401 denied for [REDACTED]", "status_code": 401}
+    }
+
+
+def test_json_serializer_is_valid_bounded_and_cycle_safe():
+    cycle: dict[str, object] = {}
+    cycle["self"] = cycle
+    payload = {
+        "api_key": "sk-super-secret-value",
+        "authorization": "Bearer token-value",
+        "cycle": cycle,
+        "payload": "x" * 100_000,
+    }
+    encoded = json_string(payload)
+    decoded = json.loads(encoded)
+    assert len(encoded.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES
+    assert "sk-super-secret-value" not in encoded
+    assert "token-value" not in encoded
+    assert decoded["api_key"] == "[REDACTED]"
+    assert decoded["cycle"]["self"] == "<cycle>"
+
+
+def test_json_serializer_bounds_iteration_keys_tokens_and_non_finite_values():
+    class BoundedSequence(Sequence):
+        def __len__(self):
+            raise AssertionError("serializer must not ask for the full length")
+
+        def __getitem__(self, index):
+            if not isinstance(index, int) or index > 50:
+                raise AssertionError("serializer consumed beyond one-item lookahead")
+            return index
+
+    class HostileKey:
+        def __str__(self):
+            raise AssertionError("serializer must not stringify arbitrary keys")
+
+    encoded = json_string(
+        {
+            "items": BoundedSequence(),
+            "token": "plain-token-value",
+            "session_token": "session-token-value",
+            "not_a_number": float("nan"),
+            HostileKey(): "safe",
+        }
+    )
+    decoded = json.loads(encoded)
+
+    assert decoded["token"] == "[REDACTED]"
+    assert decoded["session_token"] == "[REDACTED]"
+    assert decoded["not_a_number"] is None
+    assert len(decoded["items"]) == 51
+    assert decoded["items"][-1] == "<truncated:more items>"
+    assert decoded["<HostileKey>"] == "safe"
+
+
+def test_flattened_metadata_is_bounded_redacted_and_scalar_safe():
+    class HostileKey:
+        def __str__(self):
+            raise AssertionError("metadata keys must not invoke arbitrary strings")
+
+    flattened = flatten_metadata_attributes(
+        {
+            "example_run_id": "exact-marker",
+            "api_key": "sk-super-secret-value",
+            "nested": {"session_token": "plain-session-secret"},
+            "long": "🧪" * 10_000,
+            "not_a_number": float("nan"),
+            HostileKey(): "safe",
+            "missing": None,
+        }
+    )
+
+    assert flattened["example_run_id"] == "exact-marker"
+    assert flattened["api_key"] == "[REDACTED]"
+    assert json.loads(flattened["nested"])["session_token"] == "[REDACTED]"
+    assert len(flattened["long"].encode("utf-8")) <= MAX_ATTRIBUTE_BYTES
+    assert flattened["not_a_number"] == "null"
+    assert flattened["<HostileKey>"] == "safe"
+    assert "missing" not in flattened
+    assert all(len(key) <= 128 for key in flattened)
+
+
+def test_flattened_metadata_limits_field_count():
+    flattened = flatten_metadata_attributes(
+        {f"key-{index}": index for index in range(75)}
+    )
+
+    assert len(flattened) == 50
+    assert flattened["key-0"] == "0"
+    assert "key-50" not in flattened
+
+
+def test_scalar_attributes_are_bounded_and_redacted(monkeypatch):
+    captured = _capture_spans(monkeypatch)
+    secret = "Bearer raw-agent-secret-token"
+
+    _otel_emitter.emit_agent(
+        _make_span_item(),
+        SimpleNamespace(name=secret, tools=[secret], handoffs=[], output_type=None),
+    )
+    _otel_emitter.emit_handoff(
+        _make_span_item(),
+        SimpleNamespace(from_agent=secret, to_agent=f"target-{secret}"),
+    )
+    _otel_emitter.emit_response(
+        _make_span_item(),
+        SimpleNamespace(
+            input=[{"role": "user", "content": f"authorization={secret}"}],
+            response=SimpleNamespace(model=secret, output=[], tools=[], usage=None),
+            usage=None,
+        ),
+    )
+
+    encoded = json.dumps([span.attributes for span in captured], default=str)
+    assert "raw-agent-secret-token" not in encoded
+    assert "[REDACTED]" in encoded
+
+
+def test_real_sdk_primitives_keep_tree_metadata_and_agent_tools(monkeypatch):
+    captured = _capture_spans(monkeypatch)
+    processor = _RespanTracingProcessor(metadata={"example_run_id": "real-marker"})
+    set_trace_processors([processor])
+
+    with (
+        trace(
+            "contract",
+            group_id="group-1",
+            metadata={"scenario": "real-framework"},
+        ),
+        task_span("run"),
+        agent_span(
+            "Triage",
+            tools=["weather"],
+            handoffs=["Spanish"],
+            output_type="Answer",
+        ),
+        turn_span(1, "Triage"),
+    ):
+        with generation_span(
+            input=[{"role": "user", "content": "Weather?"}],
+            output=[{"role": "assistant", "content": "Sunny"}],
+            model="gpt-4o-mini",
+            usage={"input_tokens": 4, "output_tokens": 1},
+        ) as generation:
+            pass
+        with function_span("weather", input='{"city":"Tokyo"}', output="sunny"):
+            pass
+        with handoff_span("Triage", "Spanish"):
+            pass
+        with guardrail_span("safe_input", triggered=False):
+            pass
+
+    assert len(captured) == 8
+    span_ids = {span.get_span_context().span_id for span in captured}
+    assert len(span_ids) == len(captured)
+    roots = [span for span in captured if span.parent is None]
+    assert len(roots) == 1
+    assert roots[0].start_time < roots[0].end_time
+    for span in captured:
+        metadata = json.loads(span.attributes[RESPAN_METADATA])
+        assert metadata["example_run_id"] == "real-marker"
+        assert span.attributes[f"{RESPAN_METADATA}.example_run_id"] == "real-marker"
+        if span is not roots[0]:
+            assert span.parent is not None
+            assert span.parent.span_id in span_ids
+    chat = next(span for span in captured if span.attributes[RESPAN_LOG_TYPE] == "chat")
+    assert json.loads(chat.attributes[SpanAttributes.LLM_REQUEST_FUNCTIONS]) == [
+        {"type": "function", "function": {"name": "weather"}}
+    ]
+
+    processor.on_span_end(generation)
+    assert len(captured) == 8
+
+
+def test_real_sdk_error_exports_otel_error(monkeypatch):
+    captured = _capture_spans(monkeypatch)
+    processor = _RespanTracingProcessor()
+    set_trace_processors([processor])
+
+    with (
+        trace("failure"),
+        generation_span(
+            input=[{"role": "user", "content": "fail"}], model="gpt-4o-mini"
+        ) as span,
+    ):
+        span.set_error(
+            SpanError(
+                message="Provider request failed",
+                data={"status_code": 503, "error": "temporarily unavailable"},
+            )
+        )
+
+    failed = next(
+        span for span in captured if span.attributes[RESPAN_LOG_TYPE] == "chat"
+    )
+    assert failed.status.status_code is StatusCode.ERROR
+    assert failed.status.description == "Provider request failed"
+
+
+@pytest.mark.asyncio
+async def test_real_runner_offline_tool_flow_exports_one_canonical_tree(monkeypatch):
+    captured = _capture_spans(monkeypatch)
+
+    class OfflineToolModel(Model):
+        def __init__(self):
+            self.calls = 0
+
+        async def get_response(
+            self,
+            system_instructions,
+            input,
+            model_settings,
+            tools,
+            output_schema,
+            handoffs,
+            tracing,
+            *,
+            previous_response_id,
+            conversation_id,
+            prompt,
+        ):
+            del (
+                system_instructions,
+                model_settings,
+                tools,
+                output_schema,
+                handoffs,
+                tracing,
+                previous_response_id,
+                conversation_id,
+                prompt,
+            )
+            self.calls += 1
+            if self.calls == 1:
+                output = [
+                    ResponseFunctionToolCall(
+                        arguments='{"city":"Paris"}',
+                        call_id="call_weather",
+                        name="weather",
+                        status="completed",
+                        type="function_call",
+                    )
+                ]
+            else:
+                output = [
+                    ResponseOutputMessage(
+                        id="message_weather",
+                        content=[
+                            ResponseOutputText(
+                                annotations=[],
+                                logprobs=[],
+                                text="Sunny in Paris.",
+                                type="output_text",
+                            )
+                        ],
+                        role="assistant",
+                        status="completed",
+                        type="message",
+                    )
+                ]
+            output_payload = [item.model_dump(mode="json") for item in output]
+            usage = {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5}
+            with generation_span(
+                input=input,
+                output=output_payload,
+                model="offline-model",
+                usage=usage,
+            ):
+                return ModelResponse(
+                    output=output,
+                    usage=Usage(
+                        requests=1,
+                        input_tokens=3,
+                        output_tokens=2,
+                        total_tokens=5,
+                    ),
+                    response_id=f"response_{self.calls}",
+                )
+
+        async def stream_response(self, *_args, **_kwargs):
+            if False:
+                yield None
+
+    @function_tool
+    def weather(city: str) -> str:
+        """Return deterministic weather."""
+        return f"Sunny in {city}."
+
+    processor = _RespanTracingProcessor(metadata={"example_run_id": "runner-marker"})
+    set_trace_processors([processor])
+    result = await Runner.run(
+        Agent(name="Offline Agent", model=OfflineToolModel(), tools=[weather]),
+        "What is the weather?",
+        run_config=RunConfig(workflow_name="offline-runner"),
+    )
+
+    assert result.final_output == "Sunny in Paris."
+    assert len(captured) == 8
+    span_ids = {span.get_span_context().span_id for span in captured}
+    roots = [span for span in captured if span.parent is None]
+    assert len(roots) == 1
+    assert roots[0].start_time < roots[0].end_time
+    for span in captured:
+        assert json.loads(span.attributes[RESPAN_METADATA])["example_run_id"] == (
+            "runner-marker"
+        )
+        if span.parent is not None:
+            assert span.parent.span_id in span_ids
+
+    chats = [span for span in captured if span.attributes[RESPAN_LOG_TYPE] == "chat"]
+    assert len(chats) == 2
+    first_calls = json.loads(
+        chats[0].attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]
+    )
+    assert first_calls[0]["function"] == {
+        "arguments": '{"city":"Paris"}',
+        "name": "weather",
+    }
+    assert f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls" not in chats[1].attributes
+    tool = next(span for span in captured if span.attributes[RESPAN_LOG_TYPE] == "tool")
+    assert json.loads(tool.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "arguments": {"city": "Paris"},
+        "name": "weather",
+    }
+
+
+@pytest.mark.asyncio
+async def test_real_runner_offline_stream_closes_source_and_marks_chat(monkeypatch):
+    captured = _capture_spans(monkeypatch)
+
+    def response(output, status, usage=None):
+        return Response(
+            id="response_stream",
+            created_at=1,
+            error=None,
+            incomplete_details=None,
+            instructions=None,
+            metadata={},
+            model="offline-model",
+            object="response",
+            output=output,
+            parallel_tool_calls=True,
+            status=status,
+            temperature=1,
+            tool_choice="auto",
+            tools=[],
+            top_p=1,
+            usage=usage,
+        )
+
+    class OfflineStreamingModel(Model):
+        def __init__(self):
+            self.source_closed = False
+
+        async def get_response(self, *_args, **_kwargs):
+            raise AssertionError("streaming Runner must use stream_response")
+
+        async def stream_response(
+            self,
+            system_instructions,
+            input,
+            model_settings,
+            tools,
+            output_schema,
+            handoffs,
+            tracing,
+            *,
+            previous_response_id,
+            conversation_id,
+            prompt,
+        ):
+            del (
+                system_instructions,
+                model_settings,
+                tools,
+                output_schema,
+                handoffs,
+                tracing,
+                previous_response_id,
+                conversation_id,
+                prompt,
+            )
+            message = ResponseOutputMessage(
+                id="message_stream",
+                content=[
+                    ResponseOutputText(
+                        annotations=[],
+                        logprobs=[],
+                        text="Hello stream.",
+                        type="output_text",
+                    )
+                ],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+            with generation_span(
+                input=input,
+                output=[message.model_dump(mode="json")],
+                model="offline-model",
+                model_config={"stream": True},
+                usage={"input_tokens": 2, "output_tokens": 2, "total_tokens": 4},
+            ):
+                try:
+                    yield ResponseCreatedEvent(
+                        response=response([], "in_progress"),
+                        sequence_number=0,
+                        type="response.created",
+                    )
+                    yield ResponseTextDeltaEvent(
+                        content_index=0,
+                        delta="Hello stream.",
+                        item_id="message_stream",
+                        logprobs=[],
+                        output_index=0,
+                        sequence_number=1,
+                        type="response.output_text.delta",
+                    )
+                    yield ResponseCompletedEvent(
+                        response=response(
+                            [message],
+                            "completed",
+                            {
+                                "input_tokens": 2,
+                                "input_tokens_details": {
+                                    "cache_write_tokens": 0,
+                                    "cached_tokens": 0,
+                                },
+                                "output_tokens": 2,
+                                "output_tokens_details": {"reasoning_tokens": 0},
+                                "total_tokens": 4,
+                            },
+                        ),
+                        sequence_number=2,
+                        type="response.completed",
+                    )
+                finally:
+                    self.source_closed = True
+
+    OfflineStreamingModel.stream_response = _wrap_stream_method(
+        OfflineStreamingModel.stream_response
+    )
+    model = OfflineStreamingModel()
+    processor = _RespanTracingProcessor(metadata={"example_run_id": "stream-marker"})
+    set_trace_processors([processor])
+    result = Runner.run_streamed(
+        Agent(name="Streaming Agent", model=model),
+        "Stream hello.",
+        run_config=RunConfig(workflow_name="offline-stream-runner"),
+    )
+
+    async for _event in result.stream_events():
+        pass
+
+    assert result.final_output == "Hello stream."
+    assert model.source_closed is True
+    chats = [span for span in captured if span.attributes[RESPAN_LOG_TYPE] == "chat"]
+    assert len(chats) == 1
+    assert chats[0].attributes[SpanAttributes.LLM_IS_STREAMING] is True
+    assert chats[0].attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        "Hello stream."
+    )

--- a/python-sdks/instrumentations/respan-instrumentation-openai/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/README.md
@@ -1,6 +1,9 @@
 # respan-instrumentation-openai
 
-Respan instrumentation plugin for direct OpenAI SDK usage. A native, Traceloop-free instrumentation: it patches the OpenAI SDK directly and emits Respan's own LLM span conventions (`llm.request.type`, `gen_ai.*`, `traceloop.entity.*`, `respan.entity.log_type`), so chat, responses, completions, and embeddings calls are traced as real LLM calls with token/cost roll-up. Covers sync, async, and streaming.
+Respan instrumentation plugin for direct OpenAI 3.x SDK usage. The native,
+Traceloop-free integration patches sync and async Chat Completions, Responses,
+Completions, and Embeddings resources. Chat and Responses structured-output
+`parse` methods, streaming, tools, usage, and provider failures are included.
 
 ## Configuration
 
@@ -15,9 +18,11 @@ pip install respan-instrumentation-openai
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `RESPAN_API_KEY` | Yes | Your Respan API key. Authenticates both proxy and tracing. |
-| `RESPAN_BASE_URL` | No | Defaults to `https://api.respan.ai`. |
+| `RESPAN_BASE_URL` | No | Defaults to `https://api.respan.ai/api`. |
 
-All vendor-specific variables (e.g. `OPENAI_API_KEY`) are derived from these in your application code.
+Use `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL` when calling OpenAI
+directly. A Respan gateway deployment may instead use its gateway credential
+and OpenAI-compatible base URL.
 
 ## Quickstart
 
@@ -50,6 +55,7 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 
 respan.flush()
+respan.shutdown()
 ```
 
 ### 4. View Dashboard
@@ -58,4 +64,7 @@ After running the script, traces appear on your [Respan dashboard](https://platf
 
 ## Further Reading
 
-See the [examples/openai-sdk/](../../examples/openai-sdk/) directory for runnable examples including streaming, tool use, Responses API, and gateway routing.
+See `respan-example-projects/python/tracing/openai-sdk` for deterministic
+OpenAI 3.x examples. Set `RESPAN_OPENAI_LIVE=1` to opt into a configured live
+provider; deterministic mode still executes the real OpenAI SDK request and
+response parsing layers through an in-process HTTP transport.

--- a/python-sdks/instrumentations/respan-instrumentation-openai/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/pyproject.toml
@@ -13,9 +13,10 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.3.0"
 respan-sdk = ">=2.6.0"
+opentelemetry-semantic-conventions-ai = ">=0.5.1,<0.6.0"
 # Optional: the instrumentor lazy-imports openai and no-ops when it is absent, so
 # the app brings its own openai. Install with the SDK via the `instruments` extra.
-openai = { version = ">=1.0.0", optional = true }
+openai = { version = ">=3.0.0,<4.0.0", optional = true }
 
 [tool.poetry.extras]
 instruments = ["openai"]

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_constants.py
@@ -35,6 +35,7 @@ SYNC_RESPONSES_CLASS = "Responses"
 ASYNC_RESPONSES_CLASS = "AsyncResponses"
 
 CREATE_METHOD = "create"
+PARSE_METHOD = "parse"
 
 # --- request-type values (what the backend keys on via llm.request.type) ----
 
@@ -42,24 +43,8 @@ REQUEST_TYPE_CHAT = "chat"
 REQUEST_TYPE_COMPLETION = "completion"
 REQUEST_TYPE_EMBEDDING = "embedding"
 
-# --- attribute-name strings (the documented ingest contract) ----------------
-# These mirror the wire format the Respan backend parses. We define them here so
-# the package carries no Traceloop dependency.
-
-TRACELOOP_SPAN_KIND = "traceloop.span.kind"
-TRACELOOP_ENTITY_NAME = "traceloop.entity.name"
-TRACELOOP_ENTITY_PATH = "traceloop.entity.path"
-TRACELOOP_ENTITY_INPUT = "traceloop.entity.input"
-TRACELOOP_ENTITY_OUTPUT = "traceloop.entity.output"
-
-LLM_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
-LLM_PROMPTS = "gen_ai.prompt"
-LLM_COMPLETIONS = "gen_ai.completion"
-LLM_REQUEST_FUNCTIONS = "llm.request.functions"
-LLM_RESPONSE_MODEL = "gen_ai.response.model"
-LLM_RESPONSE_ID = "gen_ai.response.id"
-
-SPAN_KIND_LLM = "llm"
+# ``opentelemetry-semantic-conventions-ai`` 0.5.x does not expose this key.
+GEN_AI_RESPONSE_ID = "gen_ai.response.id"
 
 # --- response / message field keys ------------------------------------------
 

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_instrumentation.py
@@ -1,22 +1,21 @@
-"""Native OpenAI SDK instrumentation for Respan.
-
-Monkey-patches the ``create`` method of the OpenAI SDK's chat-completions,
-completions, responses, and embeddings resources (sync + async) and emits a
-Respan span per call via ``_otel_emitter``. No Traceloop dependency: spans are
-built directly with Respan's documented LLM conventions, so the backend
-classifies them as real LLM calls (``llm.request.type``) with token/cost
-roll-up — not generic "task" spans.
-"""
+"""Native, current-OpenAI-SDK instrumentation for Respan."""
 
 from __future__ import annotations
 
+import asyncio
 import importlib
+import inspect
 import logging
+import threading
 import time
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, Callable, Iterator
+from typing import Any, Self
 
+from respan_tracing.core.tracer import RespanTracer
+
+from respan_instrumentation_openai import _otel_emitter as emitter
 from respan_instrumentation_openai._constants import (
     ASYNC_CHAT_CLASS,
     ASYNC_COMPLETIONS_CLASS,
@@ -26,20 +25,25 @@ from respan_instrumentation_openai._constants import (
     COMPLETIONS_MODULE,
     CREATE_METHOD,
     EMBEDDINGS_MODULE,
+    PARSE_METHOD,
     RESPONSES_MODULE,
     SYNC_CHAT_CLASS,
     SYNC_COMPLETIONS_CLASS,
     SYNC_EMBEDDINGS_CLASS,
     SYNC_RESPONSES_CLASS,
 )
-from respan_instrumentation_openai import _otel_emitter as emitter
+from respan_instrumentation_openai._serialization import error_message
 
 logger = logging.getLogger(__name__)
 
-_original_methods: dict[tuple[type[Any], str], Any] = {}
+_ORIGINAL_METHODS: dict[tuple[type[Any], str], Any] = {}
+_INSTALLED_METHODS: dict[tuple[type[Any], str], Any] = {}
+_original_methods = _ORIGINAL_METHODS  # compatibility for existing callers/tests
+_LIFECYCLE_LOCK = threading.RLock()
+_REFCOUNT = 0
+
 _SUPPRESS_OPENAI_INSTRUMENTATION: ContextVar[bool] = ContextVar(
-    "respan_suppress_openai_instrumentation",
-    default=False,
+    "respan_suppress_openai_instrumentation", default=False
 )
 
 
@@ -56,78 +60,190 @@ def suppress_openai_instrumentation() -> Iterator[None]:
         _SUPPRESS_OPENAI_INSTRUMENTATION.reset(token)
 
 
-# ---------------------------------------------------------------------------
-# Stream aggregation (best-effort; never breaks the caller's stream)
-# ---------------------------------------------------------------------------
+def _request_kwargs_from_call(
+    original: Callable[..., Any],
+    instance: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        bound = inspect.signature(original).bind_partial(instance, *args, **kwargs)
+    except (TypeError, ValueError):
+        return dict(kwargs)
+    return {
+        key: value
+        for key, value in bound.arguments.items()
+        if key not in {"self", "cls"}
+    }
 
 
-def _aggregate_chat(chunks: list[Any]) -> dict[str, Any]:
-    parts: list[str] = []
-    tool_calls: dict[int, dict[str, Any]] = {}
-    usage = model = rid = None
-    for ch in chunks:
-        model = getattr(ch, "model", None) or model
-        rid = getattr(ch, "id", None) or rid
-        u = getattr(ch, "usage", None)
-        if u is not None:
-            usage = u
-        choices = getattr(ch, "choices", None) or []
+def _exception_status_code(exc: BaseException) -> int:
+    try:
+        response = getattr(exc, "response", None)
+    except BaseException:  # noqa: BLE001 - never mask the provider error
+        response = None
+    candidates = (exc, response)
+    for candidate in candidates:
+        try:
+            value = getattr(candidate, "status_code", None)
+        except BaseException:  # noqa: BLE001, S112 - never mask provider errors
+            continue
+        if (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 400 <= value <= 599
+        ):
+            return value
+    if isinstance(exc, asyncio.CancelledError):
+        return 499
+    return 500
+
+
+def _error_kwargs(exc: BaseException) -> dict[str, Any]:
+    return {
+        "error_message": error_message(exc),
+        "error_type": type(exc).__name__,
+        "status_code": _exception_status_code(exc),
+    }
+
+
+class _StreamAccumulator:
+    _TEXT_LIMIT = 12_000
+    _TOOL_LIMIT = 50
+    _ARGUMENT_LIMIT = 8_000
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        self.parts: list[str] = []
+        self.text_length = 0
+        self.tool_calls: dict[int, dict[str, Any]] = {}
+        self.usage = None
+        self.model = None
+        self.response_id = None
+        self.final_response = None
+
+    def _append_text(self, value: Any) -> None:
+        if (
+            not isinstance(value, str)
+            or not value
+            or self.text_length >= self._TEXT_LIMIT
+        ):
+            return
+        piece = value[: self._TEXT_LIMIT - self.text_length]
+        self.parts.append(piece)
+        self.text_length += len(piece)
+
+    def add(self, item: Any) -> None:
+        model = getattr(item, "model", None)
+        response_id = getattr(item, "id", None)
+        usage = getattr(item, "usage", None)
+        if isinstance(model, str) and model:
+            self.model = model
+        if isinstance(response_id, str) and response_id:
+            self.response_id = response_id
+        if usage is not None:
+            self.usage = usage
+
+        if self.kind == "response":
+            response = getattr(item, "response", None)
+            if response is not None:
+                self.final_response = response
+            self._append_text(getattr(item, "delta", None))
+            return
+
+        choices = getattr(item, "choices", None) or []
         if not choices:
-            continue
-        delta = getattr(choices[0], "delta", None)
+            return
+        choice = choices[0]
+        if self.kind == "completion":
+            self._append_text(getattr(choice, "text", None))
+            return
+        delta = getattr(choice, "delta", None)
         if delta is None:
-            continue
-        content = getattr(delta, "content", None)
-        if content:
-            parts.append(content)
-        # Accumulate streamed tool-call deltas by index (name once, args in fragments).
-        for tcd in getattr(delta, "tool_calls", None) or []:
-            idx = getattr(tcd, "index", 0) or 0
-            slot = tool_calls.setdefault(
-                idx, {"id": None, "type": "function", "function": {"name": "", "arguments": ""}}
+            return
+        self._append_text(getattr(delta, "content", None))
+        for tool_delta in getattr(delta, "tool_calls", None) or []:
+            index = getattr(tool_delta, "index", 0) or 0
+            if (
+                index not in self.tool_calls
+                and len(self.tool_calls) >= self._TOOL_LIMIT
+            ):
+                continue
+            slot = self.tool_calls.setdefault(
+                index,
+                {
+                    "id": None,
+                    "type": "function",
+                    "function": {"name": "", "arguments": ""},
+                },
             )
-            if getattr(tcd, "id", None):
-                slot["id"] = tcd.id
-            fn = getattr(tcd, "function", None)
-            if fn is not None:
-                if getattr(fn, "name", None):
-                    slot["function"]["name"] = fn.name
-                if getattr(fn, "arguments", None):
-                    slot["function"]["arguments"] += fn.arguments
-    message: dict[str, Any] = {"role": "assistant", "content": "".join(parts) or None}
-    if tool_calls:
-        message["tool_calls"] = [tool_calls[i] for i in sorted(tool_calls)]
-    return {"model": model, "id": rid, "usage": usage, "choices": [{"message": message}]}
+            call_id = getattr(tool_delta, "id", None)
+            if isinstance(call_id, str) and call_id:
+                slot["id"] = call_id
+            function = getattr(tool_delta, "function", None)
+            if function is None:
+                continue
+            name = getattr(function, "name", None)
+            if isinstance(name, str) and name:
+                slot["function"]["name"] = name
+            arguments = getattr(function, "arguments", None)
+            if isinstance(arguments, str) and arguments:
+                current = slot["function"]["arguments"]
+                slot["function"]["arguments"] = (current + arguments)[
+                    : self._ARGUMENT_LIMIT
+                ]
+
+    def response(self) -> Any:
+        text = "".join(self.parts)
+        if self.kind == "response":
+            return self.final_response or {
+                "model": self.model,
+                "id": self.response_id,
+                "usage": self.usage,
+                "output_text": text,
+                "output": [],
+            }
+        if self.kind == "completion":
+            return {
+                "model": self.model,
+                "id": self.response_id,
+                "usage": self.usage,
+                "choices": [{"text": text}],
+            }
+        message: dict[str, Any] = {"role": "assistant", "content": text or None}
+        if self.tool_calls:
+            message["tool_calls"] = [
+                self.tool_calls[index] for index in sorted(self.tool_calls)
+            ]
+        return {
+            "model": self.model,
+            "id": self.response_id,
+            "usage": self.usage,
+            "choices": [{"message": message}],
+        }
 
 
-def _aggregate_completion(chunks: list[Any]) -> dict[str, Any]:
-    parts: list[str] = []
-    usage = model = rid = None
-    for ch in chunks:
-        model = getattr(ch, "model", None) or model
-        rid = getattr(ch, "id", None) or rid
-        u = getattr(ch, "usage", None)
-        if u is not None:
-            usage = u
-        choices = getattr(ch, "choices", None) or []
-        if choices:
-            text = getattr(choices[0], "text", None)
-            if text:
-                parts.append(text)
-    return {"model": model, "id": rid, "usage": usage, "choices": [{"text": "".join(parts)}]}
+def _aggregate_chat(chunks: list[Any]) -> Any:
+    accumulator = _StreamAccumulator("chat")
+    for chunk in chunks:
+        accumulator.add(chunk)
+    return accumulator.response()
+
+
+def _aggregate_completion(chunks: list[Any]) -> Any:
+    accumulator = _StreamAccumulator("completion")
+    for chunk in chunks:
+        accumulator.add(chunk)
+    return accumulator.response()
 
 
 def _aggregate_response(events: list[Any]) -> Any:
-    """Responses-API streaming: the final event carries the full ``response``."""
-    final = None
-    for ev in events:
-        r = getattr(ev, "response", None)
-        if r is not None:
-            final = r
-    return final
+    accumulator = _StreamAccumulator("response")
+    for event in events:
+        accumulator.add(event)
+    return accumulator.response()
 
 
-# kind -> (emit_fn, aggregator | None)
 _KINDS: dict[str, tuple[Callable[..., None], Callable[[list[Any]], Any] | None]] = {
     "chat": (emitter.emit_chat_span, _aggregate_chat),
     "completion": (emitter.emit_completion_span, _aggregate_completion),
@@ -136,66 +252,209 @@ _KINDS: dict[str, tuple[Callable[..., None], Callable[[list[Any]], Any] | None]]
 }
 
 
-def _is_stream(obj: Any) -> bool:
-    """Detect an OpenAI streaming response.
-
-    Note: Pydantic v2 models define ``__iter__``, so a plain ``hasattr`` check
-    would misfire on every non-streaming response. We match OpenAI's real
-    ``Stream``/``AsyncStream`` types, plus ``__aiter__`` (which pydantic models
-    do *not* have) as a fallback for async streams.
-    """
+def _is_stream(value: Any) -> bool:
     try:
         from openai import AsyncStream, Stream
 
-        if isinstance(obj, (Stream, AsyncStream)):
+        if isinstance(value, Stream | AsyncStream):
             return True
-    except Exception:
+    except (ImportError, TypeError):
         pass
-    return hasattr(obj, "__aiter__")
+    return hasattr(value, "__aiter__")
 
 
-# ---------------------------------------------------------------------------
-# Iterator wrappers
-# ---------------------------------------------------------------------------
+class _SyncStreamWrapper:
+    def __init__(
+        self,
+        iterator: Any,
+        *,
+        kind: str,
+        request_kwargs: dict[str, Any],
+        start_ns: int,
+        trace_id: str | None,
+        parent_id: str | None,
+    ) -> None:
+        self._iterator = iterator
+        self._kind = kind
+        self._request_kwargs = request_kwargs
+        self._start_ns = start_ns
+        self._trace_id = trace_id
+        self._parent_id = parent_id
+        self._accumulator = _StreamAccumulator(kind)
+        self._finished = False
+        self._source_closed = False
+
+    def __iter__(self) -> _SyncStreamWrapper:
+        return self
+
+    def __next__(self) -> Any:
+        try:
+            item = next(self._iterator)
+        except StopIteration:
+            self._finish()
+            raise
+        except BaseException as exc:
+            self._close_source(suppress=True)
+            self._finish(exc)
+            raise
+        self._accumulator.add(item)
+        return item
+
+    def _finish(self, exc: BaseException | None = None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        emit_fn, _ = _KINDS[self._kind]
+        kwargs: dict[str, Any] = {}
+        if exc is not None and not isinstance(exc, GeneratorExit):
+            kwargs.update(_error_kwargs(exc))
+        emit_fn(
+            request_kwargs=self._request_kwargs,
+            response=self._accumulator.response(),
+            start_ns=self._start_ns,
+            trace_id=self._trace_id,
+            parent_id=self._parent_id,
+            **kwargs,
+        )
+
+    def _close_source(self, *, suppress: bool) -> BaseException | None:
+        if self._source_closed:
+            return None
+        self._source_closed = True
+        close = getattr(self._iterator, "close", None)
+        if not callable(close):
+            return None
+        try:
+            close()
+        except BaseException as exc:
+            if not suppress:
+                raise
+            return exc
+        return None
+
+    def close(self) -> None:
+        error = self._close_source(suppress=True)
+        self._finish(error)
+        if error is not None:
+            raise error
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        if exc is not None:
+            self._finish(exc)
+            self._close_source(suppress=True)
+        else:
+            self.close()
+        return False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._iterator, name)
+
+    def __del__(self) -> None:
+        try:
+            self._close_source(suppress=True)
+            self._finish()
+        except BaseException:
+            logger.debug("Failed to finalize abandoned OpenAI stream", exc_info=True)
 
 
-def _wrap_sync_stream(iterator, *, kind, request_kwargs, start_ns):
-    emit_fn, aggregate = _KINDS[kind]
-    chunks: list[Any] = []
-    try:
-        for chunk in iterator:
-            chunks.append(chunk)
-            yield chunk
-    except Exception as exc:
-        response = aggregate(chunks) if aggregate else None
-        emit_fn(request_kwargs=request_kwargs, start_ns=start_ns, response=response,
-                error_message=str(exc), status_code=500)
-        raise
-    else:
-        response = aggregate(chunks) if aggregate else None
-        emit_fn(request_kwargs=request_kwargs, start_ns=start_ns, response=response)
+class _AsyncStreamWrapper:
+    def __init__(
+        self,
+        iterator: Any,
+        *,
+        kind: str,
+        request_kwargs: dict[str, Any],
+        start_ns: int,
+        trace_id: str | None,
+        parent_id: str | None,
+    ) -> None:
+        self._iterator = iterator
+        self._kind = kind
+        self._request_kwargs = request_kwargs
+        self._start_ns = start_ns
+        self._trace_id = trace_id
+        self._parent_id = parent_id
+        self._accumulator = _StreamAccumulator(kind)
+        self._finished = False
+        self._source_closed = False
 
+    def __aiter__(self) -> _AsyncStreamWrapper:
+        return self
 
-async def _wrap_async_stream(aiterator, *, kind, request_kwargs, start_ns):
-    emit_fn, aggregate = _KINDS[kind]
-    chunks: list[Any] = []
-    try:
-        async for chunk in aiterator:
-            chunks.append(chunk)
-            yield chunk
-    except Exception as exc:
-        response = aggregate(chunks) if aggregate else None
-        emit_fn(request_kwargs=request_kwargs, start_ns=start_ns, response=response,
-                error_message=str(exc), status_code=500)
-        raise
-    else:
-        response = aggregate(chunks) if aggregate else None
-        emit_fn(request_kwargs=request_kwargs, start_ns=start_ns, response=response)
+    async def __anext__(self) -> Any:
+        try:
+            item = await self._iterator.__anext__()
+        except StopAsyncIteration:
+            self._finish()
+            raise
+        except BaseException as exc:
+            await self._close_source(suppress=True)
+            self._finish(exc)
+            raise
+        self._accumulator.add(item)
+        return item
 
+    def _finish(self, exc: BaseException | None = None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        emit_fn, _ = _KINDS[self._kind]
+        kwargs: dict[str, Any] = {}
+        if exc is not None and not isinstance(exc, GeneratorExit):
+            kwargs.update(_error_kwargs(exc))
+        emit_fn(
+            request_kwargs=self._request_kwargs,
+            response=self._accumulator.response(),
+            start_ns=self._start_ns,
+            trace_id=self._trace_id,
+            parent_id=self._parent_id,
+            **kwargs,
+        )
 
-# ---------------------------------------------------------------------------
-# Method wrappers
-# ---------------------------------------------------------------------------
+    async def _close_source(self, *, suppress: bool) -> BaseException | None:
+        if self._source_closed:
+            return None
+        self._source_closed = True
+        close = getattr(self._iterator, "aclose", None)
+        if not callable(close):
+            close = getattr(self._iterator, "close", None)
+        if not callable(close):
+            return None
+        try:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+        except BaseException as exc:
+            if not suppress:
+                raise
+            return exc
+        return None
+
+    async def close(self) -> None:
+        error = await self._close_source(suppress=True)
+        self._finish(error)
+        if error is not None:
+            raise error
+
+    async def aclose(self) -> None:
+        await self.close()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> bool:
+        if exc is not None:
+            self._finish(exc)
+            await self._close_source(suppress=True)
+        else:
+            await self.close()
+        return False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._iterator, name)
 
 
 def _make_sync_wrapper(original: Any, *, kind: str) -> Any:
@@ -204,18 +463,39 @@ def _make_sync_wrapper(original: Any, *, kind: str) -> Any:
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         if _is_openai_instrumentation_suppressed():
             return original(self, *args, **kwargs)
-
+        request_kwargs = _request_kwargs_from_call(original, self, args, kwargs)
         start_ns = time.time_ns()
+        trace_id, parent_id = emitter.current_trace_parent_ids()
         try:
             response = original(self, *args, **kwargs)
-        except Exception as exc:
-            emit_fn(request_kwargs=kwargs, start_ns=start_ns, error_message=str(exc), status_code=500)
+        except BaseException as exc:
+            emit_fn(
+                request_kwargs=request_kwargs,
+                start_ns=start_ns,
+                trace_id=trace_id,
+                parent_id=parent_id,
+                **_error_kwargs(exc),
+            )
             raise
         if kind != "embedding" and _is_stream(response):
-            return _wrap_sync_stream(response, kind=kind, request_kwargs=kwargs, start_ns=start_ns)
-        emit_fn(request_kwargs=kwargs, start_ns=start_ns, response=response)
+            return _SyncStreamWrapper(
+                response,
+                kind=kind,
+                request_kwargs=request_kwargs,
+                start_ns=start_ns,
+                trace_id=trace_id,
+                parent_id=parent_id,
+            )
+        emit_fn(
+            request_kwargs=request_kwargs,
+            response=response,
+            start_ns=start_ns,
+            trace_id=trace_id,
+            parent_id=parent_id,
+        )
         return response
 
+    wrapper.__respan_openai_wrapper__ = True
     return wrapper
 
 
@@ -225,126 +505,213 @@ def _make_async_wrapper(original: Any, *, kind: str) -> Any:
     async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         if _is_openai_instrumentation_suppressed():
             pending = original(self, *args, **kwargs)
-            return pending if hasattr(pending, "__aiter__") else await pending
-
+            return await pending if inspect.isawaitable(pending) else pending
+        request_kwargs = _request_kwargs_from_call(original, self, args, kwargs)
         start_ns = time.time_ns()
+        trace_id, parent_id = emitter.current_trace_parent_ids()
         try:
             pending = original(self, *args, **kwargs)
-            response = pending if hasattr(pending, "__aiter__") else await pending
-        except Exception as exc:
-            emit_fn(request_kwargs=kwargs, start_ns=start_ns, error_message=str(exc), status_code=500)
+            response = await pending if inspect.isawaitable(pending) else pending
+        except BaseException as exc:
+            emit_fn(
+                request_kwargs=request_kwargs,
+                start_ns=start_ns,
+                trace_id=trace_id,
+                parent_id=parent_id,
+                **_error_kwargs(exc),
+            )
             raise
         if kind != "embedding" and _is_stream(response):
-            return _wrap_async_stream(response, kind=kind, request_kwargs=kwargs, start_ns=start_ns)
-        emit_fn(request_kwargs=kwargs, start_ns=start_ns, response=response)
+            return _AsyncStreamWrapper(
+                response,
+                kind=kind,
+                request_kwargs=request_kwargs,
+                start_ns=start_ns,
+                trace_id=trace_id,
+                parent_id=parent_id,
+            )
+        emit_fn(
+            request_kwargs=request_kwargs,
+            response=response,
+            start_ns=start_ns,
+            trace_id=trace_id,
+            parent_id=parent_id,
+        )
         return response
 
+    wrapper.__respan_openai_wrapper__ = True
     return wrapper
-
-
-# ---------------------------------------------------------------------------
-# Patch plumbing
-# ---------------------------------------------------------------------------
 
 
 def _load_class(module_path: str, class_name: str) -> type[Any] | None:
     try:
         module = importlib.import_module(module_path)
-    except Exception as exc:
+    except ImportError as exc:
         logger.debug("OpenAI module %s unavailable: %s", module_path, exc)
         return None
     return getattr(module, class_name, None)
 
 
-def _patch(target_class: type[Any] | None, *, kind: str, is_async: bool) -> bool:
-    """Patch one target class's create method.
-
-    Returns True when the target's API surface is present (patched now or already
-    patched), False when the class or method is missing. The caller treats an
-    all-False result as an installed-but-incompatible openai SDK.
-    """
+def _patch(
+    target_class: type[Any] | None,
+    *,
+    method_name: str,
+    kind: str,
+    is_async: bool,
+) -> bool:
     if target_class is None:
         return False
-    original = getattr(target_class, CREATE_METHOD, None)
+    original = getattr(target_class, method_name, None)
     if original is None:
         return False
-    key = (target_class, CREATE_METHOD)
-    if key in _original_methods:
+    key = (target_class, method_name)
+    if key in _ORIGINAL_METHODS:
         return True
-    _original_methods[key] = original
+    _ORIGINAL_METHODS[key] = original
     factory = _make_async_wrapper if is_async else _make_sync_wrapper
-    setattr(target_class, CREATE_METHOD, factory(original, kind=kind))
+    try:
+        wrapper = factory(original, kind=kind)
+        setattr(target_class, method_name, wrapper)
+    except BaseException:
+        _ORIGINAL_METHODS.pop(key, None)
+        _INSTALLED_METHODS.pop(key, None)
+        raise
+    _INSTALLED_METHODS[key] = wrapper
     return True
 
 
-# (module, class, kind, is_async)
 _TARGETS = [
-    (CHAT_MODULE, SYNC_CHAT_CLASS, "chat", False),
-    (CHAT_MODULE, ASYNC_CHAT_CLASS, "chat", True),
-    (COMPLETIONS_MODULE, SYNC_COMPLETIONS_CLASS, "completion", False),
-    (COMPLETIONS_MODULE, ASYNC_COMPLETIONS_CLASS, "completion", True),
-    (RESPONSES_MODULE, SYNC_RESPONSES_CLASS, "response", False),
-    (RESPONSES_MODULE, ASYNC_RESPONSES_CLASS, "response", True),
-    (EMBEDDINGS_MODULE, SYNC_EMBEDDINGS_CLASS, "embedding", False),
-    (EMBEDDINGS_MODULE, ASYNC_EMBEDDINGS_CLASS, "embedding", True),
+    (CHAT_MODULE, SYNC_CHAT_CLASS, CREATE_METHOD, "chat", False),
+    (CHAT_MODULE, ASYNC_CHAT_CLASS, CREATE_METHOD, "chat", True),
+    (CHAT_MODULE, SYNC_CHAT_CLASS, PARSE_METHOD, "chat", False),
+    (CHAT_MODULE, ASYNC_CHAT_CLASS, PARSE_METHOD, "chat", True),
+    (COMPLETIONS_MODULE, SYNC_COMPLETIONS_CLASS, CREATE_METHOD, "completion", False),
+    (COMPLETIONS_MODULE, ASYNC_COMPLETIONS_CLASS, CREATE_METHOD, "completion", True),
+    (RESPONSES_MODULE, SYNC_RESPONSES_CLASS, CREATE_METHOD, "response", False),
+    (RESPONSES_MODULE, ASYNC_RESPONSES_CLASS, CREATE_METHOD, "response", True),
+    (RESPONSES_MODULE, SYNC_RESPONSES_CLASS, PARSE_METHOD, "response", False),
+    (RESPONSES_MODULE, ASYNC_RESPONSES_CLASS, PARSE_METHOD, "response", True),
+    (EMBEDDINGS_MODULE, SYNC_EMBEDDINGS_CLASS, CREATE_METHOD, "embedding", False),
+    (EMBEDDINGS_MODULE, ASYNC_EMBEDDINGS_CLASS, CREATE_METHOD, "embedding", True),
 ]
 
 
+def _install_patches() -> bool:
+    installed_before = set(_ORIGINAL_METHODS)
+    patched_any = False
+    try:
+        for module_path, class_name, method_name, kind, is_async in _TARGETS:
+            patched_any = (
+                _patch(
+                    _load_class(module_path, class_name),
+                    method_name=method_name,
+                    kind=kind,
+                    is_async=is_async,
+                )
+                or patched_any
+            )
+    except BaseException:
+        for key in set(_ORIGINAL_METHODS) - installed_before:
+            target_class, method_name = key
+            original = _ORIGINAL_METHODS[key]
+            installed = _INSTALLED_METHODS.get(key)
+            try:
+                current = getattr(target_class, method_name)
+            except BaseException:
+                logger.exception("Failed to inspect OpenAI patch %s", method_name)
+                continue
+            if installed is not None and current is not installed:
+                _ORIGINAL_METHODS.pop(key, None)
+                _INSTALLED_METHODS.pop(key, None)
+                continue
+            try:
+                setattr(target_class, method_name, original)
+            except BaseException:
+                logger.exception("Failed to roll back OpenAI patch %s", method_name)
+            else:
+                _ORIGINAL_METHODS.pop(key, None)
+                _INSTALLED_METHODS.pop(key, None)
+        raise
+    return patched_any
+
+
+def _remove_patches() -> None:
+    for key, original in list(_ORIGINAL_METHODS.items()):
+        target_class, method_name = key
+        installed = _INSTALLED_METHODS.get(key)
+        try:
+            current = getattr(target_class, method_name)
+        except BaseException:
+            logger.debug(
+                "Failed to inspect %s.%s", target_class, method_name, exc_info=True
+            )
+            continue
+        if installed is not None and current is not installed:
+            _ORIGINAL_METHODS.pop(key, None)
+            _INSTALLED_METHODS.pop(key, None)
+            continue
+        try:
+            setattr(target_class, method_name, original)
+        except BaseException:
+            logger.debug(
+                "Failed to restore %s.%s", target_class, method_name, exc_info=True
+            )
+        else:
+            _ORIGINAL_METHODS.pop(key, None)
+            _INSTALLED_METHODS.pop(key, None)
+
+
 class OpenAIInstrumentor:
-    """Respan instrumentor for direct OpenAI SDK usage.
-
-    Usage::
-
-        from respan import Respan
-        from respan_instrumentation_openai import OpenAIInstrumentor
-
-        respan = Respan(instrumentations=[OpenAIInstrumentor()])
-    """
+    """Reference-counted instrumentation for OpenAI 3.x resources."""
 
     name = "openai"
 
     def __init__(self) -> None:
         self._is_instrumented = False
 
+    @staticmethod
+    def _is_respan_tracing_enabled() -> bool:
+        tracer = getattr(RespanTracer, "_instance", None)
+        if tracer is None:
+            return True
+        return bool(getattr(tracer, "is_enabled", True))
+
     def activate(self) -> None:
-        if self._is_instrumented:
-            return
-        try:
-            import openai  # noqa: F401
-        except ImportError as exc:
-            # SDK genuinely absent — expected when the app doesn't use OpenAI
-            # (the openai SDK is an optional extra).
-            logger.debug("OpenAI instrumentation inactive — openai not installed: %s", exc)
-            return
-        try:
-            patched_any = False
-            for module_path, class_name, kind, is_async in _TARGETS:
-                if _patch(
-                    _load_class(module_path, class_name), kind=kind, is_async=is_async
-                ):
-                    patched_any = True
-            if not patched_any:
-                # openai imports but none of its known API surfaces are present:
-                # installed but incompatible — the silent-failure class this bundling
-                # is meant to fix, so warn instead of leaving it quietly untraced.
-                logger.warning(
-                    "openai is installed but no known API surface could be "
-                    "instrumented — incompatible version? OpenAI instrumentation inactive."
+        global _REFCOUNT
+        with _LIFECYCLE_LOCK:
+            if self._is_instrumented:
+                return
+            if not self._is_respan_tracing_enabled():
+                logger.info(
+                    "OpenAI instrumentation skipped because Respan tracing is disabled"
                 )
-        except Exception as exc:
-            logger.warning("Failed to activate OpenAI instrumentation: %s", exc)
-            self.deactivate()
-            return
-        self._is_instrumented = True
-        logger.info("OpenAI SDK instrumentation activated")
+                return
+            try:
+                import openai  # noqa: F401
+            except ImportError as exc:
+                logger.debug("OpenAI instrumentation inactive: %s", exc)
+                return
+            if _REFCOUNT == 0:
+                try:
+                    if not _install_patches():
+                        logger.warning(
+                            "openai is installed but no supported API surface was found"
+                        )
+                        return
+                except BaseException:
+                    logger.exception("Failed to activate OpenAI instrumentation")
+                    return
+            _REFCOUNT += 1
+            self._is_instrumented = True
+            logger.info("OpenAI SDK instrumentation activated")
 
     def deactivate(self) -> None:
-        for (target_class, method_name), original in list(_original_methods.items()):
-            try:
-                setattr(target_class, method_name, original)
-            except Exception:
-                logger.debug("Failed to restore %s.%s", target_class, method_name, exc_info=True)
-            finally:
-                _original_methods.pop((target_class, method_name), None)
-        self._is_instrumented = False
-        logger.info("OpenAI SDK instrumentation deactivated")
+        global _REFCOUNT
+        with _LIFECYCLE_LOCK:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            _REFCOUNT = max(0, _REFCOUNT - 1)
+            if _REFCOUNT == 0:
+                _remove_patches()
+            logger.info("OpenAI SDK instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_otel_emitter.py
@@ -1,217 +1,226 @@
-"""Emit OpenAI SDK calls as OTEL ReadableSpan objects.
-
-Each ``emit_*`` builds a ``ReadableSpan`` carrying Respan's documented LLM
-conventions (``llm.request.type``, ``gen_ai.system``, ``gen_ai.usage.*``,
-``traceloop.entity.*``, ``respan.log_type``) and injects it into the single
-OTEL pipeline via ``inject_span()``. The span nests under the current OTEL
-span when one is active (e.g. a ``@workflow``/``@task`` decorator), otherwise
-it is a root span (its own trace).
-"""
+"""Emit contract-compliant OpenAI SDK calls into the active OTel pipeline."""
 
 from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
 from typing import Any
 
 from opentelemetry import trace
-
+from opentelemetry.semconv_ai import SpanAttributes
 from respan_sdk.constants.llm_logging import (
     LOG_TYPE_CHAT,
-    LOG_TYPE_COMPLETION,
     LOG_TYPE_EMBEDDING,
-    LOG_TYPE_RESPONSE,
+    LOG_TYPE_TEXT,
 )
-from respan_sdk.constants.span_attributes import (
-    GEN_AI_SYSTEM,
-    LLM_REQUEST_MODEL,
-    LLM_REQUEST_TYPE,
-    LLM_USAGE_COMPLETION_TOKENS,
-    LLM_USAGE_PROMPT_TOKENS,
-    RESPAN_LOG_TYPE,
-    RESPAN_SPAN_TOOL_CALLS,
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
 )
-from respan_sdk.utils.data_processing.id_processing import format_span_id, format_trace_id
 from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
+from respan_instrumentation_openai import _translator as tr
 from respan_instrumentation_openai._constants import (
     ASSISTANT_ROLE,
     CHAT_SPAN_NAME,
     COMPLETION_SPAN_NAME,
     EMBEDDING_SPAN_NAME,
-    LLM_COMPLETIONS,
-    LLM_PROMPTS,
-    LLM_REQUEST_FUNCTIONS,
-    LLM_RESPONSE_ID,
-    LLM_RESPONSE_MODEL,
-    LLM_USAGE_TOTAL_TOKENS,
+    GEN_AI_RESPONSE_ID,
     OPENAI_SYSTEM,
     REQUEST_TYPE_CHAT,
     REQUEST_TYPE_COMPLETION,
     REQUEST_TYPE_EMBEDDING,
     RESPONSE_SPAN_NAME,
-    SPAN_KIND_LLM,
-    TRACELOOP_ENTITY_INPUT,
-    TRACELOOP_ENTITY_NAME,
-    TRACELOOP_ENTITY_OUTPUT,
-    TRACELOOP_ENTITY_PATH,
-    TRACELOOP_SPAN_KIND,
 )
-from respan_instrumentation_openai import _translator as tr
 
 logger = logging.getLogger(__name__)
 
-_PROMPT_PREFIX = f"{LLM_PROMPTS}."
-_COMPLETION_PREFIX = f"{LLM_COMPLETIONS}."
+_PROMPT_PREFIX = f"{SpanAttributes.LLM_PROMPTS}."
+_COMPLETION_PREFIX = f"{SpanAttributes.LLM_COMPLETIONS}."
+_USAGE_INPUT = getattr(
+    SpanAttributes, "LLM_USAGE_INPUT_TOKENS", "gen_ai.usage.input_tokens"
+)
+_USAGE_OUTPUT = getattr(
+    SpanAttributes, "LLM_USAGE_OUTPUT_TOKENS", "gen_ai.usage.output_tokens"
+)
 
 
-# ---------------------------------------------------------------------------
-# Trace context (nesting)
-# ---------------------------------------------------------------------------
-
-
-def _current_trace_parent_ids() -> tuple[str | None, str | None]:
-    """Return (trace_id, parent_id) hex strings from the active OTEL span.
-
-    When no live span is active the call is standalone → (None, None) → the
-    emitted span becomes a root (its own trace).
-    """
-    try:
-        ctx = trace.get_current_span().get_span_context()
-    except Exception:
+def current_trace_parent_ids() -> tuple[str | None, str | None]:
+    context = trace.get_current_span().get_span_context()
+    trace_id = getattr(context, "trace_id", 0) or 0
+    span_id = getattr(context, "span_id", 0) or 0
+    if not trace_id or not span_id:
         return None, None
-    tid = getattr(ctx, "trace_id", 0) or 0
-    sid = getattr(ctx, "span_id", 0) or 0
-    if not tid or not sid:
-        return None, None
-    return format_trace_id(trace_id=tid), format_span_id(span_id=sid)
+    return format_trace_id(trace_id=trace_id), format_span_id(span_id=span_id)
 
 
-# ---------------------------------------------------------------------------
-# Attribute builders
-# ---------------------------------------------------------------------------
-
-
-def _base_attrs(*, span_name: str, log_type: str, request_type: str) -> dict[str, Any]:
+def _base_attrs(
+    *, span_name: str, log_type: str, request_type: str, is_streaming: bool
+) -> dict[str, Any]:
+    # Auto-emitted spans intentionally do not set traceloop.span.kind.
     return {
-        TRACELOOP_SPAN_KIND: SPAN_KIND_LLM,
-        TRACELOOP_ENTITY_NAME: span_name,
-        TRACELOOP_ENTITY_PATH: span_name,
-        GEN_AI_SYSTEM: OPENAI_SYSTEM,
-        LLM_REQUEST_TYPE: request_type,
+        SpanAttributes.TRACELOOP_ENTITY_NAME: span_name,
+        SpanAttributes.TRACELOOP_ENTITY_PATH: span_name,
+        SpanAttributes.LLM_SYSTEM: OPENAI_SYSTEM,
+        SpanAttributes.LLM_REQUEST_TYPE: request_type,
+        SpanAttributes.GEN_AI_IS_STREAMING: is_streaming,
         RESPAN_LOG_TYPE: log_type,
     }
 
 
-def _set_model(attrs: dict[str, Any], request_kwargs: dict[str, Any], response: Any) -> None:
+def _set_model(
+    attrs: dict[str, Any], request_kwargs: dict[str, Any], response: Any
+) -> None:
     model = tr.request_model(request_kwargs)
     if model:
-        attrs[LLM_REQUEST_MODEL] = model
-    resp_model = tr.response_model(response)
-    if resp_model:
-        attrs[LLM_RESPONSE_MODEL] = resp_model
-    rid = tr.response_id(response)
-    if rid:
-        attrs[LLM_RESPONSE_ID] = rid
+        attrs[SpanAttributes.LLM_REQUEST_MODEL] = model
+    response_model = tr.response_model(response)
+    if response_model:
+        attrs[SpanAttributes.LLM_RESPONSE_MODEL] = response_model
+    response_id = tr.response_id(response)
+    if response_id:
+        attrs[GEN_AI_RESPONSE_ID] = response_id
 
 
 def _set_prompt_attrs(attrs: dict[str, Any], messages: list[dict[str, Any]]) -> None:
-    for i, msg in enumerate(messages):
-        role = msg.get("role")
-        content = msg.get("content")
+    for index, message in enumerate(messages):
+        role = message.get("role")
+        content = message.get("content")
         if role is not None:
-            attrs[f"{_PROMPT_PREFIX}{i}.role"] = str(role)
+            attrs[f"{_PROMPT_PREFIX}{index}.role"] = str(role)
         if content is not None:
-            attrs[f"{_PROMPT_PREFIX}{i}.content"] = tr.to_attr_value(content)
+            attrs[f"{_PROMPT_PREFIX}{index}.content"] = tr.to_attr_value(content)
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            attrs[f"{_PROMPT_PREFIX}{index}.tool_calls"] = tr.safe_json(tool_calls)
 
 
-def _set_completion_attrs(attrs: dict[str, Any], content: str) -> None:
+def _set_completion_attrs(
+    attrs: dict[str, Any], content: str, tool_calls: list[dict[str, Any]] | None = None
+) -> None:
     attrs[f"{_COMPLETION_PREFIX}0.role"] = ASSISTANT_ROLE
     attrs[f"{_COMPLETION_PREFIX}0.content"] = content
+    if tool_calls:
+        attrs[f"{_COMPLETION_PREFIX}0.tool_calls"] = tr.safe_json(tool_calls)
 
 
 def _set_usage(attrs: dict[str, Any], response: Any) -> None:
     usage = tr.extract_usage(response)
     if "prompt" in usage:
-        attrs[LLM_USAGE_PROMPT_TOKENS] = usage["prompt"]
+        attrs[_USAGE_INPUT] = usage["prompt"]
+        attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = usage["prompt"]
     if "completion" in usage:
-        attrs[LLM_USAGE_COMPLETION_TOKENS] = usage["completion"]
+        attrs[_USAGE_OUTPUT] = usage["completion"]
+        attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = usage["completion"]
     if "total" in usage:
-        attrs[LLM_USAGE_TOTAL_TOKENS] = usage["total"]
+        attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = usage["total"]
 
 
-def build_chat_attrs(*, request_kwargs: dict[str, Any], response: Any = None) -> dict[str, Any]:
-    attrs = _base_attrs(span_name=CHAT_SPAN_NAME, log_type=LOG_TYPE_CHAT, request_type=REQUEST_TYPE_CHAT)
+def build_chat_attrs(
+    *, request_kwargs: dict[str, Any], response: Any = None
+) -> dict[str, Any]:
+    attrs = _base_attrs(
+        span_name=CHAT_SPAN_NAME,
+        log_type=LOG_TYPE_CHAT,
+        request_type=REQUEST_TYPE_CHAT,
+        is_streaming=bool(request_kwargs.get("stream")),
+    )
     messages = tr.normalize_chat_messages(request_kwargs.get("messages"))
-    attrs[TRACELOOP_ENTITY_INPUT] = tr.format_input_messages(messages)
+    managed_prompt = tr.managed_prompt_input(request_kwargs.get("extra_body"))
+    if not messages and managed_prompt is not None:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = tr.safe_json(managed_prompt)
+    else:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = tr.format_input_messages(
+            messages
+        )
     _set_prompt_attrs(attrs, messages)
     tools = tr.normalize_tools(request_kwargs.get("tools"))
     if tools:
-        attrs[LLM_REQUEST_FUNCTIONS] = tr.safe_json(tools)
+        attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS] = tr.safe_json(tools)
     _set_model(attrs, request_kwargs, response)
     if response is not None:
-        attrs[TRACELOOP_ENTITY_OUTPUT] = tr.format_chat_output(response)
-        _set_completion_attrs(attrs, tr.format_chat_output(response))
+        output_message = tr.chat_output_message(response)
         tool_calls = tr.extract_chat_tool_calls(response)
-        if tool_calls:
-            attrs[RESPAN_SPAN_TOOL_CALLS] = tr.safe_json(tool_calls)
-            attrs[f"{_COMPLETION_PREFIX}0.tool_calls"] = tr.safe_json(tool_calls)
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = tr.safe_json(output_message)
+        _set_completion_attrs(
+            attrs, tr.format_chat_output(response), tool_calls=tool_calls
+        )
         _set_usage(attrs, response)
     return attrs
 
 
-def build_completion_attrs(*, request_kwargs: dict[str, Any], response: Any = None) -> dict[str, Any]:
+def build_completion_attrs(
+    *, request_kwargs: dict[str, Any], response: Any = None
+) -> dict[str, Any]:
     attrs = _base_attrs(
-        span_name=COMPLETION_SPAN_NAME, log_type=LOG_TYPE_COMPLETION, request_type=REQUEST_TYPE_COMPLETION
+        span_name=COMPLETION_SPAN_NAME,
+        log_type=LOG_TYPE_TEXT,
+        request_type=REQUEST_TYPE_COMPLETION,
+        is_streaming=bool(request_kwargs.get("stream")),
     )
     messages = tr.normalize_text_prompts(request_kwargs.get("prompt"))
-    attrs[TRACELOOP_ENTITY_INPUT] = tr.format_input_messages(messages)
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = tr.format_input_messages(messages)
     _set_prompt_attrs(attrs, messages)
     _set_model(attrs, request_kwargs, response)
     if response is not None:
         output = tr.format_completion_output(response)
-        attrs[TRACELOOP_ENTITY_OUTPUT] = output
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = tr.safe_json({"text": output})
         _set_completion_attrs(attrs, output)
         _set_usage(attrs, response)
     return attrs
 
 
-def build_response_attrs(*, request_kwargs: dict[str, Any], response: Any = None) -> dict[str, Any]:
-    attrs = _base_attrs(span_name=RESPONSE_SPAN_NAME, log_type=LOG_TYPE_RESPONSE, request_type=REQUEST_TYPE_CHAT)
-    messages = tr.normalize_responses_input(request_kwargs.get("input"))
-    attrs[TRACELOOP_ENTITY_INPUT] = tr.format_input_messages(messages)
+def build_response_attrs(
+    *, request_kwargs: dict[str, Any], response: Any = None
+) -> dict[str, Any]:
+    attrs = _base_attrs(
+        span_name=RESPONSE_SPAN_NAME,
+        log_type=LOG_TYPE_CHAT,
+        request_type=REQUEST_TYPE_CHAT,
+        is_streaming=bool(request_kwargs.get("stream")),
+    )
+    messages = tr.normalize_responses_input(
+        request_kwargs.get("input"), request_kwargs.get("instructions")
+    )
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = tr.format_input_messages(messages)
     _set_prompt_attrs(attrs, messages)
     tools = tr.normalize_tools(request_kwargs.get("tools"))
     if tools:
-        attrs[LLM_REQUEST_FUNCTIONS] = tr.safe_json(tools)
+        attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS] = tr.safe_json(tools)
     _set_model(attrs, request_kwargs, response)
     if response is not None:
+        tool_calls = tr.extract_responses_tool_calls(response)
         output = tr.format_responses_output(response)
-        attrs[TRACELOOP_ENTITY_OUTPUT] = output
-        _set_completion_attrs(attrs, output)
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = tr.safe_json(
+            tr.responses_output_payload(response)
+        )
+        _set_completion_attrs(attrs, output, tool_calls=tool_calls)
         _set_usage(attrs, response)
     return attrs
 
 
-def build_embedding_attrs(*, request_kwargs: dict[str, Any], response: Any = None) -> dict[str, Any]:
+def build_embedding_attrs(
+    *, request_kwargs: dict[str, Any], response: Any = None
+) -> dict[str, Any]:
     attrs = _base_attrs(
-        span_name=EMBEDDING_SPAN_NAME, log_type=LOG_TYPE_EMBEDDING, request_type=REQUEST_TYPE_EMBEDDING
+        span_name=EMBEDDING_SPAN_NAME,
+        log_type=LOG_TYPE_EMBEDDING,
+        request_type=REQUEST_TYPE_EMBEDDING,
+        is_streaming=False,
     )
     inputs = tr.normalize_embedding_inputs(request_kwargs.get("input"))
-    attrs[TRACELOOP_ENTITY_INPUT] = tr.safe_json(inputs)
-    attrs[f"{_PROMPT_PREFIX}0.content"] = tr.safe_json(inputs)
+    attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = tr.safe_json(inputs)
+    if inputs:
+        attrs[f"{_PROMPT_PREFIX}0.content"] = tr.safe_json(inputs)
     _set_model(attrs, request_kwargs, response)
     if response is not None:
-        summary = tr.embedding_summary(response)
-        if summary:
-            attrs[TRACELOOP_ENTITY_OUTPUT] = tr.safe_json(summary)
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = tr.safe_json(
+            tr.embedding_payload(response)
+        )
         _set_usage(attrs, response)
     return attrs
-
-
-# ---------------------------------------------------------------------------
-# Emit
-# ---------------------------------------------------------------------------
 
 
 def emit_span(
@@ -220,10 +229,29 @@ def emit_span(
     attrs: dict[str, Any],
     start_ns: int,
     error_message: str | None = None,
+    error_type: str | None = None,
     status_code: int = 200,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
     try:
-        trace_id, parent_id = _current_trace_parent_ids()
+        if trace_id is None and parent_id is None:
+            trace_id, parent_id = current_trace_parent_ids()
+        attrs["status_code"] = status_code
+        if error_message:
+            attrs["error.message"] = error_message
+            attrs["error.type"] = error_type or "OpenAIError"
+            attrs.setdefault(
+                SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                tr.safe_json(
+                    {
+                        "error": error_type or "OpenAIError",
+                        "message": error_message,
+                        "status": "error",
+                        "status_code": status_code,
+                    }
+                ),
+            )
         span = build_readable_span(
             name=span_name,
             trace_id=trace_id,
@@ -235,14 +263,26 @@ def emit_span(
             status_code=status_code,
         )
         inject_span(span=span)
-    except Exception:
+    except BaseException:
         logger.debug("Failed to emit OpenAI span %r", span_name, exc_info=True)
 
 
-def _emit(builder, span_name, *, request_kwargs, response, start_ns, error_message, status_code) -> None:
+def _emit(
+    builder: Callable[..., dict[str, Any]],
+    span_name: str,
+    *,
+    request_kwargs: dict[str, Any],
+    response: Any,
+    start_ns: int,
+    error_message: str | None,
+    error_type: str | None,
+    status_code: int,
+    trace_id: str | None,
+    parent_id: str | None,
+) -> None:
     try:
         attrs = builder(request_kwargs=request_kwargs, response=response)
-    except Exception:
+    except BaseException:
         logger.debug("Failed to build attrs for %r", span_name, exc_info=True)
         attrs = {}
     emit_span(
@@ -250,25 +290,108 @@ def _emit(builder, span_name, *, request_kwargs, response, start_ns, error_messa
         attrs=attrs,
         start_ns=start_ns,
         error_message=error_message,
+        error_type=error_type,
         status_code=status_code,
+        trace_id=trace_id,
+        parent_id=parent_id,
     )
 
 
-def emit_chat_span(*, request_kwargs, start_ns, response=None, error_message=None, status_code=200) -> None:
-    _emit(build_chat_attrs, CHAT_SPAN_NAME, request_kwargs=request_kwargs, response=response,
-          start_ns=start_ns, error_message=error_message, status_code=status_code)
+def emit_chat_span(
+    *,
+    request_kwargs,
+    start_ns,
+    response=None,
+    error_message=None,
+    error_type=None,
+    status_code=200,
+    trace_id=None,
+    parent_id=None,
+) -> None:
+    _emit(
+        build_chat_attrs,
+        CHAT_SPAN_NAME,
+        request_kwargs=request_kwargs,
+        response=response,
+        start_ns=start_ns,
+        error_message=error_message,
+        error_type=error_type,
+        status_code=status_code,
+        trace_id=trace_id,
+        parent_id=parent_id,
+    )
 
 
-def emit_completion_span(*, request_kwargs, start_ns, response=None, error_message=None, status_code=200) -> None:
-    _emit(build_completion_attrs, COMPLETION_SPAN_NAME, request_kwargs=request_kwargs, response=response,
-          start_ns=start_ns, error_message=error_message, status_code=status_code)
+def emit_completion_span(
+    *,
+    request_kwargs,
+    start_ns,
+    response=None,
+    error_message=None,
+    error_type=None,
+    status_code=200,
+    trace_id=None,
+    parent_id=None,
+) -> None:
+    _emit(
+        build_completion_attrs,
+        COMPLETION_SPAN_NAME,
+        request_kwargs=request_kwargs,
+        response=response,
+        start_ns=start_ns,
+        error_message=error_message,
+        error_type=error_type,
+        status_code=status_code,
+        trace_id=trace_id,
+        parent_id=parent_id,
+    )
 
 
-def emit_response_span(*, request_kwargs, start_ns, response=None, error_message=None, status_code=200) -> None:
-    _emit(build_response_attrs, RESPONSE_SPAN_NAME, request_kwargs=request_kwargs, response=response,
-          start_ns=start_ns, error_message=error_message, status_code=status_code)
+def emit_response_span(
+    *,
+    request_kwargs,
+    start_ns,
+    response=None,
+    error_message=None,
+    error_type=None,
+    status_code=200,
+    trace_id=None,
+    parent_id=None,
+) -> None:
+    _emit(
+        build_response_attrs,
+        RESPONSE_SPAN_NAME,
+        request_kwargs=request_kwargs,
+        response=response,
+        start_ns=start_ns,
+        error_message=error_message,
+        error_type=error_type,
+        status_code=status_code,
+        trace_id=trace_id,
+        parent_id=parent_id,
+    )
 
 
-def emit_embedding_span(*, request_kwargs, start_ns, response=None, error_message=None, status_code=200) -> None:
-    _emit(build_embedding_attrs, EMBEDDING_SPAN_NAME, request_kwargs=request_kwargs, response=response,
-          start_ns=start_ns, error_message=error_message, status_code=status_code)
+def emit_embedding_span(
+    *,
+    request_kwargs,
+    start_ns,
+    response=None,
+    error_message=None,
+    error_type=None,
+    status_code=200,
+    trace_id=None,
+    parent_id=None,
+) -> None:
+    _emit(
+        build_embedding_attrs,
+        EMBEDDING_SPAN_NAME,
+        request_kwargs=request_kwargs,
+        response=response,
+        start_ns=start_ns,
+        error_message=error_message,
+        error_type=error_type,
+        status_code=status_code,
+        trace_id=trace_id,
+        parent_id=parent_id,
+    )

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_serialization.py
@@ -1,0 +1,211 @@
+"""Bounded, redacting serializers used by the OpenAI instrumentation."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+MAX_ATTRIBUTE_LENGTH = 16_000
+MAX_ERROR_LENGTH = 2_000
+MAX_COLLECTION_ITEMS = 50
+MAX_DEPTH = 6
+
+_REDACTED = "[REDACTED]"
+_SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "credential",
+    "password",
+    "private_key",
+    "secret",
+)
+_SENSITIVE_KEYS = (
+    "access_token",
+    "auth_token",
+    "refresh_token",
+    "token",
+)
+_BEARER_RE = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+")
+_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(api[_-]?key|authorization|password|secret|token|access[_-]?token|refresh[_-]?token)\b"
+    r"([\"']?)(\s*[:=]\s*)(?![\"'])([^\s,;}]+)"
+)
+_QUOTED_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(api[_-]?key|authorization|password|secret|token|access[_-]?token|refresh[_-]?token)\b"
+    r"(?P<key_quote>[\"']?)(?P<separator>\s*[:=]\s*)"
+    r"(?P<value_quote>[\"'])(?P<value>[\s\S]*?)(?P=value_quote)"
+)
+
+
+def _truncate_utf8(value: str, limit: int) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit:
+        return value
+    return encoded[:limit].decode("utf-8", errors="ignore")
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    lowered = str(key).lower().replace("-", "_")
+    return (
+        lowered in _SENSITIVE_KEYS
+        or lowered.endswith("_token")
+        or any(marker in lowered for marker in _SENSITIVE_KEY_PARTS)
+    )
+
+
+def redact_text(value: str, *, limit: int = MAX_ATTRIBUTE_LENGTH) -> str:
+    redacted = _BEARER_RE.sub(f"Bearer {_REDACTED}", value)
+    redacted = _QUOTED_ASSIGNMENT_RE.sub(
+        lambda match: (
+            f"{match.group(1)}{match.group('key_quote')}"
+            f"{match.group('separator')}{match.group('value_quote')}"
+            f"{_REDACTED}{match.group('value_quote')}"
+        ),
+        redacted,
+    )
+    redacted = _ASSIGNMENT_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}{match.group(3)}{_REDACTED}",
+        redacted,
+    )
+    return _truncate_utf8(redacted, limit)
+
+
+def json_value(
+    value: Any,
+    *,
+    _depth: int = 0,
+    _seen: set[int] | None = None,
+    _key: str | None = None,
+) -> Any:
+    """Convert a value without arbitrary ``repr``/``str`` calls."""
+    if _key is not None and _is_sensitive_key(_key):
+        return _REDACTED
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, bytes | bytearray | memoryview):
+        return {"type": type(value).__name__, "bytes": len(value)}
+    if _depth >= MAX_DEPTH:
+        return {"type": type(value).__name__, "truncated": True}
+
+    seen = _seen if _seen is not None else set()
+    value_id = id(value)
+    if value_id in seen:
+        return {"type": type(value).__name__, "cycle": True}
+    seen.add(value_id)
+    try:
+        converted: Any
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            converted = {
+                field.name: getattr(value, field.name)
+                for field in dataclasses.fields(value)
+            }
+        elif callable(getattr(value, "model_dump", None)):
+            try:
+                converted = value.model_dump(exclude_none=True, mode="json")
+            except TypeError:
+                converted = value.model_dump()
+        elif callable(getattr(value, "to_dict", None)):
+            converted = value.to_dict()
+        elif (
+            isinstance(value, Mapping)
+            or isinstance(value, Sequence)
+            and not isinstance(value, str | bytes)
+        ):
+            converted = value
+        elif isinstance(value, type):
+            return {"type": value.__name__}
+        else:
+            return {"type": type(value).__name__}
+
+        if isinstance(converted, Mapping):
+            result: dict[str, Any] = {}
+            for index, (key, item) in enumerate(converted.items()):
+                if index >= MAX_COLLECTION_ITEMS:
+                    result["__truncated_items__"] = True
+                    break
+                key_text = (
+                    str(key)
+                    if isinstance(key, str | int | float | bool)
+                    else type(key).__name__
+                )
+                result[key_text] = json_value(
+                    item,
+                    _depth=_depth + 1,
+                    _seen=seen,
+                    _key=key_text,
+                )
+            return result
+        if isinstance(converted, Sequence) and not isinstance(converted, str | bytes):
+            # Some SDK/user sequences are lazy or report an expensive/hostile
+            # length. Consume only the retained items plus one lookahead item.
+            iterator = iter(converted)
+            result = []
+            for _ in range(MAX_COLLECTION_ITEMS):
+                try:
+                    item = next(iterator)
+                except StopIteration:
+                    return result
+                result.append(json_value(item, _depth=_depth + 1, _seen=seen))
+            try:
+                next(iterator)
+            except StopIteration:
+                return result
+            result.append({"truncated_items": True})
+            return result
+        return json_value(converted, _depth=_depth + 1, _seen=seen)
+    except Exception:  # noqa: BLE001 - serialization must never break user calls
+        return {"type": type(value).__name__, "serialization_error": True}
+    finally:
+        seen.discard(value_id)
+
+
+def json_string(value: Any, *, limit: int = MAX_ATTRIBUTE_LENGTH) -> str:
+    encoded = json.dumps(
+        json_value(value),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if len(encoded.encode("utf-8")) <= limit:
+        return encoded
+
+    # Keep the result valid JSON while bounding the final encoded length.
+    low, high = 0, len(encoded)
+    best = json.dumps({"preview": "", "truncated": True}, separators=(",", ":"))
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = json.dumps(
+            {"preview": encoded[:middle], "truncated": True},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        if len(candidate.encode("utf-8")) <= limit:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best
+
+
+def error_message(exc: BaseException) -> str:
+    """Render an exception without invoking a hostile ``__str__`` override."""
+    try:
+        message = getattr(exc, "message", None)
+    except BaseException:  # noqa: BLE001 - never mask the provider error
+        message = None
+    if not isinstance(message, str):
+        try:
+            args = getattr(exc, "args", ())
+            message = next((arg for arg in args if isinstance(arg, str)), "")
+        except BaseException:  # noqa: BLE001 - never mask the provider error
+            message = ""
+    message = (
+        redact_text(message, limit=MAX_ERROR_LENGTH) if message else type(exc).__name__
+    )
+    return _truncate_utf8(message, MAX_ERROR_LENGTH)

--- a/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/src/respan_instrumentation_openai/_translator.py
@@ -1,16 +1,9 @@
-"""Translate OpenAI SDK request/response objects into span-ready primitives.
-
-Pure functions, no OTEL imports — everything here turns OpenAI's pydantic
-objects (or dicts) into JSON-safe Python values that ``_otel_emitter`` maps
-onto span attributes.
-"""
+"""Translate current OpenAI SDK values into canonical span primitives."""
 
 from __future__ import annotations
 
 import json
 from typing import Any
-
-from respan_sdk.utils.serialization import serialize_value
 
 from respan_instrumentation_openai._constants import (
     ASSISTANT_ROLE,
@@ -18,86 +11,64 @@ from respan_instrumentation_openai._constants import (
     ROLE_KEY,
     USER_ROLE,
 )
-
-
-# ---------------------------------------------------------------------------
-# Generic helpers
-# ---------------------------------------------------------------------------
-
-
-def _dump(value: Any) -> Any:
-    """Best-effort convert an OpenAI pydantic object / dict to plain data."""
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    for attr in ("model_dump", "to_dict", "dict"):
-        fn = getattr(value, attr, None)
-        if callable(fn):
-            try:
-                return fn()
-            except Exception:
-                continue
-    return serialize_value(value=value)
+from respan_instrumentation_openai._serialization import (
+    json_string,
+    json_value,
+    redact_text,
+)
 
 
 def safe_json(value: Any) -> str:
-    try:
-        return json.dumps(_dump(value), default=str)
-    except Exception:
-        return str(value)
+    return json_string(value)
 
 
 def to_attr_value(value: Any) -> str:
-    return value if isinstance(value, str) else safe_json(value)
+    return redact_text(value) if isinstance(value, str) else safe_json(value)
 
 
-def _coerce_text(value: Any) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value
-    return safe_json(value)
+def _dump(value: Any) -> Any:
+    return json_value(value)
 
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
-    """Read ``key`` from a dict or a pydantic/attr object."""
     if obj is None:
         return default
     if isinstance(obj, dict):
         return obj.get(key, default)
-    return getattr(obj, key, default)
+    try:
+        return getattr(obj, key, default)
+    except Exception:  # noqa: BLE001 - defensive vendor object access
+        return default
 
 
-# ---------------------------------------------------------------------------
-# Model
-# ---------------------------------------------------------------------------
+def _string(value: Any) -> str:
+    if isinstance(value, str):
+        return redact_text(value)
+    if value is None:
+        return ""
+    return safe_json(value)
 
 
 def request_model(request_kwargs: dict[str, Any]) -> str | None:
     model = request_kwargs.get("model")
-    return str(model) if model else None
+    return model if isinstance(model, str) and model else None
 
 
 def response_model(response: Any) -> str | None:
     model = _get(response, "model")
-    return str(model) if model else None
+    return model if isinstance(model, str) and model else None
 
 
 def response_id(response: Any) -> str | None:
-    rid = _get(response, "id")
-    return str(rid) if rid else None
-
-
-# ---------------------------------------------------------------------------
-# Usage
-# ---------------------------------------------------------------------------
+    response_id_value = _get(response, "id")
+    return (
+        response_id_value
+        if isinstance(response_id_value, str) and response_id_value
+        else None
+    )
 
 
 def extract_usage(response: Any) -> dict[str, int]:
-    """Return ``{prompt, completion, total}`` tokens from any OpenAI response.
-
-    Handles both Chat/Completions usage (``prompt_tokens``/``completion_tokens``)
-    and Responses-API usage (``input_tokens``/``output_tokens``).
-    """
     usage = _get(response, "usage")
     if usage is None:
         return {}
@@ -108,19 +79,61 @@ def extract_usage(response: Any) -> dict[str, int]:
     if completion is None:
         completion = _get(usage, "output_tokens")
     total = _get(usage, "total_tokens")
-    out: dict[str, int] = {}
-    if prompt is not None:
-        out["prompt"] = int(prompt)
-    if completion is not None:
-        out["completion"] = int(completion)
-    if total is not None:
-        out["total"] = int(total)
-    return out
+    result: dict[str, int] = {}
+    for key, value in (
+        ("prompt", prompt),
+        ("completion", completion),
+        ("total", total),
+    ):
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            result[key] = value
+    return result
 
 
-# ---------------------------------------------------------------------------
-# Chat completions
-# ---------------------------------------------------------------------------
+def _normalize_arguments(arguments: Any) -> str:
+    if isinstance(arguments, str):
+        try:
+            return safe_json(json.loads(arguments))
+        except (TypeError, ValueError):
+            return safe_json(arguments)
+    return safe_json(arguments if arguments is not None else {})
+
+
+def _normalize_tool_call(tool_call: Any) -> dict[str, Any] | None:
+    function = _get(tool_call, "function")
+    name = _get(function, "name") or _get(tool_call, "name")
+    if not isinstance(name, str) or not name:
+        return None
+    arguments = _get(function, "arguments")
+    if arguments is None:
+        arguments = _get(tool_call, "arguments")
+    normalized: dict[str, Any] = {
+        "type": "function",
+        "function": {"name": name, "arguments": _normalize_arguments(arguments)},
+    }
+    call_id = _get(tool_call, "call_id") or _get(tool_call, "id")
+    if isinstance(call_id, str) and call_id:
+        normalized["id"] = call_id
+    return normalized
+
+
+def _normalize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
+    if not tool_calls:
+        return []
+    if not isinstance(tool_calls, list | tuple):
+        tool_calls = [tool_calls]
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for tool_call in tool_calls[:50]:
+        normalized = _normalize_tool_call(tool_call)
+        if normalized is None:
+            continue
+        signature = safe_json(normalized)
+        if signature in seen:
+            continue
+        seen.add(signature)
+        result.append(normalized)
+    return result
 
 
 def normalize_chat_messages(messages: Any) -> list[dict[str, Any]]:
@@ -128,15 +141,74 @@ def normalize_chat_messages(messages: Any) -> list[dict[str, Any]]:
         return []
     if isinstance(messages, dict):
         messages = [messages]
+    if not isinstance(messages, list | tuple):
+        messages = [messages]
     normalized: list[dict[str, Any]] = []
-    for msg in messages or []:
-        role = _get(msg, ROLE_KEY) or USER_ROLE
-        content = _get(msg, CONTENT_KEY)
-        entry: dict[str, Any] = {ROLE_KEY: role, CONTENT_KEY: _dump(content)}
-        tool_calls = _get(msg, "tool_calls")
+    for message in messages[:50]:
+        role = _get(message, ROLE_KEY) or USER_ROLE
+        entry: dict[str, Any] = {
+            ROLE_KEY: role if isinstance(role, str) else USER_ROLE,
+            CONTENT_KEY: _dump(_get(message, CONTENT_KEY)),
+        }
+        tool_calls = _normalize_tool_calls(_get(message, "tool_calls"))
         if tool_calls:
-            entry["tool_calls"] = _dump(tool_calls)
+            entry["tool_calls"] = tool_calls
+        tool_call_id = _get(message, "tool_call_id")
+        if isinstance(tool_call_id, str) and tool_call_id:
+            entry["tool_call_id"] = tool_call_id
+        name = _get(message, "name")
+        if isinstance(name, str) and name:
+            entry["name"] = name
         normalized.append(entry)
+    return normalized
+
+
+def managed_prompt_input(extra_body: Any) -> dict[str, Any] | None:
+    """Return a visible input for Respan managed-prompt-shaped requests."""
+    prompt = _get(extra_body, "prompt")
+    if prompt is None:
+        return None
+    return {"prompt": _dump(prompt)}
+
+
+def normalize_responses_input(
+    value: Any, instructions: Any = None
+) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    if isinstance(instructions, str) and instructions:
+        normalized.append({ROLE_KEY: "system", CONTENT_KEY: instructions})
+    if value is None:
+        return normalized
+    if isinstance(value, str):
+        return [*normalized, {ROLE_KEY: USER_ROLE, CONTENT_KEY: value}]
+    if isinstance(value, dict):
+        value = [value]
+    if not isinstance(value, list | tuple):
+        value = [value]
+    for item in value[:50]:
+        item_type = _get(item, "type")
+        if item_type == "function_call":
+            call = _normalize_tool_call(item)
+            if call:
+                normalized.append(
+                    {ROLE_KEY: ASSISTANT_ROLE, CONTENT_KEY: None, "tool_calls": [call]}
+                )
+            continue
+        if item_type == "function_call_output":
+            normalized.append(
+                {
+                    ROLE_KEY: "tool",
+                    CONTENT_KEY: _dump(_get(item, "output")),
+                    "tool_call_id": _get(item, "call_id"),
+                }
+            )
+            continue
+        normalized.append(
+            {
+                ROLE_KEY: _get(item, ROLE_KEY) or USER_ROLE,
+                CONTENT_KEY: _dump(_get(item, CONTENT_KEY)),
+            }
+        )
     return normalized
 
 
@@ -146,110 +218,131 @@ def format_input_messages(messages: list[dict[str, Any]]) -> str:
 
 def _first_choice(response: Any) -> Any:
     choices = _get(response, "choices") or []
-    if isinstance(choices, (list, tuple)) and choices:
-        return choices[0]
-    return None
+    return choices[0] if isinstance(choices, list | tuple) and choices else None
+
+
+def chat_output_message(response: Any) -> dict[str, Any]:
+    choice = _first_choice(response)
+    message = _get(choice, "message") if choice is not None else None
+    result: dict[str, Any] = {
+        ROLE_KEY: _get(message, ROLE_KEY) or ASSISTANT_ROLE,
+        CONTENT_KEY: _dump(_get(message, CONTENT_KEY)),
+    }
+    tool_calls = _normalize_tool_calls(_get(message, "tool_calls"))
+    if tool_calls:
+        result["tool_calls"] = tool_calls
+    parsed = _get(message, "parsed")
+    if parsed is not None:
+        result["parsed"] = _dump(parsed)
+    return result
 
 
 def format_chat_output(response: Any) -> str:
-    choice = _first_choice(response)
-    message = _get(choice, "message") if choice is not None else None
-    content = _get(message, CONTENT_KEY) if message is not None else None
-    return _coerce_text(content)
+    return _string(chat_output_message(response).get(CONTENT_KEY))
 
 
-def extract_chat_tool_calls(response: Any) -> list[dict[str, Any]] | None:
-    choice = _first_choice(response)
-    message = _get(choice, "message") if choice is not None else None
-    tool_calls = _get(message, "tool_calls") if message is not None else None
-    if not tool_calls:
-        return None
-    return _dump(tool_calls)
+def extract_chat_tool_calls(response: Any) -> list[dict[str, Any]]:
+    return chat_output_message(response).get("tool_calls", [])
 
 
-def normalize_tools(tools: Any) -> list[dict[str, Any]] | None:
+def normalize_tools(tools: Any) -> list[dict[str, Any]]:
     if not tools:
-        return None
-    return _dump(tools)
-
-
-# ---------------------------------------------------------------------------
-# Legacy completions
-# ---------------------------------------------------------------------------
+        return []
+    if not isinstance(tools, list | tuple):
+        tools = [tools]
+    normalized: list[dict[str, Any]] = []
+    for tool in tools[:50]:
+        dumped = _dump(tool)
+        if not isinstance(dumped, dict):
+            continue
+        function = dumped.get("function")
+        if isinstance(function, dict) and function.get("name"):
+            normalized.append(
+                {"type": dumped.get("type", "function"), "function": function}
+            )
+            continue
+        name = dumped.get("name")
+        if name:
+            normalized_function = {"name": name}
+            for key in ("description", "parameters", "strict"):
+                if key in dumped:
+                    normalized_function[key] = dumped[key]
+            normalized.append({"type": "function", "function": normalized_function})
+    return normalized
 
 
 def normalize_text_prompts(prompt: Any) -> list[dict[str, Any]]:
     if prompt is None:
         return []
-    if isinstance(prompt, (list, tuple)):
-        return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(p)} for p in prompt]
-    return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(prompt)}]
+    if isinstance(prompt, list | tuple):
+        return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: _dump(item)} for item in prompt[:50]]
+    return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: _dump(prompt)}]
 
 
 def format_completion_output(response: Any) -> str:
     choice = _first_choice(response)
-    return _coerce_text(_get(choice, "text") if choice is not None else None)
+    return _string(_get(choice, "text") if choice is not None else None)
 
 
-# ---------------------------------------------------------------------------
-# Responses API
-# ---------------------------------------------------------------------------
-
-
-def normalize_responses_input(value: Any) -> list[dict[str, Any]]:
-    """Normalize the Responses-API ``input`` (str or message list)."""
-    if value is None:
-        return []
-    if isinstance(value, str):
-        return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: value}]
-    if isinstance(value, dict):
-        return [{ROLE_KEY: _get(value, ROLE_KEY) or USER_ROLE, CONTENT_KEY: _dump(_get(value, CONTENT_KEY))}]
-    normalized: list[dict[str, Any]] = []
-    for item in value or []:
-        if isinstance(item, (dict,)) or hasattr(item, "role"):
-            normalized.append({ROLE_KEY: _get(item, ROLE_KEY) or USER_ROLE, CONTENT_KEY: _dump(_get(item, CONTENT_KEY))})
-        else:
-            normalized.append({ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(item)})
-    return normalized
+def _responses_output_items(response: Any) -> list[Any]:
+    output = _get(response, "output") or []
+    return list(output[:50]) if isinstance(output, list | tuple) else []
 
 
 def format_responses_output(response: Any) -> str:
-    """Prefer ``output_text``; fall back to serializing ``output``."""
-    text = _get(response, "output_text")
-    if isinstance(text, str) and text:
-        return text
-    output = _get(response, "output")
-    if output is None:
-        return ""
-    return safe_json(output)
+    output_text = _get(response, "output_text")
+    if isinstance(output_text, str) and output_text:
+        return output_text
+    parts: list[str] = []
+    for item in _responses_output_items(response):
+        if _get(item, "type") != "message":
+            continue
+        for content in _get(item, "content") or []:
+            text = _get(content, "text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
 
 
-# ---------------------------------------------------------------------------
-# Embeddings
-# ---------------------------------------------------------------------------
+def responses_output_payload(response: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"output_text": format_responses_output(response)}
+    output_parsed = _get(response, "output_parsed")
+    if output_parsed is not None:
+        payload["output_parsed"] = _dump(output_parsed)
+    tool_calls = extract_responses_tool_calls(response)
+    if tool_calls:
+        payload["tool_calls"] = tool_calls
+    return payload
 
 
-def normalize_embedding_inputs(value: Any) -> list[str]:
+def extract_responses_tool_calls(response: Any) -> list[dict[str, Any]]:
+    return _normalize_tool_calls(
+        [
+            item
+            for item in _responses_output_items(response)
+            if _get(item, "type") == "function_call"
+        ]
+    )
+
+
+def normalize_embedding_inputs(value: Any) -> list[Any]:
     if value is None:
         return []
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, (list, tuple)):
-        return [_coerce_text(v) for v in value]
-    return [_coerce_text(value)]
+    if isinstance(value, list | tuple):
+        return [_dump(item) for item in value[:50]]
+    return [_dump(value)]
+
+
+def embedding_payload(response: Any) -> list[Any]:
+    data = _get(response, "data") or []
+    if not isinstance(data, list | tuple):
+        return []
+    return [_dump(_get(item, "embedding")) for item in data[:50]]
 
 
 def embedding_summary(response: Any) -> dict[str, Any]:
-    data = _get(response, "data") or []
-    summary: dict[str, Any] = {}
-    if isinstance(data, (list, tuple)):
-        summary["vector_count"] = len(data)
-        first = data[0] if data else None
-        emb = _get(first, "embedding") if first is not None else None
-        if isinstance(emb, (list, tuple)):
-            summary["dimension"] = len(emb)
-    return summary
-
-
-# re-export so the emitter doesn't need to know the role constant
-ASSISTANT = ASSISTANT_ROLE
+    vectors = embedding_payload(response)
+    return {
+        "vector_count": len(vectors),
+        "dimension": len(vectors[0]) if vectors and isinstance(vectors[0], list) else 0,
+    }

--- a/python-sdks/instrumentations/respan-instrumentation-openai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/tests/test_instrumentation.py
@@ -1,188 +1,532 @@
-"""Unit tests for the native OpenAI instrumentation (no network)."""
+"""Contract and lifecycle tests for the native OpenAI instrumentation."""
 
 from __future__ import annotations
 
+import asyncio
 import json
+from collections.abc import Sequence
 from types import SimpleNamespace
 
 import pytest
+from opentelemetry.trace import StatusCode
 
+from respan_instrumentation_openai import _instrumentation as instrumentation
 from respan_instrumentation_openai import _otel_emitter as emitter
-from respan_instrumentation_openai import _instrumentation as instr
+from respan_instrumentation_openai import _translator as translator
 from respan_instrumentation_openai._instrumentation import OpenAIInstrumentor
+from respan_instrumentation_openai._serialization import error_message, json_string
 
 
-# --- fakes ------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def clean_instrumentation(monkeypatch):
+    instrumentation._remove_patches()
+    monkeypatch.setattr(instrumentation, "_REFCOUNT", 0)
+    monkeypatch.setattr(
+        OpenAIInstrumentor,
+        "_is_respan_tracing_enabled",
+        staticmethod(lambda: True),
+    )
+    yield
+    instrumentation._remove_patches()
+    instrumentation._REFCOUNT = 0
 
 
-def _chat_response():
+def _chat_response(*, tool_calls=None):
     return SimpleNamespace(
         id="chatcmpl-123",
         model="gpt-4.1-nano-2025-04-14",
-        choices=[SimpleNamespace(message=SimpleNamespace(content="Hello there", tool_calls=None))],
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    role="assistant", content="Hello there", tool_calls=tool_calls
+                )
+            )
+        ],
         usage=SimpleNamespace(prompt_tokens=8, completion_tokens=3, total_tokens=11),
     )
 
 
-def _embedding_response():
-    return SimpleNamespace(
-        model="text-embedding-3-small",
-        data=[SimpleNamespace(embedding=[0.1, 0.2, 0.3])],
-        usage=SimpleNamespace(prompt_tokens=5, total_tokens=5),
-    )
-
-
-def _responses_response():
+def _responses_response(*, output=None):
     return SimpleNamespace(
         id="resp-1",
         model="gpt-4.1-mini",
         output_text="done",
+        output=output or [],
         usage=SimpleNamespace(input_tokens=12, output_tokens=4, total_tokens=16),
     )
 
 
-# --- attribute builders -----------------------------------------------------
-
-
-def test_chat_attrs_are_typed_as_llm_with_tokens():
-    attrs = emitter.build_chat_attrs(
-        request_kwargs={"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "hi"}]},
-        response=_chat_response(),
+def test_chat_attrs_follow_canonical_contract_and_keep_turn_calls_separate():
+    historical = {
+        "id": "call_old",
+        "type": "function",
+        "function": {"name": "old_tool", "arguments": '{"old":true}'},
+    }
+    current = SimpleNamespace(
+        id="call_new",
+        function=SimpleNamespace(name="lookup", arguments='{"city":"Paris"}'),
     )
+    attrs = emitter.build_chat_attrs(
+        request_kwargs={
+            "model": "gpt-4.1-nano",
+            "messages": [
+                {"role": "assistant", "content": None, "tool_calls": [historical]},
+                {"role": "tool", "tool_call_id": "call_old", "content": "old result"},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        },
+        response=_chat_response(tool_calls=[current]),
+    )
+
+    assert attrs["respan.entity.log_type"] == "chat"
     assert attrs["llm.request.type"] == "chat"
     assert attrs["gen_ai.system"] == "openai"
-    assert attrs["respan.entity.log_type"] == "chat"
     assert attrs["gen_ai.request.model"] == "gpt-4.1-nano"
+    assert attrs["gen_ai.response.id"] == "chatcmpl-123"
+    assert attrs["gen_ai.is_streaming"] is False
+    assert attrs["gen_ai.usage.input_tokens"] == 8
+    assert attrs["gen_ai.usage.output_tokens"] == 3
     assert attrs["gen_ai.usage.prompt_tokens"] == 8
     assert attrs["gen_ai.usage.completion_tokens"] == 3
-    assert attrs["gen_ai.usage.total_tokens"] == 11
-    assert "Hello there" in attrs["traceloop.entity.output"]
-    # input is round-trippable JSON
-    assert json.loads(attrs["traceloop.entity.input"])[0]["content"] == "hi"
+    assert attrs["llm.usage.total_tokens"] == 11
+    assert json.loads(attrs["gen_ai.prompt.0.tool_calls"])[0]["id"] == "call_old"
+    assert json.loads(attrs["gen_ai.completion.0.tool_calls"])[0]["id"] == "call_new"
+    assert json.loads(attrs["llm.request.functions"])[0]["function"]["name"] == "lookup"
+    assert (
+        json.loads(attrs["traceloop.entity.output"])["tool_calls"][0]["id"]
+        == "call_new"
+    )
+
+    forbidden = {
+        "traceloop.span.kind",
+        "respan.span.tools",
+        "respan.span.tool_calls",
+        "tools",
+        "tool_calls",
+        "model",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_request_tokens",
+        "span_tools",
+        "has_tool_calls",
+        "parallel_tool_calls",
+    }
+    assert forbidden.isdisjoint(attrs)
 
 
-def test_embedding_attrs_typed_as_embedding():
+def test_managed_prompt_request_preserves_bounded_redacted_input():
+    attrs = emitter.build_chat_attrs(
+        request_kwargs={
+            "model": "placeholder",
+            "messages": [],
+            "extra_body": {
+                "prompt": {
+                    "prompt_id": "prompt_123",
+                    "variables": {
+                        "feature_request": "Add order notifications",
+                        "api_key": "sk-secret",
+                    },
+                }
+            },
+        },
+        response=_chat_response(),
+    )
+    assert json.loads(attrs["traceloop.entity.input"]) == {
+        "prompt": {
+            "prompt_id": "prompt_123",
+            "variables": {
+                "api_key": "[REDACTED]",
+                "feature_request": "Add order notifications",
+            },
+        }
+    }
+    assert "gen_ai.prompt.0.content" not in attrs
+
+
+def test_responses_attrs_use_chat_contract_and_canonicalize_tools():
+    call = SimpleNamespace(
+        type="function_call",
+        call_id="call_weather",
+        name="get_weather",
+        arguments='{"city":"Paris"}',
+    )
+    attrs = emitter.build_response_attrs(
+        request_kwargs={
+            "model": "gpt-4.1-mini",
+            "instructions": "Be concise",
+            "input": "weather",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {"type": "object"},
+                    "strict": True,
+                }
+            ],
+        },
+        response=_responses_response(output=[call]),
+    )
+    assert attrs["respan.entity.log_type"] == "chat"
+    assert attrs["gen_ai.prompt.0.role"] == "system"
+    assert attrs["gen_ai.prompt.1.role"] == "user"
+    tool = json.loads(attrs["llm.request.functions"])[0]
+    assert tool["function"]["name"] == "get_weather"
+    current = json.loads(attrs["gen_ai.completion.0.tool_calls"])[0]
+    assert current["id"] == "call_weather"
+    assert json.loads(current["function"]["arguments"]) == {"city": "Paris"}
+    assert attrs["gen_ai.usage.input_tokens"] == 12
+    assert attrs["gen_ai.usage.output_tokens"] == 4
+    assert attrs["gen_ai.response.id"] == "resp-1"
+
+
+def test_embedding_attrs_keep_provider_vectors_and_real_usage():
+    response = SimpleNamespace(
+        model="text-embedding-3-small",
+        data=[SimpleNamespace(embedding=[0.1, 0.2, 0.3])],
+        usage=SimpleNamespace(prompt_tokens=5, total_tokens=5),
+    )
     attrs = emitter.build_embedding_attrs(
         request_kwargs={"model": "text-embedding-3-small", "input": "reset password"},
-        response=_embedding_response(),
+        response=response,
     )
     assert attrs["llm.request.type"] == "embedding"
     assert attrs["respan.entity.log_type"] == "embedding"
-    assert attrs["gen_ai.usage.prompt_tokens"] == 5
-    assert json.loads(attrs["traceloop.entity.output"])["vector_count"] == 1
-    assert json.loads(attrs["traceloop.entity.output"])["dimension"] == 3
+    assert attrs["gen_ai.usage.input_tokens"] == 5
+    assert json.loads(attrs["traceloop.entity.output"]) == [[0.1, 0.2, 0.3]]
 
 
-def test_responses_attrs_map_input_output_tokens():
-    attrs = emitter.build_response_attrs(
-        request_kwargs={"model": "gpt-4.1-mini", "input": "hi"},
-        response=_responses_response(),
+def test_serialization_is_bounded_redacted_and_never_calls_hostile_string_methods():
+    class Hostile:
+        def __str__(self):
+            raise AssertionError("must not stringify")
+
+        def __repr__(self):
+            raise AssertionError("must not repr")
+
+    encoded = json_string(
+        {
+            "authorization": "Bearer raw-secret",
+            "nested": {"api_key": "sk-live", "value": "token=raw-token"},
+            "payload": "x" * 50_000,
+            "hostile": Hostile(),
+        }
     )
-    assert attrs["llm.request.type"] == "chat"
-    assert attrs["respan.entity.log_type"] == "response"
-    assert attrs["gen_ai.usage.prompt_tokens"] == 12  # mapped from input_tokens
-    assert attrs["gen_ai.usage.completion_tokens"] == 4  # mapped from output_tokens
-    assert attrs["traceloop.entity.output"] == "done"
+    assert len(encoded.encode("utf-8")) <= 16_000
+    decoded = json.loads(encoded)
+    assert decoded["truncated"] is True
+    assert "sk-live" not in encoded
+    assert "raw-secret" not in encoded
+    assert "raw-token" not in encoded
 
 
-# --- emit path --------------------------------------------------------------
+def test_serialization_consumes_only_bounded_sequence_prefix():
+    class BoundedSequence(Sequence[int]):
+        def __getitem__(self, index):
+            if index > 50:
+                raise AssertionError("serializer consumed beyond its lookahead")
+            return index
+
+        def __len__(self):
+            raise AssertionError("serializer must not request sequence length")
+
+    decoded = json.loads(json_string({"items": BoundedSequence()}))
+    assert decoded["items"][:2] == [0, 1]
+    assert decoded["items"][-1] == {"truncated_items": True}
+    assert len(decoded["items"]) == 51
 
 
+def test_serialization_bounds_multibyte_values_in_utf8_bytes():
+    encoded = json_string({"emoji": "U0001f600" * 16_000})
+    assert len(encoded.encode("utf-8")) <= 16_000
+    assert json.loads(encoded)["truncated"] is True
 
 
-def test_suppression_context_skips_openai_span_emission(monkeypatch):
+def test_plain_prompt_completion_and_error_attributes_are_redacted_and_byte_bounded():
+    secret = "api_key=sk-secret "
+    multibyte = "U0001f600" * 20_000
+    response = _chat_response()
+    response.choices[0].message.content = secret + multibyte
+    attrs = emitter.build_chat_attrs(
+        request_kwargs={
+            "model": "gpt",
+            "messages": [{"role": "user", "content": secret + multibyte}],
+        },
+        response=response,
+    )
+    for key in ("gen_ai.prompt.0.content", "gen_ai.completion.0.content"):
+        assert "sk-secret" not in attrs[key]
+        assert len(attrs[key].encode("utf-8")) <= 16_000
+    rendered_error = error_message(RuntimeError(secret + multibyte))
+    assert "sk-secret" not in rendered_error
+    assert len(rendered_error.encode("utf-8")) <= 2_000
+
+
+def test_suppression_context_prevents_duplicate_emission(monkeypatch):
     emitted = []
     monkeypatch.setitem(
-        instr._KINDS,
+        instrumentation._KINDS,
         "chat",
-        (lambda **kwargs: emitted.append(kwargs), instr._aggregate_chat),
+        (lambda **kwargs: emitted.append(kwargs), instrumentation._aggregate_chat),
     )
 
     def original(_self, **_kwargs):
         return _chat_response()
 
-    wrapper = instr._make_sync_wrapper(original, kind="chat")
-
-    with instr.suppress_openai_instrumentation():
-        response = wrapper(object(), model="gpt-4.1-nano", messages=[])
-
-    assert response is not None
+    wrapper = instrumentation._make_sync_wrapper(original, kind="chat")
+    with instrumentation.suppress_openai_instrumentation():
+        wrapper(object(), model="gpt-4.1-nano", messages=[])
     assert emitted == []
-
     wrapper(object(), model="gpt-4.1-nano", messages=[])
     assert len(emitted) == 1
 
 
-def test_emit_chat_injects_one_span(monkeypatch):
+def test_lifecycle_is_reference_counted_and_patches_parse_surfaces():
+    from openai.resources.chat.completions import Completions
+    from openai.resources.responses.responses import Responses
+
+    original_chat_create = Completions.create
+    original_chat_parse = Completions.parse
+    original_response_parse = Responses.parse
+    first = OpenAIInstrumentor()
+    second = OpenAIInstrumentor()
+
+    first.activate()
+    first.activate()
+    second.activate()
+    assert instrumentation._REFCOUNT == 2
+    assert Completions.create is not original_chat_create
+    assert Completions.parse is not original_chat_parse
+    assert Responses.parse is not original_response_parse
+
+    first.deactivate()
+    first.deactivate()
+    assert instrumentation._REFCOUNT == 1
+    assert Completions.parse is not original_chat_parse
+    second.deactivate()
+    assert instrumentation._REFCOUNT == 0
+    assert Completions.create is original_chat_create
+    assert Completions.parse is original_chat_parse
+    assert Responses.parse is original_response_parse
+    assert instrumentation._INSTALLED_METHODS == {}
+
+
+def test_deactivate_does_not_clobber_foreign_post_patch_wrapper():
+    from openai.resources.chat.completions import Completions
+
+    original = Completions.create
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    key = (Completions, "create")
+    assert Completions.create is instrumentation._INSTALLED_METHODS[key]
+
+    def foreign_wrapper(self, *args, **kwargs):
+        return original(self, *args, **kwargs)
+
+    try:
+        Completions.create = foreign_wrapper
+        instrumentor.deactivate()
+        assert Completions.create is foreign_wrapper
+        assert key not in instrumentation._ORIGINAL_METHODS
+        assert key not in instrumentation._INSTALLED_METHODS
+    finally:
+        Completions.create = original
+        instrumentor.deactivate()
+
+
+def test_partial_activation_failure_rolls_back_every_new_patch(monkeypatch):
+    original_patch = instrumentation._patch
+    attempts = 0
+
+    def fail_second(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 2:
+            raise RuntimeError("patch failed")
+        return original_patch(*args, **kwargs)
+
+    monkeypatch.setattr(instrumentation, "_patch", fail_second)
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    assert instrumentor._is_instrumented is False
+    assert instrumentation._REFCOUNT == 0
+    assert instrumentation._ORIGINAL_METHODS == {}
+    assert instrumentation._INSTALLED_METHODS == {}
+
+
+def test_sync_stream_early_close_closes_source_and_emits_once(monkeypatch):
+    emitted = []
+    monkeypatch.setitem(
+        instrumentation._KINDS,
+        "chat",
+        (lambda **kwargs: emitted.append(kwargs), instrumentation._aggregate_chat),
+    )
+
+    class Source:
+        def __init__(self):
+            self.items = iter([SimpleNamespace(choices=[], model="gpt", usage=None)])
+            self.closed = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self.items)
+
+        def close(self):
+            self.closed += 1
+
+    source = Source()
+    stream = instrumentation._SyncStreamWrapper(
+        source,
+        kind="chat",
+        request_kwargs={"model": "gpt", "messages": [], "stream": True},
+        start_ns=1,
+        trace_id=None,
+        parent_id=None,
+    )
+    next(stream)
+    stream.close()
+    stream.close()
+    assert source.closed == 1
+    assert len(emitted) == 1
+    assert emitted[0]["response"]["model"] == "gpt"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_cancellation_closes_source_and_emits_one_error(monkeypatch):
+    emitted = []
+    monkeypatch.setitem(
+        instrumentation._KINDS,
+        "response",
+        (lambda **kwargs: emitted.append(kwargs), instrumentation._aggregate_response),
+    )
+
+    class Source:
+        def __init__(self):
+            self.closed = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise asyncio.CancelledError()
+
+        async def close(self):
+            self.closed += 1
+
+    source = Source()
+    stream = instrumentation._AsyncStreamWrapper(
+        source,
+        kind="response",
+        request_kwargs={"model": "gpt", "input": "hi", "stream": True},
+        start_ns=1,
+        trace_id=None,
+        parent_id=None,
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await stream.__anext__()
+    await stream.aclose()
+    assert source.closed == 1
+    assert len(emitted) == 1
+    assert emitted[0]["status_code"] == 499
+    assert emitted[0]["error_type"] == "CancelledError"
+
+
+def test_hostile_exception_properties_cannot_mask_provider_error():
+    class HostileError(Exception):
+        def __getattribute__(self, name):
+            if name in {"args", "message", "response", "status_code"}:
+                raise RuntimeError("hostile property")
+            return super().__getattribute__(name)
+
+    error = HostileError()
+    assert instrumentation._error_kwargs(error) == {
+        "error_message": "HostileError",
+        "error_type": "HostileError",
+        "status_code": 500,
+    }
+
+
+def test_emit_error_preserves_precise_status_and_standard_otel_error(monkeypatch):
     captured = []
     monkeypatch.setattr(emitter, "inject_span", lambda span: captured.append(span))
     emitter.emit_chat_span(
-        request_kwargs={"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "hi"}]},
+        request_kwargs={"model": "gpt", "messages": []},
         start_ns=1,
-        response=_chat_response(),
+        error_message="invalid credentials",
+        error_type="AuthenticationError",
+        status_code=401,
     )
-    assert len(captured) == 1
     span = captured[0]
-    assert span.name == "openai.chat"
-    assert span.attributes["llm.request.type"] == "chat"
-    assert span.attributes["gen_ai.usage.total_tokens"] == 11
+    assert span.status.status_code is StatusCode.ERROR
+    assert span.attributes["status_code"] == 401
+    assert span.attributes["error.message"] == "invalid credentials"
+    assert json.loads(span.attributes["traceloop.entity.output"])["status_code"] == 401
 
 
-# --- streaming aggregation --------------------------------------------------
+def test_stream_accumulator_bounds_text_and_tool_arguments():
+    accumulator = instrumentation._StreamAccumulator("chat")
+    delta = SimpleNamespace(
+        content="x" * 30_000,
+        tool_calls=[
+            SimpleNamespace(
+                index=0,
+                id="call_1",
+                function=SimpleNamespace(name="lookup", arguments="y" * 30_000),
+            )
+        ],
+    )
+    accumulator.add(
+        SimpleNamespace(
+            id="chat_1",
+            model="gpt",
+            usage=None,
+            choices=[SimpleNamespace(delta=delta)],
+        )
+    )
+    response = accumulator.response()
+    message = response["choices"][0]["message"]
+    assert len(message["content"]) == 12_000
+    assert len(message["tool_calls"][0]["function"]["arguments"]) == 8_000
 
 
-def _chunk(content=None, tool_deltas=None, usage=None, model="gpt-4.1-nano", cid="c1"):
-    delta = SimpleNamespace(content=content, tool_calls=tool_deltas)
-    return SimpleNamespace(id=cid, model=model, usage=usage, choices=[SimpleNamespace(delta=delta)])
-
-
-def test_aggregate_chat_joins_text_and_usage():
-    chunks = [
-        _chunk(content="Hel"),
-        _chunk(content="lo"),
-        _chunk(usage=SimpleNamespace(prompt_tokens=4, completion_tokens=2, total_tokens=6)),
+def test_response_tool_history_does_not_leak_into_current_turn_calls():
+    history = [
+        {
+            "type": "function_call",
+            "call_id": "call_old",
+            "name": "lookup",
+            "arguments": '{"city":"Rome"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_old",
+            "output": "sunny",
+        },
     ]
-    agg = instr._aggregate_chat(chunks)
-    assert agg["choices"][0]["message"]["content"] == "Hello"
-    assert emitter.tr.extract_usage(agg) == {"prompt": 4, "completion": 2, "total": 6}
+    attrs = emitter.build_response_attrs(
+        request_kwargs={"model": "gpt", "input": history},
+        response=_responses_response(),
+    )
+    assert "gen_ai.completion.0.tool_calls" not in attrs
+    assert json.loads(attrs["gen_ai.prompt.0.tool_calls"])[0]["id"] == "call_old"
 
 
-def test_aggregate_chat_reassembles_streamed_tool_calls():
-    def td(index, *, tid=None, name=None, args=None):
-        fn = SimpleNamespace(name=name, arguments=args)
-        return SimpleNamespace(index=index, id=tid, function=fn)
-
-    chunks = [
-        _chunk(tool_deltas=[td(0, tid="call_1", name="get_weather", args='{"ci')]),
-        _chunk(tool_deltas=[td(0, args='ty": "Tokyo"}')]),
-        _chunk(usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)),
-    ]
-    agg = instr._aggregate_chat(chunks)
-    calls = agg["choices"][0]["message"]["tool_calls"]
-    assert len(calls) == 1
-    assert calls[0]["id"] == "call_1"
-    assert calls[0]["function"]["name"] == "get_weather"
-    assert calls[0]["function"]["arguments"] == '{"city": "Tokyo"}'
-
-
-# --- instrumentor lifecycle -------------------------------------------------
-
-
-def test_activate_patches_and_deactivate_restores():
-    pytest.importorskip("openai")
-    from openai.resources.chat.completions import Completions
-    from openai.resources.embeddings import Embeddings
-
-    original_chat = Completions.create
-    original_embed = Embeddings.create
-
-    instr = OpenAIInstrumentor()
-    instr.activate()
-    try:
-        assert Completions.create is not original_chat
-        assert Embeddings.create is not original_embed
-    finally:
-        instr.deactivate()
-
-    assert Completions.create is original_chat
-    assert Embeddings.create is original_embed
+def test_tool_argument_secrets_are_redacted():
+    call = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(
+            name="lookup", arguments='{"api_key":"sk-secret","city":"Paris"}'
+        ),
+    )
+    normalized = translator.extract_chat_tool_calls(_chat_response(tool_calls=[call]))
+    arguments = json.loads(normalized[0]["function"]["arguments"])
+    assert arguments == {"api_key": "[REDACTED]", "city": "Paris"}

--- a/python-sdks/instrumentations/respan-instrumentation-openai/tests/test_real_openai_sdk.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openai/tests/test_real_openai_sdk.py
@@ -1,0 +1,610 @@
+"""Exported-span regressions against the real current OpenAI SDK types."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx2
+import pytest
+from openai import AsyncOpenAI, AuthenticationError, OpenAI
+from opentelemetry.trace import StatusCode
+from pydantic import BaseModel
+
+from respan_instrumentation_openai import _instrumentation as instrumentation
+from respan_instrumentation_openai import _otel_emitter as emitter
+from respan_instrumentation_openai._instrumentation import OpenAIInstrumentor
+
+
+class Answer(BaseModel):
+    answer: str
+
+
+@pytest.fixture(autouse=True)
+def clean_instrumentation(monkeypatch):
+    instrumentation._remove_patches()
+    monkeypatch.setattr(instrumentation, "_REFCOUNT", 0)
+    monkeypatch.setattr(
+        OpenAIInstrumentor,
+        "_is_respan_tracing_enabled",
+        staticmethod(lambda: True),
+    )
+    yield
+    instrumentation._remove_patches()
+    instrumentation._REFCOUNT = 0
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    spans = []
+    monkeypatch.setattr(emitter, "inject_span", lambda span: spans.append(span))
+    return spans
+
+
+def _chat_payload(*, parsed: bool = False, tool: bool = False) -> dict:
+    message: dict = {
+        "role": "assistant",
+        "content": '{"answer":"yes"}' if parsed else "deterministic chat",
+    }
+    if tool:
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_weather",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    },
+                }
+            ],
+        }
+    return {
+        "id": "chat_1",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "gpt-4.1-nano",
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": "tool_calls" if tool else "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+    }
+
+
+def _response_payload(*, parsed: bool = False, tool: bool = False) -> dict:
+    output: list[dict]
+    if tool:
+        output = [
+            {
+                "id": "fc_1",
+                "type": "function_call",
+                "call_id": "call_weather",
+                "name": "get_weather",
+                "arguments": '{"city":"Paris"}',
+                "status": "completed",
+            }
+        ]
+    else:
+        output = [
+            {
+                "id": "msg_1",
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": '{"answer":"yes"}'
+                        if parsed
+                        else "deterministic response",
+                        "annotations": [],
+                    }
+                ],
+            }
+        ]
+    return {
+        "id": "resp_1",
+        "object": "response",
+        "created_at": 1,
+        "status": "completed",
+        "model": "gpt-4.1-nano",
+        "output": output,
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
+        "temperature": 1,
+        "top_p": 1,
+        "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "metadata": {},
+    }
+
+
+def _sync_handler(request: httpx2.Request) -> httpx2.Response:
+    body = json.loads(request.content)
+    if request.url.path.endswith("/chat/completions"):
+        if body.get("messages", [{}])[-1].get("content") == "fail":
+            return httpx2.Response(
+                401,
+                json={
+                    "error": {
+                        "message": "invalid test credential",
+                        "type": "invalid_request_error",
+                    }
+                },
+            )
+        return httpx2.Response(
+            200,
+            json=_chat_payload(
+                parsed="response_format" in body,
+                tool=bool(body.get("tools")) and "response_format" not in body,
+            ),
+        )
+    if request.url.path.endswith("/responses"):
+        return httpx2.Response(
+            200,
+            json=_response_payload(
+                parsed=bool(body.get("text", {}).get("format")),
+                tool=bool(body.get("tools")),
+            ),
+        )
+    raise AssertionError(request.url.path)
+
+
+async def _async_handler(request: httpx2.Request) -> httpx2.Response:
+    return _sync_handler(request)
+
+
+def _sync_client(handler=_sync_handler) -> OpenAI:
+    return OpenAI(
+        api_key="test-key",
+        base_url="https://openai.invalid/v1",
+        max_retries=0,
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+    )
+
+
+def _async_client(handler=_async_handler) -> AsyncOpenAI:
+    return AsyncOpenAI(
+        api_key="test-key",
+        base_url="https://openai.invalid/v1",
+        max_retries=0,
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler)),
+    )
+
+
+def test_real_sync_chat_create_parse_tool_and_401_export(captured):
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    client = _sync_client()
+    try:
+        chat = client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        parsed = client.beta.chat.completions.parse(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "structured"}],
+            response_format=Answer,
+        )
+        tool = client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "weather"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        )
+        with pytest.raises(AuthenticationError):
+            client.chat.completions.create(
+                model="gpt-4.1-nano",
+                messages=[{"role": "user", "content": "fail"}],
+            )
+    finally:
+        client.close()
+        instrumentor.deactivate()
+
+    assert chat.choices[0].message.content == "deterministic chat"
+    assert parsed.choices[0].message.parsed == Answer(answer="yes")
+    assert tool.choices[0].message.tool_calls[0].function.name == "get_weather"
+    assert len(captured) == 4
+    assert [span.name for span in captured] == ["openai.chat"] * 4
+    assert captured[-1].status.status_code is StatusCode.ERROR
+    assert captured[-1].attributes["status_code"] == 401
+    assert "invalid test credential" in captured[-1].attributes["error.message"]
+    assert json.loads(captured[1].attributes["traceloop.entity.output"])["parsed"] == {
+        "answer": "yes"
+    }
+    assert (
+        json.loads(captured[2].attributes["gen_ai.completion.0.tool_calls"])[0]["id"]
+        == "call_weather"
+    )
+
+
+def test_real_sync_responses_create_parse_and_tool_export(captured):
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    client = _sync_client()
+    tools = [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "parameters": {"type": "object"},
+            "strict": True,
+        }
+    ]
+    try:
+        response = client.responses.create(model="gpt-4.1-nano", input="hello")
+        parsed = client.responses.parse(
+            model="gpt-4.1-nano", input="structured", text_format=Answer
+        )
+        tool = client.responses.create(
+            model="gpt-4.1-nano", input="weather", tools=tools
+        )
+    finally:
+        client.close()
+        instrumentor.deactivate()
+
+    assert response.output_text == "deterministic response"
+    assert parsed.output_parsed == Answer(answer="yes")
+    assert tool.output[0].call_id == "call_weather"
+    assert len(captured) == 3
+    assert [span.name for span in captured] == ["openai.response"] * 3
+    assert captured[1].attributes["gen_ai.usage.input_tokens"] == 5
+    assert (
+        json.loads(captured[2].attributes["gen_ai.completion.0.tool_calls"])[0]["id"]
+        == "call_weather"
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_async_chat_and_responses_parse_export(captured):
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    client = _async_client()
+    try:
+        chat = await client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        parsed_chat = await client.beta.chat.completions.parse(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "structured"}],
+            response_format=Answer,
+        )
+        response = await client.responses.create(model="gpt-4.1-nano", input="hello")
+        parsed_response = await client.responses.parse(
+            model="gpt-4.1-nano", input="structured", text_format=Answer
+        )
+    finally:
+        await client.close()
+        instrumentor.deactivate()
+
+    assert chat.choices[0].message.content == "deterministic chat"
+    assert parsed_chat.choices[0].message.parsed == Answer(answer="yes")
+    assert response.output_text == "deterministic response"
+    assert parsed_response.output_parsed == Answer(answer="yes")
+    assert [span.name for span in captured] == [
+        "openai.chat",
+        "openai.chat",
+        "openai.response",
+        "openai.response",
+    ]
+
+
+def test_real_chat_stream_exports_one_bounded_final_span(captured):
+    chunks = [
+        {
+            "id": "chat_stream",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4.1-nano",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Hel"},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chat_stream",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4.1-nano",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "lo"},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+        {
+            "id": "chat_stream",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4.1-nano",
+            "choices": [],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+        },
+    ]
+
+    def stream_handler(request: httpx2.Request) -> httpx2.Response:
+        content = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+        content += "data: [DONE]\n\n"
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=content.encode(),
+        )
+
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    client = _sync_client(stream_handler)
+    try:
+        stream = client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        text = "".join(
+            chunk.choices[0].delta.content or "" for chunk in stream if chunk.choices
+        )
+    finally:
+        client.close()
+        instrumentor.deactivate()
+
+    assert text == "Hello"
+    assert len(captured) == 1
+    span = captured[0]
+    assert span.attributes["gen_ai.is_streaming"] is True
+    assert span.attributes["gen_ai.completion.0.content"] == "Hello"
+    assert span.attributes["llm.usage.total_tokens"] == 6
+
+
+@pytest.mark.asyncio
+async def test_real_async_chat_stream_completion_exports_usage(captured):
+    chunks = [
+        {
+            "id": "chat_stream",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4.1-nano",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Hel"},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chat_stream",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4.1-nano",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "lo"},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+        {
+            "id": "chat_stream",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4.1-nano",
+            "choices": [],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+        },
+    ]
+
+    async def stream_handler(request: httpx2.Request) -> httpx2.Response:
+        content = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+        content += "data: [DONE]\n\n"
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=content.encode(),
+        )
+
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    client = _async_client(stream_handler)
+    try:
+        stream = await client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        text = ""
+        async for chunk in stream:
+            if chunk.choices:
+                text += chunk.choices[0].delta.content or ""
+    finally:
+        await client.close()
+        instrumentor.deactivate()
+
+    assert text == "Hello"
+    assert len(captured) == 1
+    assert captured[0].attributes["gen_ai.completion.0.content"] == "Hello"
+    assert captured[0].attributes["llm.usage.total_tokens"] == 6
+
+
+@pytest.mark.asyncio
+async def test_real_async_chat_stream_close_exports_one_partial_span(captured):
+    chunks = [
+        {
+            "id": "chat_stream",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4.1-nano",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Hel"},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chat_stream",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4.1-nano",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "lo"},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+    ]
+
+    async def stream_handler(request: httpx2.Request) -> httpx2.Response:
+        content = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+        content += "data: [DONE]\n\n"
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=content.encode(),
+        )
+
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    client = _async_client(stream_handler)
+    try:
+        stream = await client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+        )
+        first = await stream.__anext__()
+        await stream.close()
+        await stream.aclose()
+        assert stream.response.is_closed
+    finally:
+        await client.close()
+        instrumentor.deactivate()
+
+    assert first.choices[0].delta.content == "Hel"
+    assert len(captured) == 1
+    span = captured[0]
+    assert span.attributes["gen_ai.is_streaming"] is True
+    assert span.attributes["gen_ai.completion.0.content"] == "Hel"
+
+
+@pytest.mark.asyncio
+async def test_real_async_chat_stream_context_exit_closes_source(captured):
+    chunks = [
+        {
+            "id": "chat_stream",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-4.1-nano",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "partial"},
+                    "finish_reason": None,
+                }
+            ],
+        }
+    ]
+
+    async def stream_handler(request: httpx2.Request) -> httpx2.Response:
+        content = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+        content += "data: [DONE]\n\n"
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=content.encode(),
+        )
+
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    client = _async_client(stream_handler)
+    try:
+        stream = await client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+        )
+        async with stream:
+            await stream.__anext__()
+        assert stream.response.is_closed
+    finally:
+        await client.close()
+        instrumentor.deactivate()
+
+    assert len(captured) == 1
+    assert captured[0].attributes["gen_ai.completion.0.content"] == "partial"
+
+
+@pytest.mark.asyncio
+async def test_real_async_chat_stream_cancellation_closes_source(captured):
+    started = asyncio.Event()
+
+    class BlockingStream(httpx2.AsyncByteStream):
+        def __init__(self) -> None:
+            self.close_count = 0
+
+        async def __aiter__(self):
+            started.set()
+            await asyncio.Event().wait()
+            yield b""
+
+        async def aclose(self) -> None:
+            self.close_count += 1
+
+    source = BlockingStream()
+
+    async def stream_handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=source,
+        )
+
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.activate()
+    client = _async_client(stream_handler)
+    try:
+        stream = await client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+        )
+        pending = asyncio.create_task(stream.__anext__())
+        await asyncio.wait_for(started.wait(), timeout=1)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        assert stream.response.is_closed
+        assert source.close_count == 1
+    finally:
+        await client.close()
+        instrumentor.deactivate()
+
+    assert len(captured) == 1
+    assert captured[0].status.status_code is StatusCode.ERROR
+    assert captured[0].attributes["status_code"] == 499

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/README.md
@@ -1,5 +1,27 @@
 # respan-instrumentation-openinference
 
-Respan instrumentation wrapper for [OpenInference](https://github.com/Arize-ai/openinference) instrumentors.
+Respan's generic wrapper for
+[OpenInference](https://github.com/Arize-ai/openinference) instrumentors.
 
-Includes an OpenInference to OpenLLMetry/Traceloop translator that converts OI span attributes to the format the Respan backend expects.
+It installs one OpenInference-to-Respan translator before the exporter and
+adapts either standard `.instrument()` delegates or processor-style delegates
+to Respan's `activate()` / `deactivate()` protocol:
+
+```python
+from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+from respan import Respan
+from respan_instrumentation_openinference import OpenInferenceInstrumentor
+
+respan = Respan(instrumentations=[OpenInferenceInstrumentor(GoogleADKInstrumentor)])
+```
+
+The translator emits the canonical span contract: log type, bounded JSON
+input/output, model, provider, provider-reported usage, messages, tool
+definitions, current-turn tool calls, and embedding content. Consumed raw
+OpenInference attributes and legacy Respan/top-level aliases are removed before
+export. Auto-instrumented spans do not receive `traceloop.span.kind`.
+
+Activation is process-wide and reference-counted per upstream instrumentor
+class. Deactivating one wrapper cannot remove a delegate still used by another
+wrapper, externally active delegates are not claimed, and the final owner
+removes the shared translator and delegate it owns.

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/pyproject.toml
@@ -12,8 +12,8 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
 respan-tracing = "^2.15.2"
-openinference-semantic-conventions = ">=0.1.28"
-opentelemetry-semantic-conventions-ai = ">=0.4.1"
+openinference-semantic-conventions = ">=0.1.32,<0.2.0"
+opentelemetry-semantic-conventions-ai = ">=0.5.1,<0.6.0"
 # Users install individual OpenInference packages as needed, e.g.:
 #   pip install openinference-instrumentation-google-adk
 

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_instrumentation.py
@@ -1,4 +1,11 @@
+"""Lifecycle management for generic OpenInference instrumentors."""
+
+from __future__ import annotations
+
 import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, ClassVar
 
 from opentelemetry import trace
 
@@ -7,35 +14,35 @@ from respan_instrumentation_openinference._translator import OpenInferenceTransl
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _SharedRegistration:
+    instrumentor: Any
+    kwargs: dict[str, Any]
+    is_span_processor: bool
+    owned_activation: bool
+    refcount: int = 1
+
+
 class OpenInferenceInstrumentor:
-    """Generic wrapper that adapts any OpenInference instrumentor to the
-    Respan ``Instrumentation`` protocol.
+    """Adapt any OpenInference instrumentor to Respan's lifecycle protocol.
 
-    Usage::
-
-        from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-
-        respan = Respan(instrumentations=[
-            OpenInferenceInstrumentor(GoogleADKInstrumentor)
-        ])
-
-    Handles both standard OI instrumentors (``.instrument()``) and
-    SpanProcessor-based ones (e.g. pydantic-ai, strands-agents) automatically.
-
-    Automatically registers an ``OpenInferenceTranslator`` SpanProcessor that
-    converts OI span attributes to OpenLLMetry/Traceloop format before export.
+    Standard ``instrument``/``uninstrument`` delegates and processor-style
+    delegates are shared process-wide per instrumentor class. The first active
+    wrapper owns activation and the last wrapper owns teardown. A single
+    translator is kept before export processors while any delegate is active.
     """
 
-    # Class-level flag: only register the translator once across all instances
-    _translator_registered = False
-    _translator = None
-    _active_span_processors = []
+    _lock: ClassVar[threading.RLock] = threading.RLock()
+    _translator: ClassVar[OpenInferenceTranslator] = OpenInferenceTranslator()
+    _translator_registered: ClassVar[bool] = False
+    _active_span_processors: ClassVar[list[Any]] = []
+    _registrations: ClassVar[dict[type, _SharedRegistration]] = {}
+    _provider: ClassVar[Any] = None
 
-    def __init__(self, instrumentor_class: type, **kwargs) -> None:
+    def __init__(self, instrumentor_class: type, **kwargs: Any) -> None:
         self._instrumentor_class = instrumentor_class
-        # tracer_provider is always set by activate(); drop to avoid collision
         kwargs.pop("tracer_provider", None)
-        self._instrumentor_kwargs = kwargs
+        self._instrumentor_kwargs = dict(kwargs)
         self._instrumentor = None
         self._is_instrumented = False
         self._is_span_processor = False
@@ -43,123 +50,263 @@ class OpenInferenceInstrumentor:
 
     @classmethod
     def _get_translator(cls) -> OpenInferenceTranslator:
-        if cls._translator is None:
-            cls._translator = OpenInferenceTranslator()
         return cls._translator
 
     @staticmethod
-    def _get_active_span_processor(tp):
-        return getattr(tp, "_active_span_processor", None)
+    def _active_processor_state(provider: Any) -> tuple[Any, tuple[Any, ...] | None]:
+        active = getattr(provider, "_active_span_processor", None)
+        processors = getattr(active, "_span_processors", None) if active else None
+        return active, processors
+
+    @staticmethod
+    def _delegate_is_active(delegate: Any) -> bool:
+        for attribute_name in (
+            "is_instrumented_by_opentelemetry",
+            "_is_instrumented_by_opentelemetry",
+        ):
+            value = getattr(delegate, attribute_name, None)
+            if value is None:
+                continue
+            try:
+                return bool(value() if callable(value) else value)
+            except Exception:
+                logger.debug(
+                    "Could not inspect OpenInference delegate state",
+                    exc_info=True,
+                )
+        return False
 
     @classmethod
-    def _rebuild_processor_chain(cls, tp) -> None:
-        asp = cls._get_active_span_processor(tp)
-        translator = cls._get_translator()
-
-        if asp is None:
-            return
-
-        processors = getattr(asp, "_span_processors", None)
+    def _existing_processor(cls, provider: Any, processor_class: type) -> Any | None:
+        """Return an externally registered processor of the requested class."""
+        _, processors = cls._active_processor_state(provider)
         if processors is None:
+            return None
+        return next(
+            (
+                processor
+                for processor in processors
+                if isinstance(processor, processor_class)
+            ),
+            None,
+        )
+
+    @classmethod
+    def _rebuild_processor_chain(cls, provider: Any) -> None:
+        active, processors = cls._active_processor_state(provider)
+        if active is None or processors is None:
             return
 
-        active_oi_processors = tuple(cls._active_span_processors)
+        processor_delegates = tuple(
+            registration.instrumentor
+            for registration in cls._registrations.values()
+            if registration.is_span_processor
+        )
         other_processors = tuple(
             processor
             for processor in processors
-            if processor is not translator and processor not in active_oi_processors
+            if processor is not cls._translator
+            and processor not in processor_delegates
+            and processor not in cls._active_span_processors
         )
-
-        asp._span_processors = (
-            *active_oi_processors,
-            translator,
-            *other_processors,
-        )
-        cls._translator_registered = True
-
-    @classmethod
-    def _remove_processor_instance(cls, tp, processor_to_remove) -> None:
-        asp = cls._get_active_span_processor(tp)
-        if asp is None:
-            return
-        processors = getattr(asp, "_span_processors", None)
-        if processors is None:
-            return
-        asp._span_processors = tuple(
-            processor
-            for processor in processors
-            if processor is not processor_to_remove
-        )
-
-    @classmethod
-    def _ensure_translator_registered(cls, tp) -> None:
-        translator = cls._get_translator()
-        asp = cls._get_active_span_processor(tp)
-        processors = getattr(asp, "_span_processors", None) if asp is not None else None
-
-        if processors is not None:
-            cls._rebuild_processor_chain(tp)
-            logger.info("Registered OpenInference → OpenLLMetry translator")
-            return
-
-        if hasattr(tp, "add_span_processor"):
-            tp.add_span_processor(translator)
+        if cls._registrations:
+            active._span_processors = (
+                *processor_delegates,
+                cls._translator,
+                *other_processors,
+            )
             cls._translator_registered = True
-            logger.info("Registered OpenInference → OpenLLMetry translator")
+        else:
+            active._span_processors = other_processors
+            cls._translator_registered = False
+        cls._active_span_processors = list(processor_delegates)
+
+    @classmethod
+    def _ensure_translator_registered(cls, provider: Any) -> None:
+        active, processors = cls._active_processor_state(provider)
+        if active is not None and processors is not None:
+            remaining = tuple(
+                processor
+                for processor in processors
+                if processor is not cls._translator
+            )
+            active._span_processors = (cls._translator, *remaining)
+            cls._translator_registered = True
+            return
+        add_span_processor = getattr(provider, "add_span_processor", None)
+        if callable(add_span_processor):
+            add_span_processor(cls._translator)
+            cls._translator_registered = True
+
+    @classmethod
+    def _remove_processor(cls, provider: Any, target: Any) -> None:
+        active, processors = cls._active_processor_state(provider)
+        if active is not None and processors is not None:
+            active._span_processors = tuple(
+                processor for processor in processors if processor is not target
+            )
+
+    @classmethod
+    def _reset_if_idle(cls) -> None:
+        if cls._registrations:
+            return
+        provider = cls._provider
+        if provider is not None:
+            cls._remove_processor(provider, cls._translator)
+        cls._translator_registered = False
+        cls._active_span_processors = []
+        cls._provider = None
 
     def activate(self) -> None:
-        self._instrumentor = self._instrumentor_class()
-        tp = trace.get_tracer_provider()
+        """Activate or reference-count one shared OpenInference delegate."""
+        if self._is_instrumented:
+            return
 
-        # Register the OI → OpenLLMetry translator once so it runs
-        # BEFORE the export processors on every OI span.  The translator
-        # enriches spans with traceloop.* attributes that is_processable_span()
-        # needs to see.  Insert at position 0 of the processor list so it
-        # runs before BufferingSpanProcessor → FilteringSpanProcessor → exporter.
-        if not OpenInferenceInstrumentor._translator_registered:
-            OpenInferenceInstrumentor._ensure_translator_registered(tp)
+        cls = OpenInferenceInstrumentor
+        with cls._lock:
+            if self._is_instrumented:
+                return
+            provider = trace.get_tracer_provider()
+            if cls._provider is not None and cls._provider is not provider:
+                raise RuntimeError(
+                    "OpenInference delegates are already active on another tracer provider"
+                )
 
-        # Standard OI instrumentors expose .instrument()
-        if hasattr(self._instrumentor, "instrument"):
-            self._instrumentor.instrument(tracer_provider=tp, **self._instrumentor_kwargs)
-        # SpanProcessor-based OI packages (pydantic-ai, strands-agents)
-        elif hasattr(tp, "add_span_processor"):
-            OpenInferenceInstrumentor._active_span_processors = [
-                *OpenInferenceInstrumentor._active_span_processors,
-                self._instrumentor,
-            ]
-            asp = self._get_active_span_processor(tp)
-            processors = getattr(asp, "_span_processors", None) if asp is not None else None
-            if processors is not None:
-                OpenInferenceInstrumentor._rebuild_processor_chain(tp)
-            else:
-                tp.add_span_processor(self._instrumentor)
-                OpenInferenceInstrumentor._ensure_translator_registered(tp)
-            self._is_span_processor = True
+            registration = cls._registrations.get(self._instrumentor_class)
+            if registration is not None:
+                if registration.kwargs != self._instrumentor_kwargs:
+                    logger.warning(
+                        "%s is already active; the first instrumentation settings win",
+                        self.name,
+                    )
+                registration.refcount += 1
+                self._instrumentor = registration.instrumentor
+                self._is_span_processor = registration.is_span_processor
+                self._is_instrumented = True
+                return
 
-        self._is_instrumented = True
-        logger.info("%s instrumentation activated (via OpenInference)", self.name)
+            delegate = self._instrumentor_class()
+            is_standard = callable(getattr(delegate, "instrument", None))
+            is_processor = not is_standard and callable(
+                getattr(provider, "add_span_processor", None)
+            )
+            if not is_standard and not is_processor:
+                raise TypeError(
+                    f"{self._instrumentor_class.__name__} is neither an "
+                    "OpenInference instrumentor nor a span processor"
+                )
+
+            owned_activation = False
+            try:
+                if is_standard:
+                    already_active = cls._delegate_is_active(delegate)
+                    if not already_active:
+                        owned_activation = True
+                        delegate.instrument(
+                            tracer_provider=provider,
+                            **self._instrumentor_kwargs,
+                        )
+                else:
+                    external_delegate = cls._existing_processor(
+                        provider, self._instrumentor_class
+                    )
+                    if external_delegate is not None:
+                        delegate = external_delegate
+                    else:
+                        provider.add_span_processor(delegate)
+                        owned_activation = True
+
+                cls._provider = provider
+                registration = _SharedRegistration(
+                    instrumentor=delegate,
+                    kwargs=dict(self._instrumentor_kwargs),
+                    is_span_processor=is_processor,
+                    owned_activation=owned_activation,
+                )
+                cls._registrations[self._instrumentor_class] = registration
+                if is_processor:
+                    cls._active_span_processors.append(delegate)
+                    cls._rebuild_processor_chain(provider)
+                else:
+                    cls._ensure_translator_registered(provider)
+                    cls._rebuild_processor_chain(provider)
+            except BaseException:
+                cls._registrations.pop(self._instrumentor_class, None)
+                if owned_activation:
+                    cls._remove_processor(provider, delegate)
+                if owned_activation and is_standard:
+                    uninstrument = getattr(delegate, "uninstrument", None)
+                    if callable(uninstrument):
+                        try:
+                            uninstrument()
+                        except Exception:
+                            logger.exception(
+                                "Failed to roll back partial OpenInference activation"
+                            )
+                if owned_activation and is_processor:
+                    shutdown = getattr(delegate, "shutdown", None)
+                    if callable(shutdown):
+                        try:
+                            shutdown()
+                        except Exception:
+                            logger.exception(
+                                "Failed to roll back OpenInference processor activation"
+                            )
+                cls._reset_if_idle()
+                raise
+
+            self._instrumentor = delegate
+            self._is_span_processor = is_processor
+            self._is_instrumented = True
+            logger.info("%s instrumentation activated (via OpenInference)", self.name)
 
     def deactivate(self) -> None:
-        if self._is_instrumented and self._instrumentor is not None:
-            try:
-                if self._is_span_processor:
-                    self._instrumentor.shutdown()
-                    OpenInferenceInstrumentor._active_span_processors = [
-                        processor
-                        for processor in OpenInferenceInstrumentor._active_span_processors
-                        if processor is not self._instrumentor
-                    ]
-                    OpenInferenceInstrumentor._remove_processor_instance(
-                        trace.get_tracer_provider(),
-                        self._instrumentor,
-                    )
-                    OpenInferenceInstrumentor._rebuild_processor_chain(
-                        trace.get_tracer_provider()
-                    )
-                else:
-                    self._instrumentor.uninstrument()
-            except Exception:
-                pass
+        """Release this wrapper and tear down only the last owned delegate."""
+        if not self._is_instrumented:
+            return
+
+        cls = OpenInferenceInstrumentor
+        with cls._lock:
+            if not self._is_instrumented:
+                return
             self._is_instrumented = False
+            registration = cls._registrations.get(self._instrumentor_class)
+            if registration is None:
+                self._instrumentor = None
+                self._is_span_processor = False
+                cls._reset_if_idle()
+                return
+
+            registration.refcount = max(0, registration.refcount - 1)
+            if registration.refcount:
+                self._instrumentor = None
+                self._is_span_processor = False
+                return
+
+            delegate = registration.instrumentor
+            provider = cls._provider or trace.get_tracer_provider()
+            cls._registrations.pop(self._instrumentor_class, None)
+            try:
+                if registration.is_span_processor:
+                    if registration.owned_activation:
+                        cls._remove_processor(provider, delegate)
+                    shutdown = getattr(delegate, "shutdown", None)
+                    if registration.owned_activation and callable(shutdown):
+                        shutdown()
+                elif registration.owned_activation:
+                    uninstrument = getattr(delegate, "uninstrument", None)
+                    if callable(uninstrument):
+                        uninstrument()
+            except Exception:
+                logger.exception("Failed to deactivate %s", self.name)
+            finally:
+                cls._active_span_processors = [
+                    processor
+                    for processor in cls._active_span_processors
+                    if processor is not delegate
+                ]
+                cls._rebuild_processor_chain(provider)
+                cls._reset_if_idle()
+                self._instrumentor = None
+                self._is_span_processor = False
         logger.info("%s instrumentation deactivated", self.name)

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_serialization.py
@@ -1,0 +1,167 @@
+"""Bounded, privacy-safe serialization for OpenInference attributes."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from typing import Any
+
+MAX_ATTRIBUTE_CHARS = 16_000
+MAX_LABEL_CHARS = 512
+_MAX_DEPTH = 8
+_MAX_ITEMS = 1_000
+_REDACTED = "[REDACTED]"
+
+_SENSITIVE_KEYS = {
+    "api-key",
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "credentials",
+    "password",
+    "private-key",
+    "private_key",
+    "refresh-token",
+    "refresh_token",
+    "secret",
+    "token",
+    "x-api-key",
+}
+_SENSITIVE_KEY_SUFFIXES = (
+    "_api_key",
+    "-api-key",
+    "_password",
+    "-password",
+    "_secret",
+    "-secret",
+    "_access_token",
+    "-access-token",
+    "_refresh_token",
+    "-refresh-token",
+)
+_BEARER_RE = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}")
+_BASIC_AUTH_RE = re.compile(r"(?i)\bbasic\s+[a-z0-9+/=]{8,}")
+_API_KEY_RE = re.compile(r"\b(?:sk|rk|pk)-[A-Za-z0-9_-]{8,}\b")
+_ASSIGNMENT_SECRET_RE = re.compile(
+    r"(?i)\b("
+    r"api[-_]?key|authorization|password|passwd|secret|"
+    r"(?:access|refresh|session|auth)?[-_]?token"
+    r")(\s*[:=]\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;]+)"
+)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.strip().lower()
+    return normalized in _SENSITIVE_KEYS or normalized.endswith(_SENSITIVE_KEY_SUFFIXES)
+
+
+def sanitize_text(value: str) -> str:
+    """Redact common credential shapes without stringifying arbitrary objects."""
+    value = _BEARER_RE.sub("Bearer [REDACTED]", value)
+    value = _BASIC_AUTH_RE.sub("Basic [REDACTED]", value)
+    value = _API_KEY_RE.sub(_REDACTED, value)
+    return _ASSIGNMENT_SECRET_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}{_REDACTED}",
+        value,
+    )
+
+
+def bounded_text(value: Any, *, max_chars: int = MAX_LABEL_CHARS) -> str:
+    """Return a redacted bounded scalar without invoking user string hooks."""
+    if not isinstance(value, str):
+        return f"[UNSUPPORTED:{type(value).__name__}]"
+    sanitized = sanitize_text(value)
+    if len(sanitized) <= max_chars:
+        return sanitized
+    suffix = "...[TRUNCATED]"
+    return f"{sanitized[: max(0, max_chars - len(suffix))]}{suffix}"
+
+
+def to_jsonable(value: Any, *, depth: int = 0) -> Any:
+    """Convert supported values to JSON data without calling user ``repr``/``str``."""
+    if depth > _MAX_DEPTH:
+        return "[MAX_DEPTH]"
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else "[NON_FINITE_FLOAT]"
+    if isinstance(value, str):
+        return sanitize_text(value)
+    if isinstance(value, bytes):
+        return sanitize_text(value.decode("utf-8", errors="replace"))
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for index, (raw_key, item) in enumerate(value.items()):
+            if index >= _MAX_ITEMS:
+                result["__truncated_items__"] = True
+                break
+            key = raw_key if isinstance(raw_key, str) else type(raw_key).__name__
+            result[key] = (
+                _REDACTED
+                if _is_sensitive_key(key)
+                else to_jsonable(item, depth=depth + 1)
+            )
+        return result
+    if isinstance(value, (list, tuple)):
+        result = [to_jsonable(item, depth=depth + 1) for item in value[:_MAX_ITEMS]]
+        if len(value) > _MAX_ITEMS:
+            result.append("[TRUNCATED_ITEMS]")
+        return result
+    return f"[UNSUPPORTED:{type(value).__name__}]"
+
+
+def parse_json(value: Any) -> Any:
+    """Parse JSON strings and leave all other supported values unchanged."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+
+
+def bounded_json(value: Any, *, max_chars: int = MAX_ATTRIBUTE_CHARS) -> str:
+    """Return redacted valid JSON no longer than ``max_chars``."""
+    normalized = to_jsonable(parse_json(value))
+    serialized = json.dumps(
+        normalized,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if len(serialized) <= max_chars:
+        return serialized
+
+    low = 0
+    high = len(serialized)
+    best = json.dumps(
+        {"preview": "", "truncated": True},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = json.dumps(
+            {"preview": serialized[:midpoint], "truncated": True},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(candidate) <= max_chars:
+            best = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return best
+
+
+def content_value(value: Any) -> str:
+    """Keep scalar message text readable; JSON-encode structured content."""
+    parsed = parse_json(value)
+    if isinstance(parsed, str):
+        text = sanitize_text(parsed)
+        if len(text) <= MAX_ATTRIBUTE_CHARS:
+            return text
+    return bounded_json(parsed)

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/src/respan_instrumentation_openinference/_translator.py
@@ -1,60 +1,29 @@
-"""Translate OpenInference spans → OpenLLMetry/Traceloop format.
+"""Translate OpenInference spans into Respan's canonical span contract."""
 
-This SpanProcessor converts spans produced by OpenInference instrumentors
-(Haystack, CrewAI, LangChain, Google ADK, etc.) into the Traceloop/OpenLLMetry
-semantic conventions that the Respan backend expects.
-
-The mapping is the exact reverse of Arize's ``openinference-instrumentation-openllmetry``
-package (``_span_processor.py``) which converts OpenLLMetry → OpenInference.
-
-Arize mapping (OpenLLMetry → OI):
-    traceloop.span.kind          → openinference.span.kind
-    traceloop.entity.input       → input.value + input.mime_type
-    traceloop.entity.output      → output.value + output.mime_type
-    gen_ai.prompt.N.*            → llm.input_messages.N.message.*
-    gen_ai.completion.N.*        → llm.output_messages.N.message.*
-    gen_ai.usage.input_tokens    → llm.token_count.prompt
-    gen_ai.usage.output_tokens   → llm.token_count.completion
-    llm.usage.total_tokens       → llm.token_count.total
-    llm.usage.cache_read_input_tokens → llm.token_count.prompt_details.cache_read
-    gen_ai.request.model         → llm.invocation_parameters.model
-    gen_ai.request.temperature   → llm.invocation_parameters.temperature
-    gen_ai.request.top_p         → llm.invocation_parameters.top_p
-    llm.top_k                    → llm.invocation_parameters.top_k
-    llm.chat.stop_sequences      → llm.invocation_parameters.stop_sequences
-    llm.request.repetition_penalty → llm.invocation_parameters.repetition_penalty
-    llm.frequency_penalty        → llm.invocation_parameters.frequency_penalty
-    llm.presence_penalty         → llm.invocation_parameters.presence_penalty
-    llm.request.functions        → llm.tools
-    gen_ai.system                → llm.system
-    gen_ai.provider.name         → llm.provider
-
-This module reverses every mapping above.
-
-References:
-- Arize source: openinference-instrumentation-openllmetry/_span_processor.py
-- OpenInference semconv: openinference.semconv.trace.SpanAttributes
-- OpenLLMetry semconv: opentelemetry.semconv_ai.SpanAttributes
-"""
+from __future__ import annotations
 
 import json
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List
+from typing import Any
 
-from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan
-from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes as TLSpanAttributes
-from openinference.semconv.trace import SpanAttributes as OISpanAttributes
-
-from respan_sdk.constants.span_attributes import (
-    GEN_AI_SYSTEM,
-    LLM_REQUEST_MODEL,
-    LLM_REQUEST_TYPE,
-    LLM_USAGE_COMPLETION_TOKENS,
-    LLM_USAGE_PROMPT_TOKENS,
-    RESPAN_LOG_TYPE,
-    RESPAN_SPAN_TOOL_CALLS,
-    RESPAN_SPAN_TOOLS,
+from openinference.semconv.trace import (
+    EmbeddingAttributes,
+)
+from openinference.semconv.trace import (
+    SpanAttributes as OISpanAttributes,
+)
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
+from opentelemetry.semconv_ai import (
+    LLMRequestTypeValues,
+)
+from opentelemetry.semconv_ai import (
+    SpanAttributes as TLSpanAttributes,
 )
 from respan_sdk.constants.llm_logging import (
     LOG_TYPE_AGENT,
@@ -65,29 +34,45 @@ from respan_sdk.constants.llm_logging import (
     LOG_TYPE_TOOL,
     LOG_TYPE_WORKFLOW,
 )
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
 
-# Traceloop attributes (from upstream opentelemetry-semantic-conventions-ai)
-TRACELOOP_SPAN_KIND = TLSpanAttributes.TRACELOOP_SPAN_KIND
+from respan_instrumentation_openinference._serialization import (
+    bounded_json,
+    bounded_text,
+    content_value,
+    parse_json,
+    to_jsonable,
+)
+
+logger = logging.getLogger(__name__)
+
+# Traceloop/GenAI attributes come from the upstream semantic-conventions package.
 TRACELOOP_ENTITY_NAME = TLSpanAttributes.TRACELOOP_ENTITY_NAME
 TRACELOOP_ENTITY_INPUT = TLSpanAttributes.TRACELOOP_ENTITY_INPUT
 TRACELOOP_ENTITY_OUTPUT = TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT
 TRACELOOP_ENTITY_PATH = TLSpanAttributes.TRACELOOP_ENTITY_PATH
+TRACELOOP_SPAN_KIND = TLSpanAttributes.TRACELOOP_SPAN_KIND
 GEN_AI_PROMPT_PREFIX = f"{TLSpanAttributes.LLM_PROMPTS}."
 GEN_AI_COMPLETION_PREFIX = f"{TLSpanAttributes.LLM_COMPLETIONS}."
-TL_LLM_REQUEST_TEMPERATURE = TLSpanAttributes.LLM_REQUEST_TEMPERATURE
-TL_LLM_REQUEST_TOP_P = TLSpanAttributes.LLM_REQUEST_TOP_P
-TL_LLM_REQUEST_MAX_TOKENS = TLSpanAttributes.LLM_REQUEST_MAX_TOKENS
-TL_LLM_REQUEST_FUNCTIONS = TLSpanAttributes.LLM_REQUEST_FUNCTIONS
-TL_LLM_REQUEST_REPETITION_PENALTY = TLSpanAttributes.LLM_REQUEST_REPETITION_PENALTY
-TL_LLM_USAGE_TOTAL_TOKENS = TLSpanAttributes.LLM_USAGE_TOTAL_TOKENS
-TL_LLM_TOP_K = TLSpanAttributes.LLM_TOP_K
-TL_LLM_CHAT_STOP_SEQUENCES = TLSpanAttributes.LLM_CHAT_STOP_SEQUENCES
-TL_LLM_FREQUENCY_PENALTY = TLSpanAttributes.LLM_FREQUENCY_PENALTY
-TL_LLM_PRESENCE_PENALTY = TLSpanAttributes.LLM_PRESENCE_PENALTY
+GEN_AI_SYSTEM = TLSpanAttributes.LLM_SYSTEM
+LLM_REQUEST_MODEL = TLSpanAttributes.LLM_REQUEST_MODEL
+LLM_REQUEST_TYPE = TLSpanAttributes.LLM_REQUEST_TYPE
+LLM_USAGE_PROMPT_TOKENS = TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS
+LLM_USAGE_COMPLETION_TOKENS = TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS
+LLM_USAGE_TOTAL_TOKENS = TLSpanAttributes.LLM_USAGE_TOTAL_TOKENS
+LLM_REQUEST_FUNCTIONS = TLSpanAttributes.LLM_REQUEST_FUNCTIONS
+LLM_REQUEST_TEMPERATURE = TLSpanAttributes.LLM_REQUEST_TEMPERATURE
+LLM_REQUEST_TOP_P = TLSpanAttributes.LLM_REQUEST_TOP_P
+LLM_REQUEST_MAX_TOKENS = TLSpanAttributes.LLM_REQUEST_MAX_TOKENS
+LLM_REQUEST_REPETITION_PENALTY = TLSpanAttributes.LLM_REQUEST_REPETITION_PENALTY
+LLM_TOP_K = TLSpanAttributes.LLM_TOP_K
+LLM_CHAT_STOP_SEQUENCES = TLSpanAttributes.LLM_CHAT_STOP_SEQUENCES
+LLM_FREQUENCY_PENALTY = TLSpanAttributes.LLM_FREQUENCY_PENALTY
+LLM_PRESENCE_PENALTY = TLSpanAttributes.LLM_PRESENCE_PENALTY
 
-# OpenInference attributes (from upstream openinference-semantic-conventions)
-OI_INPUT_VALUE = OISpanAttributes.INPUT_VALUE
+# OpenInference attributes come from its upstream semantic-conventions package.
 OI_SPAN_KIND = OISpanAttributes.OPENINFERENCE_SPAN_KIND
+OI_INPUT_VALUE = OISpanAttributes.INPUT_VALUE
 OI_INPUT_MIME_TYPE = OISpanAttributes.INPUT_MIME_TYPE
 OI_OUTPUT_VALUE = OISpanAttributes.OUTPUT_VALUE
 OI_OUTPUT_MIME_TYPE = OISpanAttributes.OUTPUT_MIME_TYPE
@@ -98,25 +83,22 @@ OI_LLM_INVOCATION_PARAMETERS = OISpanAttributes.LLM_INVOCATION_PARAMETERS
 OI_LLM_TOKEN_COUNT_PROMPT = OISpanAttributes.LLM_TOKEN_COUNT_PROMPT
 OI_LLM_TOKEN_COUNT_COMPLETION = OISpanAttributes.LLM_TOKEN_COUNT_COMPLETION
 OI_LLM_TOKEN_COUNT_TOTAL = OISpanAttributes.LLM_TOKEN_COUNT_TOTAL
-OI_LLM_TOKEN_COUNT_CACHE_READ = OISpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ
+OI_LLM_TOKEN_COUNT_CACHE_READ = (
+    OISpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ
+)
 OI_LLM_TOOLS = OISpanAttributes.LLM_TOOLS
 OI_AGENT_NAME = OISpanAttributes.AGENT_NAME
+OI_EMBEDDING_MODEL_NAME = OISpanAttributes.EMBEDDING_MODEL_NAME
+OI_EMBEDDING_INVOCATION_PARAMETERS = OISpanAttributes.EMBEDDING_INVOCATION_PARAMETERS
+OI_EMBEDDINGS = OISpanAttributes.EMBEDDING_EMBEDDINGS
+OI_TOOL_NAME = OISpanAttributes.TOOL_NAME
 
-_GEN_AI_PROVIDER_NAME = "gen_ai.provider.name"
-_GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
-_GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
 _LLM_USAGE_CACHE_READ_INPUT_TOKENS = "llm.usage.cache_read_input_tokens"
-_RESPAN_MODEL = "model"
-_RESPAN_PROMPT_TOKENS = "prompt_tokens"
-_RESPAN_COMPLETION_TOKENS = "completion_tokens"
-_RESPAN_TOTAL_REQUEST_TOKENS = "total_request_tokens"
-_RESPAN_TOOLS = "tools"
-_RESPAN_TOOL_CALLS = "tool_calls"
-
 _OI_INPUT_MESSAGES_PREFIX = "llm.input_messages."
 _OI_OUTPUT_MESSAGES_PREFIX = "llm.output_messages."
 _OI_TOKEN_COUNT_PREFIX = "llm.token_count."
 _OI_TOOLS_PREFIX = "llm.tools."
+_OI_EMBEDDINGS_PREFIX = f"{OI_EMBEDDINGS}."
 _OI_MESSAGE_ROLE = "message.role"
 _OI_MESSAGE_CONTENT = "message.content"
 _OI_MESSAGE_CONTENT_PREFIX = "message.content."
@@ -127,28 +109,10 @@ _OI_MESSAGE_FINISH_REASON = "message.finish_reason"
 _OI_TOOL_PREFIX = "tool."
 _OI_TOOL_JSON_SCHEMA = "tool.json_schema"
 _OI_TOOL_CALL_PREFIX = "tool_call."
+_OI_EMBEDDING_TEXT = EmbeddingAttributes.EMBEDDING_TEXT
+_OI_EMBEDDING_VECTOR = EmbeddingAttributes.EMBEDDING_VECTOR
 
-logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Span kind mapping: OpenInference → Traceloop
-# Exact reverse of Arize's _SPAN_KIND_MAPPING
-# ---------------------------------------------------------------------------
-_OI_KIND_TO_TRACELOOP: Dict[str, str] = {
-    "CHAIN": "workflow",
-    "LLM": LOG_TYPE_CHAT,
-    "TOOL": "tool",
-    "AGENT": "agent",
-    "RETRIEVER": "task",
-    "EMBEDDING": LOG_TYPE_EMBEDDING,
-    "RERANKER": "task",
-    "GUARDRAIL": "task",
-    "EVALUATOR": "task",
-    "PROMPT": "task",
-    "UNKNOWN": "task",
-}
-
-_OI_KIND_TO_LOG_TYPE: Dict[str, str] = {
+_OI_KIND_TO_LOG_TYPE = {
     "CHAIN": LOG_TYPE_WORKFLOW,
     "LLM": LOG_TYPE_CHAT,
     "TOOL": LOG_TYPE_TOOL,
@@ -161,595 +125,462 @@ _OI_KIND_TO_LOG_TYPE: Dict[str, str] = {
     "PROMPT": LOG_TYPE_TASK,
     "UNKNOWN": LOG_TYPE_TASK,
 }
-
-# OI span kinds that represent LLM calls
 _LLM_KINDS = {"LLM", "EMBEDDING"}
-
-# Invocation parameter key → OpenLLMetry target attribute
-_INVOCATION_PARAM_MAP: Dict[str, str] = {
+_INVOCATION_PARAM_MAP = {
     "model": LLM_REQUEST_MODEL,
-    "temperature": TL_LLM_REQUEST_TEMPERATURE,
-    "top_p": TL_LLM_REQUEST_TOP_P,
-    "max_tokens": TL_LLM_REQUEST_MAX_TOKENS,
-    "max_output_tokens": TL_LLM_REQUEST_MAX_TOKENS,
-    "top_k": TL_LLM_TOP_K,
-    "stop_sequences": TL_LLM_CHAT_STOP_SEQUENCES,
-    "stop": TL_LLM_CHAT_STOP_SEQUENCES,
-    "repetition_penalty": TL_LLM_REQUEST_REPETITION_PENALTY,
-    "frequency_penalty": TL_LLM_FREQUENCY_PENALTY,
-    "presence_penalty": TL_LLM_PRESENCE_PENALTY,
+    "temperature": LLM_REQUEST_TEMPERATURE,
+    "top_p": LLM_REQUEST_TOP_P,
+    "max_tokens": LLM_REQUEST_MAX_TOKENS,
+    "max_output_tokens": LLM_REQUEST_MAX_TOKENS,
+    "top_k": LLM_TOP_K,
+    "stop_sequences": LLM_CHAT_STOP_SEQUENCES,
+    "stop": LLM_CHAT_STOP_SEQUENCES,
+    "repetition_penalty": LLM_REQUEST_REPETITION_PENALTY,
+    "frequency_penalty": LLM_FREQUENCY_PENALTY,
+    "presence_penalty": LLM_PRESENCE_PENALTY,
+    "stream": TLSpanAttributes.LLM_IS_STREAMING,
+}
+_OFF_CONTRACT_ALIAS_KEYS = {
+    TRACELOOP_SPAN_KIND,
+    "respan.span.tools",
+    "respan.span.tool_calls",
+    "respan.span.handoffs",
+    "tools",
+    "tool_calls",
+    "model",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_request_tokens",
+    "span_tools",
+    "has_tool_calls",
+    "parallel_tool_calls",
 }
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _safe_json_str(value: Any) -> str:
-    """Ensure value is a JSON string."""
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value
-    return json.dumps(value, default=str)
-
-
-def _parse_json(value: Any) -> Any:
-    """Parse a JSON string, or return value as-is if not a string."""
-    if not isinstance(value, str):
-        return value
-    try:
-        return json.loads(value)
-    except (json.JSONDecodeError, TypeError):
-        return value
-
-
-def _collect_oi_message_buckets(
-    attrs: Dict[str, Any],
-    oi_prefix: str,
-) -> Dict[int, Dict[str, Any]]:
-    """Group indexed OI message attributes by message index."""
-    buckets: Dict[int, Dict[str, Any]] = defaultdict(dict)
-
-    for key, val in attrs.items():
-        if not key.startswith(oi_prefix):
+def _collect_buckets(attrs: dict[str, Any], prefix: str) -> dict[int, dict[str, Any]]:
+    buckets: dict[int, dict[str, Any]] = defaultdict(dict)
+    for key, value in attrs.items():
+        if not key.startswith(prefix):
             continue
-        rest = key[len(oi_prefix):]
-        parts = rest.split(".", 1)
-        if not parts[0].isdigit():
-            continue
-        idx = int(parts[0])
-        field = parts[1] if len(parts) > 1 else ""
-        buckets[idx][field] = val
-
+        rest = key[len(prefix) :]
+        index, separator, field = rest.partition(".")
+        if separator and index.isdigit():
+            buckets[int(index)][field] = value
     return buckets
 
 
-def _normalize_structured_list(value: Any) -> List[Dict[str, Any]] | None:
-    """Parse a JSON string or structured object into a list of dicts."""
-    parsed = _parse_json(value)
-    if isinstance(parsed, list):
-        normalized = [item for item in parsed if isinstance(item, dict)]
-        return normalized or None
-    if isinstance(parsed, dict):
-        return [parsed]
-    return None
-
-
-def _set_nested_value(target: Dict[str, Any], dotted_path: str, value: Any) -> None:
-    """Assign a nested dict field from a dotted path."""
+def _set_nested(target: dict[str, Any], dotted_path: str, value: Any) -> None:
     parts = dotted_path.split(".")
     cursor = target
     for part in parts[:-1]:
-        current = cursor.get(part)
-        if not isinstance(current, dict):
-            current = {}
-            cursor[part] = current
-        cursor = current
+        child = cursor.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            cursor[part] = child
+        cursor = child
     cursor[parts[-1]] = value
 
 
-def _canonicalize_for_signature(value: Any) -> Any:
-    """Recursively canonicalize structured values for deterministic signatures."""
-    if isinstance(value, dict):
-        return {
-            key: _canonicalize_for_signature(value[key])
-            for key in sorted(value)
-        }
-    if isinstance(value, list):
-        return [_canonicalize_for_signature(item) for item in value]
-    return value
-
-
-def _normalize_tool_call(tool_call: Dict[str, Any]) -> Dict[str, Any]:
-    """Normalize tool-call payloads to one canonical internal shape."""
-    normalized: Dict[str, Any] = {}
-
-    tool_call_id = tool_call.get("id")
-    if tool_call_id is not None:
-        normalized["id"] = tool_call_id
-
-    function = tool_call.get("function")
-    normalized_function: Dict[str, Any] = {}
-    if isinstance(function, dict):
-        function_name = function.get("name")
-        if function_name is not None:
-            normalized_function["name"] = function_name
-        function_arguments = function.get("arguments")
-        if function_arguments is not None:
-            normalized_function["arguments"] = function_arguments
-
-    tool_type = tool_call.get("type")
-    if tool_type is not None:
-        normalized["type"] = tool_type
-    elif normalized_function:
-        normalized["type"] = "function"
-
-    if normalized_function:
-        normalized["function"] = normalized_function
-
-    return normalized
-
-
-def _tool_call_signature(tool_call: Dict[str, Any]) -> str:
-    """Return a deterministic semantic signature for a tool call."""
-    normalized = _normalize_tool_call(tool_call)
-    function = normalized.get("function")
-    if isinstance(function, dict) and "arguments" in function:
-        function["arguments"] = _parse_json(function["arguments"])
+def _signature(value: Any) -> str:
     return json.dumps(
-        _canonicalize_for_signature(normalized),
-        default=str,
+        to_jsonable(value),
+        ensure_ascii=False,
         separators=(",", ":"),
+        sort_keys=True,
     )
 
 
+def _normalize_tool_call(tool_call: dict[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    call_id = tool_call.get("id")
+    if isinstance(call_id, (str, int)):
+        normalized["id"] = bounded_text(str(call_id))
+
+    function = tool_call.get("function")
+    normalized_function: dict[str, Any] = {}
+    if isinstance(function, dict):
+        name = function.get("name")
+        if isinstance(name, str) and name:
+            normalized_function["name"] = bounded_text(name)
+        if "arguments" in function:
+            normalized_function["arguments"] = bounded_json(function["arguments"])
+
+    tool_type = tool_call.get("type")
+    if isinstance(tool_type, str) and tool_type:
+        normalized["type"] = bounded_text(tool_type)
+    elif normalized_function:
+        normalized["type"] = "function"
+    if normalized_function:
+        normalized["function"] = normalized_function
+    return normalized
+
+
 def _extract_tool_calls_from_buckets(
-    buckets: Dict[int, Dict[str, Any]],
-) -> List[Dict[str, Any]] | None:
-    """Rebuild direct tool_calls payloads from indexed OI message attrs."""
-    result: List[Dict[str, Any]] = []
+    buckets: dict[int, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
     seen: set[str] = set()
-
-    for idx in sorted(buckets):
-        raw = buckets[idx]
-        tool_call_buckets: Dict[int, Dict[str, Any]] = defaultdict(dict)
-
-        for field_key, field_val in raw.items():
-            if not field_key.startswith(_OI_MESSAGE_TOOL_CALLS_PREFIX):
+    modern_function_signatures: set[str] = set()
+    for index in sorted(buckets):
+        raw = buckets[index]
+        tool_call_buckets: dict[int, dict[str, Any]] = defaultdict(dict)
+        for field, value in raw.items():
+            if not field.startswith(_OI_MESSAGE_TOOL_CALLS_PREFIX):
                 continue
-            rest = field_key[len(_OI_MESSAGE_TOOL_CALLS_PREFIX):]
-            parts = rest.split(".", 1)
-            if not parts[0].isdigit() or len(parts) == 1:
+            rest = field[len(_OI_MESSAGE_TOOL_CALLS_PREFIX) :]
+            tool_index, separator, tool_field = rest.partition(".")
+            if not separator or not tool_index.isdigit():
                 continue
-            tc_idx = int(parts[0])
-            tc_field = parts[1]
-            if tc_field.startswith(_OI_TOOL_CALL_PREFIX):
-                tc_field = tc_field[len(_OI_TOOL_CALL_PREFIX):]
-            tool_call_buckets[tc_idx][tc_field] = field_val
+            tool_field = tool_field.removeprefix(_OI_TOOL_CALL_PREFIX)
+            tool_call_buckets[int(tool_index)][tool_field] = value
 
-        for tc_idx in sorted(tool_call_buckets):
-            tool_call: Dict[str, Any] = {}
-            for field_key, field_val in tool_call_buckets[tc_idx].items():
-                _set_nested_value(tool_call, field_key, field_val)
-            tool_call = _normalize_tool_call(tool_call)
-            if not tool_call:
-                continue
-            signature = _tool_call_signature(tool_call)
-            if signature not in seen:
+        for tool_index in sorted(tool_call_buckets):
+            reconstructed: dict[str, Any] = {}
+            for field, value in tool_call_buckets[tool_index].items():
+                _set_nested(reconstructed, field, value)
+            tool_call = _normalize_tool_call(reconstructed)
+            signature = _signature(tool_call)
+            if tool_call and signature not in seen:
                 seen.add(signature)
                 result.append(tool_call)
+                modern_function_signatures.add(
+                    _signature(tool_call.get("function", {}))
+                )
 
-        func_name = raw.get(_OI_MESSAGE_FUNCTION_CALL_NAME)
-        func_args = raw.get(_OI_MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON)
-        if func_name is None and func_args is None:
+        legacy_name = raw.get(_OI_MESSAGE_FUNCTION_CALL_NAME)
+        legacy_arguments = raw.get(_OI_MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON)
+        if legacy_name is None and legacy_arguments is None:
             continue
-
-        legacy_tool_call: Dict[str, Any] = {
-            "type": "function",
-            "function": {},
-        }
-        if func_name is not None:
-            legacy_tool_call["function"]["name"] = func_name
-        if func_args is not None:
-            legacy_tool_call["function"]["arguments"] = func_args
-        legacy_tool_call = _normalize_tool_call(legacy_tool_call)
-        if not legacy_tool_call:
-            continue
-        signature = _tool_call_signature(legacy_tool_call)
-        if signature not in seen:
-            seen.add(signature)
-            result.append(legacy_tool_call)
-
-    return result or None
-
-
-def _extract_message_content(raw: Dict[str, Any]) -> Any:
-    """Rebuild message content from scalar or indexed OpenInference fields."""
-    content = raw.get(_OI_MESSAGE_CONTENT)
-    if content is not None:
-        return content
-
-    indexed_content: List[tuple[int, Any]] = []
-    for field_key, field_val in raw.items():
-        if not field_key.startswith(_OI_MESSAGE_CONTENT_PREFIX):
-            continue
-        idx_str = field_key[len(_OI_MESSAGE_CONTENT_PREFIX):]
-        if not idx_str.isdigit():
-            continue
-        indexed_content.append((int(idx_str), field_val))
-
-    if not indexed_content:
-        return None
-
-    ordered_values = [value for _, value in sorted(indexed_content)]
-    if len(ordered_values) == 1:
-        return ordered_values[0]
-    if all(isinstance(value, str) for value in ordered_values):
-        return "\n".join(ordered_values)
-    return ordered_values
-
-
-def _extract_tool_calls(
-    attrs: Dict[str, Any],
-    oi_prefixes: List[str],
-) -> List[Dict[str, Any]] | None:
-    """Collect unique tool calls across one or more indexed OI message groups."""
-    result: List[Dict[str, Any]] = []
-    seen: set[str] = set()
-
-    for prefix in oi_prefixes:
-        tool_calls = _extract_tool_calls_from_buckets(
-            _collect_oi_message_buckets(attrs=attrs, oi_prefix=prefix)
+        legacy = _normalize_tool_call(
+            {
+                "type": "function",
+                "function": {
+                    "name": legacy_name,
+                    "arguments": legacy_arguments,
+                },
+            }
         )
-        if not tool_calls:
-            continue
-        for tool_call in tool_calls:
-            signature = _tool_call_signature(tool_call)
-            if signature in seen:
-                continue
+        signature = _signature(legacy)
+        function_signature = _signature(legacy.get("function", {}))
+        if (
+            legacy
+            and signature not in seen
+            and function_signature not in modern_function_signatures
+        ):
             seen.add(signature)
-            result.append(tool_call)
+            result.append(legacy)
+    return result
 
-    return result or None
 
-
-def _extract_tools_from_indexed_attrs(
-    attrs: Dict[str, Any],
-) -> List[Dict[str, Any]] | None:
-    """Rebuild tool definitions from indexed OI llm.tools.N.tool.* attributes."""
-    buckets = _collect_oi_message_buckets(attrs=attrs, oi_prefix=_OI_TOOLS_PREFIX)
-    result: List[Dict[str, Any]] = []
-    seen: set[str] = set()
-
-    for idx in sorted(buckets):
-        raw = buckets[idx]
-        tool: Dict[str, Any] = {}
-
-        json_schema = raw.get(_OI_TOOL_JSON_SCHEMA)
-        if json_schema is not None:
-            parsed_json_schema = _parse_json(json_schema)
-            if isinstance(parsed_json_schema, dict):
-                tool.update(parsed_json_schema)
-            else:
-                tool["json_schema"] = parsed_json_schema
-
-        for field_key, field_val in raw.items():
-            if field_key == _OI_TOOL_JSON_SCHEMA:
-                continue
-            normalized_key = (
-                field_key[len(_OI_TOOL_PREFIX):]
-                if field_key.startswith(_OI_TOOL_PREFIX)
-                else field_key
-            )
-            _set_nested_value(
-                target=tool,
-                dotted_path=normalized_key,
-                value=_parse_json(field_val),
-            )
-
-        if "tool" in tool and len(tool) == 1 and isinstance(tool["tool"], dict):
-            tool = tool["tool"]
-        if not tool:
+def _extract_message_content(raw: dict[str, Any]) -> Any:
+    if _OI_MESSAGE_CONTENT in raw:
+        return raw[_OI_MESSAGE_CONTENT]
+    indexed = []
+    for field, value in raw.items():
+        if not field.startswith(_OI_MESSAGE_CONTENT_PREFIX):
             continue
-
-        signature = _safe_json_str(tool)
-        if signature not in seen:
-            seen.add(signature)
-            result.append(tool)
-
-    return result or None
-
-
-def _has_equivalent_modern_tool_call(
-    raw: Dict[str, Any],
-    legacy_name: Any,
-    legacy_arguments: Any,
-) -> bool:
-    """Return True when a legacy function_call matches an existing tool_call."""
-    if legacy_name is None and legacy_arguments is None:
-        return False
-
-    legacy_tool_call: Dict[str, Any] = {
-        "type": "function",
-        "function": {},
-    }
-    if legacy_name is not None:
-        legacy_tool_call["function"]["name"] = legacy_name
-    if legacy_arguments is not None:
-        legacy_tool_call["function"]["arguments"] = legacy_arguments
-
-    legacy_tool_call = _normalize_tool_call(legacy_tool_call)
-    if not legacy_tool_call:
-        return False
-
-    legacy_signature = _tool_call_signature(legacy_tool_call)
-    modern_tool_call_buckets: Dict[int, Dict[str, Any]] = defaultdict(dict)
-    for field_key, field_val in raw.items():
-        if not field_key.startswith(_OI_MESSAGE_TOOL_CALLS_PREFIX):
-            continue
-        rest = field_key[len(_OI_MESSAGE_TOOL_CALLS_PREFIX):]
-        parts = rest.split(".", 1)
-        if not parts[0].isdigit() or len(parts) == 1:
-            continue
-        tc_idx = int(parts[0])
-        tc_field = parts[1]
-        if tc_field.startswith(_OI_TOOL_CALL_PREFIX):
-            tc_field = tc_field[len(_OI_TOOL_CALL_PREFIX):]
-        modern_tool_call_buckets[tc_idx][tc_field] = field_val
-
-    for tool_call_bucket in modern_tool_call_buckets.values():
-        tool_call: Dict[str, Any] = {}
-        for field_key, field_val in tool_call_bucket.items():
-            _set_nested_value(tool_call, field_key, field_val)
-        tool_call = _normalize_tool_call(tool_call)
-        if not tool_call:
-            continue
-        if _tool_call_signature(tool_call) == legacy_signature:
-            return True
-
-    return False
+        index = field[len(_OI_MESSAGE_CONTENT_PREFIX) :]
+        if index.isdigit():
+            indexed.append((int(index), value))
+    values = [value for _, value in sorted(indexed)]
+    if len(values) == 1:
+        return values[0]
+    if values and all(isinstance(value, str) for value in values):
+        return "\n".join(values)
+    return values or None
 
 
-def _oi_messages_to_openllmetry(
-    attrs: Dict[str, Any],
-    oi_prefix: str,
-    gen_ai_prefix: str,
-) -> None:
-    """Convert OI indexed messages to OpenLLMetry gen_ai.prompt.N / gen_ai.completion.N format.
-
-    Reverse of Arize's ``_collect_oi_messages()`` which reads gen_ai.prompt.N.*
-    and builds OI Message objects stored as llm.input_messages.N.message.*.
-
-    OI format (source):
-        llm.input_messages.0.message.role = "user"
-        llm.input_messages.0.message.content = "hello"
-        llm.input_messages.0.message.tool_calls.0.tool_call.function.name = "get_weather"
-        llm.input_messages.0.message.tool_calls.0.tool_call.function.arguments = '{"city":"NYC"}'
-        llm.input_messages.0.message.function_call_name = "get_weather"
-        llm.input_messages.0.message.function_call_arguments_json = '{"city":"NYC"}'
-
-    OpenLLMetry format (target):
-        gen_ai.prompt.0.role = "user"
-        gen_ai.prompt.0.content = "hello"
-        gen_ai.prompt.0.tool_calls.0.function.name = "get_weather"
-        gen_ai.prompt.0.tool_calls.0.function.arguments = '{"city":"NYC"}'
-    """
-    buckets = _collect_oi_message_buckets(attrs=attrs, oi_prefix=oi_prefix)
-
-    for idx in sorted(buckets):
-        raw = buckets[idx]
-        target = f"{gen_ai_prefix}.{idx}"
-
-        # message.role → gen_ai.prompt.N.role
+def _message_payloads(buckets: dict[int, dict[str, Any]]) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    for index in sorted(buckets):
+        raw = buckets[index]
+        message: dict[str, Any] = {}
         role = raw.get(_OI_MESSAGE_ROLE)
-        if role:
-            attrs[f"{target}.role"] = role
-
-        # message.content / message.content.K → gen_ai.prompt.N.content
+        if isinstance(role, str):
+            message["role"] = bounded_text(role)
         content = _extract_message_content(raw)
         if content is not None:
-            attrs[f"{target}.content"] = content
-
-        # message.tool_calls.M.tool_call.function.name → gen_ai.prompt.N.tool_calls.M.function.name
-        for field_key, field_val in raw.items():
-            if field_key.startswith(_OI_MESSAGE_TOOL_CALLS_PREFIX):
-                rest = field_key[len(_OI_MESSAGE_TOOL_CALLS_PREFIX):]
-                parts = rest.split(".", 1)
-                if parts[0].isdigit() and len(parts) > 1:
-                    tc_idx = parts[0]
-                    tc_field = parts[1]
-                    # Strip "tool_call." prefix (OI nests under tool_call.*)
-                    if tc_field.startswith(_OI_TOOL_CALL_PREFIX):
-                        tc_field = tc_field[len(_OI_TOOL_CALL_PREFIX):]
-                    attrs[f"{target}.tool_calls.{tc_idx}.{tc_field}"] = field_val
-
-        structured_tool_calls = _extract_tool_calls_from_buckets({idx: raw})
-        if structured_tool_calls:
-            attrs.setdefault(f"{target}.tool_calls", structured_tool_calls)
-
-        # message.function_call_name → gen_ai.prompt.N.function_call.name
-        func_name = raw.get(_OI_MESSAGE_FUNCTION_CALL_NAME)
-        func_args = raw.get(_OI_MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON)
-        has_matching_tool_call = _has_equivalent_modern_tool_call(raw, func_name, func_args)
-        if func_name and not has_matching_tool_call:
-            attrs[f"{target}.function_call.name"] = func_name
-
-        # message.function_call_arguments_json → gen_ai.prompt.N.function_call.arguments
-        if func_args and not has_matching_tool_call:
-            attrs[f"{target}.function_call.arguments"] = func_args
-
-        # message.finish_reason → gen_ai.completion.N.finish_reason (completions only)
+            message["content"] = to_jsonable(parse_json(content))
+        tool_calls = _extract_tool_calls_from_buckets({index: raw})
+        if tool_calls:
+            message["tool_calls"] = tool_calls
         finish_reason = raw.get(_OI_MESSAGE_FINISH_REASON)
-        if finish_reason:
-            attrs[f"{target}.finish_reason"] = finish_reason
+        if isinstance(finish_reason, str):
+            message["finish_reason"] = bounded_text(finish_reason)
+        if message:
+            messages.append(message)
+    return messages
 
 
-# ---------------------------------------------------------------------------
-# Main processor
-# ---------------------------------------------------------------------------
+def _messages_to_canonical(
+    attrs: dict[str, Any],
+    buckets: dict[int, dict[str, Any]],
+    target_prefix: str,
+) -> None:
+    for index in sorted(buckets):
+        raw = buckets[index]
+        target = f"{target_prefix}{index}"
+        role = raw.get(_OI_MESSAGE_ROLE)
+        if isinstance(role, str):
+            attrs[f"{target}.role"] = bounded_text(role)
+        content = _extract_message_content(raw)
+        if content is not None:
+            attrs[f"{target}.content"] = content_value(content)
+        tool_calls = _extract_tool_calls_from_buckets({index: raw})
+        if tool_calls:
+            attrs[f"{target}.tool_calls"] = bounded_json(tool_calls)
+        finish_reason = raw.get(_OI_MESSAGE_FINISH_REASON)
+        if isinstance(finish_reason, str):
+            attrs[f"{target}.finish_reason"] = bounded_text(finish_reason)
+
+
+def _normalize_tools(value: Any) -> list[dict[str, Any]]:
+    parsed = parse_json(value)
+    candidates = parsed if isinstance(parsed, list) else [parsed]
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        normalized = to_jsonable(candidate)
+        if not isinstance(normalized, dict):
+            continue
+        signature = _signature(normalized)
+        if signature not in seen:
+            seen.add(signature)
+            result.append(normalized)
+    return result
+
+
+def _indexed_tools(attrs: dict[str, Any]) -> list[dict[str, Any]]:
+    buckets = _collect_buckets(attrs, _OI_TOOLS_PREFIX)
+    tools: list[dict[str, Any]] = []
+    for index in sorted(buckets):
+        raw = buckets[index]
+        reconstructed: dict[str, Any] = {}
+        schema = raw.get(_OI_TOOL_JSON_SCHEMA)
+        if schema is not None:
+            parsed_schema = parse_json(schema)
+            if isinstance(parsed_schema, dict):
+                reconstructed.update(parsed_schema)
+            else:
+                reconstructed["json_schema"] = parsed_schema
+        for field, value in raw.items():
+            if field == _OI_TOOL_JSON_SCHEMA:
+                continue
+            normalized_field = field.removeprefix(_OI_TOOL_PREFIX)
+            _set_nested(reconstructed, normalized_field, parse_json(value))
+        if reconstructed:
+            tools.extend(_normalize_tools(reconstructed))
+    return _normalize_tools(tools)
+
+
+def _attribute_value(value: Any) -> Any:
+    normalized = to_jsonable(value)
+    if isinstance(normalized, str):
+        return bounded_text(normalized)
+    if normalized is None or isinstance(normalized, (bool, int, float, str)):
+        return normalized
+    if (
+        isinstance(normalized, list)
+        and all(isinstance(item, (bool, int, float, str)) for item in normalized)
+        and len({type(item) for item in normalized}) <= 1
+    ):
+        return tuple(normalized)
+    return bounded_json(normalized)
+
+
+def _lower_label(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return bounded_text(value.strip().lower())
+
 
 class OpenInferenceTranslator(SpanProcessor):
-    """SpanProcessor that translates OpenInference attributes to OpenLLMetry/Traceloop.
-
-    Detects OI spans by the presence of ``openinference.span.kind`` and
-    enriches them with the Traceloop attributes the Respan backend expects.
-
-    All mappings are the exact reverse of Arize's openinference-instrumentation-openllmetry.
-    After translation, redundant raw OpenInference attributes are removed so they
-    do not leak into passthrough metadata / custom properties.
-    """
+    """Normalize ended OpenInference spans before Respan export."""
 
     def on_start(self, span: Any, parent_context: Any = None) -> None:
-        pass
+        del span, parent_context
 
     def on_end(self, span: ReadableSpan) -> None:
         original_attrs = getattr(span, "_attributes", None)
         if original_attrs is None:
             return
         attrs = dict(original_attrs)
-
         oi_kind = attrs.get(OI_SPAN_KIND)
-        if not oi_kind:
+        if not isinstance(oi_kind, str) or not oi_kind:
             return
 
-        oi_kind_upper = str(oi_kind).upper()
-        is_llm_kind = oi_kind_upper in _LLM_KINDS
-        is_llm_only = oi_kind_upper == "LLM"
-        logger.debug("[OI→TL] Translating %s span: %s", oi_kind_upper, span.name)
+        kind = oi_kind.upper()
+        logger.debug("[OI->Respan] Translating %s span: %s", kind, span.name)
+        attrs.setdefault(RESPAN_LOG_TYPE, _OI_KIND_TO_LOG_TYPE.get(kind, LOG_TYPE_TASK))
 
-        # --- Span kind (reverse of Arize _SPAN_KIND_MAPPING) ---
-        traceloop_kind = _OI_KIND_TO_TRACELOOP.get(oi_kind_upper, "task")
-        attrs.setdefault(TRACELOOP_SPAN_KIND, traceloop_kind)
-        attrs.setdefault(RESPAN_LOG_TYPE, _OI_KIND_TO_LOG_TYPE.get(oi_kind_upper, "task"))
+        entity_name = attrs.get(OI_TOOL_NAME) if kind == "TOOL" else None
+        entity_name = entity_name or attrs.get(OI_AGENT_NAME) or span.name
+        if isinstance(entity_name, str):
+            attrs.setdefault(TRACELOOP_ENTITY_NAME, bounded_text(entity_name))
+        canonical_name = attrs.get(TRACELOOP_ENTITY_NAME)
+        default_path = (
+            ""
+            if getattr(span, "parent", None) is None
+            else bounded_text(
+                canonical_name if isinstance(canonical_name, str) else span.name
+            )
+        )
+        attrs.setdefault(TRACELOOP_ENTITY_PATH, default_path)
 
-        # --- Entity name ---
-        entity_name = attrs.get(OI_AGENT_NAME) or span.name
-        attrs.setdefault(TRACELOOP_ENTITY_NAME, entity_name)
+        input_value = attrs.get(OI_INPUT_VALUE)
+        if input_value is None:
+            input_value = attrs.get(TRACELOOP_ENTITY_INPUT)
+        output_value = attrs.get(OI_OUTPUT_VALUE)
+        if output_value is None:
+            output_value = attrs.get(TRACELOOP_ENTITY_OUTPUT)
+        if kind == "TOOL":
+            arguments = parse_json(input_value) if input_value is not None else {}
+            if isinstance(arguments, dict) and set(arguments) == {"name", "arguments"}:
+                tool_input = arguments
+            else:
+                tool_input = {"name": entity_name, "arguments": arguments}
+            attrs[TRACELOOP_ENTITY_INPUT] = bounded_json(tool_input)
+        elif input_value is not None:
+            attrs[TRACELOOP_ENTITY_INPUT] = bounded_json(input_value)
+        if output_value is not None:
+            attrs[TRACELOOP_ENTITY_OUTPUT] = bounded_json(output_value)
 
-        # --- Entity path (empty = root candidate) ---
-        attrs.setdefault(TRACELOOP_ENTITY_PATH, "")
+        model = attrs.get(OI_LLM_MODEL_NAME) or attrs.get(OI_EMBEDDING_MODEL_NAME)
+        if isinstance(model, str) and model:
+            attrs.setdefault(LLM_REQUEST_MODEL, bounded_text(model))
 
-        # --- Input / output (reverse of Arize _map_generic_span) ---
-        input_val = attrs.get(OI_INPUT_VALUE)
-        if input_val is not None:
-            attrs.setdefault(TRACELOOP_ENTITY_INPUT, _safe_json_str(input_val))
-
-        output_val = attrs.get(OI_OUTPUT_VALUE)
-        if output_val is not None:
-            attrs.setdefault(TRACELOOP_ENTITY_OUTPUT, _safe_json_str(output_val))
-
-        # --- Model name (reverse: llm.model_name → gen_ai.request.model) ---
-        model = attrs.get(OI_LLM_MODEL_NAME)
-        if model:
-            attrs.setdefault(LLM_REQUEST_MODEL, model)
-            if is_llm_kind:
-                attrs.setdefault(_RESPAN_MODEL, model)
-
-        # --- System / provider (reverse of Arize _extract_llm_provider_and_system) ---
-        system = attrs.get(OI_LLM_SYSTEM)
-        if system:
-            attrs.setdefault(GEN_AI_SYSTEM, str(system).lower())
-
-        provider = attrs.get(OI_LLM_PROVIDER)
-        if provider:
-            attrs.setdefault(_GEN_AI_PROVIDER_NAME, str(provider).lower())
-            # Also set gen_ai.system if not already set (provider is a good fallback)
-            attrs.setdefault(GEN_AI_SYSTEM, str(provider).lower())
-
-        # --- Token counts (reverse of Arize token_count extraction) ---
-        prompt_tokens = attrs.get(OI_LLM_TOKEN_COUNT_PROMPT)
-        if prompt_tokens is not None:
-            attrs.setdefault(LLM_USAGE_PROMPT_TOKENS, prompt_tokens)
-            attrs.setdefault(_GEN_AI_USAGE_INPUT_TOKENS, prompt_tokens)
-            if is_llm_kind:
-                attrs.setdefault(_RESPAN_PROMPT_TOKENS, prompt_tokens)
-
-        completion_tokens = attrs.get(OI_LLM_TOKEN_COUNT_COMPLETION)
-        if completion_tokens is not None:
-            attrs.setdefault(LLM_USAGE_COMPLETION_TOKENS, completion_tokens)
-            attrs.setdefault(_GEN_AI_USAGE_OUTPUT_TOKENS, completion_tokens)
-            if is_llm_kind:
-                attrs.setdefault(_RESPAN_COMPLETION_TOKENS, completion_tokens)
-
-        total_tokens = attrs.get(OI_LLM_TOKEN_COUNT_TOTAL)
-        if total_tokens is not None:
-            attrs.setdefault(TL_LLM_USAGE_TOTAL_TOKENS, total_tokens)
-            if is_llm_kind:
-                attrs.setdefault(_RESPAN_TOTAL_REQUEST_TOKENS, total_tokens)
-        elif is_llm_kind and (
-            prompt_tokens is not None or completion_tokens is not None
-        ):
-            attrs.setdefault(
-                _RESPAN_TOTAL_REQUEST_TOKENS,
-                (prompt_tokens or 0) + (completion_tokens or 0),
+        system = _lower_label(attrs.get(OI_LLM_SYSTEM))
+        provider = _lower_label(attrs.get(OI_LLM_PROVIDER))
+        canonical_system = _lower_label(attrs.get(GEN_AI_SYSTEM))
+        canonical_provider = _lower_label(attrs.get(GEN_AI_PROVIDER_NAME))
+        if canonical_system or system or provider or canonical_provider:
+            attrs[GEN_AI_SYSTEM] = (
+                canonical_system or system or provider or canonical_provider
+            )
+        if canonical_provider or provider or system or canonical_system:
+            attrs[GEN_AI_PROVIDER_NAME] = (
+                canonical_provider or provider or system or canonical_system
             )
 
+        prompt_tokens = attrs.get(OI_LLM_TOKEN_COUNT_PROMPT)
+        completion_tokens = attrs.get(OI_LLM_TOKEN_COUNT_COMPLETION)
+        total_tokens = attrs.get(OI_LLM_TOKEN_COUNT_TOTAL)
+        if isinstance(prompt_tokens, int) and not isinstance(prompt_tokens, bool):
+            attrs.setdefault(LLM_USAGE_PROMPT_TOKENS, prompt_tokens)
+            attrs.setdefault(GEN_AI_USAGE_INPUT_TOKENS, prompt_tokens)
+        if isinstance(completion_tokens, int) and not isinstance(
+            completion_tokens, bool
+        ):
+            attrs.setdefault(LLM_USAGE_COMPLETION_TOKENS, completion_tokens)
+            attrs.setdefault(GEN_AI_USAGE_OUTPUT_TOKENS, completion_tokens)
+        if isinstance(total_tokens, int) and not isinstance(total_tokens, bool):
+            attrs.setdefault(LLM_USAGE_TOTAL_TOKENS, total_tokens)
+        elif isinstance(prompt_tokens, int) and isinstance(completion_tokens, int):
+            attrs.setdefault(LLM_USAGE_TOTAL_TOKENS, prompt_tokens + completion_tokens)
         cache_read = attrs.get(OI_LLM_TOKEN_COUNT_CACHE_READ)
-        if cache_read is not None:
+        if isinstance(cache_read, int) and not isinstance(cache_read, bool):
             attrs.setdefault(_LLM_USAGE_CACHE_READ_INPUT_TOKENS, cache_read)
 
-        direct_tools = _normalize_structured_list(attrs.get(OI_LLM_TOOLS))
-        if direct_tools is None:
-            direct_tools = _extract_tools_from_indexed_attrs(attrs)
-        if direct_tools is not None:
-            attrs.setdefault(RESPAN_SPAN_TOOLS, _safe_json_str(direct_tools))
-            if is_llm_only:
-                attrs.setdefault(_RESPAN_TOOLS, direct_tools)
+        if kind in _LLM_KINDS:
+            self._translate_llm(attrs, kind)
+        if kind == "EMBEDDING":
+            self._translate_embedding(attrs)
 
-        direct_tool_calls = _extract_tool_calls(
-            attrs=attrs,
-            oi_prefixes=[_OI_OUTPUT_MESSAGES_PREFIX],
-        )
-        if direct_tool_calls is not None:
-            attrs.setdefault(RESPAN_SPAN_TOOL_CALLS, _safe_json_str(direct_tool_calls))
-            if is_llm_only:
-                attrs.setdefault(_RESPAN_TOOL_CALLS, direct_tool_calls)
-
-        # --- LLM-specific: messages, invocation params, tools ---
-        if oi_kind_upper in _LLM_KINDS:
-            self._translate_llm(attrs=attrs, oi_kind_upper=oi_kind_upper)
-
-        self._remove_redundant_oi_attrs(attrs)
+        self._normalize_canonical_content(attrs)
+        self._remove_raw_and_alias_attrs(attrs)
         span._attributes = attrs
 
-    def _translate_llm(self, attrs: Dict[str, Any], oi_kind_upper: str) -> None:
-        """Extra translation for LLM/EMBEDDING spans."""
-        request_type = (
+    def _translate_llm(self, attrs: dict[str, Any], kind: str) -> None:
+        attrs.setdefault(
+            LLM_REQUEST_TYPE,
             LLMRequestTypeValues.EMBEDDING.value
-            if oi_kind_upper == "EMBEDDING"
-            else LLMRequestTypeValues.CHAT.value
+            if kind == "EMBEDDING"
+            else LLMRequestTypeValues.CHAT.value,
         )
-        attrs.setdefault(LLM_REQUEST_TYPE, request_type)
+        input_buckets = _collect_buckets(attrs, _OI_INPUT_MESSAGES_PREFIX)
+        output_buckets = _collect_buckets(attrs, _OI_OUTPUT_MESSAGES_PREFIX)
+        _messages_to_canonical(attrs, input_buckets, GEN_AI_PROMPT_PREFIX)
+        _messages_to_canonical(attrs, output_buckets, GEN_AI_COMPLETION_PREFIX)
+        if TRACELOOP_ENTITY_INPUT not in attrs and input_buckets:
+            attrs[TRACELOOP_ENTITY_INPUT] = bounded_json(
+                {"messages": _message_payloads(input_buckets)}
+            )
+        if TRACELOOP_ENTITY_OUTPUT not in attrs and output_buckets:
+            attrs[TRACELOOP_ENTITY_OUTPUT] = bounded_json(
+                {"messages": _message_payloads(output_buckets)}
+            )
 
-        # --- Messages (reverse of Arize _collect_oi_messages) ---
-        _oi_messages_to_openllmetry(attrs, _OI_INPUT_MESSAGES_PREFIX, GEN_AI_PROMPT_PREFIX.rstrip("."))
-        _oi_messages_to_openllmetry(attrs, _OI_OUTPUT_MESSAGES_PREFIX, GEN_AI_COMPLETION_PREFIX.rstrip("."))
+        invocation = attrs.get(OI_LLM_INVOCATION_PARAMETERS)
+        if kind == "EMBEDDING" and invocation is None:
+            invocation = attrs.get(OI_EMBEDDING_INVOCATION_PARAMETERS)
+        parameters = parse_json(invocation)
+        if isinstance(parameters, dict):
+            for key, value in parameters.items():
+                target = _INVOCATION_PARAM_MAP.get(key)
+                if target:
+                    attrs.setdefault(target, _attribute_value(value))
 
-        # --- Invocation parameters (reverse of Arize invocation_params extraction) ---
-        # OI stores all params as a single JSON string; OpenLLMetry uses individual attributes
-        inv_params_raw = attrs.get(OI_LLM_INVOCATION_PARAMETERS)
-        if inv_params_raw:
-            params = _parse_json(inv_params_raw)
-            if isinstance(params, dict):
-                for key, val in params.items():
-                    target_attr = _INVOCATION_PARAM_MAP.get(key)
-                    if target_attr:
-                        attrs.setdefault(target_attr, val)
-
-        # --- Tools (reverse of Arize _handle_tool_list) ---
-        # OI: llm.tools = JSON string of tool definitions
-        # OpenLLMetry: llm.request.functions = JSON string of tool definitions
-        tools_raw = attrs.get(OI_LLM_TOOLS)
-        if tools_raw:
-            attrs.setdefault(TL_LLM_REQUEST_FUNCTIONS, tools_raw)
-        elif attrs.get(RESPAN_SPAN_TOOLS):
-            attrs.setdefault(TL_LLM_REQUEST_FUNCTIONS, attrs[RESPAN_SPAN_TOOLS])
+        tools = _normalize_tools(attrs.get(OI_LLM_TOOLS))
+        if not tools:
+            tools = _indexed_tools(attrs)
+        if tools and kind == "LLM":
+            attrs.setdefault(LLM_REQUEST_FUNCTIONS, bounded_json(tools))
 
     @staticmethod
-    def _remove_redundant_oi_attrs(attrs: Dict[str, Any]) -> None:
-        """Remove noisy raw OpenInference attrs while keeping promoted fields."""
-        keys_to_remove = {
+    def _translate_embedding(attrs: dict[str, Any]) -> None:
+        buckets = _collect_buckets(attrs, _OI_EMBEDDINGS_PREFIX)
+        texts: list[Any] = []
+        vectors: list[Any] = []
+        for index in sorted(buckets):
+            raw = buckets[index]
+            if _OI_EMBEDDING_TEXT in raw:
+                texts.append(raw[_OI_EMBEDDING_TEXT])
+            if _OI_EMBEDDING_VECTOR in raw:
+                vectors.append(raw[_OI_EMBEDDING_VECTOR])
+        if texts and TRACELOOP_ENTITY_INPUT not in attrs:
+            attrs[TRACELOOP_ENTITY_INPUT] = bounded_json(
+                texts[0] if len(texts) == 1 else texts
+            )
+        if vectors and TRACELOOP_ENTITY_OUTPUT not in attrs:
+            attrs[TRACELOOP_ENTITY_OUTPUT] = bounded_json(
+                vectors[0] if len(vectors) == 1 else vectors
+            )
+
+    @staticmethod
+    def _normalize_canonical_content(attrs: dict[str, Any]) -> None:
+        label_keys = {
+            TRACELOOP_ENTITY_NAME,
+            TRACELOOP_ENTITY_PATH,
+            GEN_AI_SYSTEM,
+            GEN_AI_PROVIDER_NAME,
+            LLM_REQUEST_MODEL,
+            LLM_REQUEST_TYPE,
+        }
+        for key, value in tuple(attrs.items()):
+            if (
+                key in {TRACELOOP_ENTITY_INPUT, TRACELOOP_ENTITY_OUTPUT}
+                or key == LLM_REQUEST_FUNCTIONS
+                or (
+                    key.startswith((GEN_AI_PROMPT_PREFIX, GEN_AI_COMPLETION_PREFIX))
+                    and key.endswith(".tool_calls")
+                )
+            ):
+                attrs[key] = bounded_json(value)
+            elif key.startswith(
+                (GEN_AI_PROMPT_PREFIX, GEN_AI_COMPLETION_PREFIX)
+            ) and key.endswith(".content"):
+                attrs[key] = content_value(value)
+            elif key in label_keys or (
+                key.startswith((GEN_AI_PROMPT_PREFIX, GEN_AI_COMPLETION_PREFIX))
+                and key.endswith((".role", ".finish_reason"))
+            ):
+                attrs[key] = bounded_text(value)
+
+    @staticmethod
+    def _remove_raw_and_alias_attrs(attrs: dict[str, Any]) -> None:
+        exact_raw_keys = {
             OI_SPAN_KIND,
             OI_INPUT_VALUE,
             OI_INPUT_MIME_TYPE,
@@ -765,23 +596,33 @@ class OpenInferenceTranslator(SpanProcessor):
             OI_LLM_TOKEN_COUNT_CACHE_READ,
             OI_LLM_TOOLS,
             OI_AGENT_NAME,
+            OI_EMBEDDING_MODEL_NAME,
+            OI_EMBEDDING_INVOCATION_PARAMETERS,
+            OI_TOOL_NAME,
+            *_OFF_CONTRACT_ALIAS_KEYS,
         }
-        prefixes_to_remove = (
+        raw_prefixes = (
             _OI_INPUT_MESSAGES_PREFIX,
             _OI_OUTPUT_MESSAGES_PREFIX,
             _OI_TOKEN_COUNT_PREFIX,
             _OI_TOOLS_PREFIX,
+            _OI_EMBEDDINGS_PREFIX,
+            "openinference.",
+            "llm.cost.",
+            "llm.choices",
+            "llm.function_call",
+            "llm.prompt",
+            "tool.",
         )
-
-        for key in keys_to_remove:
+        for key in exact_raw_keys:
             attrs.pop(key, None)
-
-        for key in list(attrs.keys()):
-            if any(key.startswith(prefix) for prefix in prefixes_to_remove):
+        for key in tuple(attrs):
+            if key.startswith(raw_prefixes):
                 attrs.pop(key, None)
 
     def shutdown(self) -> None:
         pass
 
-    def force_flush(self, timeout_millis: int = 30000) -> bool:
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        del timeout_millis
         return True

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_lifecycle.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_lifecycle.py
@@ -1,0 +1,292 @@
+"""Lifecycle and duplicate-prevention tests for the generic wrapper."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from respan_instrumentation_openinference._instrumentation import (
+    OpenInferenceInstrumentor,
+)
+from respan_instrumentation_openinference._translator import OpenInferenceTranslator
+
+
+class FakeTracerProvider:
+    def __init__(self):
+        self._active_span_processor = SimpleNamespace(
+            _span_processors=("export-a", "export-b")
+        )
+
+    def add_span_processor(self, processor):
+        self._active_span_processor._span_processors = (
+            *self._active_span_processor._span_processors,
+            processor,
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_shared_state(monkeypatch):
+    provider = FakeTracerProvider()
+    monkeypatch.setattr(
+        OpenInferenceInstrumentor, "_translator", OpenInferenceTranslator()
+    )
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_translator_registered", False)
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_active_span_processors", [])
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_registrations", {})
+    monkeypatch.setattr(OpenInferenceInstrumentor, "_provider", None)
+    monkeypatch.setattr(
+        "respan_instrumentation_openinference._instrumentation.trace.get_tracer_provider",
+        lambda: provider,
+    )
+    return provider
+
+
+def test_processor_delegate_runs_before_one_translator_and_exporters(
+    reset_shared_state,
+):
+    class FakeOIProcessor:
+        shutdown_count = 0
+
+        def shutdown(self):
+            type(self).shutdown_count += 1
+
+    wrapper = OpenInferenceInstrumentor(FakeOIProcessor)
+    wrapper.activate()
+
+    processors = reset_shared_state._active_span_processor._span_processors
+    assert processors[0] is wrapper._instrumentor
+    assert processors.count(OpenInferenceInstrumentor._translator) == 1
+    assert processors[2:] == ("export-a", "export-b")
+
+    wrapper.deactivate()
+    assert reset_shared_state._active_span_processor._span_processors == (
+        "export-a",
+        "export-b",
+    )
+    assert FakeOIProcessor.shutdown_count == 1
+
+
+def test_standard_delegate_is_reference_counted_across_wrappers(reset_shared_state):
+    class StandardDelegate:
+        instrument_count = 0
+        uninstrument_count = 0
+
+        def instrument(self, **kwargs):
+            assert kwargs["tracer_provider"] is reset_shared_state
+            type(self).instrument_count += 1
+
+        def uninstrument(self):
+            type(self).uninstrument_count += 1
+
+    first = OpenInferenceInstrumentor(StandardDelegate)
+    second = OpenInferenceInstrumentor(StandardDelegate)
+    first.activate()
+    second.activate()
+
+    assert first._instrumentor is second._instrumentor
+    assert StandardDelegate.instrument_count == 1
+    processors = reset_shared_state._active_span_processor._span_processors
+    assert processors.count(OpenInferenceInstrumentor._translator) == 1
+
+    first.deactivate()
+    assert StandardDelegate.uninstrument_count == 0
+    assert OpenInferenceInstrumentor._translator in (
+        reset_shared_state._active_span_processor._span_processors
+    )
+    second.deactivate()
+    assert StandardDelegate.uninstrument_count == 1
+    assert OpenInferenceInstrumentor._translator not in (
+        reset_shared_state._active_span_processor._span_processors
+    )
+
+
+def test_external_standard_activation_is_not_owned(reset_shared_state):
+    class ExternalDelegate:
+        is_instrumented_by_opentelemetry = True
+        instrument_count = 0
+        uninstrument_count = 0
+
+        def instrument(self, **kwargs):
+            type(self).instrument_count += 1
+
+        def uninstrument(self):
+            type(self).uninstrument_count += 1
+
+    wrapper = OpenInferenceInstrumentor(ExternalDelegate)
+    wrapper.activate()
+    wrapper.deactivate()
+
+    assert ExternalDelegate.instrument_count == 0
+    assert ExternalDelegate.uninstrument_count == 0
+
+
+def test_external_processor_is_adopted_without_duplicate_or_shutdown(
+    reset_shared_state,
+):
+    class ExternalProcessor:
+        shutdown_count = 0
+
+        def shutdown(self):
+            type(self).shutdown_count += 1
+
+    external = ExternalProcessor()
+    reset_shared_state.add_span_processor(external)
+
+    wrapper = OpenInferenceInstrumentor(ExternalProcessor)
+    wrapper.activate()
+    processors = reset_shared_state._active_span_processor._span_processors
+
+    assert wrapper._instrumentor is external
+    assert sum(isinstance(item, ExternalProcessor) for item in processors) == 1
+    assert processors.index(external) < processors.index(
+        OpenInferenceInstrumentor._translator
+    )
+
+    wrapper.deactivate()
+    processors = reset_shared_state._active_span_processor._span_processors
+    assert sum(isinstance(item, ExternalProcessor) for item in processors) == 1
+    assert ExternalProcessor.shutdown_count == 0
+
+
+def test_activation_failure_rolls_back_translator_and_delegate(reset_shared_state):
+    class BrokenDelegate:
+        uninstrument_count = 0
+
+        def instrument(self, **kwargs):
+            self._is_instrumented_by_opentelemetry = True
+            raise RuntimeError("activation failed")
+
+        def uninstrument(self):
+            type(self).uninstrument_count += 1
+
+    wrapper = OpenInferenceInstrumentor(BrokenDelegate)
+    with pytest.raises(RuntimeError, match="activation failed"):
+        wrapper.activate()
+
+    assert OpenInferenceInstrumentor._registrations == {}
+    assert OpenInferenceInstrumentor._provider is None
+    assert OpenInferenceInstrumentor._translator not in (
+        reset_shared_state._active_span_processor._span_processors
+    )
+    assert BrokenDelegate.uninstrument_count == 1
+
+
+def test_concurrent_same_class_activation_has_one_delegate(reset_shared_state):
+    class ConcurrentDelegate:
+        instrument_count = 0
+        uninstrument_count = 0
+
+        def instrument(self, **kwargs):
+            type(self).instrument_count += 1
+
+        def uninstrument(self):
+            type(self).uninstrument_count += 1
+
+    wrappers = [OpenInferenceInstrumentor(ConcurrentDelegate) for _ in range(12)]
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        list(executor.map(lambda wrapper: wrapper.activate(), wrappers))
+
+    assert ConcurrentDelegate.instrument_count == 1
+    assert len(OpenInferenceInstrumentor._registrations) == 1
+    assert (
+        reset_shared_state._active_span_processor._span_processors.count(
+            OpenInferenceInstrumentor._translator
+        )
+        == 1
+    )
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        list(executor.map(lambda wrapper: wrapper.deactivate(), wrappers))
+    assert ConcurrentDelegate.uninstrument_count == 1
+    assert OpenInferenceInstrumentor._registrations == {}
+
+
+def test_same_wrapper_activation_and_deactivation_are_idempotent():
+    class StandardDelegate:
+        instrument_count = 0
+        uninstrument_count = 0
+
+        def instrument(self, **kwargs):
+            type(self).instrument_count += 1
+
+        def uninstrument(self):
+            type(self).uninstrument_count += 1
+
+    wrapper = OpenInferenceInstrumentor(StandardDelegate)
+    wrapper.activate()
+    wrapper.activate()
+    wrapper.deactivate()
+    wrapper.deactivate()
+
+    assert StandardDelegate.instrument_count == 1
+    assert StandardDelegate.uninstrument_count == 1
+
+
+def test_real_provider_wrapper_orders_source_translation_and_export(
+    monkeypatch,
+):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    export_processor = SimpleSpanProcessor(exporter)
+    provider.add_span_processor(export_processor)
+    monkeypatch.setattr(
+        "respan_instrumentation_openinference._instrumentation.trace.get_tracer_provider",
+        lambda: provider,
+    )
+
+    class SourceProcessor(SpanProcessor):
+        shutdown_count = 0
+
+        def on_start(self, span, parent_context=None):
+            del span, parent_context
+
+        def on_end(self, span):
+            span._attributes = {
+                **dict(span._attributes),
+                "openinference.span.kind": "LLM",
+                "llm.model_name": "gpt-4.1-mini",
+                "llm.invocation_parameters": '{"stream":true}',
+            }
+
+        def shutdown(self):
+            type(self).shutdown_count += 1
+
+        def force_flush(self, timeout_millis=30_000):
+            del timeout_millis
+            return True
+
+    wrapper = OpenInferenceInstrumentor(SourceProcessor)
+    wrapper.activate()
+    try:
+        processors = provider._active_span_processor._span_processors
+        assert processors == (
+            wrapper._instrumentor,
+            OpenInferenceInstrumentor._translator,
+            export_processor,
+        )
+
+        tracer = provider.get_tracer("openinference-wrapper-contract")
+        with tracer.start_as_current_span("source.chat"):
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        attrs = spans[0].attributes
+        assert attrs["respan.entity.log_type"] == "chat"
+        assert attrs["gen_ai.request.model"] == "gpt-4.1-mini"
+        assert attrs["llm.is_streaming"] is True
+        assert "openinference.span.kind" not in attrs
+        assert "llm.invocation_parameters" not in attrs
+    finally:
+        wrapper.deactivate()
+
+    assert provider._active_span_processor._span_processors == (export_processor,)
+    assert SourceProcessor.shutdown_count == 1
+    provider.shutdown()

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_readable_spans.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_readable_spans.py
@@ -1,0 +1,170 @@
+"""End-to-end processor tests using real exported ``ReadableSpan`` objects."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from opentelemetry.trace import Status, StatusCode
+
+from respan_instrumentation_openinference._serialization import MAX_ATTRIBUTE_CHARS
+from respan_instrumentation_openinference._translator import OpenInferenceTranslator
+
+
+@pytest.fixture
+def real_export_pipeline():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(OpenInferenceTranslator())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield provider.get_tracer("openinference-contract-tests"), exporter
+    provider.shutdown()
+
+
+def test_real_chat_readable_span_has_canonical_contract_once(real_export_pipeline):
+    tracer, exporter = real_export_pipeline
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup_weather",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+    with tracer.start_as_current_span("openai.chat") as span:
+        span.set_attribute("openinference.span.kind", "LLM")
+        span.set_attribute("llm.model_name", "gpt-4.1-mini")
+        span.set_attribute("llm.system", "openai")
+        span.set_attribute("llm.provider", "openai")
+        span.set_attribute("llm.invocation_parameters", '{"stream":true}')
+        span.set_attribute("llm.token_count.prompt", 11)
+        span.set_attribute("llm.token_count.completion", 5)
+        span.set_attribute("llm.token_count.total", 16)
+        span.set_attribute("llm.tools", json.dumps(tools))
+        span.set_attribute("llm.input_messages.0.message.role", "user")
+        span.set_attribute("llm.input_messages.0.message.content", "Weather in Tokyo?")
+        span.set_attribute("llm.output_messages.0.message.role", "assistant")
+        span.set_attribute(
+            "llm.output_messages.0.message.tool_calls.0.tool_call.id",
+            "call-1",
+        )
+        span.set_attribute(
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.name",
+            "lookup_weather",
+        )
+        span.set_attribute(
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments",
+            '{"city":"Tokyo"}',
+        )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    readable = spans[0]
+    assert isinstance(readable, ReadableSpan)
+    assert readable.status.status_code is StatusCode.UNSET
+    attrs = readable.attributes
+    assert attrs["respan.entity.log_type"] == "chat"
+    assert attrs["gen_ai.request.model"] == "gpt-4.1-mini"
+    assert attrs["gen_ai.provider.name"] == "openai"
+    assert attrs[TLSpanAttributes.LLM_IS_STREAMING] is True
+    assert json.loads(attrs["llm.request.functions"]) == tools
+    assert json.loads(attrs["gen_ai.completion.0.tool_calls"])[0]["id"] == "call-1"
+    assert "traceloop.span.kind" not in attrs
+    assert "respan.span.tools" not in attrs
+    assert "tools" not in attrs
+
+
+def test_real_failed_span_keeps_otel_error_and_invents_no_usage(real_export_pipeline):
+    tracer, exporter = real_export_pipeline
+    error = RuntimeError("openinference deterministic provider failure")
+    with tracer.start_as_current_span("openai.chat.failure") as span:
+        span.set_attribute("openinference.span.kind", "LLM")
+        span.set_attribute("llm.model_name", "gpt-4.1-mini")
+        span.set_attribute("llm.system", "openai")
+        span.set_attribute("input.value", '{"messages":[{"role":"user"}]}')
+        span.record_exception(error)
+        span.set_status(Status(StatusCode.ERROR, str(error)))
+
+    readable = exporter.get_finished_spans()[0]
+    assert readable.status.status_code is StatusCode.ERROR
+    assert readable.status.description == str(error)
+    assert [event.name for event in readable.events] == ["exception"]
+    assert readable.events[0].attributes["exception.type"].endswith("RuntimeError")
+    for usage_key in (
+        "gen_ai.usage.prompt_tokens",
+        "gen_ai.usage.input_tokens",
+        "gen_ai.usage.completion_tokens",
+        "gen_ai.usage.output_tokens",
+        "llm.usage.total_tokens",
+        "prompt_tokens",
+        "total_request_tokens",
+    ):
+        assert usage_key not in readable.attributes
+
+
+def test_real_tool_and_embedding_spans_keep_hierarchy_and_content(real_export_pipeline):
+    tracer, exporter = real_export_pipeline
+    with tracer.start_as_current_span("workflow") as root:
+        root.set_attribute("openinference.span.kind", "CHAIN")
+        root_context = root.get_span_context()
+        with tracer.start_as_current_span("lookup_weather") as tool:
+            tool.set_attribute("openinference.span.kind", "TOOL")
+            tool.set_attribute("tool.name", "lookup_weather")
+            tool.set_attribute("input.value", '{"city":"Tokyo"}')
+            tool.set_attribute("output.value", '{"temperature_c":22}')
+        with tracer.start_as_current_span("embed.query") as embedding:
+            embedding.set_attribute("openinference.span.kind", "EMBEDDING")
+            embedding.set_attribute("embedding.model_name", "text-embedding-3-small")
+            embedding.set_attribute(
+                "embedding.embeddings.0.embedding.text",
+                "Tokyo weather",
+            )
+            embedding.set_attribute(
+                "embedding.embeddings.0.embedding.vector",
+                (0.1, 0.2, 0.3),
+            )
+
+    spans = {span.name: span for span in exporter.get_finished_spans()}
+    assert set(spans) == {"workflow", "lookup_weather", "embed.query"}
+    assert spans["workflow"].attributes["traceloop.entity.path"] == ""
+    for name in ("lookup_weather", "embed.query"):
+        assert spans[name].parent.span_id == root_context.span_id
+        assert spans[name].attributes["traceloop.entity.path"] == name
+
+    tool_input = json.loads(
+        spans["lookup_weather"].attributes["traceloop.entity.input"]
+    )
+    assert tool_input == {
+        "name": "lookup_weather",
+        "arguments": {"city": "Tokyo"},
+    }
+    assert json.loads(spans["embed.query"].attributes["traceloop.entity.output"]) == [
+        0.1,
+        0.2,
+        0.3,
+    ]
+
+
+def test_real_span_redacts_and_bounds_content_before_export(real_export_pipeline):
+    tracer, exporter = real_export_pipeline
+    payload = {
+        "authorization": "Bearer credential-should-not-export",
+        "nested": {"api_key": "sk-secret-value-12345"},
+        "body": "x" * (MAX_ATTRIBUTE_CHARS * 2),
+    }
+    with tracer.start_as_current_span("private.chat") as span:
+        span.set_attribute("openinference.span.kind", "LLM")
+        span.set_attribute("input.value", json.dumps(payload))
+
+    entity_input = exporter.get_finished_spans()[0].attributes["traceloop.entity.input"]
+    assert len(entity_input) <= MAX_ATTRIBUTE_CHARS
+    assert "credential-should-not-export" not in entity_input
+    assert "secret-value-12345" not in entity_input
+    json.loads(entity_input)

--- a/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openinference/tests/test_translator.py
@@ -1,8 +1,6 @@
-"""Unit tests for OpenInferenceTranslator.
+"""Contract tests for OpenInference-to-Respan translation."""
 
-Uses a lightweight mock span (just needs ``_attributes`` and ``name``)
-so we don't depend on any OpenInference packages at test time.
-"""
+from __future__ import annotations
 
 import json
 from types import SimpleNamespace
@@ -10,548 +8,407 @@ from types import SimpleNamespace
 import pytest
 from opentelemetry.attributes import BoundedAttributes
 
-from respan_instrumentation_openinference._instrumentation import OpenInferenceInstrumentor
-from respan_instrumentation_openinference._translator import OpenInferenceTranslator
-from respan_sdk.constants.span_attributes import (
-    RESPAN_SPAN_TOOL_CALLS,
-    RESPAN_SPAN_TOOLS,
+from respan_instrumentation_openinference._serialization import (
+    MAX_ATTRIBUTE_CHARS,
+    MAX_LABEL_CHARS,
 )
+from respan_instrumentation_openinference._translator import OpenInferenceTranslator
 
 
-def _make_span(attrs: dict, name: str = "test-span"):
-    """Return a minimal mock ReadableSpan with a mutable _attributes dict."""
-    span = SimpleNamespace()
-    span._attributes = dict(attrs)
-    span.name = name
-    return span
+def _make_span(attrs: dict, name: str = "test-span") -> SimpleNamespace:
+    return SimpleNamespace(_attributes=dict(attrs), name=name)
 
 
 @pytest.fixture
-def translator():
+def translator() -> OpenInferenceTranslator:
     return OpenInferenceTranslator()
 
 
-def test_span_processor_registration_orders_processor_before_translator(monkeypatch):
-    class FakeOIProcessor:
-        def shutdown(self):
-            self.did_shutdown = True
-
-    class FakeTracerProvider:
-        def __init__(self):
-            self._active_span_processor = SimpleNamespace(
-                _span_processors=("export-a", "export-b")
-            )
-
-        def add_span_processor(self, processor):
-            self._active_span_processor._span_processors = (
-                *self._active_span_processor._span_processors,
-                processor,
-            )
-
-    provider = FakeTracerProvider()
-    monkeypatch.setattr(OpenInferenceInstrumentor, "_translator_registered", False)
-    monkeypatch.setattr(OpenInferenceInstrumentor, "_translator", None)
-    monkeypatch.setattr(OpenInferenceInstrumentor, "_active_span_processors", [])
-    monkeypatch.setattr(
-        "respan_instrumentation_openinference._instrumentation.trace.get_tracer_provider",
-        lambda: provider,
-    )
-
-    instrumentor = OpenInferenceInstrumentor(FakeOIProcessor)
-    instrumentor.activate()
-
-    processors = provider._active_span_processor._span_processors
-    assert processors[0] is instrumentor._instrumentor
-    assert isinstance(processors[1], OpenInferenceTranslator)
-    assert processors[2:] == ("export-a", "export-b")
-
-    instrumentor.deactivate()
-
-    processors = provider._active_span_processor._span_processors
-    assert not any(processor is instrumentor._instrumentor for processor in processors)
-    assert isinstance(processors[0], OpenInferenceTranslator)
-
-
-# ------------------------------------------------------------------
-# 1. Non-OI span is ignored
-# ------------------------------------------------------------------
-
-def test_non_oi_span_ignored(translator):
-    """Span without openinference.span.kind is not modified."""
-    span = _make_span({"some.attr": "value"})
-    original = dict(span._attributes)
+def test_non_openinference_span_is_untouched(translator):
+    span = _make_span({"custom.keep": "value"})
     translator.on_end(span)
-    assert span._attributes == original
+    assert span._attributes == {"custom.keep": "value"}
 
 
-# ------------------------------------------------------------------
-# 2. CHAIN → workflow
-# ------------------------------------------------------------------
-
-def test_chain_span_maps_to_workflow(translator):
-    span = _make_span({"openinference.span.kind": "CHAIN"})
-    translator.on_end(span)
-    assert span._attributes["traceloop.span.kind"] == "workflow"
-    assert span._attributes["respan.entity.log_type"] == "workflow"
-
-
-# ------------------------------------------------------------------
-# 3. LLM → chat + llm.request.type=chat
-# ------------------------------------------------------------------
-
-def test_llm_span_maps_to_chat(translator):
-    span = _make_span({"openinference.span.kind": "LLM"})
-    translator.on_end(span)
-    assert span._attributes["traceloop.span.kind"] == "chat"
-    assert span._attributes["llm.request.type"] == "chat"
-    assert span._attributes["respan.entity.log_type"] == "chat"
-
-
-def test_embedding_span_maps_to_embedding(translator):
-    span = _make_span({"openinference.span.kind": "EMBEDDING"})
-    translator.on_end(span)
-    assert span._attributes["traceloop.span.kind"] == "embedding"
-    assert span._attributes["llm.request.type"] == "embedding"
-    assert span._attributes["respan.entity.log_type"] == "embedding"
-
-
-# ------------------------------------------------------------------
-# 4. TOOL → tool
-# ------------------------------------------------------------------
-
-def test_tool_span_maps_to_tool(translator):
-    span = _make_span({"openinference.span.kind": "TOOL"})
-    translator.on_end(span)
-    assert span._attributes["traceloop.span.kind"] == "tool"
-    assert span._attributes["respan.entity.log_type"] == "tool"
-
-
-# ------------------------------------------------------------------
-# 5. AGENT → agent
-# ------------------------------------------------------------------
-
-def test_agent_span_maps_to_agent(translator):
-    span = _make_span({"openinference.span.kind": "AGENT"})
-    translator.on_end(span)
-    assert span._attributes["traceloop.span.kind"] == "agent"
-    assert span._attributes["respan.entity.log_type"] == "agent"
-
-
-# ------------------------------------------------------------------
-# 6. input/output mapped
-# ------------------------------------------------------------------
-
-def test_input_output_mapped(translator):
-    span = _make_span({
-        "openinference.span.kind": "CHAIN",
-        "input.value": "hello world",
-        "output.value": "goodbye world",
-    })
-    translator.on_end(span)
-    assert span._attributes["traceloop.entity.input"] == "hello world"
-    assert span._attributes["traceloop.entity.output"] == "goodbye world"
-
-
-# ------------------------------------------------------------------
-# 7. model name mapped
-# ------------------------------------------------------------------
-
-def test_model_name_mapped(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.model_name": "gpt-4o",
-    })
-    translator.on_end(span)
-    assert span._attributes["gen_ai.request.model"] == "gpt-4o"
-    assert span._attributes["model"] == "gpt-4o"
-
-
-# ------------------------------------------------------------------
-# 8. token counts mapped
-# ------------------------------------------------------------------
-
-def test_token_counts_mapped(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.token_count.prompt": 100,
-        "llm.token_count.completion": 50,
-        "llm.token_count.total": 150,
-        "llm.token_count.prompt_details.cache_read": 20,
-    })
-    translator.on_end(span)
-    assert span._attributes["gen_ai.usage.prompt_tokens"] == 100
-    assert span._attributes["gen_ai.usage.input_tokens"] == 100
-    assert span._attributes["gen_ai.usage.completion_tokens"] == 50
-    assert span._attributes["gen_ai.usage.output_tokens"] == 50
-    assert span._attributes["llm.usage.total_tokens"] == 150
-    assert span._attributes["llm.usage.cache_read_input_tokens"] == 20
-    assert span._attributes["prompt_tokens"] == 100
-    assert span._attributes["completion_tokens"] == 50
-    assert span._attributes["total_request_tokens"] == 150
-
-
-def test_non_llm_token_count_does_not_emit_backend_accounting_alias(translator):
-    span = _make_span({
-        "openinference.span.kind": "CHAIN",
-        "llm.token_count.total": 150,
-    })
-
+@pytest.mark.parametrize(
+    ("kind", "log_type"),
+    [
+        ("CHAIN", "workflow"),
+        ("LLM", "chat"),
+        ("TOOL", "tool"),
+        ("AGENT", "agent"),
+        ("RETRIEVER", "task"),
+        ("EMBEDDING", "embedding"),
+        ("GUARDRAIL", "guardrail"),
+    ],
+)
+def test_kind_maps_only_to_auto_span_log_type(translator, kind, log_type):
+    span = _make_span({"openinference.span.kind": kind})
     translator.on_end(span)
 
-    assert span._attributes["llm.usage.total_tokens"] == 150
-    assert "total_request_tokens" not in span._attributes
-
-
-# ------------------------------------------------------------------
-# 9. system / provider mapped
-# ------------------------------------------------------------------
-
-def test_system_provider_mapped(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.system": "OpenAI",
-        "llm.provider": "Azure",
-    })
-    translator.on_end(span)
-    assert span._attributes["gen_ai.system"] == "openai"
-    assert span._attributes["gen_ai.provider.name"] == "azure"
-
-
-# ------------------------------------------------------------------
-# 10. setdefault does not overwrite existing attributes
-# ------------------------------------------------------------------
-
-def test_setdefault_does_not_overwrite(translator):
-    span = _make_span({
-        "openinference.span.kind": "CHAIN",
-        "traceloop.span.kind": "agent",  # pre-existing
-        "traceloop.entity.input": "keep me",  # pre-existing
-        "input.value": "should not overwrite",
-    })
-    translator.on_end(span)
-    # Pre-existing values must be preserved
-    assert span._attributes["traceloop.span.kind"] == "agent"
-    assert span._attributes["traceloop.entity.input"] == "keep me"
-
-
-# ------------------------------------------------------------------
-# 11. messages translated
-# ------------------------------------------------------------------
-
-def test_messages_translated(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.input_messages.0.message.role": "user",
-        "llm.input_messages.0.message.content": "Hello!",
-        "llm.input_messages.1.message.role": "assistant",
-        "llm.input_messages.1.message.content": "Hi there!",
-        "llm.output_messages.0.message.role": "assistant",
-        "llm.output_messages.0.message.content": "Goodbye!",
-    })
-    translator.on_end(span)
-    assert span._attributes["gen_ai.prompt.0.role"] == "user"
-    assert span._attributes["gen_ai.prompt.0.content"] == "Hello!"
-    assert span._attributes["gen_ai.prompt.1.role"] == "assistant"
-    assert span._attributes["gen_ai.prompt.1.content"] == "Hi there!"
-    assert span._attributes["gen_ai.completion.0.role"] == "assistant"
-    assert span._attributes["gen_ai.completion.0.content"] == "Goodbye!"
-
-
-def test_indexed_message_content_translated(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.output_messages.0.message.role": "assistant",
-        "llm.output_messages.0.message.content.0": "First line",
-        "llm.output_messages.0.message.content.1": "Second line",
-        "llm.output_messages.1.message.role": "assistant",
-        "llm.output_messages.1.message.content.0": "Final answer",
-    })
-
-    translator.on_end(span)
-
-    assert span._attributes["gen_ai.completion.0.role"] == "assistant"
-    assert span._attributes["gen_ai.completion.0.content"] == "First line\nSecond line"
-    assert span._attributes["gen_ai.completion.1.role"] == "assistant"
-    assert span._attributes["gen_ai.completion.1.content"] == "Final answer"
-
-
-def test_indexed_message_content_preserves_empty_blocks(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.output_messages.0.message.role": "assistant",
-        "llm.output_messages.0.message.content.0": "",
-        "llm.output_messages.0.message.content.1": "tool result here",
-    })
-
-    translator.on_end(span)
-
-    assert span._attributes["gen_ai.completion.0.content"] == "\ntool result here"
-
-
-def test_equivalent_legacy_function_call_is_deduplicated(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.input_messages.0.message.role": "assistant",
-        "llm.input_messages.0.message.tool_calls.0.tool_call.function.name": "get_weather",
-        "llm.input_messages.0.message.tool_calls.0.tool_call.function.arguments": '{"city":"NYC","unit":"F"}',
-        "llm.input_messages.0.message.function_call_name": "get_weather",
-        "llm.input_messages.0.message.function_call_arguments_json": '{"unit":"F","city":"NYC"}',
-    })
-    translator.on_end(span)
-    assert span._attributes["gen_ai.prompt.0.tool_calls.0.function.name"] == "get_weather"
-    assert span._attributes["gen_ai.prompt.0.tool_calls.0.function.arguments"] == '{"city":"NYC","unit":"F"}'
-    assert span._attributes["gen_ai.prompt.0.tool_calls"] == [
-        {
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"city":"NYC","unit":"F"}',
-            },
-        }
-    ]
-    assert "gen_ai.prompt.0.function_call.name" not in span._attributes
-    assert "gen_ai.prompt.0.function_call.arguments" not in span._attributes
-
-
-def test_legacy_function_call_preserved_without_matching_tool_call(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.input_messages.0.message.role": "assistant",
-        "llm.input_messages.0.message.function_call_name": "get_weather",
-        "llm.input_messages.0.message.function_call_arguments_json": '{"city":"NYC"}',
-    })
-    translator.on_end(span)
-    assert span._attributes["gen_ai.prompt.0.function_call.name"] == "get_weather"
-    assert span._attributes["gen_ai.prompt.0.function_call.arguments"] == '{"city":"NYC"}'
-
-
-# ------------------------------------------------------------------
-# 12. invocation parameters extracted
-# ------------------------------------------------------------------
-
-def test_invocation_params_extracted(translator):
-    params = {
-        "model": "claude-3-opus",
-        "temperature": 0.7,
-        "top_p": 0.9,
-        "max_tokens": 1024,
-    }
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.invocation_parameters": json.dumps(params),
-    })
-    translator.on_end(span)
-    assert span._attributes["gen_ai.request.model"] == "claude-3-opus"
-    assert span._attributes["gen_ai.request.temperature"] == 0.7
-    assert span._attributes["gen_ai.request.top_p"] == 0.9
-    assert span._attributes["gen_ai.request.max_tokens"] == 1024
-
-
-def test_redundant_oi_attrs_removed_after_translation(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "input.value": "hello world",
-        "output.value": "goodbye world",
-        "llm.model_name": "claude-3-opus",
-        "llm.provider": "Anthropic",
-        "llm.system": "Anthropic",
-        "llm.invocation_parameters": json.dumps({"temperature": 0.7}),
-        "llm.token_count.prompt": 100,
-        "llm.output_messages.0.message.role": "assistant",
-        "llm.output_messages.0.message.content": "Goodbye!",
-    })
-
-    translator.on_end(span)
-
-    assert span._attributes["traceloop.entity.input"] == "hello world"
-    assert span._attributes["traceloop.entity.output"] == "goodbye world"
-    assert span._attributes["gen_ai.request.model"] == "claude-3-opus"
-    assert span._attributes["gen_ai.request.temperature"] == 0.7
-    assert span._attributes["gen_ai.usage.prompt_tokens"] == 100
-    assert span._attributes["gen_ai.completion.0.content"] == "Goodbye!"
-
+    assert span._attributes["respan.entity.log_type"] == log_type
+    assert "traceloop.span.kind" not in span._attributes
     assert "openinference.span.kind" not in span._attributes
-    assert "input.value" not in span._attributes
-    assert "output.value" not in span._attributes
-    assert "llm.model_name" not in span._attributes
-    assert "llm.provider" not in span._attributes
-    assert "llm.system" not in span._attributes
-    assert "llm.invocation_parameters" not in span._attributes
-    assert "llm.token_count.prompt" not in span._attributes
-    assert "llm.output_messages.0.message.role" not in span._attributes
-    assert "llm.output_messages.0.message.content" not in span._attributes
 
 
-def test_tools_and_tool_calls_promoted(translator):
-    tools = [
+def test_entity_input_output_are_valid_json_and_custom_attrs_survive(translator):
+    span = _make_span(
         {
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "description": "Look up weather",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"city": {"type": "string"}},
-                },
-            },
+            "openinference.span.kind": "CHAIN",
+            "input.value": "hello world",
+            "output.value": {"answer": 42},
+            "custom.request_id": "request-123",
         }
-    ]
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.tools": json.dumps(tools),
-        "llm.output_messages.0.message.role": "assistant",
-        "llm.output_messages.0.message.tool_calls.0.tool_call.id": "call_1",
-        "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": "get_weather",
-        "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments": '{"city":"NYC"}',
-    })
-
+    )
     translator.on_end(span)
 
-    expected_tool_calls = [
+    assert json.loads(span._attributes["traceloop.entity.input"]) == "hello world"
+    assert json.loads(span._attributes["traceloop.entity.output"]) == {"answer": 42}
+    assert span._attributes["custom.request_id"] == "request-123"
+
+
+def test_model_provider_and_real_usage_are_canonical_only(translator):
+    span = _make_span(
         {
-            "id": "call_1",
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"city":"NYC"}',
-            },
+            "openinference.span.kind": "LLM",
+            "llm.model_name": "gpt-4.1-mini",
+            "llm.system": "OpenAI",
+            "llm.provider": "Azure",
+            "llm.token_count.prompt": 11,
+            "llm.token_count.completion": 5,
+            "llm.token_count.total": 16,
+            "llm.token_count.prompt_details.cache_read": 3,
+            "model": "forbidden",
+            "prompt_tokens": 999,
         }
-    ]
-    assert json.loads(span._attributes[RESPAN_SPAN_TOOLS]) == tools
-    assert json.loads(span._attributes[RESPAN_SPAN_TOOL_CALLS]) == expected_tool_calls
-    assert span._attributes["gen_ai.completion.0.tool_calls"] == expected_tool_calls
-    assert span._attributes["llm.request.functions"] == json.dumps(tools)
-    assert (
-        span._attributes["gen_ai.completion.0.tool_calls.0.function.name"]
-        == "get_weather"
     )
-    assert span._attributes["tools"] == tools
-    assert span._attributes["tool_calls"] == expected_tool_calls
+    translator.on_end(span)
+    attrs = span._attributes
+
+    assert attrs["gen_ai.request.model"] == "gpt-4.1-mini"
+    assert attrs["gen_ai.system"] == "openai"
+    assert attrs["gen_ai.provider.name"] == "azure"
+    assert attrs["gen_ai.usage.prompt_tokens"] == 11
+    assert attrs["gen_ai.usage.input_tokens"] == 11
+    assert attrs["gen_ai.usage.completion_tokens"] == 5
+    assert attrs["gen_ai.usage.output_tokens"] == 5
+    assert attrs["llm.usage.total_tokens"] == 16
+    assert attrs["llm.usage.cache_read_input_tokens"] == 3
+    assert "model" not in attrs
+    assert "prompt_tokens" not in attrs
+    assert "completion_tokens" not in attrs
+    assert "total_request_tokens" not in attrs
 
 
-def test_indexed_anthropic_tools_promoted_from_bounded_attrs(translator):
-    tools = [
+def test_provider_and_system_fall_back_to_each_other(translator):
+    provider_only = _make_span(
+        {"openinference.span.kind": "LLM", "llm.provider": "Anthropic"}
+    )
+    translator.on_end(provider_only)
+    assert provider_only._attributes["gen_ai.system"] == "anthropic"
+    assert provider_only._attributes["gen_ai.provider.name"] == "anthropic"
+
+    system_only = _make_span({"openinference.span.kind": "LLM", "llm.system": "OpenAI"})
+    translator.on_end(system_only)
+    assert system_only._attributes["gen_ai.system"] == "openai"
+    assert system_only._attributes["gen_ai.provider.name"] == "openai"
+
+
+def test_messages_reconstruct_canonical_content_and_entity_json(translator):
+    span = _make_span(
         {
-            "name": "get_weather",
-            "description": "Get current weather for a city.",
-            "input_schema": {
+            "openinference.span.kind": "LLM",
+            "llm.input_messages.0.message.role": "user",
+            "llm.input_messages.0.message.content": "Hello",
+            "llm.output_messages.0.message.role": "assistant",
+            "llm.output_messages.0.message.content.0": "First",
+            "llm.output_messages.0.message.content.1": "Second",
+            "llm.output_messages.0.message.finish_reason": "stop",
+        }
+    )
+    translator.on_end(span)
+    attrs = span._attributes
+
+    assert attrs["gen_ai.prompt.0.role"] == "user"
+    assert attrs["gen_ai.prompt.0.content"] == "Hello"
+    assert attrs["gen_ai.completion.0.role"] == "assistant"
+    assert attrs["gen_ai.completion.0.content"] == "First\nSecond"
+    assert attrs["gen_ai.completion.0.finish_reason"] == "stop"
+    assert json.loads(attrs["traceloop.entity.input"]) == {
+        "messages": [{"content": "Hello", "role": "user"}]
+    }
+    assert json.loads(attrs["traceloop.entity.output"]) == {
+        "messages": [
+            {
+                "content": "First\nSecond",
+                "finish_reason": "stop",
+                "role": "assistant",
+            }
+        ]
+    }
+
+
+def test_tools_and_current_turn_calls_are_json_and_alias_free(translator):
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "lookup_weather",
+            "description": "Look up weather",
+            "parameters": {
                 "type": "object",
                 "properties": {"city": {"type": "string"}},
-                "required": ["city"],
+            },
+        },
+    }
+    span = _make_span(
+        {
+            "openinference.span.kind": "LLM",
+            "llm.tools": json.dumps([tool, tool]),
+            "llm.output_messages.0.message.role": "assistant",
+            "llm.output_messages.0.message.tool_calls.0.tool_call.id": "call-1",
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": "lookup_weather",
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments": '{"city":"Tokyo"}',
+            "llm.output_messages.0.message.function_call_name": "lookup_weather",
+            "llm.output_messages.0.message.function_call_arguments_json": '{"city":"Tokyo"}',
+        }
+    )
+    translator.on_end(span)
+    attrs = span._attributes
+
+    assert json.loads(attrs["llm.request.functions"]) == [tool]
+    calls = json.loads(attrs["gen_ai.completion.0.tool_calls"])
+    assert calls == [
+        {
+            "id": "call-1",
+            "type": "function",
+            "function": {
+                "name": "lookup_weather",
+                "arguments": '{"city":"Tokyo"}',
             },
         }
     ]
+    for alias in (
+        "respan.span.tools",
+        "respan.span.tool_calls",
+        "tools",
+        "tool_calls",
+    ):
+        assert alias not in attrs
+    assert not any(key.startswith("llm.output_messages.") for key in attrs)
+
+
+def test_history_calls_stay_on_prompt_and_not_current_turn(translator):
+    span = _make_span(
+        {
+            "openinference.span.kind": "LLM",
+            "llm.input_messages.0.message.role": "assistant",
+            "llm.input_messages.0.message.tool_calls.0.tool_call.id": "history-1",
+            "llm.input_messages.0.message.tool_calls.0.tool_call.function.name": "lookup",
+            "llm.input_messages.0.message.tool_calls.0.tool_call.function.arguments": '{"q":"old"}',
+            "llm.output_messages.0.message.role": "assistant",
+            "llm.output_messages.0.message.content": "No tool this turn",
+        }
+    )
+    translator.on_end(span)
+
+    history = json.loads(span._attributes["gen_ai.prompt.0.tool_calls"])
+    assert history[0]["id"] == "history-1"
+    assert "gen_ai.completion.0.tool_calls" not in span._attributes
+
+
+def test_indexed_tools_from_bounded_attributes_are_promoted(translator):
+    tool = {
+        "name": "lookup_weather",
+        "description": "Get weather",
+        "input_schema": {"type": "object"},
+    }
     span = _make_span({})
     span._attributes = BoundedAttributes(
         maxlen=64,
         attributes={
             "openinference.span.kind": "LLM",
-            "llm.tools.0.tool.json_schema": json.dumps(tools[0]),
-            "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": "get_weather",
-            "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments": '{"city":"Tokyo"}',
+            "llm.tools.0.tool.json_schema": json.dumps(tool),
         },
         immutable=False,
     )
-
     translator.on_end(span)
 
     assert isinstance(span._attributes, dict)
-    expected_tool_calls = [
-        {
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"city":"Tokyo"}',
-            },
-        }
-    ]
-    assert json.loads(span._attributes[RESPAN_SPAN_TOOLS]) == tools
-    assert json.loads(span._attributes[RESPAN_SPAN_TOOL_CALLS]) == expected_tool_calls
-    assert span._attributes["gen_ai.completion.0.tool_calls"] == expected_tool_calls
-    assert span._attributes["llm.request.functions"] == json.dumps(tools)
-    assert span._attributes["tools"] == tools
-    assert span._attributes["tool_calls"] == expected_tool_calls
+    assert json.loads(span._attributes["llm.request.functions"]) == [tool]
     assert "llm.tools.0.tool.json_schema" not in span._attributes
-    assert (
-        "llm.output_messages.0.message.tool_calls.0.tool_call.function.name"
-        not in span._attributes
+
+
+def test_tool_span_has_contract_input_and_output(translator):
+    span = _make_span(
+        {
+            "openinference.span.kind": "TOOL",
+            "tool.name": "lookup_weather",
+            "input.value": '{"city":"Tokyo"}',
+            "output.value": '{"temperature_c":22}',
+        },
+        name="tool-call",
     )
-    assert (
-        "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments"
-        not in span._attributes
+    translator.on_end(span)
+
+    assert span._attributes["traceloop.entity.name"] == "lookup_weather"
+    assert json.loads(span._attributes["traceloop.entity.input"]) == {
+        "name": "lookup_weather",
+        "arguments": {"city": "Tokyo"},
+    }
+    assert json.loads(span._attributes["traceloop.entity.output"]) == {
+        "temperature_c": 22
+    }
+    assert "tool.name" not in span._attributes
+
+
+def test_embedding_indexed_fields_map_model_input_and_vector(translator):
+    span = _make_span(
+        {
+            "openinference.span.kind": "EMBEDDING",
+            "embedding.model_name": "text-embedding-3-small",
+            "embedding.embeddings.0.embedding.text": "hello",
+            "embedding.embeddings.0.embedding.vector": [0.1, 0.2, 0.3],
+        }
     )
-
-
-def test_legacy_function_call_fields_promoted_as_tool_calls(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.output_messages.0.message.function_call_name": "Glob",
-        "llm.output_messages.0.message.function_call_arguments_json": '{"pattern":"*.py"}',
-    })
-
     translator.on_end(span)
 
-    expected_tool_calls = [
+    assert span._attributes["llm.request.type"] == "embedding"
+    assert span._attributes["gen_ai.request.model"] == "text-embedding-3-small"
+    assert json.loads(span._attributes["traceloop.entity.input"]) == "hello"
+    assert json.loads(span._attributes["traceloop.entity.output"]) == [0.1, 0.2, 0.3]
+    assert not any(key.startswith("embedding.") for key in span._attributes)
+
+
+def test_invocation_parameters_use_canonical_attributes(translator):
+    span = _make_span(
         {
-            "type": "function",
-            "function": {
-                "name": "Glob",
-                "arguments": '{"pattern":"*.py"}',
-            },
+            "openinference.span.kind": "LLM",
+            "llm.invocation_parameters": json.dumps(
+                {
+                    "model": "claude-sonnet",
+                    "temperature": 0.2,
+                    "stop": ["END"],
+                    "stream": True,
+                }
+            ),
         }
-    ]
-    assert json.loads(span._attributes[RESPAN_SPAN_TOOL_CALLS]) == expected_tool_calls
-    assert span._attributes["gen_ai.completion.0.tool_calls"] == expected_tool_calls
-    assert span._attributes["tool_calls"] == expected_tool_calls
-
-
-def test_mixed_modern_and_legacy_tool_call_fields_deduplicate(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": "Glob",
-        "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments": '{"pattern":"*.py"}',
-        "llm.output_messages.0.message.function_call_name": "Glob",
-        "llm.output_messages.0.message.function_call_arguments_json": '{"pattern":"*.py"}',
-    })
-
+    )
     translator.on_end(span)
 
-    expected_tool_calls = [
+    assert span._attributes["gen_ai.request.model"] == "claude-sonnet"
+    assert span._attributes["gen_ai.request.temperature"] == 0.2
+    assert span._attributes["llm.chat.stop_sequences"] == ("END",)
+    assert span._attributes["llm.is_streaming"] is True
+    assert "llm.invocation_parameters" not in span._attributes
+
+
+def test_sensitive_nested_values_are_redacted_and_output_is_bounded(translator):
+    span = _make_span(
         {
-            "type": "function",
-            "function": {
-                "name": "Glob",
-                "arguments": '{"pattern":"*.py"}',
-            },
+            "openinference.span.kind": "LLM",
+            "input.value": json.dumps(
+                {
+                    "authorization": "Bearer top-secret-token",
+                    "nested": {"api_key": "sk-supersecret123", "prompt": "safe"},
+                    "large": "x" * (MAX_ATTRIBUTE_CHARS * 2),
+                }
+            ),
+            "output.value": "Bearer another-secret-token",
         }
-    ]
-    assert json.loads(span._attributes[RESPAN_SPAN_TOOL_CALLS]) == expected_tool_calls
-    assert span._attributes["gen_ai.completion.0.tool_calls"] == expected_tool_calls
-    assert span._attributes["tool_calls"] == expected_tool_calls
-
-
-def test_input_history_tool_calls_do_not_become_top_level_tool_calls(translator):
-    span = _make_span({
-        "openinference.span.kind": "LLM",
-        "llm.input_messages.0.message.role": "assistant",
-        "llm.input_messages.0.message.tool_calls.0.tool_call.id": "call_history",
-        "llm.input_messages.0.message.tool_calls.0.tool_call.function.name": "lookup_weather",
-        "llm.input_messages.0.message.tool_calls.0.tool_call.function.arguments": '{"city":"Tokyo"}',
-        "llm.output_messages.0.message.role": "assistant",
-        "llm.output_messages.0.message.content": "No tool call in this turn",
-    })
-
+    )
     translator.on_end(span)
 
-    assert RESPAN_SPAN_TOOL_CALLS not in span._attributes
-    assert "tool_calls" not in span._attributes
-    assert span._attributes["gen_ai.prompt.0.tool_calls"] == [
+    entity_input = span._attributes["traceloop.entity.input"]
+    entity_output = span._attributes["traceloop.entity.output"]
+    assert len(entity_input) <= MAX_ATTRIBUTE_CHARS
+    assert len(entity_output) <= MAX_ATTRIBUTE_CHARS
+    assert "top-secret-token" not in entity_input
+    assert "supersecret123" not in entity_input
+    assert "another-secret-token" not in entity_output
+    json.loads(entity_input)
+    json.loads(entity_output)
+
+
+def test_preexisting_canonical_content_is_also_bounded_and_redacted(translator):
+    span = _make_span(
         {
-            "id": "call_history",
-            "function": {
-                "name": "lookup_weather",
-                "arguments": '{"city":"Tokyo"}',
-            },
-            "type": "function",
+            "openinference.span.kind": "LLM",
+            "traceloop.entity.input": json.dumps(
+                {"password": "do-not-export", "body": "x" * 32_000}
+            ),
+            "gen_ai.completion.0.content": "Bearer hidden-credential-value",
+            "tool.description": "raw OpenInference field",
         }
-    ]
+    )
+    translator.on_end(span)
+
+    entity_input = span._attributes["traceloop.entity.input"]
+    assert len(entity_input) <= MAX_ATTRIBUTE_CHARS
+    assert "do-not-export" not in entity_input
+    assert (
+        "hidden-credential-value" not in span._attributes["gen_ai.completion.0.content"]
+    )
+    assert "tool.description" not in span._attributes
+
+
+def test_preexisting_canonical_labels_are_bounded_and_redacted(translator):
+    span = _make_span(
+        {
+            "openinference.span.kind": "LLM",
+            "traceloop.entity.name": (
+                "Bearer entity-name-secret " + ("n" * MAX_LABEL_CHARS * 2)
+            ),
+            "traceloop.entity.path": (
+                "password=cleartext-path-secret " + ("p" * MAX_LABEL_CHARS * 2)
+            ),
+            "traceloop.entity.input": "password=cleartext-body-secret",
+            "gen_ai.request.model": (
+                "sk-model-secret-12345678 " + ("m" * MAX_LABEL_CHARS * 2)
+            ),
+            "gen_ai.prompt.0.role": (
+                "Bearer role-secret-value " + ("r" * MAX_LABEL_CHARS * 2)
+            ),
+        }
+    )
+    translator.on_end(span)
+    attrs = span._attributes
+
+    for key in (
+        "traceloop.entity.name",
+        "traceloop.entity.path",
+        "gen_ai.request.model",
+        "gen_ai.prompt.0.role",
+    ):
+        assert len(attrs[key]) <= MAX_LABEL_CHARS
+        assert "[TRUNCATED]" in attrs[key]
+    exported = json.dumps(attrs, sort_keys=True)
+    for secret in (
+        "entity-name-secret",
+        "cleartext-path-secret",
+        "cleartext-body-secret",
+        "model-secret-12345678",
+        "role-secret-value",
+    ):
+        assert secret not in exported
+    assert json.loads(attrs["traceloop.entity.input"]) == "password=[REDACTED]"
+
+
+def test_serializer_never_calls_arbitrary_stringification(translator):
+    class Explosive:
+        def __str__(self):
+            raise AssertionError("must not stringify arbitrary values")
+
+        def __repr__(self):
+            raise AssertionError("must not repr arbitrary values")
+
+    span = _make_span(
+        {
+            "openinference.span.kind": "CHAIN",
+            "input.value": {"value": Explosive()},
+        }
+    )
+    translator.on_end(span)
+
+    assert json.loads(span._attributes["traceloop.entity.input"]) == {
+        "value": "[UNSUPPORTED:Explosive]"
+    }


### PR DESCRIPTION
## Summary

- repair OpenAI 3.x create/parse, sync/async streaming, tool, usage, response-ID, error, lifecycle, and serialization behavior
- repair OpenAI Agents 0.20 trace/task/turn/agent/chat/tool/handoff/guardrail semantics, lifecycle, streaming, metadata propagation, and privacy
- make OpenInference translation canonical-only, lifecycle-safe, bounded/redacted, and verified through real OTel ReadableSpan/provider chains
- add one patch release intent for all three packages; package versions are intentionally left to the release pipeline

## Validation

- [x] package tests: OpenAI 27/27, OpenAI Agents 20/20, OpenInference 34/34
- [x] all three package Ruff/format checks pass
- [x] all three wheels build and pass isolated install/import/pip checks
- [x] exact marker `otel2-fix-py-group-20-20260817T182331Z`: 47 traces and all 269 displayed record details inspected, with unique IDs, resolved parents, bounded payloads, canonical tools/calls, and no credential leakage
- [x] the complete Agents live suite also passed earlier under `otel2-fix-py-group-20-20260817T174131Z`: 23 traces / 402 inspected records; the replacement marker proves the later metadata compatibility fix on every Agents record

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- current ingestion still projects some native OTel errors as success/200, leaves convenience tool arrays empty, and has provider/stream/token-estimation gaps
- canonical `respan.metadata` is retained; OpenAI Agents also emits the repository-supported bounded flattened compatibility form until ingest merges the aggregate bucket
- shared `Respan.log_batch_results()` task typing, marker indexing, and synthetic-root behavior are recorded as a separate core gap and are not changed here
- the repository credential remains valid, but the final Agents live phase was externally blocked after authentication by missing provider key/managed credits

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/68
