### PR TITLE
fix(instrumentation-py): repair OpenLIT, OpenRouter, and PGVector OTel 2.x spans

### DIFF
--- a/.release-intents/20260818-openlit-openrouter-pgvector-otel2.json
+++ b/.release-intents/20260818-openlit-openrouter-pgvector-otel2.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair OpenLIT, OpenRouter, and PGVector instrumentation for OpenTelemetry 2.x span contracts, lifecycle safety, bounded serialization, and current SDK behavior",
+  "packages": {
+    "respan-instrumentation-openlit": "patch",
+    "respan-instrumentation-openrouter": "patch",
+    "respan-instrumentation-pgvector": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/README.md
@@ -28,16 +28,36 @@ metrics and events disabled, and an offline empty pricing file. OpenLIT therefor
 owns provider/framework patching while Respan owns export. Pass a custom
 `pricing_json` if OpenLIT cost calculation is required.
 
-`capture_content=False` disables OpenLIT message capture and strips any content
-attributes from pre-existing OpenLIT spans before export. `disabled_instrumentors`
-is forwarded to OpenLIT and can be used to exclude selected libraries.
+`capture_content=False` disables OpenLIT message capture, strips content-bearing
+attributes and events, and replaces error status descriptions with a generic
+message before export. OpenLIT events are removed in both modes so provider or
+retry integrations cannot bypass the bounded canonical attributes.
+`max_content_length` bounds redacted OpenAI request content by UTF-8 bytes.
+`disabled_instrumentors` is forwarded to OpenLIT and can exclude selected
+libraries.
+
+Generic HTTP client instrumentors are disabled by default so a provider call
+does not also export nested transport noise. Set `capture_transport_spans=True`
+to opt in. Calls made while multiple adapter instances are active share one
+OpenLIT activation; every instance must use the same configuration and be
+deactivated before the owned patches are removed.
+
+For current OpenAI Chat Completions and Responses calls, the adapter retains
+canonical `gen_ai.provider.name` / `gen_ai.system`, maps request tools to
+`llm.request.functions`, maps current-turn calls to indexed
+`gen_ai.completion.0.tool_calls`, preserves provider HTTP errors, and only
+retains token usage when the OpenAI response actually supplied it. OpenLIT
+spans from other providers retain their native usage because OpenLIT does not
+expose a cross-provider provenance hook that distinguishes provider counts from
+upstream estimates.
 
 For OpenAI sync and async embedding calls, the adapter enriches OpenLIT native
 spans with every returned vector element in canonical `traceloop.entity.output`.
-The enrichment does not wrap provider methods or create another span, and it is
+The corresponding `traceloop.entity.input` contains the raw embedded value(s),
+not a chat-message envelope. The enrichment does not create another span and is
 disabled together with all other payload capture by `capture_content=False`.
 
 Do not also enable a Respan provider instrumentation for the same client in the
 same process unless two nested provider spans are intentional. Deactivation only
-uninstruments OpenLIT instrumentors that this plugin activated; pre-existing
-OpenLIT instrumentation is preserved.
+removes OpenLIT wrappers that this plugin activated; pre-existing and later
+foreign wrappers/processors are preserved.

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_constants.py
@@ -12,10 +12,13 @@ OPENLIT_TOOL_OUTPUT = "gen_ai.tool.output"
 OPENLIT_TOOL_ARGS = "gen_ai.tool.args"
 OPENLIT_WORKFLOW_INPUT = "gen_ai.workflow.input"
 OPENLIT_WORKFLOW_OUTPUT = "gen_ai.workflow.output"
+OPENLIT_PROVIDER_USAGE = "openlit.respan.provider_usage"
 
 OPENLIT_OPERATION_LOG_TYPES = {
     "chat": "chat",
+    "completion": "text",
     "text_completion": "text",
+    "embedding": "embedding",
     "embeddings": "embedding",
     "execute_tool": "tool",
     "invoke_agent": "agent",
@@ -37,6 +40,7 @@ OFF_CONTRACT_ALIASES = {
     "span_tools",
     "has_tool_calls",
     "parallel_tool_calls",
+    "traceloop.span.kind",
     "respan.span.tools",
     "respan.span.tool_calls",
     "respan.span.handoffs",

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_embeddings.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_embeddings.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import importlib
 import json
 import logging
-from collections.abc import Mapping, Sequence
+import math
+from collections.abc import Callable, Mapping, Sequence
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any
 
 from opentelemetry.semconv_ai import SpanAttributes
 
@@ -22,10 +23,17 @@ _OPENAI_EMBEDDING_MODULES = (
 EmbeddingHook = tuple[ModuleType, Callable[..., Any], Callable[..., Any]]
 
 
+def _safe_get(value: Any, name: str, default: Any = None) -> Any:
+    try:
+        if isinstance(value, Mapping):
+            return value.get(name, default)
+        return getattr(value, name, default)
+    except Exception:  # noqa: BLE001 - provider objects may expose descriptors.
+        return default
+
+
 def _response_data(response: Any) -> Sequence[Any]:
-    data = getattr(response, "data", None)
-    if data is None and isinstance(response, Mapping):
-        data = response.get("data")
+    data = _safe_get(response, "data")
     if isinstance(data, Sequence) and not isinstance(data, str | bytes):
         return data
     return ()
@@ -33,58 +41,96 @@ def _response_data(response: Any) -> Sequence[Any]:
 
 def _embedding_vectors(response: Any) -> list[list[Any]]:
     vectors: list[list[Any]] = []
-    for item in _response_data(response):
-        vector = getattr(item, "embedding", None)
-        if vector is None and isinstance(item, Mapping):
-            vector = item.get("embedding")
-        if isinstance(vector, Sequence) and not isinstance(vector, str | bytes):
-            vectors.append(list(vector))
+    try:
+        items = iter(_response_data(response))
+        for item in items:
+            vector = _safe_get(item, "embedding")
+            if not isinstance(vector, Sequence) or isinstance(vector, str | bytes):
+                continue
+            values: list[int | float | None] = []
+            try:
+                for value in vector:
+                    if isinstance(value, bool):
+                        values.append(int(value))
+                    elif isinstance(value, int) or (
+                        isinstance(value, float) and math.isfinite(value)
+                    ):
+                        values.append(value)
+                    else:
+                        values.append(None)
+            except Exception as exc:  # noqa: BLE001 - hostile provider iterator.
+                logger.debug("OpenLIT embedding vector skipped: %s", type(exc).__name__)
+                continue
+            vectors.append(values)
+    except Exception:  # noqa: BLE001 - fail open on hostile response collections.
+        return []
     return vectors
 
 
-def _enrich_embedding_span(*, response: Any, span: Any, capture_content: bool) -> None:
+def _enrich_embedding_span(
+    *,
+    response: Any,
+    span: Any,
+    capture_content: bool,
+) -> None:
     if not capture_content or span is None:
         return
-    vectors = _embedding_vectors(response)
-    if vectors:
-        span.set_attribute(
-            SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-            json.dumps(vectors, separators=(",", ":"), default=str),
-        )
+    try:
+        vectors = _embedding_vectors(response)
+        if vectors:
+            span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                json.dumps(
+                    vectors,
+                    allow_nan=False,
+                    separators=(",", ":"),
+                ),
+            )
+    except Exception as exc:  # noqa: BLE001 - tracing must not break provider calls.
+        logger.debug("OpenLIT embedding enrichment skipped: %s", type(exc).__name__)
 
 
-def install_openai_embedding_hooks(*, capture_content: bool) -> list[EmbeddingHook]:
+def install_openai_embedding_hooks(
+    *,
+    capture_content: bool,
+    max_content_length: int = 16_000,
+) -> list[EmbeddingHook]:
     """Hook OpenLIT response processing without wrapping provider calls."""
 
+    del max_content_length  # Full vectors are required by the span contract.
     hooks: list[EmbeddingHook] = []
-    for module_name in _OPENAI_EMBEDDING_MODULES:
-        try:
-            module = importlib.import_module(module_name)
-        except ImportError:
-            logger.debug("OpenLIT OpenAI module unavailable: %s", module_name)
-            continue
-        original = getattr(module, "process_embedding_response", None)
-        if not callable(original):
-            continue
+    try:
+        for module_name in _OPENAI_EMBEDDING_MODULES:
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError:
+                logger.debug("OpenLIT OpenAI module unavailable: %s", module_name)
+                continue
+            original = getattr(module, "process_embedding_response", None)
+            if not callable(original):
+                continue
 
-        @wraps(original)
-        def process_embedding_response(
-            *args: Any,
-            __original: Callable[..., Any] = original,
-            **kwargs: Any,
-        ) -> Any:
-            result = __original(*args, **kwargs)
-            response = kwargs.get("response", args[0] if args else result)
-            span = kwargs.get("span")
-            _enrich_embedding_span(
-                response=response,
-                span=span,
-                capture_content=capture_content,
-            )
-            return result
+            @wraps(original)
+            def process_embedding_response(
+                *args: Any,
+                __original: Callable[..., Any] = original,
+                **kwargs: Any,
+            ) -> Any:
+                result = __original(*args, **kwargs)
+                response = kwargs.get("response", args[0] if args else result)
+                span = kwargs.get("span")
+                _enrich_embedding_span(
+                    response=response,
+                    span=span,
+                    capture_content=capture_content,
+                )
+                return result
 
-        module.process_embedding_response = process_embedding_response
-        hooks.append((module, original, process_embedding_response))
+            module.process_embedding_response = process_embedding_response
+            hooks.append((module, original, process_embedding_response))
+    except Exception:
+        remove_openai_embedding_hooks(hooks)
+        raise
     return hooks
 
 

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_instrumentation.py
@@ -9,6 +9,7 @@ from importlib.resources import files
 from typing import Any
 
 from opentelemetry import trace
+from respan_tracing.core.tracer import RespanTracer
 
 from respan_instrumentation_openlit._constants import OPENLIT_INSTRUMENTATION_NAME
 from respan_instrumentation_openlit._embeddings import (
@@ -16,8 +17,22 @@ from respan_instrumentation_openlit._embeddings import (
     install_openai_embedding_hooks,
     remove_openai_embedding_hooks,
 )
+from respan_instrumentation_openlit._openai_hooks import (
+    ChunkHook,
+    FactoryHook,
+    OpenAIPatch,
+    RequestHook,
+    capture_openai_patches,
+    install_openai_request_hooks,
+    install_openai_stream_factory_hooks,
+    install_openai_stream_usage_hooks,
+    remove_openai_request_hooks,
+    remove_openai_stream_factory_hooks,
+    remove_openai_stream_usage_hooks,
+    restore_openai_patches,
+    snapshot_openai_resource_methods,
+)
 from respan_instrumentation_openlit._processor import OpenLITSpanProcessor
-from respan_tracing.core.tracer import RespanTracer
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +42,17 @@ _PROCESSOR: OpenLITSpanProcessor | None = None
 _PROVIDER: Any = None
 _OWNED_INSTRUMENTORS: list[Any] = []
 _EMBEDDING_HOOKS: list[EmbeddingHook] = []
+_REQUEST_HOOKS: list[RequestHook] = []
+_STREAM_USAGE_HOOKS: list[ChunkHook] = []
+_OPENAI_PATCHES: list[OpenAIPatch] = []
+_CONFIG: tuple[Any, ...] | None = None
+
+_DEFAULT_DISABLED_TRANSPORT_INSTRUMENTORS = (
+    "httpx",
+    "requests",
+    "urllib",
+    "urllib3",
+)
 
 
 def _is_respan_tracing_enabled() -> bool:
@@ -78,6 +104,52 @@ def _unregister(provider: Any, processor: OpenLITSpanProcessor) -> None:
         )
 
 
+def _uninstrument_owned(instrumentors: list[Any]) -> None:
+    for instrumentor in reversed(instrumentors):
+        uninstrument = getattr(instrumentor, "uninstrument", None)
+        if callable(uninstrument) and _is_instrumented(instrumentor):
+            try:
+                uninstrument()
+            except Exception:
+                logger.exception("Failed to deactivate an OpenLIT instrumentor")
+
+
+def _disabled_instrumentors(
+    configured: list[str], *, capture_transport_spans: bool
+) -> list[str]:
+    result = list(dict.fromkeys(configured))
+    if not capture_transport_spans:
+        result.extend(
+            name
+            for name in _DEFAULT_DISABLED_TRANSPORT_INSTRUMENTORS
+            if name not in result
+        )
+    return result
+
+
+def _init_with_owned_instrumentors(
+    openlit: Any,
+    instrumentors: dict[str, Any],
+    **kwargs: Any,
+) -> None:
+    """Make OpenLIT initialize the exact instances this adapter can unwind."""
+
+    original = getattr(openlit, "get_all_instrumentors", None)
+    if not callable(original):
+        openlit.init(**kwargs)
+        return
+
+    def owned_instrumentors() -> dict[str, Any]:
+        return instrumentors
+
+    openlit.get_all_instrumentors = owned_instrumentors
+    try:
+        openlit.init(**kwargs)
+    finally:
+        if getattr(openlit, "get_all_instrumentors", None) is owned_instrumentors:
+            openlit.get_all_instrumentors = original
+
+
 class OpenLITInstrumentor:
     """Enable OpenLIT once and normalize its native spans for Respan."""
 
@@ -91,19 +163,29 @@ class OpenLITInstrumentor:
         pricing_json: str | None = None,
         disable_metrics: bool = True,
         disable_events: bool = True,
+        capture_transport_spans: bool = False,
+        max_content_length: int = 16_000,
     ) -> None:
+        if not isinstance(max_content_length, int) or not (
+            128 <= max_content_length <= 16_000
+        ):
+            raise ValueError("max_content_length must be between 128 and 16000 bytes")
         self._capture_content = capture_content
         self._disabled_instrumentors = list(disabled_instrumentors or [])
         self._pricing_json = pricing_json
         self._disable_metrics = disable_metrics
         self._disable_events = disable_events
+        self._capture_transport_spans = capture_transport_spans
+        self._max_content_length = max_content_length
         self._is_instrumented = False
 
     def activate(self) -> None:
         """Activate OpenLIT without adding a second exporter or wrapper span."""
-        global _EMBEDDING_HOOKS, _OWNED_INSTRUMENTORS, _PROCESSOR, _PROVIDER, _REFCOUNT
+        global _CONFIG, _EMBEDDING_HOOKS, _OPENAI_PATCHES, _OWNED_INSTRUMENTORS
+        global _PROCESSOR, _PROVIDER, _REFCOUNT, _REQUEST_HOOKS
+        global _STREAM_USAGE_HOOKS
 
-        if self._is_instrumented or not _is_respan_tracing_enabled():
+        if not _is_respan_tracing_enabled():
             return
         try:
             openlit = importlib.import_module("openlit")
@@ -112,50 +194,135 @@ class OpenLITInstrumentor:
             return
 
         with _LOCK:
+            if self._is_instrumented:
+                return
+            pricing_json = self._pricing_json or str(
+                files("respan_instrumentation_openlit").joinpath("_pricing.json")
+            )
+            disabled_instrumentors = _disabled_instrumentors(
+                self._disabled_instrumentors,
+                capture_transport_spans=self._capture_transport_spans,
+            )
+            config = (
+                self._capture_content,
+                tuple(disabled_instrumentors),
+                pricing_json,
+                self._disable_metrics,
+                self._disable_events,
+                self._capture_transport_spans,
+                self._max_content_length,
+            )
+            if _REFCOUNT and _CONFIG != config:
+                raise RuntimeError(
+                    "OpenLIT is already active with a different adapter configuration"
+                )
             if _REFCOUNT == 0:
+                instrumentors = _instrumentors()
+                openai_before = snapshot_openai_resource_methods()
                 before = {
                     name: _is_instrumented(value)
-                    for name, value in _instrumentors().items()
+                    for name, value in instrumentors.items()
                 }
-                pricing_json = self._pricing_json or str(
-                    files("respan_instrumentation_openlit").joinpath("_pricing.json")
-                )
-                openlit.init(
-                    capture_message_content=self._capture_content,
-                    disabled_instrumentors=self._disabled_instrumentors,
-                    disable_metrics=self._disable_metrics,
-                    disable_events=self._disable_events,
-                    pricing_json=pricing_json,
-                )
-                _EMBEDDING_HOOKS = install_openai_embedding_hooks(
-                    capture_content=self._capture_content
-                )
-                _PROVIDER = trace.get_tracer_provider()
-                _PROCESSOR = OpenLITSpanProcessor(capture_content=self._capture_content)
-                _register_first(_PROVIDER, _PROCESSOR)
-                after = _instrumentors()
-                _OWNED_INSTRUMENTORS = [
-                    value
-                    for name, value in after.items()
-                    if _is_instrumented(value) and not before.get(name, False)
-                ]
-            elif _PROCESSOR is not None and (
-                _PROCESSOR.capture_content != self._capture_content
-            ):
-                logger.warning(
-                    "OpenLIT is already active; the first capture_content setting wins"
-                )
+                request_hooks: list[RequestHook] = []
+                factory_hooks: list[FactoryHook] = []
+                openai_patches: list[OpenAIPatch] = []
+                stream_usage_hooks: list[ChunkHook] = []
+                embedding_hooks: list[EmbeddingHook] = []
+                processor: OpenLITSpanProcessor | None = None
+                provider: Any = None
+                owned_instrumentors: list[Any] = []
+                try:
+                    request_hooks = install_openai_request_hooks(
+                        capture_content=self._capture_content,
+                        max_content_length=self._max_content_length,
+                    )
+                    factory_hooks = install_openai_stream_factory_hooks(
+                        max_content_length=self._max_content_length
+                    )
+                    try:
+                        _init_with_owned_instrumentors(
+                            openlit,
+                            instrumentors,
+                            capture_message_content=self._capture_content,
+                            disabled_instrumentors=disabled_instrumentors,
+                            disable_metrics=self._disable_metrics,
+                            disable_events=self._disable_events,
+                            pricing_json=pricing_json,
+                            max_content_length=self._max_content_length,
+                        )
+                    finally:
+                        remove_openai_stream_factory_hooks(factory_hooks)
+                        factory_hooks = []
+                    openai_patches = capture_openai_patches(openai_before)
+                    if (
+                        "openai" in instrumentors
+                        and "openai" not in disabled_instrumentors
+                        and not _is_instrumented(instrumentors["openai"])
+                    ):
+                        raise RuntimeError(
+                            "OpenLIT did not activate its OpenAI instrumentor"
+                        )
+                    after = instrumentors
+                    owned_instrumentors = [
+                        value
+                        for name, value in after.items()
+                        if _is_instrumented(value) and not before.get(name, False)
+                    ]
+                    stream_usage_hooks = install_openai_stream_usage_hooks()
+                    embedding_hooks = install_openai_embedding_hooks(
+                        capture_content=self._capture_content,
+                        max_content_length=self._max_content_length,
+                    )
+                    provider = trace.get_tracer_provider()
+                    processor = OpenLITSpanProcessor(
+                        capture_content=self._capture_content
+                    )
+                    _register_first(provider, processor)
+                except Exception:  # noqa: BLE001 - transactional third-party install.
+                    if not owned_instrumentors:
+                        try:
+                            after = instrumentors
+                            owned_instrumentors = [
+                                value
+                                for name, value in after.items()
+                                if _is_instrumented(value)
+                                and not before.get(name, False)
+                            ]
+                        except Exception:  # noqa: BLE001 - best-effort rollback scan.
+                            owned_instrumentors = []
+                    if processor is not None and provider is not None:
+                        _unregister(provider, processor)
+                    remove_openai_embedding_hooks(embedding_hooks)
+                    remove_openai_stream_usage_hooks(stream_usage_hooks)
+                    remove_openai_stream_factory_hooks(factory_hooks)
+                    if not openai_patches:
+                        openai_patches = capture_openai_patches(openai_before)
+                    _uninstrument_owned(owned_instrumentors)
+                    restore_openai_patches(openai_patches)
+                    remove_openai_request_hooks(request_hooks)
+                    raise RuntimeError("Failed to activate OpenLIT instrumentation")
+
+                _REQUEST_HOOKS = request_hooks
+                _OPENAI_PATCHES = openai_patches
+                _STREAM_USAGE_HOOKS = stream_usage_hooks
+                _EMBEDDING_HOOKS = embedding_hooks
+                _OWNED_INSTRUMENTORS = owned_instrumentors
+                _PROVIDER = provider
+                _PROCESSOR = processor
+                _CONFIG = config
 
             _REFCOUNT += 1
             self._is_instrumented = True
 
     def deactivate(self) -> None:
         """Remove Respan normalization and only OpenLIT hooks owned by this adapter."""
-        global _EMBEDDING_HOOKS, _OWNED_INSTRUMENTORS, _PROCESSOR, _PROVIDER, _REFCOUNT
+        global _CONFIG, _EMBEDDING_HOOKS, _OPENAI_PATCHES, _OWNED_INSTRUMENTORS
+        global _PROCESSOR, _PROVIDER, _REFCOUNT, _REQUEST_HOOKS
+        global _STREAM_USAGE_HOOKS
 
-        if not self._is_instrumented:
-            return
         with _LOCK:
+            if not self._is_instrumented:
+                return
             self._is_instrumented = False
             _REFCOUNT = max(0, _REFCOUNT - 1)
             if _REFCOUNT:
@@ -164,13 +331,14 @@ class OpenLITInstrumentor:
                 _unregister(_PROVIDER, _PROCESSOR)
             remove_openai_embedding_hooks(_EMBEDDING_HOOKS)
             _EMBEDDING_HOOKS = []
-            for instrumentor in reversed(_OWNED_INSTRUMENTORS):
-                uninstrument = getattr(instrumentor, "uninstrument", None)
-                if callable(uninstrument) and _is_instrumented(instrumentor):
-                    try:
-                        uninstrument()
-                    except Exception:
-                        logger.exception("Failed to deactivate an OpenLIT instrumentor")
+            remove_openai_stream_usage_hooks(_STREAM_USAGE_HOOKS)
+            _STREAM_USAGE_HOOKS = []
+            _uninstrument_owned(_OWNED_INSTRUMENTORS)
             _OWNED_INSTRUMENTORS = []
+            restore_openai_patches(_OPENAI_PATCHES)
+            _OPENAI_PATCHES = []
+            remove_openai_request_hooks(_REQUEST_HOOKS)
+            _REQUEST_HOOKS = []
             _PROCESSOR = None
             _PROVIDER = None
+            _CONFIG = None

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_openai_hooks.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_openai_hooks.py
@@ -1,0 +1,781 @@
+"""Small compatibility hooks for data OpenLIT does not retain on its spans.
+
+The hooks run *inside* OpenLIT's OpenAI wrappers.  They do not create spans or
+make provider calls; they only enrich the active OpenLIT span with request data,
+the provider HTTP status, and whether token usage came from the provider.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from collections.abc import Callable, Mapping
+from functools import wraps
+from types import TracebackType
+from typing import Any, Self
+
+from opentelemetry import trace
+from opentelemetry.semconv.attributes.http_attributes import (
+    HTTP_RESPONSE_STATUS_CODE,
+)
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import Status, StatusCode
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from wrapt import FunctionWrapper
+
+from respan_instrumentation_openlit._constants import OPENLIT_PROVIDER_USAGE
+from respan_instrumentation_openlit._processor import (
+    GEN_AI_INPUT_MESSAGES,
+    GEN_AI_OUTPUT_MESSAGES,
+    GEN_AI_TOOL_DEFINITIONS,
+)
+from respan_instrumentation_openlit._serialization import (
+    input_messages,
+    json_string,
+    safe_text,
+    tool_definitions,
+)
+
+RequestHook = tuple[Any, str, Callable[..., Any], Callable[..., Any]]
+ChunkHook = tuple[Any, str, Callable[..., Any], Callable[..., Any]]
+FactoryHook = tuple[Any, str, Callable[..., Any], Callable[..., Any]]
+OpenAIPatch = tuple[Any, str, Any, Any]
+
+_REQUEST_TARGETS = (
+    ("openai.resources.chat.completions", "Completions", "create", False, False),
+    ("openai.resources.chat.completions", "AsyncCompletions", "create", True, False),
+    ("openai.resources.chat.completions", "Completions", "parse", False, False),
+    ("openai.resources.chat.completions", "AsyncCompletions", "parse", True, False),
+    ("openai.resources.responses.responses", "Responses", "create", False, False),
+    (
+        "openai.resources.responses.responses",
+        "AsyncResponses",
+        "create",
+        True,
+        False,
+    ),
+    ("openai.resources.responses.responses", "Responses", "parse", False, False),
+    (
+        "openai.resources.responses.responses",
+        "AsyncResponses",
+        "parse",
+        True,
+        False,
+    ),
+    ("openai.resources.embeddings", "Embeddings", "create", False, True),
+    ("openai.resources.embeddings", "AsyncEmbeddings", "create", True, True),
+)
+
+_OPENLIT_OPENAI_MODULES = (
+    "openlit.instrumentation.openai.openai",
+    "openlit.instrumentation.openai.async_openai",
+)
+
+_STREAM_FACTORY_TARGETS = (
+    ("chat_completions", False),
+    ("async_chat_completions", True),
+    ("responses", False),
+    ("async_responses", True),
+)
+
+
+def _loaded_patch_owners() -> list[Any]:
+    owners: list[Any] = []
+    seen: set[int] = set()
+    for module in tuple(sys.modules.values()):
+        if module is None:
+            continue
+        if id(module) not in seen:
+            seen.add(id(module))
+            owners.append(module)
+        for value in tuple(vars(module).values()):
+            if not isinstance(value, type) or id(value) in seen:
+                continue
+            seen.add(id(value))
+            owners.append(value)
+    return owners
+
+
+def _is_openlit_wrapper(value: Any) -> bool:
+    if not isinstance(value, FunctionWrapper):
+        return False
+    wrapper = _safe_get(value, "_self_wrapper")
+    module_name = _safe_get(wrapper, "__module__", "")
+    return isinstance(module_name, str) and module_name.startswith(
+        "openlit.instrumentation."
+    )
+
+
+def snapshot_openai_resource_methods() -> dict[tuple[Any, str], Any]:
+    """Capture pre-existing wrappers before OpenLIT patches loaded libraries."""
+
+    snapshot: dict[tuple[Any, str], Any] = {}
+    for owner in _loaded_patch_owners():
+        for name, value in tuple(vars(owner).items()):
+            if isinstance(value, FunctionWrapper):
+                snapshot[(owner, name)] = value
+    return snapshot
+
+
+def capture_openai_patches(
+    before: Mapping[tuple[Any, str], Any],
+) -> list[OpenAIPatch]:
+    """Record only the outer wrappers installed by this OpenLIT activation."""
+
+    patches: list[OpenAIPatch] = []
+    for owner in _loaded_patch_owners():
+        for name, current in tuple(vars(owner).items()):
+            if not _is_openlit_wrapper(current):
+                continue
+            baseline = before.get((owner, name))
+            if current is baseline:
+                continue
+            previous = current
+            seen: set[int] = set()
+            while (
+                _is_openlit_wrapper(previous)
+                and previous is not baseline
+                and id(previous) not in seen
+            ):
+                seen.add(id(previous))
+                previous = _safe_get(previous, "__wrapped__")
+            if previous is current or previous is None:
+                continue
+            patches.append((owner, name, previous, current))
+    return patches
+
+
+def restore_openai_patches(patches: list[OpenAIPatch]) -> None:
+    """Restore owned wrappers without overwriting a later foreign patch."""
+
+    for owner, name, previous, installed in reversed(patches):
+        current = vars(owner).get(name)
+        if current is installed:
+            setattr(owner, name, previous)
+            continue
+        seen: set[int] = set()
+        while isinstance(current, FunctionWrapper) and id(current) not in seen:
+            seen.add(id(current))
+            wrapped = _safe_get(current, "__wrapped__")
+            if wrapped is installed:
+                current.__wrapped__ = previous
+                break
+            current = wrapped
+
+
+def _openlit_span() -> Any | None:
+    span = trace.get_current_span()
+    if not getattr(span, "is_recording", lambda: False)():
+        return None
+    scope = getattr(span, "instrumentation_scope", None) or getattr(
+        span, "instrumentation_info", None
+    )
+    scope_name = str(getattr(scope, "name", "") or "")
+    if not scope_name.startswith("openlit.instrumentation.openai"):
+        return None
+    return span
+
+
+def _safe_get(value: Any, name: str, default: Any = None) -> Any:
+    try:
+        if isinstance(value, Mapping):
+            return value.get(name, default)
+        return getattr(value, name, default)
+    except Exception:  # noqa: BLE001 - SDK/user objects may expose descriptors.
+        return default
+
+
+def _has_provider_usage(response: Any) -> bool:
+    usage = _safe_get(response, "usage")
+    if usage is None:
+        return False
+    for name in (
+        "prompt_tokens",
+        "completion_tokens",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+    ):
+        if _safe_get(usage, name) is not None:
+            return True
+    return False
+
+
+def _http_status_code(error: BaseException) -> int | None:
+    response = _safe_get(error, "response")
+    candidates = (_safe_get(error, "status_code"), _safe_get(response, "status_code"))
+    for candidate in candidates:
+        try:
+            code = int(candidate)
+        except (TypeError, ValueError):
+            continue
+        if 100 <= code <= 599:
+            return code
+    return None
+
+
+def _set_request_attributes(
+    span: Any,
+    kwargs: Mapping[str, Any],
+    *,
+    capture_content: bool,
+    max_content_length: int,
+    is_embedding: bool,
+) -> None:
+    if not capture_content:
+        return
+    request_input = kwargs.get("messages")
+    if request_input is None:
+        request_input = kwargs.get("input")
+    if request_input is not None:
+        if is_embedding:
+            span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_INPUT,
+                json_string(request_input, max_bytes=max_content_length),
+            )
+        else:
+            span.set_attribute(
+                GEN_AI_INPUT_MESSAGES,
+                json_string(
+                    input_messages(request_input), max_bytes=max_content_length
+                ),
+            )
+    tools = kwargs.get("tools")
+    if tools:
+        span.set_attribute(
+            GEN_AI_TOOL_DEFINITIONS,
+            json_string(tool_definitions(tools), max_bytes=max_content_length),
+        )
+
+
+def _mark_response(span: Any, response: Any) -> None:
+    span.set_attribute(OPENLIT_PROVIDER_USAGE, _has_provider_usage(response))
+
+
+def _mark_error(span: Any, error: BaseException) -> None:
+    status_code = _http_status_code(error)
+    if status_code is not None:
+        span.set_attribute(HTTP_RESPONSE_STATUS_CODE, status_code)
+    span.set_attribute(OPENLIT_PROVIDER_USAGE, False)
+
+
+def _sync_wrapper(
+    original: Callable[..., Any],
+    *,
+    capture_content: bool,
+    max_content_length: int,
+    is_embedding: bool,
+) -> Callable[..., Any]:
+    @wraps(original)
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        span = _openlit_span()
+        if span is not None:
+            _set_request_attributes(
+                span,
+                kwargs,
+                capture_content=capture_content,
+                max_content_length=max_content_length,
+                is_embedding=is_embedding,
+            )
+        try:
+            result = original(*args, **kwargs)
+        except Exception as exc:
+            if span is not None:
+                _mark_error(span, exc)
+            raise
+        if span is not None:
+            _mark_response(span, result)
+        return result
+
+    return wrapped
+
+
+def _async_wrapper(
+    original: Callable[..., Any],
+    *,
+    capture_content: bool,
+    max_content_length: int,
+    is_embedding: bool,
+) -> Callable[..., Any]:
+    @wraps(original)
+    async def wrapped(*args: Any, **kwargs: Any) -> Any:
+        span = _openlit_span()
+        if span is not None:
+            _set_request_attributes(
+                span,
+                kwargs,
+                capture_content=capture_content,
+                max_content_length=max_content_length,
+                is_embedding=is_embedding,
+            )
+        try:
+            result = await original(*args, **kwargs)
+        except Exception as exc:
+            if span is not None:
+                _mark_error(span, exc)
+            raise
+        if span is not None:
+            _mark_response(span, result)
+        return result
+
+    return wrapped
+
+
+def install_openai_request_hooks(
+    *,
+    capture_content: bool,
+    max_content_length: int,
+) -> list[RequestHook]:
+    """Install hooks before OpenLIT wraps the OpenAI resource methods."""
+
+    hooks: list[RequestHook] = []
+    try:
+        for (
+            module_name,
+            class_name,
+            method_name,
+            is_async,
+            is_embedding,
+        ) in _REQUEST_TARGETS:
+            try:
+                module = importlib.import_module(module_name)
+                owner = getattr(module, class_name)
+                original = getattr(owner, method_name)
+            except (AttributeError, ImportError):
+                continue
+            replacement = (
+                _async_wrapper(
+                    original,
+                    capture_content=capture_content,
+                    max_content_length=max_content_length,
+                    is_embedding=is_embedding,
+                )
+                if is_async
+                else _sync_wrapper(
+                    original,
+                    capture_content=capture_content,
+                    max_content_length=max_content_length,
+                    is_embedding=is_embedding,
+                )
+            )
+            setattr(owner, method_name, replacement)
+            hooks.append((owner, method_name, original, replacement))
+    except Exception:
+        remove_openai_request_hooks(hooks)
+        raise
+    return hooks
+
+
+def remove_openai_request_hooks(hooks: list[RequestHook]) -> None:
+    """Restore only OpenAI methods which still contain this adapter's hook."""
+
+    for owner, method_name, original, replacement in reversed(hooks):
+        current = vars(owner).get(method_name)
+        if current is replacement:
+            setattr(owner, method_name, original)
+            continue
+        seen: set[int] = set()
+        while isinstance(current, FunctionWrapper) and id(current) not in seen:
+            seen.add(id(current))
+            wrapped = _safe_get(current, "__wrapped__")
+            if wrapped is replacement:
+                current.__wrapped__ = original
+                break
+            current = wrapped
+
+
+def _finish_early_stream(
+    scope: Any,
+    *,
+    capture_content: bool,
+    max_content_length: int,
+    error: BaseException | None = None,
+) -> None:
+    """End an OpenLIT stream span that upstream leaves open on early close."""
+
+    span = _safe_get(scope, "_span")
+    is_recording = _safe_get(span, "is_recording")
+    if span is None or not callable(is_recording) or not is_recording():
+        return
+    if capture_content:
+        partial_text = _safe_get(scope, "_llmresponse")
+        if isinstance(partial_text, str) and partial_text:
+            span.set_attribute(
+                GEN_AI_OUTPUT_MESSAGES,
+                json_string(
+                    [
+                        {
+                            "role": "assistant",
+                            "parts": [
+                                {
+                                    "type": "text",
+                                    "content": safe_text(
+                                        partial_text,
+                                        limit=4_000,
+                                    ),
+                                }
+                            ],
+                            "finish_reason": "cancelled",
+                        }
+                    ],
+                    max_bytes=max_content_length,
+                ),
+            )
+    if error is None:
+        span.set_status(Status(StatusCode.OK))
+    else:
+        message = safe_text(type(error).__name__, default="stream cancelled")
+        span.set_attribute(ERROR_MESSAGE_ATTR, message)
+        status_code = _http_status_code(error)
+        if status_code is not None:
+            span.set_attribute(HTTP_RESPONSE_STATUS_CODE, status_code)
+        span.set_status(Status(StatusCode.ERROR, message))
+    span.end()
+
+
+class _SyncStreamProxy:
+    def __init__(
+        self,
+        wrapped: Any,
+        *,
+        capture_content: bool,
+        max_content_length: int = 16_000,
+    ) -> None:
+        self._wrapped = wrapped
+        self._capture_content = capture_content
+        self._max_content_length = max_content_length
+        self._finished = False
+        self._source_closed = False
+
+    def __iter__(self) -> _SyncStreamProxy:
+        return self
+
+    def __next__(self) -> Any:
+        if self._finished:
+            raise StopIteration
+        try:
+            return next(self._wrapped)
+        except StopIteration:
+            self._finished = True
+            raise
+        except Exception as exc:
+            self._close(error=exc)
+            raise
+
+    def __enter__(self) -> Self:
+        enter = _safe_get(self._wrapped, "__enter__")
+        try:
+            if callable(enter):
+                enter()
+        except BaseException as exc:
+            self._close(error=exc)
+            raise
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        suppress = False
+        exit_method = _safe_get(self._wrapped, "__exit__")
+        try:
+            if callable(exit_method):
+                suppress = bool(exit_method(exc_type, exc, traceback))
+                self._source_closed = True
+        except BaseException as exit_error:
+            self._finish(error=exc or exit_error)
+            raise
+        else:
+            self._finish(error=exc if isinstance(exc, BaseException) else None)
+        return suppress
+
+    def _close_source(self) -> None:
+        if self._source_closed:
+            return
+        close = _safe_get(self._wrapped, "close")
+        if callable(close):
+            close()
+        self._source_closed = True
+
+    def _finish(self, *, error: BaseException | None = None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        _finish_early_stream(
+            self._wrapped,
+            capture_content=self._capture_content,
+            max_content_length=self._max_content_length,
+            error=error,
+        )
+
+    def _close(self, *, error: BaseException | None = None) -> None:
+        close_error: BaseException | None = None
+        try:
+            self._close_source()
+        except BaseException as exc:  # noqa: BLE001 - preserve cancellation.
+            close_error = exc
+        finally:
+            self._finish(error=error or close_error)
+        if error is None and close_error is not None:
+            raise close_error
+
+    def close(self) -> None:
+        self._close()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+
+class _AsyncStreamProxy:
+    def __init__(
+        self,
+        wrapped: Any,
+        *,
+        capture_content: bool,
+        max_content_length: int = 16_000,
+    ) -> None:
+        self._wrapped = wrapped
+        self._capture_content = capture_content
+        self._max_content_length = max_content_length
+        self._finished = False
+        self._source_closed = False
+
+    def __aiter__(self) -> _AsyncStreamProxy:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._finished:
+            raise StopAsyncIteration
+        try:
+            return await self._wrapped.__anext__()
+        except StopAsyncIteration:
+            self._finished = True
+            raise
+        except asyncio.CancelledError as exc:
+            await self._close(error=exc)
+            raise
+        except Exception as exc:
+            await self._close(error=exc)
+            raise
+
+    async def __aenter__(self) -> Self:
+        enter = _safe_get(self._wrapped, "__aenter__")
+        try:
+            if callable(enter):
+                await enter()
+        except BaseException as exc:
+            await self._close(error=exc)
+            raise
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        suppress = False
+        exit_method = _safe_get(self._wrapped, "__aexit__")
+        try:
+            if callable(exit_method):
+                suppress = bool(await exit_method(exc_type, exc, traceback))
+                self._source_closed = True
+        except BaseException as exit_error:
+            self._finish(error=exc or exit_error)
+            raise
+        else:
+            self._finish(error=exc if isinstance(exc, BaseException) else None)
+        return suppress
+
+    async def _close_source(self) -> None:
+        if self._source_closed:
+            return
+        close = _safe_get(self._wrapped, "close")
+        if callable(close):
+            result = close()
+            if hasattr(result, "__await__"):
+                await result
+        self._source_closed = True
+
+    def _finish(self, *, error: BaseException | None = None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        _finish_early_stream(
+            self._wrapped,
+            capture_content=self._capture_content,
+            max_content_length=self._max_content_length,
+            error=error,
+        )
+
+    async def _close(self, *, error: BaseException | None = None) -> None:
+        close_error: BaseException | None = None
+        try:
+            await self._close_source()
+        except BaseException as exc:  # noqa: BLE001 - preserve cancellation.
+            close_error = exc
+        finally:
+            self._finish(error=error or close_error)
+        if error is None and close_error is not None:
+            raise close_error
+
+    async def close(self) -> None:
+        await self._close()
+
+    async def aclose(self) -> None:
+        await self._close()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+
+def _factory_capture_content(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> bool:
+    if len(args) > 5:
+        return bool(args[5])
+    return bool(kwargs.get("capture_message_content", False))
+
+
+def _sync_stream_factory(
+    original: Callable[..., Any], *, max_content_length: int
+) -> Callable[..., Any]:
+    @wraps(original)
+    def factory(*factory_args: Any, **factory_kwargs: Any) -> Callable[..., Any]:
+        upstream_wrapper = original(*factory_args, **factory_kwargs)
+        capture_content = _factory_capture_content(factory_args, factory_kwargs)
+
+        @wraps(upstream_wrapper)
+        def wrapper(
+            wrapped: Callable[..., Any],
+            instance: Any,
+            args: tuple[Any, ...],
+            kwargs: dict[str, Any],
+        ) -> Any:
+            result = upstream_wrapper(wrapped, instance, args, kwargs)
+            if kwargs.get("stream") and _safe_get(result, "_span") is not None:
+                return _SyncStreamProxy(
+                    result,
+                    capture_content=capture_content,
+                    max_content_length=max_content_length,
+                )
+            return result
+
+        return wrapper
+
+    return factory
+
+
+def _async_stream_factory(
+    original: Callable[..., Any], *, max_content_length: int
+) -> Callable[..., Any]:
+    @wraps(original)
+    def factory(*factory_args: Any, **factory_kwargs: Any) -> Callable[..., Any]:
+        upstream_wrapper = original(*factory_args, **factory_kwargs)
+        capture_content = _factory_capture_content(factory_args, factory_kwargs)
+
+        @wraps(upstream_wrapper)
+        async def wrapper(
+            wrapped: Callable[..., Any],
+            instance: Any,
+            args: tuple[Any, ...],
+            kwargs: dict[str, Any],
+        ) -> Any:
+            result = await upstream_wrapper(wrapped, instance, args, kwargs)
+            if kwargs.get("stream") and _safe_get(result, "_span") is not None:
+                return _AsyncStreamProxy(
+                    result,
+                    capture_content=capture_content,
+                    max_content_length=max_content_length,
+                )
+            return result
+
+        return wrapper
+
+    return factory
+
+
+def install_openai_stream_factory_hooks(
+    *, max_content_length: int = 16_000
+) -> list[FactoryHook]:
+    """Patch wrapper factories only while OpenLIT constructs its wrappers."""
+
+    try:
+        module = importlib.import_module("openlit.instrumentation.openai")
+    except ImportError:
+        return []
+    hooks: list[FactoryHook] = []
+    try:
+        for name, is_async in _STREAM_FACTORY_TARGETS:
+            original = getattr(module, name, None)
+            if not callable(original):
+                continue
+            replacement = (
+                _async_stream_factory(original, max_content_length=max_content_length)
+                if is_async
+                else _sync_stream_factory(
+                    original, max_content_length=max_content_length
+                )
+            )
+            setattr(module, name, replacement)
+            hooks.append((module, name, original, replacement))
+    except Exception:
+        remove_openai_stream_factory_hooks(hooks)
+        raise
+    return hooks
+
+
+def remove_openai_stream_factory_hooks(hooks: list[FactoryHook]) -> None:
+    """Restore wrapper factories without overwriting later foreign patches."""
+
+    for module, name, original, replacement in reversed(hooks):
+        if getattr(module, name, None) is replacement:
+            setattr(module, name, original)
+
+
+def install_openai_stream_usage_hooks() -> list[ChunkHook]:
+    """Mark streaming usage as provider-supplied when the usage chunk arrives."""
+
+    hooks: list[ChunkHook] = []
+    try:
+        for module_name in _OPENLIT_OPENAI_MODULES:
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError:
+                continue
+
+            for name in ("process_chat_chunk", "process_response_chunk"):
+                original = getattr(module, name, None)
+                if not callable(original):
+                    continue
+
+                @wraps(original)
+                def process_chunk(
+                    scope: Any,
+                    chunk: Any,
+                    *,
+                    __original: Callable[..., Any] = original,
+                ) -> Any:
+                    result = __original(scope, chunk)
+                    response = _safe_get(chunk, "response", chunk)
+                    if _has_provider_usage(response):
+                        span = getattr(scope, "_span", None)
+                        if span is not None:
+                            span.set_attribute(OPENLIT_PROVIDER_USAGE, True)
+                    return result
+
+                setattr(module, name, process_chunk)
+                hooks.append((module, name, original, process_chunk))
+    except Exception:
+        remove_openai_stream_usage_hooks(hooks)
+        raise
+    return hooks
+
+
+def remove_openai_stream_usage_hooks(hooks: list[ChunkHook]) -> None:
+    """Restore only OpenLIT chunk processors still owned by this adapter."""
+
+    for module, name, original, replacement in reversed(hooks):
+        if getattr(module, name, None) is replacement:
+            setattr(module, name, original)

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_processor.py
@@ -7,14 +7,18 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
-from opentelemetry.trace import StatusCode
 from opentelemetry.semconv_ai import LLMRequestTypeValues
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from opentelemetry.trace import Status, StatusCode
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.llm_logging import LogMethodChoices
+from respan_sdk.constants.span_attributes import RESPAN_LOG_METHOD, RESPAN_LOG_TYPE
 
 from respan_instrumentation_openlit._constants import (
     OFF_CONTRACT_ALIASES,
     OPENLIT_INSTRUMENTATION_NAME,
     OPENLIT_OPERATION_LOG_TYPES,
+    OPENLIT_PROVIDER_USAGE,
     OPENLIT_REQUEST_PROVIDER,
     OPENLIT_RESPONSE_TOOL_CALLS,
     OPENLIT_SCOPE_PREFIX,
@@ -27,9 +31,19 @@ from respan_instrumentation_openlit._constants import (
     STANDARD_DB_ATTRIBUTES,
     STANDARD_GEN_AI_ATTRIBUTES,
 )
-from respan_sdk.constants import ERROR_MESSAGE_ATTR
-from respan_sdk.constants.llm_logging import LogMethodChoices
-from respan_sdk.constants.span_attributes import RESPAN_LOG_METHOD, RESPAN_LOG_TYPE
+from respan_instrumentation_openlit._serialization import (
+    MAX_ATTRIBUTE_BYTES,
+    MAX_COLLECTION_ITEMS,
+    MAX_STRING_CHARS,
+    safe_text,
+    safe_url,
+)
+from respan_instrumentation_openlit._serialization import (
+    json_string as _bounded_json_string,
+)
+from respan_instrumentation_openlit._serialization import (
+    json_value as _bounded_json_value,
+)
 
 try:
     from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
@@ -73,6 +87,10 @@ GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = _otel_key(
     "GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS",
     "gen_ai.usage.cache_read.input_tokens",
 )
+GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = _otel_key(
+    "GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS",
+    "gen_ai.usage.cache_creation.input_tokens",
+)
 DB_SYSTEM_NAME = "db.system.name"
 DB_OPERATION_NAME = "db.operation.name"
 DB_QUERY_TEXT = "db.query.text"
@@ -94,30 +112,36 @@ _CACHE_READ_USAGE = getattr(
 
 def _json_value(value: Any) -> Any:
     if isinstance(value, str):
-        try:
-            return json.loads(value)
-        except (json.JSONDecodeError, TypeError):
-            return value
-    return value
+        if len(value.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES:
+            try:
+                return _bounded_json_value(json.loads(value))
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return safe_text(value, limit=MAX_STRING_CHARS)
+    return _bounded_json_value(value)
 
 
 def _json_string(value: Any) -> str:
-    if isinstance(value, str):
-        try:
-            json.loads(value)
-        except (json.JSONDecodeError, TypeError):
-            return json.dumps(value)
-        return value
-    return json.dumps(value, default=str)
+    return _bounded_json_string(_json_value(value))
 
 
 def _sequence(value: Any) -> list[Any]:
     parsed = _json_value(value)
     if isinstance(parsed, list):
-        return parsed
+        return parsed[:MAX_COLLECTION_ITEMS]
     if parsed is None:
         return []
     return [parsed]
+
+
+def _is_truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "on", "true", "yes"}
+    return False
 
 
 def _part_payload(part: Any) -> Any:
@@ -150,13 +174,17 @@ def _message_content(message: Mapping[str, Any]) -> Any:
 def _message_tool_calls(message: Mapping[str, Any]) -> list[dict[str, Any]]:
     direct = _json_value(message.get("tool_calls"))
     if isinstance(direct, list):
-        return [dict(item) for item in direct if isinstance(item, Mapping)]
+        return [
+            dict(item)
+            for item in direct[:MAX_COLLECTION_ITEMS]
+            if isinstance(item, Mapping)
+        ]
 
     calls: list[dict[str, Any]] = []
     parts = message.get("parts")
     if not isinstance(parts, Sequence) or isinstance(parts, str | bytes):
         return calls
-    for part in parts:
+    for part in parts[:MAX_COLLECTION_ITEMS]:
         if not isinstance(part, Mapping) or part.get("type") not in {
             "tool_call",
             "function_call",
@@ -181,7 +209,7 @@ def _set_message_attributes(
     messages: list[Any],
     target_prefix: str,
 ) -> None:
-    for index, raw_message in enumerate(messages):
+    for index, raw_message in enumerate(messages[:MAX_COLLECTION_ITEMS]):
         if isinstance(raw_message, str):
             message: Mapping[str, Any] = {"role": "user", "content": raw_message}
         elif isinstance(raw_message, Mapping):
@@ -192,11 +220,15 @@ def _set_message_attributes(
         role = message.get("role") or (
             "assistant" if target_prefix == _COMPLETION_PREFIX else "user"
         )
-        attrs[f"{target_prefix}{index}.role"] = str(role)
+        attrs[f"{target_prefix}{index}.role"] = safe_text(
+            role, default="user", limit=64
+        )
         content = _message_content(message)
         if content is not None:
             attrs[f"{target_prefix}{index}.content"] = (
-                content if isinstance(content, str) else _json_string(content)
+                safe_text(content, limit=MAX_STRING_CHARS)
+                if isinstance(content, str)
+                else _json_string(content)
             )
         tool_calls = _message_tool_calls(message)
         if tool_calls:
@@ -207,7 +239,18 @@ def _scope_name(span: ReadableSpan) -> str:
     scope = getattr(span, "instrumentation_scope", None) or getattr(
         span, "instrumentation_info", None
     )
-    return str(getattr(scope, "name", "") or "")
+    return safe_text(getattr(scope, "name", ""), limit=256)
+
+
+def _has_parent(span: ReadableSpan) -> bool:
+    parent = getattr(span, "parent", None)
+    if parent is None:
+        return False
+    is_valid = getattr(parent, "is_valid", None)
+    if is_valid is not None:
+        return bool(is_valid)
+    span_id = getattr(parent, "span_id", None)
+    return bool(span_id) if span_id is not None else True
 
 
 def _is_openlit_span(span: ReadableSpan, attrs: Mapping[str, Any]) -> bool:
@@ -223,7 +266,7 @@ def _is_openlit_span(span: ReadableSpan, attrs: Mapping[str, Any]) -> bool:
 
 
 def _operation_log_type(attrs: Mapping[str, Any]) -> str:
-    operation = str(attrs.get(GEN_AI_OPERATION_NAME) or "").lower()
+    operation = safe_text(attrs.get(GEN_AI_OPERATION_NAME), limit=128).lower()
     if attrs.get(DB_SYSTEM_NAME):
         return "task"
     return OPENLIT_OPERATION_LOG_TYPES.get(operation, "task")
@@ -243,8 +286,8 @@ def _entity_name(span: ReadableSpan, attrs: Mapping[str, Any], log_type: str) ->
                 filter(
                     None,
                     [
-                        str(attrs.get(DB_SYSTEM_NAME) or ""),
-                        str(attrs.get(DB_OPERATION_NAME) or ""),
+                        safe_text(attrs.get(DB_SYSTEM_NAME), limit=128),
+                        safe_text(attrs.get(DB_OPERATION_NAME), limit=128),
                     ],
                 )
             ),
@@ -253,8 +296,12 @@ def _entity_name(span: ReadableSpan, attrs: Mapping[str, Any], log_type: str) ->
         candidates = ()
     for candidate in candidates:
         if candidate:
-            return str(candidate)
-    return str(getattr(span, "name", None) or OPENLIT_INSTRUMENTATION_NAME)
+            return safe_text(candidate, default=OPENLIT_INSTRUMENTATION_NAME, limit=256)
+    return safe_text(
+        getattr(span, "name", None),
+        default=OPENLIT_INSTRUMENTATION_NAME,
+        limit=256,
+    )
 
 
 def _set_usage(attrs: dict[str, Any]) -> None:
@@ -280,6 +327,25 @@ def _set_usage(attrs: dict[str, Any]) -> None:
         attrs[_CACHE_READ_USAGE] = cache_read_tokens
 
 
+def _clear_synthetic_usage(attrs: dict[str, Any]) -> None:
+    for key in (
+        GEN_AI_USAGE_INPUT_TOKENS,
+        GEN_AI_USAGE_OUTPUT_TOKENS,
+        GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+        "gen_ai.usage.cache_creation_input_tokens",
+        "gen_ai.usage.cache_read_input_tokens",
+        OPENLIT_USAGE_TOTAL_TOKENS,
+        TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS,
+        TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
+        TLSpanAttributes.LLM_USAGE_TOTAL_TOKENS,
+        _MODERN_INPUT_USAGE,
+        _MODERN_OUTPUT_USAGE,
+        _CACHE_READ_USAGE,
+    ):
+        attrs.pop(key, None)
+
+
 def _strip_content(attrs: dict[str, Any]) -> None:
     for key in (
         GEN_AI_INPUT_MESSAGES,
@@ -288,6 +354,10 @@ def _strip_content(attrs: dict[str, Any]) -> None:
         GEN_AI_TOOL_DEFINITIONS,
         GEN_AI_TOOL_CALL_ARGUMENTS,
         GEN_AI_TOOL_CALL_RESULT,
+        "gen_ai.prompt",
+        "gen_ai.completion",
+        "gen_ai.retrieval.query.text",
+        "gen_ai.retrieval.documents",
         OPENLIT_RESPONSE_TOOL_CALLS,
         OPENLIT_TOOL_ARGS,
         OPENLIT_TOOL_INPUT,
@@ -295,13 +365,21 @@ def _strip_content(attrs: dict[str, Any]) -> None:
         OPENLIT_WORKFLOW_INPUT,
         OPENLIT_WORKFLOW_OUTPUT,
         DB_QUERY_TEXT,
+        "db.query.parameter",
         TLSpanAttributes.LLM_REQUEST_FUNCTIONS,
         TLSpanAttributes.TRACELOOP_ENTITY_INPUT,
         TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
     ):
         attrs.pop(key, None)
     for key in list(attrs):
-        if key.startswith(_PROMPT_PREFIX) or key.startswith(_COMPLETION_PREFIX):
+        if key.startswith(
+            (
+                _PROMPT_PREFIX,
+                _COMPLETION_PREFIX,
+                "gen_ai.retrieval.",
+                "db.query.parameter.",
+            )
+        ):
             attrs.pop(key, None)
 
 
@@ -309,15 +387,31 @@ def _strip_openlit_vendor_attributes(attrs: dict[str, Any]) -> None:
     """Drop OpenLIT-only fields while retaining standard span semantics."""
 
     for key in list(attrs):
-        if key.startswith("openlit."):
-            attrs.pop(key, None)
-        elif (
-            key.startswith("gen_ai.")
-            and key not in STANDARD_GEN_AI_ATTRIBUTES
-            and not key.startswith(("gen_ai.prompt.", "gen_ai.completion."))
+        if (
+            key.startswith("openlit.")
+            or (
+                key.startswith("gen_ai.")
+                and key not in STANDARD_GEN_AI_ATTRIBUTES
+                and not key.startswith(("gen_ai.prompt.", "gen_ai.completion."))
+            )
+            or key.startswith("db.")
+            and key not in STANDARD_DB_ATTRIBUTES
         ):
             attrs.pop(key, None)
-        elif key.startswith("db.") and key not in STANDARD_DB_ATTRIBUTES:
+
+
+def _sanitize_url_attributes(attrs: dict[str, Any]) -> None:
+    for key in list(attrs):
+        normalized = key.lower()
+        if not (
+            normalized in {"http.url", "url.full", "url.original"}
+            or normalized.endswith((".url", "_url", ".base_url", "_base_url"))
+        ):
+            continue
+        sanitized = safe_url(attrs[key])
+        if sanitized:
+            attrs[key] = sanitized
+        else:
             attrs.pop(key, None)
 
 
@@ -338,7 +432,9 @@ def _backend_status_code(attrs: Mapping[str, Any], *, is_error: bool) -> int:
     return 500 if is_error else 200
 
 
-def _set_backend_status(span: ReadableSpan, attrs: dict[str, Any]) -> None:
+def _set_backend_status(
+    span: ReadableSpan, attrs: dict[str, Any], *, capture_content: bool
+) -> None:
     status = getattr(span, "status", None)
     otel_error = getattr(status, "status_code", None) is StatusCode.ERROR
     code = _backend_status_code(attrs, is_error=otel_error)
@@ -356,18 +452,40 @@ def _set_backend_status(span: ReadableSpan, attrs: dict[str, Any]) -> None:
             message = event_attrs.get("exception.message")
             if message:
                 break
-    message = str(message or "OpenLIT operation failed")
-    attrs[ERROR_MESSAGE_ATTR] = message
-    attrs.setdefault(
-        TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-        _json_string(
-            {
-                "status": "error",
-                "error": str(attrs.get("error.type") or "OpenLITError"),
-                "message": message,
-            }
-        ),
+    message = (
+        safe_text(message, default="OpenLIT operation failed", limit=1_024)
+        if capture_content
+        else "OpenLIT operation failed"
     )
+    attrs[ERROR_MESSAGE_ATTR] = message
+    sanitized_status = Status(StatusCode.ERROR, message)
+    if hasattr(span, "_status"):
+        span._status = sanitized_status
+    else:
+        try:
+            span.status = sanitized_status
+        except AttributeError:
+            pass
+    if capture_content:
+        attrs.setdefault(
+            TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+            _json_string(
+                {
+                    "status": "error",
+                    "error": safe_text(
+                        attrs.get("error.type"), default="OpenLITError", limit=256
+                    ),
+                    "message": message,
+                }
+            ),
+        )
+
+
+def _remove_openlit_events(span: ReadableSpan) -> None:
+    events = getattr(span, "_events", None)
+    if events is None:
+        return
+    span._events = ()
 
 
 def translate_openlit_span(span: ReadableSpan, *, capture_content: bool) -> bool:
@@ -389,34 +507,57 @@ def translate_openlit_span(span: ReadableSpan, *, capture_content: bool) -> bool
     attrs[RESPAN_LOG_METHOD] = LogMethodChoices.TRACING_INTEGRATION.value
     attrs[RESPAN_LOG_TYPE] = log_type
     attrs[TLSpanAttributes.TRACELOOP_ENTITY_NAME] = entity_name
-    attrs[TLSpanAttributes.TRACELOOP_ENTITY_PATH] = entity_name
+    attrs[TLSpanAttributes.TRACELOOP_ENTITY_PATH] = (
+        entity_name if _has_parent(span) else ""
+    )
 
     provider = attrs.get(GEN_AI_PROVIDER_NAME) or attrs.pop(
         OPENLIT_REQUEST_PROVIDER, None
     )
     if provider is not None:
-        attrs[TLSpanAttributes.LLM_SYSTEM] = str(provider)
+        attrs[TLSpanAttributes.LLM_SYSTEM] = safe_text(provider, limit=128)
 
-    operation = str(attrs.get(GEN_AI_OPERATION_NAME) or "").lower()
-    if log_type == "chat":
+    if _is_truthy(attrs.get("gen_ai.request.stream")):
+        attrs[TLSpanAttributes.LLM_IS_STREAMING] = True
+
+    operation = safe_text(attrs.get(GEN_AI_OPERATION_NAME), limit=128).lower()
+    if log_type in {"chat", "text"}:
         attrs[TLSpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
-    elif operation in {"text_completion", "completion"}:
-        attrs[TLSpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.COMPLETION.value
     elif operation in {"embeddings", "embedding"}:
         attrs[TLSpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.EMBEDDING.value
 
-    _set_usage(attrs)
+    provider_usage = attrs.pop(OPENLIT_PROVIDER_USAGE, None)
+    if provider_usage is False:
+        _clear_synthetic_usage(attrs)
+    else:
+        _set_usage(attrs)
 
     if capture_content:
         input_messages = _sequence(attrs.get(GEN_AI_INPUT_MESSAGES))
         output_messages = _sequence(attrs.get(GEN_AI_OUTPUT_MESSAGES))
         if input_messages:
-            attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = _json_string(
-                input_messages
-            )
-            _set_message_attributes(
-                attrs, messages=input_messages, target_prefix=_PROMPT_PREFIX
-            )
+            if log_type == "embedding":
+                if TLSpanAttributes.TRACELOOP_ENTITY_INPUT not in attrs:
+                    embedding_input = [
+                        _message_content(message)
+                        if isinstance(message, Mapping)
+                        else message
+                        for message in input_messages
+                    ]
+                    attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = _json_string(
+                        embedding_input
+                    )
+                attrs.pop(GEN_AI_INPUT_MESSAGES, None)
+                for key in list(attrs):
+                    if key.startswith(_PROMPT_PREFIX):
+                        attrs.pop(key, None)
+            else:
+                attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = _json_string(
+                    input_messages
+                )
+                _set_message_attributes(
+                    attrs, messages=input_messages, target_prefix=_PROMPT_PREFIX
+                )
         if output_messages:
             attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _json_string(
                 output_messages
@@ -451,6 +592,9 @@ def translate_openlit_span(span: ReadableSpan, *, capture_content: bool) -> bool
                 attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _json_string(
                     _json_value(tool_output)
                 )
+            for key in list(attrs):
+                if key.startswith("gen_ai.tool."):
+                    attrs.pop(key, None)
         elif log_type == "workflow":
             workflow_input = attrs.get(OPENLIT_WORKFLOW_INPUT)
             workflow_output = attrs.get(OPENLIT_WORKFLOW_OUTPUT)
@@ -469,7 +613,13 @@ def translate_openlit_span(span: ReadableSpan, *, capture_content: bool) -> bool
     else:
         _strip_content(attrs)
 
-    _set_backend_status(span, attrs)
+    for key in list(attrs):
+        if key.startswith("gen_ai.tool."):
+            attrs.pop(key, None)
+
+    _set_backend_status(span, attrs, capture_content=capture_content)
+    _remove_openlit_events(span)
+    _sanitize_url_attributes(attrs)
     for key in OFF_CONTRACT_ALIASES:
         attrs.pop(key, None)
     _strip_openlit_vendor_attributes(attrs)

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/src/respan_instrumentation_openlit/_serialization.py
@@ -1,0 +1,315 @@
+"""Bounded, redacting JSON helpers for OpenLIT request enrichment."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+MAX_ATTRIBUTE_BYTES = 16_000
+MAX_COLLECTION_ITEMS = 50
+MAX_DEPTH = 6
+MAX_STRING_CHARS = 4_000
+REDACTED = "[REDACTED]"
+
+_SENSITIVE_KEYS = {
+    "apikey",
+    "authorization",
+    "authtoken",
+    "clientsecret",
+    "cookie",
+    "credential",
+    "credentials",
+    "password",
+    "passwd",
+    "privatekey",
+    "refreshtoken",
+    "secret",
+    "sessioncookie",
+    "sessiontoken",
+    "token",
+}
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b"),
+)
+_CREDENTIAL_URI = re.compile(r"(?i)\b([a-z][a-z0-9+.-]*://)([^/@\s]+)@")
+_MEMORY_ADDRESS = re.compile(r"(?i)\b0x[0-9a-f]{6,}\b")
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)(?<![a-z0-9])"
+    r"([a-z0-9_-]*(?:api[_-]?key|authorization|password|secret|session[_-]?token|token))"
+    r"(\s*[:=]\s*)([^\s,;]+)"
+)
+
+
+def _redact_text(value: str) -> str:
+    redacted = value
+    redacted = _CREDENTIAL_URI.sub(
+        lambda match: f"{match.group(1)}{REDACTED}@", redacted
+    )
+    redacted = _MEMORY_ADDRESS.sub("<memory-address>", redacted)
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub(REDACTED, redacted)
+    redacted = _SECRET_ASSIGNMENT.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}{REDACTED}", redacted
+    )
+    if len(redacted) <= MAX_STRING_CHARS:
+        return redacted
+    return f"{redacted[:MAX_STRING_CHARS]}...[truncated]"
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    normalized = re.sub(r"[^a-z0-9]", "", key.lower())
+    return normalized in _SENSITIVE_KEYS or normalized.endswith(
+        (
+            "apikey",
+            "credential",
+            "credentials",
+            "password",
+            "passwd",
+            "privatekey",
+            "secret",
+            "secretkey",
+            "token",
+        )
+    )
+
+
+def safe_text(value: Any, *, default: str = "", limit: int = 512) -> str:
+    """Return bounded scalar text without arbitrary ``str``/``repr`` calls."""
+
+    if isinstance(value, str):
+        return _redact_text(value)[:limit]
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return ("true" if value else "false")[:limit]
+    if isinstance(value, int):
+        return str(value)[:limit]
+    if isinstance(value, float) and math.isfinite(value):
+        return str(value)[:limit]
+    return f"<{type(value).__name__}>"[:limit]
+
+
+def safe_url(value: Any, *, limit: int = 2_048) -> str:
+    """Return a bounded URL without credentials, query, or fragment."""
+
+    if not isinstance(value, str):
+        return ""
+    try:
+        parsed = urlsplit(value)
+        if not parsed.scheme or not parsed.netloc or parsed.hostname is None:
+            return safe_text(value.split("?", 1)[0].split("#", 1)[0], limit=limit)
+        host = parsed.hostname
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        netloc = f"{host}:{port}" if port is not None else host
+        sanitized = urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+    except ValueError:
+        sanitized = value.split("?", 1)[0].split("#", 1)[0]
+    return safe_text(sanitized, limit=limit)
+
+
+def _safe_key(key: Any) -> str:
+    if isinstance(key, str):
+        return _redact_text(key)
+    return safe_text(key, default="null", limit=128)
+
+
+def _public_dataclass_fields(value: Any) -> Mapping[str, Any] | None:
+    if not dataclasses.is_dataclass(value) or isinstance(value, type):
+        return None
+    result: dict[str, Any] = {}
+    try:
+        fields = dataclasses.fields(value)
+        for field in fields[:MAX_COLLECTION_ITEMS]:
+            result[field.name] = getattr(value, field.name)
+    except Exception:  # noqa: BLE001 - user dataclasses can expose descriptors.
+        return None
+    return result
+
+
+def json_value(
+    value: Any,
+    *,
+    _depth: int = 0,
+    _seen: set[int] | None = None,
+    _max_items: int = MAX_COLLECTION_ITEMS,
+) -> Any:
+    """Convert to finite JSON data without custom string or dump hooks."""
+
+    if value is None or isinstance(value, bool | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return _redact_text(value)
+    if isinstance(value, bytes | bytearray | memoryview):
+        return f"<{type(value).__name__}:{len(value)} bytes>"
+    if _depth >= MAX_DEPTH:
+        return f"<{type(value).__name__}:max-depth>"
+
+    seen = _seen if _seen is not None else set()
+    object_id = id(value)
+    if object_id in seen:
+        return "<cycle>"
+    seen.add(object_id)
+    try:
+        mapping: Mapping[Any, Any] | None = None
+        sequence: Sequence[Any] | None = None
+        if isinstance(value, Mapping):
+            mapping = value
+        elif isinstance(value, Sequence) and not isinstance(
+            value, str | bytes | bytearray
+        ):
+            sequence = value
+        else:
+            mapping = _public_dataclass_fields(value)
+
+        if mapping is not None:
+            result: dict[str, Any] = {}
+            try:
+                iterator = mapping.items()
+                for index, (key, item) in enumerate(iterator):
+                    if index >= _max_items:
+                        result["__truncated_items__"] = True
+                        break
+                    key_text = _safe_key(key)
+                    result[key_text] = (
+                        REDACTED
+                        if _is_sensitive_key(key)
+                        else json_value(
+                            item,
+                            _depth=_depth + 1,
+                            _seen=seen,
+                            _max_items=_max_items,
+                        )
+                    )
+            except Exception:  # noqa: BLE001 - mappings can have hostile iterators.
+                result["__serialization_error__"] = type(value).__name__
+            return result
+
+        if sequence is not None:
+            try:
+                items = list(islice(iter(sequence), _max_items + 1))
+            except Exception:  # noqa: BLE001 - sequences can have hostile iterators.
+                return f"<{type(value).__name__}:unserializable>"
+            result = [
+                json_value(
+                    item,
+                    _depth=_depth + 1,
+                    _seen=seen,
+                    _max_items=_max_items,
+                )
+                for item in items[:_max_items]
+            ]
+            if len(items) > _max_items:
+                result.append("<truncated:more items>")
+            return result
+
+        return f"<{type(value).__name__}>"
+    except Exception:  # noqa: BLE001 - tracing must not break provider calls.
+        return f"<{type(value).__name__}:unserializable>"
+    finally:
+        seen.discard(object_id)
+
+
+def json_string(
+    value: Any,
+    *,
+    max_bytes: int = MAX_ATTRIBUTE_BYTES,
+    max_collection_items: int = MAX_COLLECTION_ITEMS,
+) -> str:
+    """Return redacted valid JSON capped by an exact UTF-8 byte budget."""
+
+    max_bytes = max(128, min(int(max_bytes), MAX_ATTRIBUTE_BYTES))
+    max_collection_items = max(1, min(int(max_collection_items), 8_192))
+    normalized = json_value(value, _max_items=max_collection_items)
+    encoded = json.dumps(
+        normalized,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    encoded_bytes = len(encoded.encode("utf-8"))
+    if encoded_bytes <= max_bytes:
+        return encoded
+
+    preview = encoded[: max_bytes // 2]
+    while True:
+        bounded = json.dumps(
+            {
+                "original_bytes": encoded_bytes,
+                "preview": preview,
+                "truncated": True,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(bounded.encode("utf-8")) <= max_bytes:
+            return bounded
+        preview = preview[: max(0, len(preview) - 128)]
+
+
+def input_messages(value: Any) -> list[dict[str, Any]]:
+    """Normalize common OpenAI message inputs to finite GenAI messages."""
+
+    normalized = json_value(value)
+    raw_messages = normalized if isinstance(normalized, list) else [normalized]
+    messages: list[dict[str, Any]] = []
+    for item in raw_messages[:MAX_COLLECTION_ITEMS]:
+        if isinstance(item, Mapping):
+            role = safe_text(item.get("role"), default="user", limit=64)
+            if isinstance(item.get("parts"), list):
+                parts = item["parts"][:MAX_COLLECTION_ITEMS]
+            else:
+                content = item.get("content")
+                parts = [{"type": "text", "content": content}]
+            message: dict[str, Any] = {"role": role, "parts": parts}
+            tool_calls = item.get("tool_calls")
+            if tool_calls:
+                message["tool_calls"] = tool_calls
+            messages.append(message)
+        else:
+            messages.append(
+                {"role": "user", "parts": [{"type": "text", "content": item}]}
+            )
+    return messages
+
+
+def tool_definitions(value: Any) -> list[dict[str, Any]]:
+    """Normalize OpenAI function tools to the OTel GenAI definition shape."""
+
+    normalized = json_value(value)
+    raw_tools = normalized if isinstance(normalized, list) else [normalized]
+    definitions: list[dict[str, Any]] = []
+    for item in raw_tools[:MAX_COLLECTION_ITEMS]:
+        if not isinstance(item, Mapping):
+            continue
+        function = item.get("function")
+        source = function if isinstance(function, Mapping) else item
+        name = source.get("name")
+        if not name:
+            continue
+        definition: dict[str, Any] = {
+            "type": safe_text(item.get("type"), default="function", limit=64),
+            "name": safe_text(name, default="unknown", limit=256),
+        }
+        for key in ("description", "parameters"):
+            if source.get(key) is not None:
+                definition[key] = source[key]
+        definitions.append(definition)
+    return definitions

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_backend_status.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_backend_status.py
@@ -1,9 +1,7 @@
-import json
 from types import SimpleNamespace
 
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import Status, StatusCode
-
 from respan_instrumentation_openlit._processor import translate_openlit_span
 
 
@@ -23,12 +21,8 @@ def test_otel_error_sets_backend_visible_status_and_message() -> None:
     )
     translate_openlit_span(span, capture_content=False)
     assert span._attributes["status_code"] == 500
-    assert span._attributes["error.message"] == "openlit provider failed"
-    assert json.loads(span._attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
-        "error": "OpenLITError",
-        "message": "openlit provider failed",
-        "status": "error",
-    }
+    assert span._attributes["error.message"] == "OpenLIT operation failed"
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in span._attributes
 
 
 def test_upstream_http_status_is_preserved() -> None:
@@ -41,8 +35,8 @@ def test_upstream_http_status_is_preserved() -> None:
     )
     translate_openlit_span(span, capture_content=False)
     assert span._attributes["status_code"] == 429
-    assert span._attributes["error.message"] == "rate limited"
-    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT in span._attributes
+    assert span._attributes["error.message"] == "OpenLIT operation failed"
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in span._attributes
 
 
 def test_success_sets_backend_visible_200() -> None:

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_embedding_hooks.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_embedding_hooks.py
@@ -113,3 +113,21 @@ def test_embedding_hooks_restore_only_functions_the_adapter_owns(
 
     assert sync_module.process_embedding_response is sync_original
     assert async_module.process_embedding_response is external_replacement
+
+
+def test_embedding_hook_fails_open_for_hostile_provider_response(monkeypatch) -> None:
+    class HostileResponse:
+        @property
+        def data(self):
+            raise RuntimeError("hostile response descriptor")
+
+    module, _ = _module("sync_openai")
+    monkeypatch.setattr(embeddings, "_OPENAI_EMBEDDING_MODULES", ("sync_openai",))
+    monkeypatch.setattr(embeddings.importlib, "import_module", lambda name: module)
+    hooks = embeddings.install_openai_embedding_hooks(capture_content=True)
+    span = RecordingSpan()
+    response = HostileResponse()
+
+    assert module.process_embedding_response(response=response, span=span) is response
+    assert span.attributes == {}
+    embeddings.remove_openai_embedding_hooks(hooks)

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_hook_lifecycle.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_hook_lifecycle.py
@@ -1,13 +1,17 @@
-from types import SimpleNamespace
+from concurrent.futures import ThreadPoolExecutor
+from types import ModuleType, SimpleNamespace
 
+import pytest
 from respan_instrumentation_openlit import OpenLITInstrumentor
 
 
 def test_embedding_hooks_follow_adapter_reference_count(monkeypatch) -> None:
     import respan_instrumentation_openlit._instrumentation as lifecycle
 
+    foreign_processor = object()
+
     class Active:
-        _span_processors: tuple[object, ...] = ()
+        _span_processors: tuple[object, ...] = (foreign_processor,)
 
     class Provider:
         _active_span_processor = Active()
@@ -18,9 +22,11 @@ def test_embedding_hooks_follow_adapter_reference_count(monkeypatch) -> None:
     removed_hooks: list[list[object]] = []
     hook = object()
 
+    init_kwargs: dict[str, object] = {}
+
     def init(**kwargs) -> None:
         nonlocal init_calls
-        del kwargs
+        init_kwargs.update(kwargs)
         init_calls += 1
 
     original_import_module = lifecycle.importlib.import_module
@@ -31,12 +37,29 @@ def test_embedding_hooks_follow_adapter_reference_count(monkeypatch) -> None:
         return original_import_module(name)
 
     monkeypatch.setattr(lifecycle.importlib, "import_module", import_module)
-    monkeypatch.setattr(lifecycle, "_instrumentors", lambda: {})
+    monkeypatch.setattr(lifecycle, "_instrumentors", dict)
+    monkeypatch.setattr(lifecycle, "snapshot_openai_resource_methods", dict)
+    monkeypatch.setattr(lifecycle, "capture_openai_patches", lambda before: [])
+    monkeypatch.setattr(lifecycle, "restore_openai_patches", lambda patches: None)
+    monkeypatch.setattr(lifecycle, "install_openai_request_hooks", lambda **kwargs: [])
+    monkeypatch.setattr(lifecycle, "remove_openai_request_hooks", lambda hooks: None)
+    monkeypatch.setattr(
+        lifecycle, "install_openai_stream_factory_hooks", lambda **kwargs: []
+    )
+    monkeypatch.setattr(
+        lifecycle, "remove_openai_stream_factory_hooks", lambda hooks: None
+    )
+    monkeypatch.setattr(lifecycle, "install_openai_stream_usage_hooks", list)
+    monkeypatch.setattr(
+        lifecycle, "remove_openai_stream_usage_hooks", lambda hooks: None
+    )
     monkeypatch.setattr(lifecycle.trace, "get_tracer_provider", lambda: provider)
     monkeypatch.setattr(
         lifecycle,
         "install_openai_embedding_hooks",
-        lambda *, capture_content: install_calls.append(capture_content) or [hook],
+        lambda *, capture_content, max_content_length: (
+            install_calls.append(capture_content) or [hook]
+        ),
     )
     monkeypatch.setattr(
         lifecycle,
@@ -48,23 +71,347 @@ def test_embedding_hooks_follow_adapter_reference_count(monkeypatch) -> None:
     monkeypatch.setattr(lifecycle, "_PROVIDER", None)
     monkeypatch.setattr(lifecycle, "_OWNED_INSTRUMENTORS", [])
     monkeypatch.setattr(lifecycle, "_EMBEDDING_HOOKS", [])
+    monkeypatch.setattr(lifecycle, "_REQUEST_HOOKS", [])
+    monkeypatch.setattr(lifecycle, "_STREAM_USAGE_HOOKS", [])
+    monkeypatch.setattr(lifecycle, "_OPENAI_PATCHES", [])
+    monkeypatch.setattr(lifecycle, "_CONFIG", None)
 
     first = OpenLITInstrumentor(capture_content=True)
-    second = OpenLITInstrumentor(capture_content=False)
+    second = OpenLITInstrumentor(capture_content=True)
     first.activate()
     second.activate()
 
     assert init_calls == 1
+    assert init_kwargs["max_content_length"] == 16_000
+    assert set(init_kwargs["disabled_instrumentors"]) >= {
+        "httpx",
+        "requests",
+        "urllib",
+        "urllib3",
+    }
     assert install_calls == [True]
     assert lifecycle._REFCOUNT == 2
-    assert len(provider._active_span_processor._span_processors) == 1
+    assert provider._active_span_processor._span_processors[1:] == (foreign_processor,)
 
     first.deactivate()
     assert lifecycle._REFCOUNT == 1
     assert removed_hooks == []
-    assert len(provider._active_span_processor._span_processors) == 1
+    assert provider._active_span_processor._span_processors[1:] == (foreign_processor,)
 
     second.deactivate()
     assert lifecycle._REFCOUNT == 0
     assert removed_hooks == [[hook]]
-    assert provider._active_span_processor._span_processors == ()
+    assert provider._active_span_processor._span_processors == (foreign_processor,)
+
+
+def test_concurrent_same_instance_activation_is_idempotent(monkeypatch) -> None:
+    import respan_instrumentation_openlit._instrumentation as lifecycle
+
+    class Active:
+        _span_processors: tuple[object, ...] = ()
+
+    class Provider:
+        _active_span_processor = Active()
+
+    init_calls = 0
+
+    def init(**kwargs) -> None:
+        nonlocal init_calls
+        del kwargs
+        init_calls += 1
+
+    original_import_module = lifecycle.importlib.import_module
+    monkeypatch.setattr(
+        lifecycle.importlib,
+        "import_module",
+        lambda name: (
+            SimpleNamespace(init=init)
+            if name == "openlit"
+            else original_import_module(name)
+        ),
+    )
+    monkeypatch.setattr(lifecycle, "_instrumentors", dict)
+    monkeypatch.setattr(lifecycle, "snapshot_openai_resource_methods", dict)
+    monkeypatch.setattr(lifecycle, "capture_openai_patches", lambda before: [])
+    monkeypatch.setattr(lifecycle, "restore_openai_patches", lambda patches: None)
+    monkeypatch.setattr(lifecycle, "install_openai_request_hooks", lambda **kwargs: [])
+    monkeypatch.setattr(lifecycle, "remove_openai_request_hooks", lambda hooks: None)
+    monkeypatch.setattr(
+        lifecycle, "install_openai_stream_factory_hooks", lambda **kwargs: []
+    )
+    monkeypatch.setattr(
+        lifecycle, "remove_openai_stream_factory_hooks", lambda hooks: None
+    )
+    monkeypatch.setattr(lifecycle, "install_openai_stream_usage_hooks", list)
+    monkeypatch.setattr(
+        lifecycle, "remove_openai_stream_usage_hooks", lambda hooks: None
+    )
+    monkeypatch.setattr(
+        lifecycle, "install_openai_embedding_hooks", lambda **kwargs: []
+    )
+    monkeypatch.setattr(lifecycle, "remove_openai_embedding_hooks", lambda hooks: None)
+    monkeypatch.setattr(lifecycle.trace, "get_tracer_provider", lambda: Provider())
+    for name, value in (
+        ("_REFCOUNT", 0),
+        ("_PROCESSOR", None),
+        ("_PROVIDER", None),
+        ("_OWNED_INSTRUMENTORS", []),
+        ("_EMBEDDING_HOOKS", []),
+        ("_REQUEST_HOOKS", []),
+        ("_STREAM_USAGE_HOOKS", []),
+        ("_OPENAI_PATCHES", []),
+        ("_CONFIG", None),
+    ):
+        monkeypatch.setattr(lifecycle, name, value)
+
+    instrumentor = OpenLITInstrumentor()
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(lambda _: instrumentor.activate(), range(32)))
+    assert init_calls == 1
+    assert lifecycle._REFCOUNT == 1
+    instrumentor.deactivate()
+    assert lifecycle._REFCOUNT == 0
+
+    instrumentors = [OpenLITInstrumentor() for _ in range(8)]
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(lambda item: item.activate(), instrumentors))
+    assert init_calls == 2
+    assert lifecycle._REFCOUNT == len(instrumentors)
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(lambda item: item.deactivate(), instrumentors))
+    assert lifecycle._REFCOUNT == 0
+
+
+def test_active_configuration_mismatch_is_rejected(monkeypatch) -> None:
+    import respan_instrumentation_openlit._instrumentation as lifecycle
+
+    class Active:
+        _span_processors: tuple[object, ...] = ()
+
+    class Provider:
+        _active_span_processor = Active()
+
+    original_import_module = lifecycle.importlib.import_module
+    monkeypatch.setattr(
+        lifecycle.importlib,
+        "import_module",
+        lambda name: (
+            SimpleNamespace(init=lambda **kwargs: None)
+            if name == "openlit"
+            else original_import_module(name)
+        ),
+    )
+    monkeypatch.setattr(lifecycle, "_instrumentors", dict)
+    monkeypatch.setattr(lifecycle, "snapshot_openai_resource_methods", dict)
+    monkeypatch.setattr(lifecycle, "capture_openai_patches", lambda before: [])
+    monkeypatch.setattr(lifecycle, "restore_openai_patches", lambda patches: None)
+    monkeypatch.setattr(lifecycle, "install_openai_request_hooks", lambda **kwargs: [])
+    monkeypatch.setattr(lifecycle, "remove_openai_request_hooks", lambda hooks: None)
+    monkeypatch.setattr(
+        lifecycle, "install_openai_stream_factory_hooks", lambda **kwargs: []
+    )
+    monkeypatch.setattr(
+        lifecycle, "remove_openai_stream_factory_hooks", lambda hooks: None
+    )
+    monkeypatch.setattr(lifecycle, "install_openai_stream_usage_hooks", list)
+    monkeypatch.setattr(
+        lifecycle, "remove_openai_stream_usage_hooks", lambda hooks: None
+    )
+    monkeypatch.setattr(
+        lifecycle, "install_openai_embedding_hooks", lambda **kwargs: []
+    )
+    monkeypatch.setattr(lifecycle, "remove_openai_embedding_hooks", lambda hooks: None)
+    monkeypatch.setattr(lifecycle.trace, "get_tracer_provider", lambda: Provider())
+    for name, value in (
+        ("_REFCOUNT", 0),
+        ("_PROCESSOR", None),
+        ("_PROVIDER", None),
+        ("_OWNED_INSTRUMENTORS", []),
+        ("_EMBEDDING_HOOKS", []),
+        ("_REQUEST_HOOKS", []),
+        ("_STREAM_USAGE_HOOKS", []),
+        ("_OPENAI_PATCHES", []),
+        ("_CONFIG", None),
+    ):
+        monkeypatch.setattr(lifecycle, name, value)
+
+    first = OpenLITInstrumentor(capture_content=True)
+    first.activate()
+    second = OpenLITInstrumentor(capture_content=False)
+    with pytest.raises(RuntimeError, match="different adapter configuration"):
+        second.activate()
+    assert lifecycle._REFCOUNT == 1
+    assert not second._is_instrumented
+    first.deactivate()
+    assert lifecycle._REFCOUNT == 0
+
+
+def test_partial_activation_rolls_back_and_raises(monkeypatch) -> None:
+    import respan_instrumentation_openlit._instrumentation as lifecycle
+
+    class Upstream:
+        _is_instrumented_by_opentelemetry = False
+        uninstrument_calls = 0
+
+        def uninstrument(self) -> None:
+            self._is_instrumented_by_opentelemetry = False
+            self.uninstrument_calls += 1
+
+    upstream = Upstream()
+    request_hook = object()
+    factory_hook = object()
+    restored: list[str] = []
+
+    def init(**kwargs) -> None:
+        del kwargs
+        upstream._is_instrumented_by_opentelemetry = True
+        raise ValueError("partial OpenLIT install")
+
+    original_import_module = lifecycle.importlib.import_module
+    monkeypatch.setattr(
+        lifecycle.importlib,
+        "import_module",
+        lambda name: (
+            SimpleNamespace(init=init)
+            if name == "openlit"
+            else original_import_module(name)
+        ),
+    )
+    monkeypatch.setattr(lifecycle, "_instrumentors", lambda: {"openai": upstream})
+    monkeypatch.setattr(lifecycle, "snapshot_openai_resource_methods", dict)
+    monkeypatch.setattr(lifecycle, "capture_openai_patches", lambda before: [])
+    monkeypatch.setattr(
+        lifecycle,
+        "restore_openai_patches",
+        lambda patches: restored.append("patches"),
+    )
+    monkeypatch.setattr(
+        lifecycle, "install_openai_request_hooks", lambda **kwargs: [request_hook]
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "remove_openai_request_hooks",
+        lambda hooks: restored.append("request") if hooks == [request_hook] else None,
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "install_openai_stream_factory_hooks",
+        lambda **kwargs: [factory_hook],
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "remove_openai_stream_factory_hooks",
+        lambda hooks: restored.append("factory") if hooks == [factory_hook] else None,
+    )
+    monkeypatch.setattr(lifecycle, "install_openai_stream_usage_hooks", list)
+    monkeypatch.setattr(
+        lifecycle, "remove_openai_stream_usage_hooks", lambda hooks: None
+    )
+    monkeypatch.setattr(
+        lifecycle, "install_openai_embedding_hooks", lambda **kwargs: []
+    )
+    monkeypatch.setattr(lifecycle, "remove_openai_embedding_hooks", lambda hooks: None)
+    for name, value in (
+        ("_REFCOUNT", 0),
+        ("_PROCESSOR", None),
+        ("_PROVIDER", None),
+        ("_OWNED_INSTRUMENTORS", []),
+        ("_EMBEDDING_HOOKS", []),
+        ("_REQUEST_HOOKS", []),
+        ("_STREAM_USAGE_HOOKS", []),
+        ("_OPENAI_PATCHES", []),
+        ("_CONFIG", None),
+    ):
+        monkeypatch.setattr(lifecycle, name, value)
+
+    instrumentor = OpenLITInstrumentor()
+    with pytest.raises(RuntimeError, match="Failed to activate OpenLIT"):
+        instrumentor.activate()
+    assert upstream.uninstrument_calls == 1
+    assert "factory" in restored
+    assert "patches" in restored
+    assert "request" in restored
+    assert lifecycle._REFCOUNT == 0
+    assert lifecycle._CONFIG is None
+    assert not instrumentor._is_instrumented
+
+
+def test_restore_openai_patches_preserves_later_foreign_patch() -> None:
+    from respan_instrumentation_openlit._openai_hooks import (
+        remove_openai_request_hooks,
+        restore_openai_patches,
+    )
+    from wrapt import FunctionWrapper
+
+    def original(self):
+        return self
+
+    def installed(self):
+        return self
+
+    def foreign(self):
+        return self
+
+    class Resource:
+        method = installed
+
+    foreign_wrapper = FunctionWrapper(
+        installed, lambda wrapped, _, args, kwargs: wrapped(*args, **kwargs)
+    )
+    Resource.method = foreign_wrapper
+    restore_openai_patches([(Resource, "method", original, installed)])
+    assert vars(Resource)["method"] is foreign_wrapper
+    assert vars(Resource)["method"].__wrapped__ is original
+
+    Resource.method = FunctionWrapper(
+        installed,
+        lambda wrapped, _, args, kwargs: wrapped(*args, **kwargs),
+    )
+    request_hook = installed
+    remove_openai_request_hooks([(Resource, "method", original, request_hook)])
+    assert isinstance(vars(Resource)["method"], FunctionWrapper)
+    assert vars(Resource)["method"].__wrapped__ is original
+
+
+def test_request_hook_partial_install_is_transactional(monkeypatch) -> None:
+    import respan_instrumentation_openlit._openai_hooks as hooks
+
+    def first_create(self):
+        return self
+
+    def second_create(self):
+        return self
+
+    class First:
+        create = first_create
+
+    class RejectCreate(type):
+        def __setattr__(cls, name, value):
+            if name == "create":
+                raise RuntimeError("reject partial hook")
+            return super().__setattr__(name, value)
+
+    class Second(metaclass=RejectCreate):
+        create = second_create
+
+    first_module = ModuleType("first_resource")
+    first_module.First = First
+    second_module = ModuleType("second_resource")
+    second_module.Second = Second
+    modules = {"first_resource": first_module, "second_resource": second_module}
+    monkeypatch.setattr(
+        hooks,
+        "_REQUEST_TARGETS",
+        (
+            ("first_resource", "First", "create", False, False),
+            ("second_resource", "Second", "create", False, False),
+        ),
+    )
+    monkeypatch.setattr(hooks.importlib, "import_module", lambda name: modules[name])
+
+    with pytest.raises(RuntimeError, match="reject partial hook"):
+        hooks.install_openai_request_hooks(
+            capture_content=True,
+            max_content_length=1_024,
+        )
+    assert vars(First)["create"] is first_create

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_openlit_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_openlit_instrumentation.py
@@ -4,7 +4,7 @@ import json
 from types import SimpleNamespace
 
 from opentelemetry.semconv_ai import SpanAttributes
-
+from opentelemetry.trace import Status, StatusCode
 from respan_instrumentation_openlit import OpenLITInstrumentor
 from respan_instrumentation_openlit._processor import translate_openlit_span
 from respan_sdk.constants.span_attributes import RESPAN_LOG_METHOD, RESPAN_LOG_TYPE
@@ -17,6 +17,20 @@ class FakeSpan:
         self._attributes = attributes
         self.name = name
         self.instrumentation_scope = SimpleNamespace(name="openlit")
+        self._status = Status(StatusCode.UNSET)
+        self._events: tuple[object, ...] = ()
+
+    @property
+    def status(self) -> Status:
+        return self._status
+
+    @status.setter
+    def status(self, value: Status) -> None:
+        self._status = value
+
+    @property
+    def events(self) -> tuple[object, ...]:
+        return self._events
 
 
 def test_chat_span_is_normalized_to_canonical_contract() -> None:
@@ -25,6 +39,7 @@ def test_chat_span_is_normalized_to_canonical_contract() -> None:
             "gen_ai.operation.name": "chat",
             "gen_ai.provider.name": "openai",
             "gen_ai.request.model": "gpt-4.1-mini",
+            "gen_ai.request.stream": "true",
             "gen_ai.input.messages": json.dumps([{"role": "user", "content": "hello"}]),
             "gen_ai.output.messages": json.dumps(
                 [{"role": "assistant", "content": "hi"}]
@@ -37,6 +52,7 @@ def test_chat_span_is_normalized_to_canonical_contract() -> None:
             "gen_ai.usage.total_tokens": 6,
             "model": "forbidden-alias",
             "tool_calls": "forbidden-alias",
+            "traceloop.span.kind": "llm",
         }
     )
 
@@ -44,7 +60,9 @@ def test_chat_span_is_normalized_to_canonical_contract() -> None:
     attrs = span._attributes
     assert attrs[RESPAN_LOG_TYPE] == "chat"
     assert attrs[RESPAN_LOG_METHOD] == "tracing_integration"
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
     assert attrs[SpanAttributes.LLM_SYSTEM] == "openai"
+    assert attrs[SpanAttributes.LLM_IS_STREAMING] is True
     assert attrs[f"{SpanAttributes.LLM_PROMPTS}.0.role"] == "user"
     assert attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"] == "hello"
     assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "hi"
@@ -58,6 +76,7 @@ def test_chat_span_is_normalized_to_canonical_contract() -> None:
     assert "traceloop.span.kind" not in attrs
     assert "model" not in attrs
     assert "tool_calls" not in attrs
+    assert not any(key.startswith("gen_ai.tool.") for key in attrs)
 
 
 def test_tool_span_uses_entity_input_and_output() -> None:
@@ -80,6 +99,7 @@ def test_tool_span_uses_entity_input_and_output() -> None:
         "temperature": 18
     }
     assert not any(key.endswith("tool_calls") for key in attrs)
+    assert not any(key.startswith("gen_ai.tool.") for key in attrs)
 
 
 def test_capture_content_false_removes_sensitive_payloads_but_keeps_usage() -> None:
@@ -99,6 +119,96 @@ def test_capture_content_false_removes_sensitive_payloads_but_keeps_usage() -> N
     assert "secret" not in json.dumps(attrs)
     assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 11
     assert RESPAN_LOG_TYPE in attrs
+
+
+def test_capture_content_false_strips_all_content_and_exception_events() -> None:
+    secret = "privacy-sentinel-openlit"
+    span = FakeSpan(
+        {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.prompt": secret,
+            "gen_ai.completion": secret,
+            "gen_ai.prompt.42.content": secret,
+            "gen_ai.completion.42.content": secret,
+            "gen_ai.retrieval.query.text": secret,
+            "gen_ai.retrieval.documents": secret,
+            "db.query.text": secret,
+            "db.query.parameter": secret,
+            "db.query.parameter.42": secret,
+        }
+    )
+    span.status = Status(StatusCode.ERROR, f"password={secret}")
+    span._events = (
+        SimpleNamespace(
+            name="exception",
+            attributes={
+                "exception.message": f"postgresql://user:{secret}@db/private",
+                "exception.stacktrace": f"Bearer {secret}",
+            },
+        ),
+        SimpleNamespace(name="kept", attributes={"safe": True}),
+        SimpleNamespace(name="prompt", attributes={"content": secret}),
+    )
+
+    translate_openlit_span(span, capture_content=False)
+
+    assert secret not in json.dumps(span._attributes)
+    assert span._attributes["error.message"] == "OpenLIT operation failed"
+    assert span.events == ()
+    assert secret not in (span.status.description or "")
+    assert span.status.description == "OpenLIT operation failed"
+
+
+def test_url_attributes_remove_credentials_query_and_fragment_in_both_modes() -> None:
+    for capture_content in (True, False):
+        span = FakeSpan(
+            {
+                "gen_ai.operation.name": "chat",
+                "url.full": (
+                    "https://user:plain-password@host.example/v1/models"
+                    "?api_key=plain-secret#private-fragment"
+                ),
+                "client.base_url": (
+                    "https://tenant:tenant-secret@api.example/v1?token=plain-token"
+                ),
+                "server.address": "host.example",
+            }
+        )
+
+        translate_openlit_span(span, capture_content=capture_content)
+
+        assert span._attributes["url.full"] == ("https://host.example/v1/models")
+        assert span._attributes["client.base_url"] == "https://api.example/v1"
+        assert span._attributes["server.address"] == "host.example"
+        serialized = json.dumps(span._attributes)
+        assert "plain-password" not in serialized
+        assert "plain-secret" not in serialized
+        assert "private-fragment" not in serialized
+        assert "tenant-secret" not in serialized
+        assert "plain-token" not in serialized
+
+
+def test_singular_operations_and_native_non_openai_usage_are_preserved() -> None:
+    embedding = FakeSpan(
+        {
+            "gen_ai.operation.name": "embedding",
+            "gen_ai.provider.name": "anthropic",
+            "gen_ai.usage.input_tokens": 9,
+            "gen_ai.usage.output_tokens": 0,
+        }
+    )
+    embedding.instrumentation_scope = SimpleNamespace(
+        name="openlit.instrumentation.anthropic"
+    )
+    translate_openlit_span(embedding, capture_content=True)
+    assert embedding._attributes[RESPAN_LOG_TYPE] == "embedding"
+    assert embedding._attributes[SpanAttributes.LLM_REQUEST_TYPE] == "embedding"
+    assert embedding._attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 9
+
+    completion = FakeSpan({"gen_ai.operation.name": "completion"})
+    translate_openlit_span(completion, capture_content=True)
+    assert completion._attributes[RESPAN_LOG_TYPE] == "text"
+    assert completion._attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
 
 
 def test_non_openlit_span_is_ignored() -> None:

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_real_openlit_openai.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_real_openlit_openai.py
@@ -1,0 +1,808 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import pytest
+from anthropic import Anthropic
+from openai import AsyncOpenAI, OpenAI, RateLimitError
+from openai.resources.chat.completions import Completions
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import StatusCode
+from respan_instrumentation_openlit import OpenLITInstrumentor
+from respan_instrumentation_openlit._constants import OFF_CONTRACT_ALIASES
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from wrapt import FunctionWrapper
+
+_MODEL = "gpt-4.1-mini"
+_TOOL_NAME = "lookup_weather"
+_PRIVATE_INPUT = "openlit-private-input-do-not-export"
+_PRIVATE_OUTPUT = "openlit-private-output-do-not-export"
+
+
+def _chat_response(
+    *,
+    content: str | None,
+    prompt_tokens: int | None,
+    completion_tokens: int | None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    message: dict[str, Any] = {"role": "assistant", "content": content}
+    finish_reason = "stop"
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+        finish_reason = "tool_calls"
+    response: dict[str, Any] = {
+        "id": f"chatcmpl-openlit-{time.time_ns()}",
+        "object": "chat.completion",
+        "created": 1_700_000_000,
+        "model": _MODEL,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+    if prompt_tokens is not None and completion_tokens is not None:
+        response["usage"] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+    return response
+
+
+def _responses_response(
+    prompt: str,
+    *,
+    status: str = "completed",
+    include_usage: bool = True,
+) -> dict[str, Any]:
+    text = f"Responses API: {prompt}"
+    response: dict[str, Any] = {
+        "id": f"resp-openlit-{time.time_ns()}",
+        "object": "response",
+        "created_at": 1_700_000_000.0,
+        "model": _MODEL,
+        "output": (
+            [
+                {
+                    "id": "msg_openlit_response",
+                    "type": "message",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": text,
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ]
+            if status == "completed"
+            else []
+        ),
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
+        "status": status,
+    }
+    if include_usage:
+        response["usage"] = {
+            "input_tokens": 6,
+            "input_tokens_details": {
+                "cached_tokens": 0,
+                "cache_write_tokens": 0,
+            },
+            "output_tokens": 4,
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "total_tokens": 10,
+        }
+    return response
+
+
+class _OpenAIHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format: str, *args: Any) -> None:
+        del format, args
+
+    def _request(self) -> dict[str, Any]:
+        length = int(self.headers.get("content-length", "0") or "0")
+        return json.loads(self.rfile.read(length)) if length else {}
+
+    def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_stream(self) -> None:
+        chunks = [
+            {
+                "id": "chatcmpl-openlit-stream",
+                "object": "chat.completion.chunk",
+                "created": 1_700_000_000,
+                "model": _MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "OpenLIT "},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl-openlit-stream",
+                "object": "chat.completion.chunk",
+                "created": 1_700_000_000,
+                "model": _MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "stream works."},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl-openlit-stream",
+                "object": "chat.completion.chunk",
+                "created": 1_700_000_000,
+                "model": _MODEL,
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 11,
+                    "total_tokens": 18,
+                },
+            },
+        ]
+        body = (
+            "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+            + "data: [DONE]\n\n"
+        )
+        encoded = body.encode()
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _send_responses_stream(self, prompt: str) -> None:
+        created = {
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": _responses_response(
+                prompt, status="in_progress", include_usage=False
+            ),
+        }
+        delta = {
+            "type": "response.output_text.delta",
+            "sequence_number": 1,
+            "item_id": "msg_openlit_response",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": f"Responses API: {prompt}",
+            "logprobs": [],
+        }
+        completed = {
+            "type": "response.completed",
+            "sequence_number": 2,
+            "response": _responses_response(prompt),
+        }
+        body = (
+            "".join(
+                f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+                for event in (created, delta, completed)
+            )
+            + "data: [DONE]\n\n"
+        )
+        encoded = body.encode()
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_POST(self) -> None:
+        request = self._request()
+        if self.path.endswith("/messages"):
+            messages = request.get("messages") or []
+            prompt = str(messages[0].get("content") if messages else "")
+            self._send_json(
+                200,
+                {
+                    "id": f"msg-openlit-{time.time_ns()}",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "content": [{"type": "text", "text": f"Anthropic API: {prompt}"}],
+                    "stop_reason": "end_turn",
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 5, "output_tokens": 3},
+                },
+            )
+            return
+        if self.path.endswith("/responses"):
+            prompt = str(request.get("input") or "")
+            if request.get("stream"):
+                self._send_responses_stream(prompt)
+            else:
+                self._send_json(200, _responses_response(prompt))
+            return
+        if self.path.endswith("/embeddings"):
+            self._send_json(
+                200,
+                {
+                    "object": "list",
+                    "model": _MODEL,
+                    "data": [
+                        {
+                            "object": "embedding",
+                            "index": 0,
+                            "embedding": [0.1, 0.2, 0.3],
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 4, "total_tokens": 4},
+                },
+            )
+            return
+        if not self.path.endswith("/chat/completions"):
+            self._send_json(404, {"error": {"message": "not found"}})
+            return
+        messages = request.get("messages") or []
+        prompt = str(messages[0].get("content") if messages else "")
+        if prompt == "rate-limit":
+            self._send_json(
+                429,
+                {
+                    "error": {
+                        "message": "deterministic rate limit",
+                        "type": "rate_limit_error",
+                    }
+                },
+            )
+            return
+        if request.get("stream"):
+            self._send_stream()
+            return
+        if prompt == "tool":
+            self._send_json(
+                200,
+                _chat_response(
+                    content=None,
+                    prompt_tokens=12,
+                    completion_tokens=7,
+                    tool_calls=[
+                        {
+                            "id": "call_openlit_weather",
+                            "type": "function",
+                            "function": {
+                                "name": _TOOL_NAME,
+                                "arguments": json.dumps({"city": "Tokyo"}),
+                            },
+                        }
+                    ],
+                ),
+            )
+            return
+        if prompt == "without-provider-usage":
+            self._send_json(
+                200,
+                _chat_response(
+                    content="No provider usage was returned.",
+                    prompt_tokens=None,
+                    completion_tokens=None,
+                ),
+            )
+            return
+        if prompt == _PRIVATE_INPUT:
+            content, prompt_tokens, completion_tokens = _PRIVATE_OUTPUT, 3, 2
+        else:
+            content, prompt_tokens, completion_tokens = "Async OpenLIT works.", 5, 3
+        self._send_json(
+            200,
+            _chat_response(
+                content=content,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            ),
+        )
+
+
+def _tool_definition(secret: bool = False) -> list[dict[str, Any]]:
+    description = _PRIVATE_INPUT if secret else "Look up weather for a city"
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": _TOOL_NAME,
+                "description": description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+
+def _scope_name(span: Any) -> str:
+    return str(getattr(span.instrumentation_scope, "name", "") or "")
+
+
+def _chat_with_prompt(spans: list[Any], prompt: str) -> Any:
+    for span in spans:
+        attrs = span.attributes
+        if attrs.get(f"{SpanAttributes.LLM_PROMPTS}.0.content") == prompt:
+            return span
+    raise AssertionError(f"missing OpenLIT chat span for {prompt!r}")
+
+
+def _assert_no_aliases(attrs: dict[str, Any]) -> None:
+    assert OFF_CONTRACT_ALIASES.isdisjoint(attrs)
+
+
+def test_real_current_openlit_openai_export_contract_and_privacy(
+    monkeypatch,
+) -> None:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OpenAIHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    base_url = f"http://127.0.0.1:{server.server_port}/v1"
+
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    instrumentor = OpenLITInstrumentor(max_content_length=4_096)
+    client = OpenAI(
+        api_key="local-openlit-key",
+        base_url=base_url,
+        max_retries=0,
+        timeout=3,
+    )
+    anthropic_client = Anthropic(
+        api_key="local-anthropic-key",
+        base_url=base_url,
+        max_retries=0,
+        timeout=3,
+    )
+    foreign_calls = 0
+    foreign_wrapper = None
+
+    async def run_async_chat() -> None:
+        async with AsyncOpenAI(
+            api_key="local-openlit-key",
+            base_url=base_url,
+            max_retries=0,
+            timeout=3,
+        ) as async_client:
+            await async_client.chat.completions.create(
+                model=_MODEL,
+                messages=[{"role": "user", "content": "async"}],
+            )
+            cancelled_stream = await async_client.chat.completions.create(
+                model=_MODEL,
+                messages=[{"role": "user", "content": "async-cancel"}],
+                stream=True,
+                stream_options={"include_usage": True},
+            )
+            first_chunk = await cancelled_stream.__anext__()
+            assert first_chunk.choices[0].delta.content == "OpenLIT "
+            source_response = cancelled_stream.response
+            await cancelled_stream.close()
+            await cancelled_stream.close()
+            assert source_response.is_closed
+            response = await async_client.responses.create(
+                model=_MODEL,
+                input="responses-async",
+            )
+            assert response.output_text == "Responses API: responses-async"
+            response_stream = await async_client.responses.create(
+                model=_MODEL,
+                input="responses-async-stream",
+                stream=True,
+            )
+            response_text = ""
+            async for event in response_stream:
+                if event.type == "response.output_text.delta":
+                    response_text += event.delta
+            assert response_text == "Responses API: responses-async-stream"
+            early_response_stream = await async_client.responses.create(
+                model=_MODEL,
+                input="responses-async-early",
+                stream=True,
+            )
+            first_event = await early_response_stream.__anext__()
+            assert first_event.type == "response.created"
+            source_response = early_response_stream.response
+            await early_response_stream.close()
+            await early_response_stream.close()
+            assert source_response.is_closed
+
+    try:
+        instrumentor.activate()
+        client.chat.completions.create(
+            model=_MODEL,
+            messages=[{"role": "user", "content": "tool"}],
+            tools=_tool_definition(),
+            tool_choice={"type": "function", "function": {"name": _TOOL_NAME}},
+        )
+        stream = client.chat.completions.create(
+            model=_MODEL,
+            messages=[{"role": "user", "content": "stream"}],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        assert (
+            "".join(
+                chunk.choices[0].delta.content or ""
+                for chunk in stream
+                if chunk.choices
+            )
+            == "OpenLIT stream works."
+        )
+        early_stream = client.chat.completions.create(
+            model=_MODEL,
+            messages=[{"role": "user", "content": "early-close"}],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        assert next(early_stream).choices[0].delta.content == "OpenLIT "
+        source_response = early_stream.response
+        early_stream.close()
+        early_stream.close()
+        assert source_response.is_closed
+        response = client.responses.create(
+            model=_MODEL,
+            input="responses-sync",
+        )
+        assert response.output_text == "Responses API: responses-sync"
+        response_stream = client.responses.create(
+            model=_MODEL,
+            input="responses-sync-stream",
+            stream=True,
+        )
+        assert (
+            "".join(
+                event.delta
+                for event in response_stream
+                if event.type == "response.output_text.delta"
+            )
+            == "Responses API: responses-sync-stream"
+        )
+        early_response_stream = client.responses.create(
+            model=_MODEL,
+            input="responses-sync-early",
+            stream=True,
+        )
+        assert next(early_response_stream).type == "response.created"
+        source_response = early_response_stream.response
+        early_response_stream.close()
+        early_response_stream.close()
+        assert source_response.is_closed
+        asyncio.run(run_async_chat())
+        client.chat.completions.create(
+            model=_MODEL,
+            messages=[{"role": "user", "content": "without-provider-usage"}],
+        )
+        with trace.get_tracer("openlit-real-contract-test").start_as_current_span(
+            "parent"
+        ):
+            client.chat.completions.create(
+                model=_MODEL,
+                messages=[{"role": "user", "content": "nested"}],
+            )
+        with pytest.raises(RateLimitError) as raised:
+            client.chat.completions.create(
+                model=_MODEL,
+                messages=[{"role": "user", "content": "rate-limit"}],
+            )
+        assert raised.value.status_code == 429
+        client.embeddings.create(model=_MODEL, input=["bounded embedding input"])
+        anthropic_response = anthropic_client.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "anthropic-active"}],
+        )
+        assert anthropic_response.content[0].text == ("Anthropic API: anthropic-active")
+
+        installed_create = vars(Completions)["create"]
+
+        def foreign_openai_wrapper(wrapped, instance, args, kwargs):
+            del instance
+            nonlocal foreign_calls
+            foreign_calls += 1
+            return wrapped(*args, **kwargs)
+
+        foreign_wrapper = FunctionWrapper(installed_create, foreign_openai_wrapper)
+        monkeypatch.setattr(Completions, "create", foreign_wrapper)
+        provider.force_flush()
+    finally:
+        client.close()
+        anthropic_client.close()
+        instrumentor.deactivate()
+
+    assert foreign_wrapper is not None
+    assert vars(Completions)["create"] is foreign_wrapper
+    finished_before_uninstrumented_calls = len(exporter.get_finished_spans())
+    uninstrumented_client = OpenAI(
+        api_key="local-openlit-key",
+        base_url=base_url,
+        max_retries=0,
+        timeout=3,
+    )
+    uninstrumented_anthropic = Anthropic(
+        api_key="local-anthropic-key",
+        base_url=base_url,
+        max_retries=0,
+        timeout=3,
+    )
+    try:
+        uninstrumented_client.chat.completions.create(
+            model=_MODEL,
+            messages=[{"role": "user", "content": "after-deactivate"}],
+        )
+        uninstrumented_anthropic.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "anthropic-deactivated"}],
+        )
+        provider.force_flush()
+    finally:
+        uninstrumented_client.close()
+        uninstrumented_anthropic.close()
+    assert len(exporter.get_finished_spans()) == finished_before_uninstrumented_calls
+    assert foreign_calls == 1
+
+    spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if _scope_name(span).startswith("openlit.instrumentation.openai")
+    ]
+    assert len(spans) == 15
+    assert all(not _scope_name(span).endswith(("httpx", "requests")) for span in spans)
+    anthropic_spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if _scope_name(span).startswith("openlit.instrumentation.anthropic")
+    ]
+    assert len(anthropic_spans) == 1
+    assert anthropic_spans[0].attributes[SpanAttributes.LLM_SYSTEM] == "anthropic"
+
+    tool_span = _chat_with_prompt(spans, "tool")
+    tool_attrs = dict(tool_span.attributes)
+    definitions = json.loads(tool_attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])
+    calls = json.loads(tool_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])
+    assert definitions == [
+        {
+            "type": "function",
+            "name": _TOOL_NAME,
+            "description": "Look up weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    assert calls == [
+        {
+            "id": "call_openlit_weather",
+            "type": "function",
+            "function": {
+                "name": _TOOL_NAME,
+                "arguments": {"city": "Tokyo"},
+            },
+        }
+    ]
+    assert tool_attrs["gen_ai.provider.name"] == "openai"
+    assert tool_attrs[SpanAttributes.LLM_SYSTEM] == "openai"
+    assert tool_attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 12
+    assert tool_attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 7
+    assert not any(key.startswith("gen_ai.tool.") for key in tool_attrs)
+    _assert_no_aliases(tool_attrs)
+
+    stream_span = _chat_with_prompt(spans, "stream")
+    stream_attrs = dict(stream_span.attributes)
+    assert stream_attrs["gen_ai.request.stream"] is True
+    assert stream_attrs[SpanAttributes.LLM_IS_STREAMING] is True
+    assert stream_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        "OpenLIT stream works."
+    )
+    assert stream_attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 7
+    assert stream_attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 11
+    assert stream_attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 18
+    _assert_no_aliases(stream_attrs)
+
+    for prompt in ("early-close", "async-cancel"):
+        partial_spans = [
+            span
+            for span in spans
+            if span.attributes.get(f"{SpanAttributes.LLM_PROMPTS}.0.content") == prompt
+        ]
+        assert len(partial_spans) == 1
+        partial_attrs = partial_spans[0].attributes
+        assert partial_attrs["gen_ai.request.stream"] is True
+        assert partial_attrs[SpanAttributes.LLM_IS_STREAMING] is True
+        assert partial_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+            "OpenLIT "
+        )
+        assert SpanAttributes.LLM_USAGE_TOTAL_TOKENS not in partial_attrs
+
+    async_span = _chat_with_prompt(spans, "async")
+    assert async_span.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 5
+    assert async_span.attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 3
+
+    for prompt in (
+        "responses-sync",
+        "responses-async",
+        "responses-sync-stream",
+        "responses-async-stream",
+    ):
+        response_span = _chat_with_prompt(spans, prompt)
+        response_attrs = response_span.attributes
+        assert response_attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 6
+        assert response_attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 4
+        assert response_attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 10
+        assert response_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+            f"Responses API: {prompt}"
+        )
+        assert response_attrs["gen_ai.request.stream"] is prompt.endswith("stream")
+        if prompt.endswith("stream"):
+            assert response_attrs[SpanAttributes.LLM_IS_STREAMING] is True
+        else:
+            assert SpanAttributes.LLM_IS_STREAMING not in response_attrs
+
+    for prompt in ("responses-sync-early", "responses-async-early"):
+        response_span = _chat_with_prompt(spans, prompt)
+        assert response_span.attributes["gen_ai.request.stream"] is True
+        assert response_span.attributes[SpanAttributes.LLM_IS_STREAMING] is True
+        assert SpanAttributes.LLM_USAGE_TOTAL_TOKENS not in response_span.attributes
+
+    no_usage_span = _chat_with_prompt(spans, "without-provider-usage")
+    for key in (
+        "gen_ai.usage.input_tokens",
+        "gen_ai.usage.output_tokens",
+        SpanAttributes.LLM_USAGE_PROMPT_TOKENS,
+        SpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
+        SpanAttributes.LLM_USAGE_TOTAL_TOKENS,
+    ):
+        assert key not in no_usage_span.attributes
+
+    assert all(
+        span.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+        for span in spans
+        if span.attributes.get(f"{SpanAttributes.LLM_PROMPTS}.0.content") != "nested"
+    )
+    nested_span = _chat_with_prompt(spans, "nested")
+    assert nested_span.parent is not None
+    assert (
+        nested_span.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH]
+        == (nested_span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME])
+    )
+
+    error_span = _chat_with_prompt(spans, "rate-limit")
+    error_attrs = dict(error_span.attributes)
+    assert error_span.status.status_code is StatusCode.ERROR
+    assert error_attrs["http.response.status_code"] == 429
+    assert error_attrs["status_code"] == 429
+    assert "deterministic rate limit" in error_attrs["error.message"]
+    assert (
+        json.loads(error_attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT])[0]["parts"][0][
+            "content"
+        ]
+        == "rate-limit"
+    )
+    assert not any(
+        key.startswith(f"{SpanAttributes.LLM_COMPLETIONS}.") for key in error_attrs
+    )
+    for key in (
+        "gen_ai.usage.input_tokens",
+        "gen_ai.usage.output_tokens",
+        SpanAttributes.LLM_USAGE_PROMPT_TOKENS,
+        SpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
+        SpanAttributes.LLM_USAGE_TOTAL_TOKENS,
+    ):
+        assert key not in error_attrs
+    _assert_no_aliases(error_attrs)
+
+    embedding_span = next(
+        span for span in spans if span.attributes.get(RESPAN_LOG_TYPE) == "embedding"
+    )
+    assert embedding_span.attributes[SpanAttributes.LLM_REQUEST_TYPE] == "embedding"
+    assert embedding_span.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 4
+    assert json.loads(
+        embedding_span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+    ) == ["bounded embedding input"]
+    assert json.loads(
+        embedding_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    ) == [[0.1, 0.2, 0.3]]
+
+    exporter.clear()
+    private_instrumentor = OpenLITInstrumentor(
+        capture_content=False,
+        max_content_length=128,
+    )
+    private_client = OpenAI(
+        api_key="private-local-key",
+        base_url=base_url,
+        max_retries=0,
+        timeout=3,
+    )
+    private_anthropic = Anthropic(
+        api_key="private-local-anthropic-key",
+        base_url=base_url,
+        max_retries=0,
+        timeout=3,
+    )
+    try:
+        private_instrumentor.activate()
+        private_client.chat.completions.create(
+            model=_MODEL,
+            messages=[{"role": "user", "content": _PRIVATE_INPUT}],
+            tools=_tool_definition(secret=True),
+        )
+        private_anthropic.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=16,
+            messages=[{"role": "user", "content": _PRIVATE_INPUT}],
+        )
+        provider.force_flush()
+    finally:
+        private_client.close()
+        private_anthropic.close()
+        private_instrumentor.deactivate()
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=3)
+        provider.shutdown()
+
+    private_spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if _scope_name(span).startswith("openlit.instrumentation.openai")
+    ]
+    assert len(private_spans) == 1, [
+        (span.name, _scope_name(span)) for span in private_spans
+    ]
+    private_attrs = dict(private_spans[0].attributes)
+    serialized = json.dumps(private_attrs, default=str)
+    assert _PRIVATE_INPUT not in serialized
+    assert _PRIVATE_OUTPUT not in serialized
+    assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in private_attrs
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in private_attrs
+    assert SpanAttributes.LLM_REQUEST_FUNCTIONS not in private_attrs
+    assert private_attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 3
+    assert private_attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 2
+    assert private_attrs["gen_ai.provider.name"] == "openai"
+    assert private_attrs[SpanAttributes.LLM_SYSTEM] == "openai"
+    _assert_no_aliases(private_attrs)
+    private_anthropic_spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if _scope_name(span).startswith("openlit.instrumentation.anthropic")
+    ]
+    assert len(private_anthropic_spans) == 1
+    assert _PRIVATE_INPUT not in json.dumps(
+        dict(private_anthropic_spans[0].attributes), default=str
+    )
+    assert foreign_calls == 2

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_serialization.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+
+from respan_instrumentation_openlit._serialization import (
+    REDACTED,
+    input_messages,
+    json_string,
+    json_value,
+    safe_url,
+    tool_definitions,
+)
+
+
+class Hostile:
+    def __str__(self) -> str:
+        raise AssertionError("custom __str__ must not run")
+
+    def __repr__(self) -> str:
+        raise AssertionError("custom __repr__ must not run")
+
+
+class HostileMapping(Mapping):
+    def __getitem__(self, key):
+        raise AssertionError(key)
+
+    def __iter__(self):
+        raise AssertionError("hostile iterator")
+
+    def __len__(self):
+        raise AssertionError("hostile length")
+
+    def items(self):
+        raise RuntimeError("hostile items")
+
+
+def test_json_value_is_finite_redacting_and_cycle_safe() -> None:
+    cycle: dict[str, object] = {}
+    cycle["self"] = cycle
+    normalized = json_value(
+        {
+            "authorization": "Bearer raw-secret-value",
+            "api_key": "sk-this-should-never-leak",
+            "message": "token=private-value",
+            "dsn": "postgresql://alice:private-value@db.internal/example",
+            "environment": "OPENAI_API_KEY=private-value",
+            "nested": {
+                "db_password": "nested-password",
+                "service_token": "nested-token",
+                "tenant_secret": "nested-secret",
+                "cloud_api_key": "nested-api-key",
+                "service_credential": "nested-credential",
+            },
+            "address": "object at 0xDEADBEEF",
+            "nan": math.nan,
+            "infinity": math.inf,
+            "cycle": cycle,
+            "hostile": Hostile(),
+            "hostile_mapping": HostileMapping(),
+        }
+    )
+    assert normalized["authorization"] == REDACTED
+    assert normalized["api_key"] == REDACTED
+    assert "private-value" not in normalized["message"]
+    assert "private-value" not in normalized["dsn"]
+    assert "private-value" not in normalized["environment"]
+    assert normalized["nested"] == {
+        "cloud_api_key": REDACTED,
+        "db_password": REDACTED,
+        "service_credential": REDACTED,
+        "service_token": REDACTED,
+        "tenant_secret": REDACTED,
+    }
+    assert "0xDEADBEEF" not in normalized["address"]
+    assert normalized["nan"] is None
+    assert normalized["infinity"] is None
+    assert normalized["cycle"]["self"] == "<cycle>"
+    assert normalized["hostile"] == "<Hostile>"
+    assert normalized["hostile_mapping"]["__serialization_error__"] == (
+        "HostileMapping"
+    )
+
+
+def test_json_string_is_valid_json_with_exact_utf8_byte_cap() -> None:
+    encoded = json_string(
+        {"unicode": "界" * 20_000, "authorization": "Bearer secret-value"},
+        max_bytes=512,
+    )
+    assert len(encoded.encode("utf-8")) <= 512
+    payload = json.loads(encoded)
+    assert payload["truncated"] is True
+    assert payload["original_bytes"] > 512
+    assert "secret-value" not in encoded
+
+
+def test_safe_url_drops_userinfo_query_and_fragment() -> None:
+    assert (
+        safe_url("https://alice:private@db.internal:8443/v1?api_key=secret#fragment")
+        == "https://db.internal:8443/v1"
+    )
+    assert safe_url("https://[::1]:4318/v1?token=secret") == ("https://[::1]:4318/v1")
+    assert safe_url(Hostile()) == ""
+
+
+def test_openai_message_and_tool_normalization_does_not_invoke_hostile_text() -> None:
+    messages = input_messages(
+        [
+            {"role": "user", "content": Hostile(), "password": "secret"},
+            {"role": "user", "content": "authorization=private-value"},
+        ]
+    )
+    assert messages[0]["parts"][0]["content"] == "<Hostile>"
+    assert "private-value" not in json.dumps(messages)
+
+    tools = tool_definitions(
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "api_key=private-value",
+                    "parameters": {"type": "object", "token": "private-value"},
+                },
+            },
+            Hostile(),
+        ]
+    )
+    assert tools[0]["name"] == "lookup"
+    assert "private-value" not in json.dumps(tools)

--- a/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_stream_lifecycle.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openlit/tests/test_stream_lifecycle.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from respan_instrumentation_openlit._openai_hooks import (
+    _AsyncStreamProxy,
+    _SyncStreamProxy,
+)
+
+
+class RecordingSpan:
+    def __init__(self) -> None:
+        self.attributes: dict[str, object] = {}
+        self.status = None
+        self.end_calls = 0
+        self._recording = True
+
+    def is_recording(self) -> bool:
+        return self._recording
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+    def set_status(self, status) -> None:
+        self.status = status
+
+    def end(self) -> None:
+        self.end_calls += 1
+        self._recording = False
+
+
+class BlockingAsyncStream:
+    def __init__(self) -> None:
+        self._span = RecordingSpan()
+        self._llmresponse = "partial async output"
+        self.started = asyncio.Event()
+        self.close_calls = 0
+
+    async def __anext__(self):
+        self.started.set()
+        await asyncio.Event().wait()
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class ProviderFailure(RuntimeError):
+    pass
+
+
+class CloseFailure(RuntimeError):
+    pass
+
+
+class EnterFailure(RuntimeError):
+    pass
+
+
+class ExitFailure(RuntimeError):
+    pass
+
+
+class FailingSyncStream:
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        self._span = RecordingSpan()
+        self._llmresponse = "partial"
+        self.close_calls = 0
+
+    def __next__(self):
+        raise ProviderFailure("provider iteration failed")
+
+    def __enter__(self):
+        if self.mode == "enter":
+            raise EnterFailure("enter failed")
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        del exc_type, exc, traceback
+        if self.mode == "exit":
+            raise ExitFailure("exit failed")
+        return False
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.mode in {"close", "iteration"}:
+            raise CloseFailure("close failed")
+
+
+class FailingAsyncStream(FailingSyncStream):
+    async def __anext__(self):
+        raise ProviderFailure("provider iteration failed")
+
+    async def __aenter__(self):
+        if self.mode == "enter":
+            raise EnterFailure("enter failed")
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        del exc_type, exc, traceback
+        if self.mode == "exit":
+            raise ExitFailure("exit failed")
+        return False
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        if self.mode in {"close", "iteration"}:
+            raise CloseFailure("close failed")
+
+
+def test_async_stream_cancellation_closes_source_and_ends_exactly_once() -> None:
+    async def run() -> None:
+        source = BlockingAsyncStream()
+        proxy = _AsyncStreamProxy(source, capture_content=True)
+        task = asyncio.create_task(proxy.__anext__())
+        await source.started.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert source.close_calls == 1
+        assert source._span.end_calls == 1
+        assert source._span.status.is_ok is False
+        assert source._span.attributes["error.message"] == "CancelledError"
+
+        await proxy.close()
+        assert source.close_calls == 1
+        assert source._span.end_calls == 1
+
+    asyncio.run(run())
+
+
+def test_sync_stream_failures_finish_once_and_preserve_provider_error() -> None:
+    iteration = FailingSyncStream("iteration")
+    proxy = _SyncStreamProxy(iteration, capture_content=True)
+    with pytest.raises(ProviderFailure):
+        next(proxy)
+    assert iteration._span.end_calls == 1
+    assert iteration._span.attributes["error.message"] == "ProviderFailure"
+
+    entering = FailingSyncStream("enter")
+    with pytest.raises(EnterFailure):
+        _SyncStreamProxy(entering, capture_content=True).__enter__()
+    assert entering._span.end_calls == 1
+    assert entering.close_calls == 1
+
+    exiting = FailingSyncStream("exit")
+    with pytest.raises(ExitFailure):
+        _SyncStreamProxy(exiting, capture_content=True).__exit__(None, None, None)
+    assert exiting._span.end_calls == 1
+    assert exiting._span.attributes["error.message"] == "ExitFailure"
+
+    closing = FailingSyncStream("close")
+    with pytest.raises(CloseFailure):
+        _SyncStreamProxy(closing, capture_content=True).close()
+    assert closing._span.end_calls == 1
+
+
+def test_async_stream_failures_finish_once_and_preserve_provider_error() -> None:
+    async def run() -> None:
+        iteration = FailingAsyncStream("iteration")
+        proxy = _AsyncStreamProxy(iteration, capture_content=True)
+        with pytest.raises(ProviderFailure):
+            await proxy.__anext__()
+        assert iteration._span.end_calls == 1
+        assert iteration._span.attributes["error.message"] == "ProviderFailure"
+
+        entering = FailingAsyncStream("enter")
+        with pytest.raises(EnterFailure):
+            await _AsyncStreamProxy(entering, capture_content=True).__aenter__()
+        assert entering._span.end_calls == 1
+        assert entering.close_calls == 1
+
+        exiting = FailingAsyncStream("exit")
+        with pytest.raises(ExitFailure):
+            await _AsyncStreamProxy(exiting, capture_content=True).__aexit__(
+                None, None, None
+            )
+        assert exiting._span.end_calls == 1
+        assert exiting._span.attributes["error.message"] == "ExitFailure"
+
+        closing = FailingAsyncStream("close")
+        with pytest.raises(CloseFailure):
+            await _AsyncStreamProxy(closing, capture_content=True).close()
+        assert closing._span.end_calls == 1
+
+    asyncio.run(run())

--- a/python-sdks/instrumentations/respan-instrumentation-openrouter/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-openrouter/README.md
@@ -6,11 +6,22 @@ OpenRouter's Python usage is OpenAI-compatible, so this package delegates SDK
 patching to `respan-instrumentation-openai` and adds a package-local processor
 that normalizes those spans as OpenRouter spans before export.
 
+The processor emits `gen_ai.system=openrouter` and
+`gen_ai.provider.name=openrouter`, canonical request tool definitions and
+current-turn completion tool calls, modern and legacy usage fields, precise
+OTEL error status, and both current and Traceloop streaming flags. It removes
+legacy tool aliases rather than duplicating the canonical fields.
+
 ## Install
 
 ```bash
 pip install respan-ai respan-instrumentation-openrouter openai
 ```
+
+Version `0.1.0` is validated with OpenAI Python `>=3.0.0,<4.0.0` and the
+`respan-instrumentation-openai` `>=1.2.1,<2.0.0` delegate surface. These bounds
+are intentional because OpenRouter's stream bridge integrates with that
+delegate's current lifecycle hooks.
 
 ## Environment
 
@@ -74,3 +85,8 @@ finally:
 the package is intended for OpenRouter-specific OpenAI-compatible clients. Set
 `normalize_all_openai_spans=False` if the same process also emits regular OpenAI
 spans and only spans with OpenRouter URL markers should be rewritten.
+
+Set `capture_content=False` to retain provider, model, usage, stream, lifecycle,
+and error data while removing prompt, completion, tool-definition, and tool-call
+content. Captured chat content is secret-redacted and bounded by UTF-8 bytes;
+embedding vectors remain intact under the shared span contract.

--- a/python-sdks/instrumentations/respan-instrumentation-openrouter/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-openrouter/pyproject.toml
@@ -13,8 +13,8 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.26"
-respan-instrumentation-openai = ">=1.0.0"
-openai = ">=1.0.0"
+respan-instrumentation-openai = ">=1.2.1,<2.0.0"
+openai = ">=3.0.0,<4.0.0"
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
 
 [tool.poetry.plugins."respan.instrumentations"]

--- a/python-sdks/instrumentations/respan-instrumentation-openrouter/src/respan_instrumentation_openrouter/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openrouter/src/respan_instrumentation_openrouter/_constants.py
@@ -1,7 +1,28 @@
 """OpenRouter instrumentation-local constants."""
 
 OPENROUTER_INSTRUMENTATION_NAME = "openrouter"
+OPENROUTER_INSTRUMENTATION_SCOPE = "respan.instrumentation.openrouter"
 OPENROUTER_SYSTEM_NAME = "openrouter"
+
+MAX_ATTRIBUTE_BYTES = 16_000
+MAX_COLLECTION_ITEMS = 128
+MAX_ERROR_BYTES = 4_000
+
+SENSITIVE_KEY_NAMES = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "auth_token",
+        "authorization",
+        "client_secret",
+        "credential",
+        "db_password",
+        "password",
+        "refresh_token",
+        "secret",
+        "token",
+    }
+)
 
 OPENAI_INSTRUMENTATION_SCOPE_FRAGMENT = "openai"
 OPENROUTER_HOST_MARKERS = (

--- a/python-sdks/instrumentations/respan-instrumentation-openrouter/src/respan_instrumentation_openrouter/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openrouter/src/respan_instrumentation_openrouter/_instrumentation.py
@@ -2,19 +2,473 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
-from typing import Any
+import threading
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from functools import wraps
+from types import TracebackType
+from typing import Any, Self
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from respan_instrumentation_openai import OpenAIInstrumentor
+from respan_instrumentation_openai import _instrumentation as openai_instrumentation
 from respan_tracing.core.tracer import RespanTracer
 
 from respan_instrumentation_openrouter._constants import (
+    MAX_ATTRIBUTE_BYTES,
+    MAX_COLLECTION_ITEMS,
+    MAX_ERROR_BYTES,
     OPENROUTER_INSTRUMENTATION_NAME,
 )
-from respan_instrumentation_openrouter._processor import OpenRouterSpanProcessor
+from respan_instrumentation_openrouter._processor import (
+    OpenRouterSpanProcessor,
+    _http_status_code,
+    _redact_text,
+    openrouter_emission_context,
+)
 
 logger = logging.getLogger(__name__)
+
+_BRIDGE_LOCK = threading.RLock()
+_ACTIVE_BRIDGE_OWNER: OpenRouterInstrumentor | None = None
+_ACTIVE_RUNTIME: _OpenRouterRuntime | None = None
+_TRUNCATION_SUFFIX = "...[truncated]"
+
+
+def _safe_error_message(value: Any) -> str | None:
+    """Return useful error text without invoking arbitrary string hooks."""
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return _redact_text(value, limit=MAX_ERROR_BYTES)
+    if isinstance(value, BaseException):
+        for argument in value.args:
+            if isinstance(argument, str) and argument:
+                return _redact_text(argument, limit=MAX_ERROR_BYTES)
+        return type(value).__name__
+    return type(value).__name__
+
+
+def _exception_status_code(exc: BaseException) -> int:
+    try:
+        status_code = getattr(exc, "status_code", None)
+    except Exception:  # noqa: BLE001 - provider exceptions may expose hostile properties
+        status_code = None
+    if status_code is None:
+        try:
+            response = getattr(exc, "response", None)
+            status_code = getattr(response, "status_code", None)
+        except Exception:  # noqa: BLE001 - response objects are provider-owned
+            status_code = None
+    if type(status_code) is int and 400 <= status_code <= 599:
+        return status_code
+    if (
+        type(status_code) is str
+        and len(status_code) == 3
+        and status_code.isascii()
+        and status_code.isdigit()
+    ):
+        resolved = int(status_code)
+        if 400 <= resolved <= 599:
+            return resolved
+    return _http_status_code(_safe_error_message(exc)) or 500
+
+
+def _append_bounded_text(current: str, fragment: Any) -> str:
+    if not isinstance(fragment, str) or not fragment:
+        return current
+    current_bytes = len(current.encode("utf-8"))
+    remaining = MAX_ATTRIBUTE_BYTES - current_bytes
+    if remaining <= 0 or current.endswith(_TRUNCATION_SUFFIX):
+        return current
+    candidate = fragment[:remaining]
+    encoded = candidate.encode("utf-8")
+    if len(fragment) <= remaining and len(encoded) <= remaining:
+        return current + fragment
+    suffix = _TRUNCATION_SUFFIX.encode("utf-8")
+    if remaining <= len(suffix):
+        return current + suffix[:remaining].decode("utf-8", errors="ignore")
+    prefix = encoded[: remaining - len(suffix)].decode("utf-8", errors="ignore")
+    return current + prefix + _TRUNCATION_SUFFIX
+
+
+class _StreamAccumulator:
+    """Incrementally retain complete bounded stream semantics."""
+
+    def __init__(self, kind: str) -> None:
+        self._kind = kind
+        self._model: str | None = None
+        self._response_id: str | None = None
+        self._usage: Any = None
+        self._content = ""
+        self._tool_calls: dict[int, dict[str, Any]] = {}
+        self._response: Any = None
+
+    def append(self, item: Any) -> None:
+        if self._kind == "response":
+            response = getattr(item, "response", None)
+            if response is not None:
+                self._response = response
+            return
+
+        model = getattr(item, "model", None)
+        if isinstance(model, str) and model:
+            self._model = model
+        response_id = getattr(item, "id", None)
+        if isinstance(response_id, str) and response_id:
+            self._response_id = response_id
+        usage = getattr(item, "usage", None)
+        if usage is not None:
+            self._usage = usage
+
+        choices = getattr(item, "choices", None)
+        if not isinstance(choices, (list, tuple)) or not choices:
+            return
+        choice = choices[0]
+        if self._kind == "completion":
+            self._content = _append_bounded_text(
+                self._content,
+                getattr(choice, "text", None),
+            )
+            return
+        if self._kind != "chat":
+            return
+
+        delta = getattr(choice, "delta", None)
+        if delta is None:
+            return
+        self._content = _append_bounded_text(
+            self._content,
+            getattr(delta, "content", None),
+        )
+        tool_call_deltas = getattr(delta, "tool_calls", None)
+        if not isinstance(tool_call_deltas, (list, tuple)):
+            return
+        for tool_call_delta in tool_call_deltas[:MAX_COLLECTION_ITEMS]:
+            index = getattr(tool_call_delta, "index", 0)
+            if not isinstance(index, int) or index < 0:
+                index = 0
+            if index not in self._tool_calls:
+                if len(self._tool_calls) >= MAX_COLLECTION_ITEMS:
+                    continue
+                self._tool_calls[index] = {
+                    "id": None,
+                    "type": "function",
+                    "function": {"name": "", "arguments": ""},
+                }
+            slot = self._tool_calls[index]
+            tool_call_id = getattr(tool_call_delta, "id", None)
+            if isinstance(tool_call_id, str) and tool_call_id:
+                slot["id"] = tool_call_id
+            function = getattr(tool_call_delta, "function", None)
+            if function is None:
+                continue
+            name = getattr(function, "name", None)
+            if isinstance(name, str) and name:
+                slot["function"]["name"] = name
+            slot["function"]["arguments"] = _append_bounded_text(
+                slot["function"]["arguments"],
+                getattr(function, "arguments", None),
+            )
+
+    def response(self) -> Any:
+        if self._kind == "response":
+            return self._response
+        if self._kind == "completion":
+            return {
+                "model": self._model,
+                "id": self._response_id,
+                "usage": self._usage,
+                "choices": [{"text": self._content}],
+            }
+        if self._kind == "chat":
+            message: dict[str, Any] = {
+                "role": "assistant",
+                "content": self._content or None,
+            }
+            if self._tool_calls:
+                message["tool_calls"] = [
+                    self._tool_calls[index] for index in sorted(self._tool_calls)
+                ]
+            return {
+                "model": self._model,
+                "id": self._response_id,
+                "usage": self._usage,
+                "choices": [{"message": message}],
+            }
+        return None
+
+
+class _StreamProxyBase:
+    def __init__(
+        self,
+        stream: Any,
+        *,
+        kind: str,
+        request_kwargs: dict[str, Any],
+        start_ns: int,
+        emit_fn: Any,
+    ) -> None:
+        self._stream = stream
+        self._request_kwargs = request_kwargs
+        self._start_ns = start_ns
+        self._emit_fn = emit_fn
+        self._accumulator = _StreamAccumulator(kind)
+        self._call_context = otel_context.get_current()
+        self._emitted = False
+        self._exhausted = False
+
+    def _emit_once(self, error: BaseException | None = None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        token = otel_context.attach(self._call_context)
+        try:
+            _emit_safely(
+                self._emit_fn,
+                request_kwargs=self._request_kwargs,
+                start_ns=self._start_ns,
+                response=self._accumulator.response(),
+                error_message=_safe_error_message(error),
+                status_code=_exception_status_code(error) if error is not None else 200,
+            )
+        finally:
+            otel_context.detach(token)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+class _SyncStreamProxy(_StreamProxyBase):
+    def __init__(self, stream: Any, **kwargs: Any) -> None:
+        super().__init__(stream, **kwargs)
+        self._iterator = (
+            stream if callable(getattr(stream, "__next__", None)) else iter(stream)
+        )
+
+    def __iter__(self) -> _SyncStreamProxy:
+        return self
+
+    def __next__(self) -> Any:
+        try:
+            item = next(self._iterator)
+        except StopIteration:
+            self._exhausted = True
+            self._emit_once()
+            raise
+        except BaseException as exc:
+            self._emit_once(exc)
+            self._close_after_error()
+            raise
+        try:
+            self._accumulator.append(item)
+        except Exception:
+            logger.exception("Failed to aggregate delegated OpenRouter stream item")
+        return item
+
+    def _close_after_error(self) -> None:
+        close = getattr(self._stream, "close", None)
+        if callable(close):
+            try:
+                close()
+            except BaseException:
+                logger.debug(
+                    "Failed to close delegated OpenRouter sync stream",
+                    exc_info=True,
+                )
+
+    def close(self) -> Any:
+        close = getattr(self._stream, "close", None)
+        try:
+            result = close() if callable(close) else None
+        except BaseException as exc:
+            self._emit_once(exc)
+            raise
+        self._emit_once()
+        return result
+
+    def __enter__(self) -> Self:
+        enter = getattr(self._stream, "__enter__", None)
+        if callable(enter):
+            entered = enter()
+            if entered is not None and entered is not self._stream:
+                self._iterator = (
+                    entered
+                    if callable(getattr(entered, "__next__", None))
+                    else iter(entered)
+                )
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Any:
+        exit_method = getattr(self._stream, "__exit__", None)
+        try:
+            result = (
+                exit_method(exc_type, exc, traceback)
+                if callable(exit_method)
+                else self.close()
+            )
+        except BaseException as close_error:
+            self._emit_once(close_error)
+            raise
+        self._emit_once()
+        return result
+
+
+class _AsyncStreamProxy(_StreamProxyBase):
+    def __init__(self, stream: Any, **kwargs: Any) -> None:
+        super().__init__(stream, **kwargs)
+        self._iteration_stream = stream
+        self._aiterator: Any = None
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self._iterate_delegate()
+
+    async def _iterate_delegate(self) -> AsyncIterator[Any]:
+        try:
+            async for item in self._iteration_stream:
+                try:
+                    self._accumulator.append(item)
+                except Exception:
+                    logger.exception(
+                        "Failed to aggregate delegated OpenRouter stream item"
+                    )
+                yield item
+        except GeneratorExit:
+            self._emit_once()
+            await self._close_after_error()
+            raise
+        except BaseException as exc:
+            self._emit_once(exc)
+            await self._close_after_error()
+            raise
+        self._exhausted = True
+        self._emit_once()
+
+    async def __anext__(self) -> Any:
+        if self._aiterator is None:
+            self._aiterator = self._iteration_stream.__aiter__()
+        try:
+            item = await self._aiterator.__anext__()
+        except StopAsyncIteration:
+            self._exhausted = True
+            self._emit_once()
+            raise
+        except BaseException as exc:
+            self._emit_once(exc)
+            await self._close_after_error()
+            raise
+        try:
+            self._accumulator.append(item)
+        except Exception:
+            logger.exception("Failed to aggregate delegated OpenRouter stream item")
+        return item
+
+    async def _call_close(self) -> Any:
+        close = getattr(self._stream, "close", None)
+        if not callable(close):
+            close = getattr(self._stream, "aclose", None)
+        if not callable(close):
+            return None
+        result = close()
+        return await result if inspect.isawaitable(result) else result
+
+    async def _close_after_error(self) -> None:
+        try:
+            await self._call_close()
+        except BaseException:
+            logger.debug(
+                "Failed to close delegated OpenRouter async stream",
+                exc_info=True,
+            )
+
+    async def close(self) -> Any:
+        try:
+            result = await self._call_close()
+        except BaseException as exc:
+            self._emit_once(exc)
+            raise
+        self._emit_once()
+        return result
+
+    async def aclose(self) -> Any:
+        return await self.close()
+
+    async def __aenter__(self) -> Self:
+        enter = getattr(self._stream, "__aenter__", None)
+        if callable(enter):
+            entered = enter()
+            entered = await entered if inspect.isawaitable(entered) else entered
+            if entered is not None and entered is not self._stream:
+                self._iteration_stream = entered
+                self._aiterator = None
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Any:
+        exit_method = getattr(self._stream, "__aexit__", None)
+        try:
+            if callable(exit_method):
+                result = exit_method(exc_type, exc, traceback)
+                result = await result if inspect.isawaitable(result) else result
+            else:
+                result = await self.close()
+        except BaseException as close_error:
+            self._emit_once(close_error)
+            raise
+        self._emit_once()
+        return result
+
+
+@dataclass(frozen=True)
+class _DelegateMethodPatch:
+    target: type[Any]
+    attribute: str
+    previous: Any
+    installed: Any
+
+
+@dataclass(eq=False)
+class _OpenRouterRuntime:
+    tracer_provider: Any
+    delegate: Any
+    processor: OpenRouterSpanProcessor
+    owns_delegate_patches: bool
+    normalize_all_openai_spans: bool
+    capture_content: bool
+    members: set[OpenRouterInstrumentor] = field(default_factory=set)
+    delegate_kind_entries: dict[str, tuple[Any, Any]] = field(default_factory=dict)
+    bridged_emitters: dict[str, Any] = field(default_factory=dict)
+    delegate_sync_stream_wrapper: Any = None
+    delegate_async_stream_wrapper: Any = None
+    bridge_sync_stream_wrapper: Any = None
+    bridge_async_stream_wrapper: Any = None
+    delegate_method_patches: list[_DelegateMethodPatch] = field(default_factory=list)
+    delegate_class: type[Any] | None = None
+    delegate_activate: Any = None
+    delegate_deactivate: Any = None
+    coordinated_activate: Any = None
+    coordinated_deactivate: Any = None
+    external_delegate_members: set[Any] = field(default_factory=set)
+    preexisting_delegate_active: bool = False
+    lifecycle_active: bool = False
+
+    @property
+    def config(self) -> tuple[bool, bool]:
+        return self.normalize_all_openai_spans, self.capture_content
 
 
 def _active_span_processors(tracer_provider: Any) -> tuple[Any, tuple[Any, ...] | None]:
@@ -39,13 +493,9 @@ def _register_processor_before_exporters(
             tracer_provider.add_span_processor(processor)
         return
 
-    remaining_processors = tuple(
-        existing_processor
-        for existing_processor in processors
-        if existing_processor is not processor
-        and not isinstance(existing_processor, OpenRouterSpanProcessor)
-    )
-    active_span_processor._span_processors = (processor, *remaining_processors)
+    if any(existing_processor is processor for existing_processor in processors):
+        return
+    active_span_processor._span_processors = (processor, *processors)
 
 
 def _unregister_processor(
@@ -65,16 +515,232 @@ def _unregister_processor(
     )
 
 
+def _emit_safely(emit_fn: Any, **kwargs: Any) -> None:
+    try:
+        emit_fn(**kwargs)
+    except Exception:
+        logger.exception("OpenRouter instrumentation failed to emit a delegated span")
+
+
+def _delegate_instrumentation_suppressed() -> bool:
+    """Read optional delegate suppression state across supported releases."""
+
+    callback = getattr(
+        openai_instrumentation,
+        "_is_openai_instrumentation_suppressed",
+        None,
+    )
+    if not callable(callback):
+        return False
+    try:
+        return bool(callback())
+    except Exception:
+        logger.debug("Failed to read OpenAI delegate suppression state", exc_info=True)
+        return False
+
+
+def _make_safe_sync_wrapper(original: Any, *, kind: str) -> Any:
+    emit_fn, _aggregate = openai_instrumentation._KINDS[kind]
+
+    @wraps(original)
+    def wrapper(resource: Any, *args: Any, **kwargs: Any) -> Any:
+        if _delegate_instrumentation_suppressed():
+            return original(resource, *args, **kwargs)
+
+        start_ns = time.time_ns()
+        try:
+            response = original(resource, *args, **kwargs)
+        except Exception as exc:
+            _emit_safely(
+                emit_fn,
+                request_kwargs=kwargs,
+                start_ns=start_ns,
+                error_message=_safe_error_message(exc),
+                status_code=_exception_status_code(exc),
+            )
+            raise
+        if kind != "embedding" and openai_instrumentation._is_stream(response):
+            return openai_instrumentation._wrap_sync_stream(
+                response,
+                kind=kind,
+                request_kwargs=kwargs,
+                start_ns=start_ns,
+            )
+        _emit_safely(
+            emit_fn,
+            request_kwargs=kwargs,
+            start_ns=start_ns,
+            response=response,
+        )
+        return response
+
+    wrapper.__respan_openrouter_wrapper__ = True
+    return wrapper
+
+
+def _make_safe_async_wrapper(original: Any, *, kind: str) -> Any:
+    emit_fn, _aggregate = openai_instrumentation._KINDS[kind]
+
+    @wraps(original)
+    async def wrapper(resource: Any, *args: Any, **kwargs: Any) -> Any:
+        if _delegate_instrumentation_suppressed():
+            pending = original(resource, *args, **kwargs)
+            return pending if hasattr(pending, "__aiter__") else await pending
+
+        start_ns = time.time_ns()
+        try:
+            pending = original(resource, *args, **kwargs)
+            response = pending if hasattr(pending, "__aiter__") else await pending
+        except Exception as exc:
+            _emit_safely(
+                emit_fn,
+                request_kwargs=kwargs,
+                start_ns=start_ns,
+                error_message=_safe_error_message(exc),
+                status_code=_exception_status_code(exc),
+            )
+            raise
+        if kind != "embedding" and openai_instrumentation._is_stream(response):
+            return openai_instrumentation._wrap_async_stream(
+                response,
+                kind=kind,
+                request_kwargs=kwargs,
+                start_ns=start_ns,
+            )
+        _emit_safely(
+            emit_fn,
+            request_kwargs=kwargs,
+            start_ns=start_ns,
+            response=response,
+        )
+        return response
+
+    wrapper.__respan_openrouter_wrapper__ = True
+    return wrapper
+
+
+def _is_replaceable_delegate_wrapper(current: Any, original: Any) -> bool:
+    if getattr(current, "__respan_openrouter_wrapper__", False):
+        return True
+    if not inspect.isfunction(current):
+        return False
+    if current.__module__ != openai_instrumentation.__name__:
+        return False
+    try:
+        return inspect.getclosurevars(current).nonlocals.get("original") is original
+    except (TypeError, ValueError):
+        return False
+
+
+def _install_safe_delegate_methods(runtime: _OpenRouterRuntime) -> None:
+    original_methods = getattr(openai_instrumentation, "_original_methods", {})
+    targets = getattr(openai_instrumentation, "_TARGETS", ())
+    for module_path, class_name, kind, is_async in targets:
+        target = openai_instrumentation._load_class(module_path, class_name)
+        if target is None:
+            continue
+        key = (target, "create")
+        original = original_methods.get(key)
+        if original is None:
+            continue
+        current = inspect.getattr_static(target, "create")
+        if not _is_replaceable_delegate_wrapper(current, original):
+            logger.warning(
+                "OpenRouter left a foreign wrapper on %s.%s unchanged",
+                target.__name__,
+                "create",
+            )
+            continue
+        factory = _make_safe_async_wrapper if is_async else _make_safe_sync_wrapper
+        installed = factory(original, kind=kind)
+        target.create = installed
+        runtime.delegate_method_patches.append(
+            _DelegateMethodPatch(target, "create", current, installed)
+        )
+
+
+def _restore_safe_delegate_methods(runtime: _OpenRouterRuntime) -> None:
+    for patch in reversed(runtime.delegate_method_patches):
+        if inspect.getattr_static(patch.target, patch.attribute) is patch.installed:
+            setattr(patch.target, patch.attribute, patch.previous)
+    runtime.delegate_method_patches.clear()
+
+
+def _install_delegate_lifecycle(runtime: _OpenRouterRuntime) -> None:
+    delegate_class = type(runtime.delegate)
+    original_activate = delegate_class.activate
+    original_deactivate = delegate_class.deactivate
+    runtime.delegate_class = delegate_class
+    runtime.delegate_activate = original_activate
+    runtime.delegate_deactivate = original_deactivate
+    runtime.preexisting_delegate_active = not runtime.owns_delegate_patches
+    runtime.lifecycle_active = True
+
+    def coordinated_activate(delegate_self: Any) -> None:
+        with _BRIDGE_LOCK:
+            if runtime.lifecycle_active:
+                if delegate_self is not runtime.delegate:
+                    runtime.external_delegate_members.add(delegate_self)
+                delegate_self._is_instrumented = True
+                return
+        original_activate(delegate_self)
+
+    def coordinated_deactivate(delegate_self: Any) -> None:
+        with _BRIDGE_LOCK:
+            if runtime.lifecycle_active:
+                if delegate_self in runtime.external_delegate_members:
+                    runtime.external_delegate_members.discard(delegate_self)
+                    delegate_self._is_instrumented = False
+                    return
+                if delegate_self is not runtime.delegate:
+                    runtime.preexisting_delegate_active = False
+                    delegate_self._is_instrumented = False
+                    return
+                return
+        original_deactivate(delegate_self)
+
+    runtime.coordinated_activate = coordinated_activate
+    runtime.coordinated_deactivate = coordinated_deactivate
+    delegate_class.activate = coordinated_activate
+    delegate_class.deactivate = coordinated_deactivate
+
+
+def _restore_delegate_lifecycle(runtime: _OpenRouterRuntime) -> None:
+    runtime.lifecycle_active = False
+    delegate_class = runtime.delegate_class
+    if delegate_class is not None:
+        if delegate_class.activate is runtime.coordinated_activate:
+            delegate_class.activate = runtime.delegate_activate
+        if delegate_class.deactivate is runtime.coordinated_deactivate:
+            delegate_class.deactivate = runtime.delegate_deactivate
+    runtime.coordinated_activate = None
+    runtime.coordinated_deactivate = None
+
+
+def _has_external_delegate_owner(runtime: _OpenRouterRuntime) -> bool:
+    return runtime.preexisting_delegate_active or any(
+        bool(getattr(member, "_is_instrumented", False))
+        for member in runtime.external_delegate_members
+    )
+
+
 class OpenRouterInstrumentor:
     """Respan instrumentor for OpenRouter's OpenAI-compatible Python usage."""
 
     name = OPENROUTER_INSTRUMENTATION_NAME
 
-    def __init__(self, *, normalize_all_openai_spans: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        normalize_all_openai_spans: bool = True,
+        capture_content: bool = True,
+    ) -> None:
         self._normalize_all_openai_spans = normalize_all_openai_spans
+        self._capture_content = capture_content
         self._delegate = None
         self._processor: OpenRouterSpanProcessor | None = None
         self._is_instrumented = False
+        self._runtime: _OpenRouterRuntime | None = None
 
     @staticmethod
     def _is_respan_tracing_enabled() -> bool:
@@ -83,8 +749,137 @@ class OpenRouterInstrumentor:
             return True
         return bool(getattr(tracer, "is_enabled", True))
 
+    @staticmethod
+    def _install_delegate_bridge(runtime: _OpenRouterRuntime) -> None:
+        with _BRIDGE_LOCK:
+            kinds = getattr(openai_instrumentation, "_KINDS", None)
+            if not isinstance(kinds, dict):
+                raise TypeError("OpenAI delegate does not expose its emission registry")
+
+            runtime.delegate_kind_entries = dict(kinds)
+            for kind, entry in runtime.delegate_kind_entries.items():
+                emit_fn, aggregate = entry
+
+                def bridged_emit(
+                    *,
+                    _kind: str = kind,
+                    _emit_fn: Any = emit_fn,
+                    **kwargs: Any,
+                ) -> Any:
+                    request_kwargs = kwargs.get("request_kwargs") or {}
+                    if not isinstance(request_kwargs, dict):
+                        request_kwargs = {}
+                    error_message = _safe_error_message(kwargs.get("error_message"))
+                    status_value = kwargs.get("status_code", 200)
+                    if type(status_value) is int:
+                        status_code = status_value
+                    elif (
+                        type(status_value) is str
+                        and len(status_value) == 3
+                        and status_value.isascii()
+                        and status_value.isdigit()
+                    ):
+                        status_code = int(status_value)
+                    else:
+                        status_code = 500 if error_message else 200
+                    with openrouter_emission_context(
+                        kind=_kind,
+                        request_kwargs=request_kwargs,
+                        error_message=error_message,
+                        status_code=status_code,
+                    ):
+                        safe_kwargs = dict(kwargs)
+                        safe_kwargs["request_kwargs"] = request_kwargs
+                        safe_kwargs["error_message"] = error_message
+                        safe_kwargs["status_code"] = status_code
+                        return _emit_fn(**safe_kwargs)
+
+                runtime.bridged_emitters[kind] = bridged_emit
+                kinds[kind] = (bridged_emit, aggregate)
+
+            runtime.delegate_sync_stream_wrapper = (
+                openai_instrumentation._wrap_sync_stream
+            )
+            runtime.delegate_async_stream_wrapper = (
+                openai_instrumentation._wrap_async_stream
+            )
+
+            def sync_stream_wrapper(
+                iterator: Any,
+                *,
+                kind: str,
+                request_kwargs: dict[str, Any],
+                start_ns: int,
+            ) -> _SyncStreamProxy:
+                emit_fn, _aggregate = openai_instrumentation._KINDS[kind]
+                return _SyncStreamProxy(
+                    iterator,
+                    kind=kind,
+                    request_kwargs=request_kwargs,
+                    start_ns=start_ns,
+                    emit_fn=emit_fn,
+                )
+
+            def async_stream_wrapper(
+                aiterator: Any,
+                *,
+                kind: str,
+                request_kwargs: dict[str, Any],
+                start_ns: int,
+            ) -> _AsyncStreamProxy:
+                emit_fn, _aggregate = openai_instrumentation._KINDS[kind]
+                return _AsyncStreamProxy(
+                    aiterator,
+                    kind=kind,
+                    request_kwargs=request_kwargs,
+                    start_ns=start_ns,
+                    emit_fn=emit_fn,
+                )
+
+            runtime.bridge_sync_stream_wrapper = sync_stream_wrapper
+            runtime.bridge_async_stream_wrapper = async_stream_wrapper
+            openai_instrumentation._wrap_sync_stream = sync_stream_wrapper
+            openai_instrumentation._wrap_async_stream = async_stream_wrapper
+
+    @staticmethod
+    def _uninstall_delegate_bridge(runtime: _OpenRouterRuntime) -> None:
+        with _BRIDGE_LOCK:
+            kinds = getattr(openai_instrumentation, "_KINDS", {})
+            for kind, original_entry in runtime.delegate_kind_entries.items():
+                current_entry = kinds.get(kind)
+                if (
+                    isinstance(current_entry, tuple)
+                    and current_entry
+                    and current_entry[0] is runtime.bridged_emitters.get(kind)
+                ):
+                    kinds[kind] = original_entry
+
+            if (
+                getattr(openai_instrumentation, "_wrap_sync_stream", None)
+                is runtime.bridge_sync_stream_wrapper
+            ):
+                openai_instrumentation._wrap_sync_stream = (
+                    runtime.delegate_sync_stream_wrapper
+                )
+            if (
+                getattr(openai_instrumentation, "_wrap_async_stream", None)
+                is runtime.bridge_async_stream_wrapper
+            ):
+                openai_instrumentation._wrap_async_stream = (
+                    runtime.delegate_async_stream_wrapper
+                )
+
+            runtime.delegate_kind_entries.clear()
+            runtime.bridged_emitters.clear()
+            runtime.delegate_sync_stream_wrapper = None
+            runtime.delegate_async_stream_wrapper = None
+            runtime.bridge_sync_stream_wrapper = None
+            runtime.bridge_async_stream_wrapper = None
+
     def activate(self) -> None:
         """Instrument OpenRouter calls made through the OpenAI Python client."""
+        global _ACTIVE_BRIDGE_OWNER, _ACTIVE_RUNTIME
+
         if self._is_instrumented:
             return
 
@@ -94,45 +889,151 @@ class OpenRouterInstrumentor:
             )
             return
 
-        try:
-            self._delegate = OpenAIInstrumentor()
-            self._delegate.activate()
-            if getattr(self._delegate, "_is_instrumented", True) is False:
-                self._delegate = None
+        requested_config = (
+            self._normalize_all_openai_spans,
+            self._capture_content,
+        )
+        with _BRIDGE_LOCK:
+            if _ACTIVE_RUNTIME is not None:
+                if _ACTIVE_RUNTIME.config != requested_config:
+                    logger.error(
+                        "OpenRouter instrumentation config mismatch: active "
+                        "normalize_all_openai_spans=%s capture_content=%s; "
+                        "requested normalize_all_openai_spans=%s capture_content=%s",
+                        *_ACTIVE_RUNTIME.config,
+                        *requested_config,
+                    )
+                    return
+                _ACTIVE_RUNTIME.members.add(self)
+                self._runtime = _ACTIVE_RUNTIME
+                self._delegate = _ACTIVE_RUNTIME.delegate
+                self._processor = _ACTIVE_RUNTIME.processor
+                self._is_instrumented = True
+                if _ACTIVE_BRIDGE_OWNER is None:
+                    _ACTIVE_BRIDGE_OWNER = self
+                logger.info("OpenRouter instrumentation joined the active runtime")
                 return
 
-            self._processor = OpenRouterSpanProcessor(
-                normalize_all_openai_spans=self._normalize_all_openai_spans,
+            tracer_provider = trace.get_tracer_provider()
+            delegate = None
+            processor = None
+            runtime = None
+            delegate_methods = getattr(
+                openai_instrumentation,
+                "_original_methods",
+                {},
             )
-            _register_processor_before_exporters(
-                tracer_provider=trace.get_tracer_provider(),
-                processor=self._processor,
-            )
+            delegate_was_active = bool(delegate_methods)
+            try:
+                delegate = OpenAIInstrumentor()
+                processor = OpenRouterSpanProcessor(
+                    normalize_all_openai_spans=self._normalize_all_openai_spans,
+                    capture_content=self._capture_content,
+                )
+                runtime = _OpenRouterRuntime(
+                    tracer_provider=tracer_provider,
+                    delegate=delegate,
+                    processor=processor,
+                    owns_delegate_patches=not delegate_was_active,
+                    normalize_all_openai_spans=self._normalize_all_openai_spans,
+                    capture_content=self._capture_content,
+                )
+                _register_processor_before_exporters(
+                    tracer_provider=tracer_provider,
+                    processor=processor,
+                )
+                # The delegate wrapper factories capture their emitter at activation
+                # time. Install the bridge first so non-streaming failures retain the
+                # safe message and precise provider status.
+                self._install_delegate_bridge(runtime)
+                delegate.activate()
+                if (
+                    getattr(delegate, "_is_instrumented", True) is False
+                    and not delegate_was_active
+                ):
+                    self._uninstall_delegate_bridge(runtime)
+                    _unregister_processor(tracer_provider, processor)
+                    return
+                _install_safe_delegate_methods(runtime)
+                _install_delegate_lifecycle(runtime)
+            except Exception:
+                if runtime is not None:
+                    _restore_delegate_lifecycle(runtime)
+                    _restore_safe_delegate_methods(runtime)
+                    self._uninstall_delegate_bridge(runtime)
+                _unregister_processor(
+                    tracer_provider=tracer_provider,
+                    processor=processor,
+                )
+                if delegate is not None and not delegate_was_active:
+                    try:
+                        delegate.deactivate()
+                    except Exception:
+                        logger.exception(
+                            "Failed to clean up OpenRouter instrumentation"
+                        )
+                logger.exception("Failed to activate OpenRouter instrumentation")
+                return
+
+            runtime.members.add(self)
+            _ACTIVE_RUNTIME = runtime
+            _ACTIVE_BRIDGE_OWNER = self
+            self._runtime = runtime
+            self._delegate = delegate
+            self._processor = processor
             self._is_instrumented = True
             logger.info("OpenRouter instrumentation activated")
-        except Exception:
-            if self._delegate is not None:
-                try:
-                    self._delegate.deactivate()
-                except Exception:
-                    logger.exception("Failed to clean up OpenRouter instrumentation")
-            self._delegate = None
-            self._processor = None
-            self._is_instrumented = False
-            logger.exception("Failed to activate OpenRouter instrumentation")
 
     def deactivate(self) -> None:
-        """Deactivate OpenRouter instrumentation."""
-        _unregister_processor(
-            tracer_provider=trace.get_tracer_provider(),
-            processor=self._processor,
-        )
-        if self._is_instrumented and self._delegate is not None:
-            try:
-                self._delegate.deactivate()
-            except Exception:
-                logger.exception("Failed to deactivate OpenRouter instrumentation")
-        self._delegate = None
-        self._processor = None
-        self._is_instrumented = False
-        logger.info("OpenRouter instrumentation deactivated")
+        """Release this instance and tear down the shared runtime when last."""
+        global _ACTIVE_BRIDGE_OWNER, _ACTIVE_RUNTIME
+
+        with _BRIDGE_LOCK:
+            runtime = self._runtime
+            if runtime is None or not self._is_instrumented:
+                self._delegate = None
+                self._processor = None
+                self._runtime = None
+                self._is_instrumented = False
+                return
+
+            runtime.members.discard(self)
+            self._delegate = None
+            self._processor = None
+            self._runtime = None
+            self._is_instrumented = False
+
+            if runtime.members:
+                if _ACTIVE_BRIDGE_OWNER is self:
+                    _ACTIVE_BRIDGE_OWNER = next(iter(runtime.members))
+                logger.info(
+                    "OpenRouter instrumentation instance released; shared runtime retained"
+                )
+                return
+
+            if _ACTIVE_RUNTIME is runtime:
+                _ACTIVE_RUNTIME = None
+            if _ACTIVE_BRIDGE_OWNER is self or not runtime.members:
+                _ACTIVE_BRIDGE_OWNER = None
+
+            external_delegate_owner = _has_external_delegate_owner(runtime)
+            _restore_delegate_lifecycle(runtime)
+            self._uninstall_delegate_bridge(runtime)
+            _unregister_processor(
+                tracer_provider=runtime.tracer_provider,
+                processor=runtime.processor,
+            )
+            if external_delegate_owner:
+                # Restore the exact delegate wrappers that the independent owner
+                # joined; its eventual deactivate call still owns final teardown.
+                _restore_safe_delegate_methods(runtime)
+            else:
+                try:
+                    runtime.delegate_deactivate(runtime.delegate)
+                except Exception:
+                    logger.exception(
+                        "Failed to deactivate OpenRouter delegate instrumentation"
+                    )
+                finally:
+                    _restore_safe_delegate_methods(runtime)
+            logger.info("OpenRouter instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-openrouter/src/respan_instrumentation_openrouter/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openrouter/src/respan_instrumentation_openrouter/_processor.py
@@ -3,13 +3,35 @@
 from __future__ import annotations
 
 import json
+import math
+import re
 from collections import defaultdict
+from collections.abc import Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_REQUEST_STREAM,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
 from opentelemetry.semconv_ai import LLMRequestTypeValues
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
-from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
+from opentelemetry.trace import SpanContext, Status, StatusCode
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_TEXT,
+)
 from respan_sdk.constants.span_attributes import (
     RESPAN_LOG_TYPE,
     RESPAN_SPAN_HANDOFFS,
@@ -18,10 +40,15 @@ from respan_sdk.constants.span_attributes import (
 )
 
 from respan_instrumentation_openrouter._constants import (
+    MAX_ATTRIBUTE_BYTES,
+    MAX_COLLECTION_ITEMS,
+    MAX_ERROR_BYTES,
     OPENAI_INSTRUMENTATION_SCOPE_FRAGMENT,
     OPENROUTER_HOST_MARKERS,
+    OPENROUTER_INSTRUMENTATION_SCOPE,
     OPENROUTER_SYSTEM_NAME,
     OPENROUTER_URL_ATTRIBUTE_KEYS,
+    SENSITIVE_KEY_NAMES,
 )
 
 OTEL_SCOPE_NAME_ATTR = "otel.scope.name"
@@ -30,9 +57,7 @@ GEN_AI_PROMPT_PREFIX = f"{TLSpanAttributes.LLM_PROMPTS}."
 GEN_AI_COMPLETION_PREFIX = f"{TLSpanAttributes.LLM_COMPLETIONS}."
 GEN_AI_TOOL_CALLS_SUFFIX = ".tool_calls"
 GEN_AI_TOOL_CALLS_INDEX_FRAGMENT = ".tool_calls."
-GEN_AI_COMPLETION_TOOL_CALLS_ATTR = (
-    f"{TLSpanAttributes.LLM_COMPLETIONS}.0.tool_calls"
-)
+GEN_AI_COMPLETION_TOOL_CALLS_ATTR = f"{TLSpanAttributes.LLM_COMPLETIONS}.0.tool_calls"
 GEN_AI_OUTPUT_MESSAGES_ATTR = getattr(
     TLSpanAttributes,
     "GEN_AI_OUTPUT_MESSAGES",
@@ -42,6 +67,13 @@ GEN_AI_TOOL_DEFINITIONS_ATTR = getattr(
     TLSpanAttributes,
     "GEN_AI_TOOL_DEFINITIONS",
     "gen_ai.tool.definitions",
+)
+
+_PROVIDER_CONTROLLED_IDENTITY_KEYS = (
+    TLSpanAttributes.LLM_REQUEST_MODEL,
+    TLSpanAttributes.LLM_RESPONSE_MODEL,
+    "gen_ai.response.id",
+    TLSpanAttributes.LLM_OPENAI_RESPONSE_SYSTEM_FINGERPRINT,
 )
 
 _OFF_CONTRACT_ALIAS_ATTRIBUTES = frozenset(
@@ -58,10 +90,89 @@ _OFF_CONTRACT_ALIAS_ATTRIBUTES = frozenset(
         RESPAN_SPAN_HANDOFFS,
         RESPAN_SPAN_TOOL_CALLS,
         RESPAN_SPAN_TOOLS,
+        TLSpanAttributes.TRACELOOP_SPAN_KIND,
     }
 )
 
 _OPENAI_OMIT_VALUE_PREFIX = "<openai.Omit object"
+
+_PROVIDER_ERROR_MARKER = r"(?:openrouter|openai|provider|api(?:[_ -]?key)?)"
+_HTTP_STATUS_PATTERNS = (
+    re.compile(
+        rf"\b{_PROVIDER_ERROR_MARKER}\b[^\r\n]{{0,64}}"
+        r"\berror\s+code\s*[:=]\s*([1-5]\d{2})\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\berror\s+code\s*[:=]\s*([1-5]\d{2})\b"
+        rf"[^\r\n]{{0,64}}\b{_PROVIDER_ERROR_MARKER}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:openrouter|openai|provider|api)\b[^\r\n]{0,64}"
+        r"\bHTTP\s+([1-5]\d{2})\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bHTTP\s+([1-5]\d{2})\b[^\r\n]{0,64}"
+        r"\b(?:openrouter|openai|provider|api)\b",
+        re.IGNORECASE,
+    ),
+)
+_BEARER_SECRET = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
+_OPENAI_STYLE_SECRET = re.compile(r"\bsk-(?:or-v1-)?[A-Za-z0-9_-]{8,}\b")
+_SECRET_FIELD_PATTERN = (
+    r"(?:api[_-]?key|authorization|access[_-]?token|refresh[_-]?token|"
+    r"auth[_-]?token|client[_-]?secret|db[_-]?password|password|credential|"
+    r"secret|token)"
+)
+_KEY_VALUE_SECRET = re.compile(
+    rf"(?P<prefix>['\"]?{_SECRET_FIELD_PATTERN}['\"]?\s*[:=]\s*)"
+    rf"(?:(?P<quote>['\"])(?P<quoted>[^'\"]*)(?P=quote)|"
+    rf"(?P<bare>[^\s,;&?#}}\]]+))",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class OpenRouterEmissionContext:
+    """Request facts lost by the delegated OpenAI ReadableSpan builder."""
+
+    kind: str
+    stream: bool
+    error_message: str | None
+    status_code: int
+
+
+_CURRENT_EMISSION: ContextVar[OpenRouterEmissionContext | None] = ContextVar(
+    "respan_openrouter_emission",
+    default=None,
+)
+
+
+@contextmanager
+def openrouter_emission_context(
+    *,
+    kind: str,
+    request_kwargs: Mapping[str, Any],
+    error_message: str | None,
+    status_code: int,
+):
+    """Expose delegate-only request/error facts to the synchronous processor."""
+
+    resolved_status = _resolve_http_status(error_message, status_code)
+    token = _CURRENT_EMISSION.set(
+        OpenRouterEmissionContext(
+            kind=kind,
+            stream=bool(request_kwargs.get("stream")),
+            error_message=error_message,
+            status_code=resolved_status,
+        )
+    )
+    try:
+        yield
+    finally:
+        _CURRENT_EMISSION.reset(token)
 
 
 def _span_scope_name(span: ReadableSpan, attrs: dict[str, Any]) -> str | None:
@@ -92,9 +203,9 @@ def _is_openai_span(span: ReadableSpan, attrs: dict[str, Any]) -> bool:
 def _has_openrouter_url_marker(attrs: dict[str, Any]) -> bool:
     for key in OPENROUTER_URL_ATTRIBUTE_KEYS:
         value = attrs.get(key)
-        if value is None:
+        if not isinstance(value, str):
             continue
-        normalized_value = str(value).lower()
+        normalized_value = value[:2_048].lower()
         if any(marker in normalized_value for marker in OPENROUTER_HOST_MARKERS):
             return True
     return False
@@ -109,11 +220,20 @@ def _json_string(value: Any) -> str | None:
         return None
     if isinstance(value, str):
         return value
-    return json.dumps(value, default=str)
+    return json.dumps(
+        _safe_json_value(value),
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
 
 
 def _parse_json_if_string(value: Any) -> Any:
     if not isinstance(value, str):
+        return value
+    if len(value) > MAX_ATTRIBUTE_BYTES:
+        return value
+    if len(value.encode("utf-8")) > MAX_ATTRIBUTE_BYTES:
         return value
     try:
         return json.loads(value)
@@ -124,7 +244,235 @@ def _parse_json_if_string(value: Any) -> Any:
 def _is_openai_omit(value: Any) -> bool:
     if isinstance(value, str) and value.startswith(_OPENAI_OMIT_VALUE_PREFIX):
         return True
-    return repr(value).startswith(_OPENAI_OMIT_VALUE_PREFIX)
+    value_type = type(value)
+    return value_type.__name__ == "Omit" and value_type.__module__.startswith("openai")
+
+
+def _http_status_code(message: str | None) -> int | None:
+    if not message:
+        return None
+    message = _truncate_utf8(message, limit=MAX_ERROR_BYTES)
+    for pattern in _HTTP_STATUS_PATTERNS:
+        match = pattern.search(message)
+        if match is not None:
+            return int(match.group(1))
+    return None
+
+
+def _resolve_http_status(message: str | None, explicit_status: Any) -> int:
+    if type(explicit_status) is int:
+        resolved_explicit = explicit_status
+    elif type(explicit_status) is str and re.fullmatch(r"[1-5]\d{2}", explicit_status):
+        resolved_explicit = int(explicit_status)
+    else:
+        resolved_explicit = None
+    if resolved_explicit is not None and 400 <= resolved_explicit <= 599:
+        return resolved_explicit
+    return _http_status_code(message) or 500
+
+
+def _truncate_utf8(value: str, *, limit: int) -> str:
+    if limit <= 0:
+        return ""
+    candidate = value[:limit]
+    encoded = candidate.encode("utf-8")
+    if len(value) <= limit and len(encoded) <= limit:
+        return value
+    suffix = "...[truncated]"
+    suffix_bytes = suffix.encode("utf-8")
+    if limit <= len(suffix_bytes):
+        return suffix_bytes[: max(0, limit)].decode("utf-8", errors="ignore")
+    prefix = encoded[: max(0, limit - len(suffix_bytes))]
+    return prefix.decode("utf-8", errors="ignore") + suffix
+
+
+def _redact_text(value: str, *, limit: int = MAX_ATTRIBUTE_BYTES) -> str:
+    candidate = _truncate_utf8(value, limit=max(limit * 2, limit))
+    redacted = _BEARER_SECRET.sub("Bearer [REDACTED]", candidate)
+    redacted = _OPENAI_STYLE_SECRET.sub("[REDACTED]", redacted)
+
+    def replace_secret(match: re.Match[str]) -> str:
+        quote = match.group("quote") or ""
+        return f"{match.group('prefix')}{quote}[REDACTED]{quote}"
+
+    redacted = _KEY_VALUE_SECRET.sub(replace_secret, redacted)
+    return _truncate_utf8(redacted, limit=limit)
+
+
+def _is_sensitive_key(value: str) -> bool:
+    normalized = value.lower().replace("-", "_")
+    collapsed = normalized.replace("_", "")
+    collapsed_sensitive_names = {
+        sensitive_name.replace("_", "") for sensitive_name in SENSITIVE_KEY_NAMES
+    }
+    return (
+        normalized in SENSITIVE_KEY_NAMES
+        or collapsed in collapsed_sensitive_names
+        or normalized.endswith(
+            (
+                "_api_key",
+                "_authorization",
+                "_credential",
+                "_password",
+                "_secret",
+                "_token",
+            )
+        )
+    )
+
+
+def _redact_url(value: str) -> str:
+    """Redact credentials and sensitive query values without losing URL identity."""
+
+    safe_value = _redact_text(value)
+    try:
+        parts = urlsplit(safe_value)
+    except ValueError:
+        return safe_value
+    if not parts.scheme or not parts.netloc:
+        return safe_value
+
+    netloc = parts.netloc.rsplit("@", 1)[-1]
+    try:
+        query_items = parse_qsl(
+            parts.query,
+            keep_blank_values=True,
+            max_num_fields=MAX_COLLECTION_ITEMS,
+        )
+    except ValueError:
+        query = "truncated_query=%5BREDACTED%5D"
+    else:
+        query = urlencode(
+            [
+                (
+                    _redact_text(key, limit=256),
+                    "[REDACTED]" if _is_sensitive_key(key) else _redact_text(item),
+                )
+                for key, item in query_items
+            ]
+        )
+    return _truncate_utf8(
+        urlunsplit(
+            (
+                parts.scheme,
+                netloc,
+                parts.path,
+                query,
+                _redact_text(parts.fragment),
+            )
+        ),
+        limit=MAX_ATTRIBUTE_BYTES,
+    )
+
+
+def _safe_json_value(
+    value: Any,
+    *,
+    depth: int = 0,
+    budget: list[int] | None = None,
+) -> Any:
+    """Create a bounded JSON value while retaining useful message/tool shape."""
+
+    if budget is None:
+        budget = [MAX_COLLECTION_ITEMS * 4]
+    if budget[0] <= 0:
+        return "[truncated-items]"
+    budget[0] -= 1
+    if depth > 8:
+        return "[max-depth]"
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else "[non-finite]"
+    if isinstance(value, str):
+        return _redact_text(value)
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for index, (key, item) in enumerate(value.items()):
+            if index >= MAX_COLLECTION_ITEMS:
+                result["__truncated_items__"] = len(value) - MAX_COLLECTION_ITEMS
+                break
+            key_text = key if isinstance(key, str) else f"<{type(key).__name__}>"
+            key_text = _redact_text(key_text, limit=256)
+            result[key_text] = (
+                "[REDACTED]"
+                if _is_sensitive_key(key_text)
+                else _safe_json_value(item, depth=depth + 1, budget=budget)
+            )
+        return result
+    if isinstance(value, (list, tuple)):
+        items = [
+            _safe_json_value(item, depth=depth + 1, budget=budget)
+            for item in value[:MAX_COLLECTION_ITEMS]
+        ]
+        if len(value) > MAX_COLLECTION_ITEMS:
+            return {
+                "count": len(value),
+                "items": items,
+                "truncated": True,
+            }
+        return items
+    return {"type": type(value).__name__}
+
+
+def _bounded_json_string(value: Any) -> str | None:
+    if isinstance(value, str):
+        if len(value) > MAX_ATTRIBUTE_BYTES or len(value.encode("utf-8")) > (
+            MAX_ATTRIBUTE_BYTES
+        ):
+            parsed = _redact_text(value)
+        else:
+            try:
+                parsed = json.loads(value)
+            except (TypeError, json.JSONDecodeError):
+                parsed = _redact_text(value)
+    else:
+        parsed = value
+    if parsed is None:
+        return None
+    sanitized = _safe_json_value(parsed)
+    text = json.dumps(
+        sanitized,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    if len(text.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES:
+        return text
+    preview = _redact_text(text, limit=max(0, MAX_ATTRIBUTE_BYTES - 160))
+    bounded = json.dumps(
+        {
+            "original_bytes": len(text.encode("utf-8")),
+            "preview": preview,
+            "truncated": True,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    while len(bounded.encode("utf-8")) > MAX_ATTRIBUTE_BYTES and preview:
+        overflow = len(bounded.encode("utf-8")) - MAX_ATTRIBUTE_BYTES
+        preview = _truncate_utf8(
+            preview,
+            limit=max(0, len(preview.encode("utf-8")) - overflow - 16),
+        )
+        bounded = json.dumps(
+            {
+                "original_bytes": len(text.encode("utf-8")),
+                "preview": preview,
+                "truncated": True,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    return bounded
+
+
+@lru_cache(maxsize=1)
+def _package_version() -> str | None:
+    try:
+        return version("respan-instrumentation-openrouter")
+    except PackageNotFoundError:
+        return None
 
 
 def _set_nested_value(target: dict[str, Any], dotted_path: str, value: Any) -> None:
@@ -147,10 +495,9 @@ def _is_gen_ai_message_tool_call_key(key: str) -> bool:
 
 
 def _is_gen_ai_message_tool_call_aggregate_key(key: str) -> bool:
-    return (
-        key.startswith((GEN_AI_PROMPT_PREFIX, GEN_AI_COMPLETION_PREFIX))
-        and key.endswith(GEN_AI_TOOL_CALLS_SUFFIX)
-    )
+    return key.startswith(
+        (GEN_AI_PROMPT_PREFIX, GEN_AI_COMPLETION_PREFIX)
+    ) and key.endswith(GEN_AI_TOOL_CALLS_SUFFIX)
 
 
 def _tool_calls_content(value: Any) -> str | None:
@@ -159,7 +506,7 @@ def _tool_calls_content(value: Any) -> str | None:
         return None
 
     descriptions: list[str] = []
-    for tool_call in tool_calls:
+    for tool_call in tool_calls[:MAX_COLLECTION_ITEMS]:
         if not isinstance(tool_call, dict):
             continue
         function = tool_call.get("function")
@@ -169,17 +516,18 @@ def _tool_calls_content(value: Any) -> str | None:
         if not isinstance(name, str) or not name:
             continue
         arguments = function.get("arguments")
-        if arguments in {None, ""}:
+        if arguments is None or arguments == "":
             descriptions.append(name)
         elif isinstance(arguments, str):
             descriptions.append(f"{name}({arguments})")
         else:
-            descriptions.append(f"{name}({json.dumps(arguments, default=str)})")
+            safe_arguments = _bounded_json_string(arguments) or "{}"
+            descriptions.append(f"{name}({safe_arguments})")
 
     if not descriptions:
         return None
     prefix = "Tool call" if len(descriptions) == 1 else "Tool calls"
-    return f"{prefix}: {', '.join(descriptions)}"
+    return _redact_text(f"{prefix}: {', '.join(descriptions)}")
 
 
 def _normalize_gen_ai_tool_calls(attrs: dict[str, Any]) -> None:
@@ -209,7 +557,8 @@ def _normalize_gen_ai_tool_calls(attrs: dict[str, Any]) -> None:
             attrs[key] = _json_string(structured_tool_calls) or "[]"
             message_key = key[: -len(GEN_AI_TOOL_CALLS_SUFFIX)]
             content_key = f"{message_key}.content"
-            if attrs.get(content_key) in {None, ""}:
+            content_value = attrs.get(content_key)
+            if content_value is None or content_value == "":
                 attrs[content_key] = _tool_calls_content(structured_tool_calls) or ""
             role_key = f"{message_key}.role"
             if attrs.get(role_key) is None:
@@ -226,7 +575,13 @@ def _canonical_tool_definition(tool_definition: Any) -> Any:
     if "function" in tool_definition:
         return tool_definition
 
-    function = {"name": tool_definition.get("name")}
+    name = tool_definition.get("name")
+    if not isinstance(name, str) or not name:
+        # An incomplete upstream definition is still useful diagnostic data.
+        # Preserve it verbatim instead of fabricating a callable named null.
+        return tool_definition
+
+    function = {"name": name}
     if tool_definition.get("description") is not None:
         function["description"] = tool_definition.get("description")
     if tool_definition.get("parameters") is not None:
@@ -238,7 +593,10 @@ def _canonical_tool_definitions(value: Any) -> Any:
     tool_definitions = _parse_json_if_string(value)
     if not isinstance(tool_definitions, list):
         return tool_definitions
-    return [_canonical_tool_definition(tool) for tool in tool_definitions]
+    return [
+        _canonical_tool_definition(tool)
+        for tool in tool_definitions[:MAX_COLLECTION_ITEMS]
+    ]
 
 
 def _tool_call_from_output_part(part: dict[str, Any]) -> dict[str, Any] | None:
@@ -247,13 +605,16 @@ def _tool_call_from_output_part(part: dict[str, Any]) -> dict[str, Any] | None:
         return None
     arguments = part.get("arguments")
     if not isinstance(arguments, str):
-        arguments = json.dumps(arguments or {}, default=str)
+        arguments = _bounded_json_string(arguments if arguments is not None else {})
+        if arguments is None:
+            arguments = "{}"
     tool_call: dict[str, Any] = {
         "type": "function",
         "function": {"name": name, "arguments": arguments},
     }
-    if part.get("id") is not None:
-        tool_call["id"] = part.get("id")
+    tool_call_id = part.get("id")
+    if isinstance(tool_call_id, str) and tool_call_id:
+        tool_call["id"] = tool_call_id
     return tool_call
 
 
@@ -262,7 +623,7 @@ def _normalize_gen_ai_output_messages(attrs: dict[str, Any]) -> None:
     if not isinstance(output_messages, list):
         return
 
-    for message_index, message in enumerate(output_messages):
+    for message_index, message in enumerate(output_messages[:MAX_COLLECTION_ITEMS]):
         if not isinstance(message, dict):
             continue
         prefix = f"{TLSpanAttributes.LLM_COMPLETIONS}.{message_index}"
@@ -274,20 +635,21 @@ def _normalize_gen_ai_output_messages(attrs: dict[str, Any]) -> None:
         if not isinstance(parts, list):
             continue
 
-        content_parts: list[str] = []
+        content = ""
         tool_calls: list[dict[str, Any]] = []
-        for part in parts:
+        for part in parts[:MAX_COLLECTION_ITEMS]:
             if not isinstance(part, dict):
                 continue
             part_type = part.get("type")
-            if part_type == "text" and part.get("content") is not None:
-                content_parts.append(str(part.get("content")))
+            if part_type == "text" and isinstance(part.get("content"), str):
+                remaining = MAX_ATTRIBUTE_BYTES - len(content.encode("utf-8"))
+                if remaining > 0:
+                    content += _redact_text(part["content"], limit=remaining)
             elif part_type == "tool_call":
                 tool_call = _tool_call_from_output_part(part)
                 if tool_call is not None:
                     tool_calls.append(tool_call)
 
-        content = "".join(content_parts)
         if content:
             attrs.setdefault(f"{prefix}.content", content)
         if tool_calls:
@@ -308,9 +670,7 @@ def _normalize_structured_contract_attrs(attrs: dict[str, Any]) -> None:
 
     tool_calls_value = attrs.get(GEN_AI_COMPLETION_TOOL_CALLS_ATTR)
     if tool_calls_value is None:
-        tool_calls_value = attrs.get(RESPAN_SPAN_TOOL_CALLS) or attrs.get(
-            "tool_calls"
-        )
+        tool_calls_value = attrs.get(RESPAN_SPAN_TOOL_CALLS) or attrs.get("tool_calls")
     tool_calls_json = _json_string(_parse_json_if_string(tool_calls_value))
     if tool_calls_json:
         attrs[GEN_AI_COMPLETION_TOOL_CALLS_ATTR] = tool_calls_json
@@ -323,11 +683,213 @@ def _has_llm_message_attrs(attrs: dict[str, Any]) -> bool:
     )
 
 
+def _normalize_usage(attrs: dict[str, Any]) -> None:
+    prompt_tokens = attrs.get(TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS)
+    completion_tokens = attrs.get(TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS)
+    total_tokens = attrs.get(TLSpanAttributes.LLM_USAGE_TOTAL_TOKENS)
+
+    if prompt_tokens is not None:
+        attrs[GEN_AI_USAGE_INPUT_TOKENS] = prompt_tokens
+    if completion_tokens is not None:
+        attrs[GEN_AI_USAGE_OUTPUT_TOKENS] = completion_tokens
+    if total_tokens is not None:
+        attrs[TLSpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS] = total_tokens
+
+
+def _normalize_stream(
+    attrs: dict[str, Any], emission: OpenRouterEmissionContext | None
+) -> None:
+    is_stream = bool(
+        (emission is not None and emission.stream)
+        or attrs.get(GEN_AI_REQUEST_STREAM)
+        or attrs.get(TLSpanAttributes.LLM_IS_STREAMING)
+        or attrs.get(TLSpanAttributes.GEN_AI_IS_STREAMING)
+    )
+    if not is_stream:
+        return
+    attrs[GEN_AI_REQUEST_STREAM] = True
+    attrs[TLSpanAttributes.LLM_IS_STREAMING] = True
+
+
+def _error_message(
+    span: ReadableSpan, emission: OpenRouterEmissionContext | None
+) -> str | None:
+    if emission is not None and emission.error_message:
+        return emission.error_message
+    try:
+        status = getattr(span, "status", None)
+        status_code = getattr(status, "status_code", None)
+    except Exception:  # noqa: BLE001 - span/status properties may be hostile
+        return None
+    if status_code is StatusCode.ERROR:
+        try:
+            description = getattr(status, "description", None)
+        except Exception:  # noqa: BLE001 - status descriptions may be hostile
+            description = None
+        if isinstance(description, str) and description:
+            return description
+        return "OpenRouter request failed"
+    return None
+
+
+def _normalize_error(
+    span: ReadableSpan,
+    attrs: dict[str, Any],
+    emission: OpenRouterEmissionContext | None,
+) -> None:
+    message = _error_message(span, emission)
+    if message is None:
+        return
+
+    safe_message = _redact_text(message, limit=MAX_ERROR_BYTES)
+    emitted_status = emission.status_code if emission is not None else None
+    status_code = _resolve_http_status(message, emitted_status)
+    attrs[ERROR_MESSAGE_ATTR] = safe_message
+    attrs["http.response.status_code"] = status_code
+    attrs.setdefault(
+        TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+        json.dumps(
+            {
+                "error": "OpenRouterError",
+                "message": safe_message,
+                "status": "error",
+                "status_code": status_code,
+            },
+            separators=(",", ":"),
+        ),
+    )
+    # ReadableSpan exposes status as read-only but stores it in this mutable
+    # field. Downstream processors/exporters must observe an OTEL error.
+    if hasattr(span, "_status"):
+        span._status = Status(StatusCode.ERROR, safe_message)
+
+
+def _drop_content(attrs: dict[str, Any]) -> None:
+    content_keys = {
+        TLSpanAttributes.TRACELOOP_ENTITY_INPUT,
+        TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+        TLSpanAttributes.LLM_REQUEST_FUNCTIONS,
+        GEN_AI_OUTPUT_MESSAGES_ATTR,
+        GEN_AI_TOOL_DEFINITIONS_ATTR,
+    }
+    for key in tuple(attrs):
+        if key in content_keys or key.startswith(
+            (GEN_AI_PROMPT_PREFIX, GEN_AI_COMPLETION_PREFIX)
+        ):
+            attrs.pop(key, None)
+
+
+def _bound_content(attrs: dict[str, Any]) -> None:
+    request_type = attrs.get(TLSpanAttributes.LLM_REQUEST_TYPE)
+    json_keys = {
+        TLSpanAttributes.TRACELOOP_ENTITY_INPUT,
+        TLSpanAttributes.LLM_REQUEST_FUNCTIONS,
+        GEN_AI_OUTPUT_MESSAGES_ATTR,
+        GEN_AI_TOOL_DEFINITIONS_ATTR,
+    }
+    if request_type != LLMRequestTypeValues.EMBEDDING.value:
+        json_keys.add(TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT)
+
+    for key in tuple(attrs):
+        value = attrs.get(key)
+        if value is None:
+            continue
+        if key in json_keys or key.endswith(GEN_AI_TOOL_CALLS_SUFFIX):
+            bounded = _bounded_json_string(value)
+            if bounded is not None:
+                attrs[key] = bounded
+        elif key.startswith((GEN_AI_PROMPT_PREFIX, GEN_AI_COMPLETION_PREFIX)):
+            if isinstance(value, str):
+                attrs[key] = _redact_text(value)
+
+
+def _canonical_operation_kind(
+    attrs: dict[str, Any], emission: OpenRouterEmissionContext | None
+) -> str:
+    if emission is not None and emission.kind in {
+        "chat",
+        "completion",
+        "embedding",
+        "response",
+    }:
+        return emission.kind
+
+    request_type = attrs.get(TLSpanAttributes.LLM_REQUEST_TYPE)
+    if request_type == LLMRequestTypeValues.EMBEDDING.value:
+        return "embedding"
+    log_type = attrs.get(RESPAN_LOG_TYPE)
+    if log_type in {"completion", LOG_TYPE_TEXT}:
+        return "completion"
+    if log_type == "response":
+        return "response"
+    entity_name = attrs.get(TLSpanAttributes.TRACELOOP_ENTITY_NAME)
+    if isinstance(entity_name, str):
+        suffix = entity_name.rsplit(".", 1)[-1]
+        if suffix in {"chat", "completion", "response"}:
+            return suffix
+        if suffix in {"embedding", "embeddings"}:
+            return "embedding"
+    return "chat"
+
+
+def _normalize_common_contract(
+    span: ReadableSpan,
+    attrs: dict[str, Any],
+    emission: OpenRouterEmissionContext | None,
+) -> None:
+    kind = _canonical_operation_kind(attrs, emission)
+    if kind == "embedding":
+        attrs[TLSpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.EMBEDDING.value
+        attrs[RESPAN_LOG_TYPE] = LOG_TYPE_EMBEDDING
+        detail = "embeddings"
+    elif kind == "completion":
+        attrs[TLSpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+        attrs[RESPAN_LOG_TYPE] = LOG_TYPE_TEXT
+        detail = "completion"
+    else:
+        attrs[TLSpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+        attrs[RESPAN_LOG_TYPE] = LOG_TYPE_CHAT
+        detail = "response" if kind == "response" else "chat"
+
+    entity_name = f"openrouter.{detail}"
+    attrs[TLSpanAttributes.TRACELOOP_ENTITY_NAME] = entity_name
+    try:
+        parent = getattr(span, "parent", None)
+    except Exception:  # noqa: BLE001 - parent properties may be hostile
+        parent = None
+    is_nested = parent is not None
+    if isinstance(parent, SpanContext):
+        is_nested = parent.is_valid
+    attrs[TLSpanAttributes.TRACELOOP_ENTITY_PATH] = entity_name if is_nested else ""
+
+
+def _sanitize_url_attributes(attrs: dict[str, Any]) -> None:
+    for key in OPENROUTER_URL_ATTRIBUTE_KEYS:
+        value = attrs.get(key)
+        if isinstance(value, str):
+            attrs[key] = _redact_url(value)
+
+
+def _sanitize_identity_attributes(attrs: dict[str, Any]) -> None:
+    """Bound retained provider identifiers without coercing arbitrary values."""
+
+    for key in _PROVIDER_CONTROLLED_IDENTITY_KEYS:
+        value = attrs.get(key)
+        if isinstance(value, str):
+            attrs[key] = _redact_text(value)
+
+
 class OpenRouterSpanProcessor(SpanProcessor):
     """Normalize OpenAI-compatible OpenRouter spans before Respan export."""
 
-    def __init__(self, *, normalize_all_openai_spans: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        normalize_all_openai_spans: bool = True,
+        capture_content: bool = True,
+    ) -> None:
         self._normalize_all_openai_spans = normalize_all_openai_spans
+        self._capture_content = capture_content
 
     def on_start(self, span: Any, parent_context: Any = None) -> None:
         pass
@@ -350,23 +912,36 @@ class OpenRouterSpanProcessor(SpanProcessor):
             return
 
         attrs[TLSpanAttributes.LLM_SYSTEM] = OPENROUTER_SYSTEM_NAME
+        attrs[GEN_AI_PROVIDER_NAME] = OPENROUTER_SYSTEM_NAME
 
-        if _has_llm_message_attrs(attrs) or attrs.get(TLSpanAttributes.LLM_REQUEST_MODEL):
-            attrs.setdefault(
-                TLSpanAttributes.LLM_REQUEST_TYPE,
-                LLMRequestTypeValues.CHAT.value,
-            )
-            attrs.setdefault(RESPAN_LOG_TYPE, LOG_TYPE_CHAT)
+        emission = _CURRENT_EMISSION.get()
+        _normalize_common_contract(span, attrs, emission)
 
         _normalize_gen_ai_output_messages(attrs)
         _normalize_gen_ai_tool_calls(attrs)
         _normalize_structured_contract_attrs(attrs)
+        _normalize_usage(attrs)
+
+        _normalize_stream(attrs, emission)
+        _normalize_error(span, attrs, emission)
+        _sanitize_identity_attributes(attrs)
+        _sanitize_url_attributes(attrs)
 
         for key, value in list(attrs.items()):
             if key in _OFF_CONTRACT_ALIAS_ATTRIBUTES or _is_openai_omit(value):
                 attrs.pop(key, None)
 
+        if self._capture_content:
+            _bound_content(attrs)
+        else:
+            _drop_content(attrs)
+
         span._attributes = attrs
+        if hasattr(span, "_instrumentation_scope"):
+            span._instrumentation_scope = InstrumentationScope(
+                name=OPENROUTER_INSTRUMENTATION_SCOPE,
+                version=_package_version(),
+            )
 
     def shutdown(self) -> None:
         pass

--- a/python-sdks/instrumentations/respan-instrumentation-openrouter/tests/test_delegate_contract.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openrouter/tests/test_delegate_contract.py
@@ -1,0 +1,1032 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import tomllib
+from openai.resources.chat.completions import AsyncCompletions, Completions
+from openai.resources.completions import Completions as LegacyCompletions
+from openai.resources.responses import Responses
+from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_chunk import (
+    Choice as ChunkChoice,
+)
+from openai.types.chat.chat_completion_chunk import (
+    ChoiceDelta,
+)
+from openai.types.completion_usage import CompletionUsage
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_REQUEST_STREAM,
+)
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import (
+    NonRecordingSpan,
+    SpanContext,
+    StatusCode,
+    TraceFlags,
+    TraceState,
+    use_span,
+)
+from respan_instrumentation_openai import OpenAIInstrumentor as DirectOpenAIInstrumentor
+from respan_instrumentation_openai import _instrumentation as openai_instrumentation
+from respan_instrumentation_openai import _otel_emitter as openai_emitter
+from respan_instrumentation_openrouter import OpenRouterInstrumentor, _instrumentation
+from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_TEXT
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+
+
+def test_declared_versions_match_the_validated_delegate_surface() -> None:
+    project = tomllib.loads(
+        (Path(__file__).parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    dependencies = project["tool"]["poetry"]["dependencies"]
+
+    assert dependencies["openai"] == ">=3.0.0,<4.0.0"
+    assert dependencies["respan-instrumentation-openai"] == ">=1.2.1,<2.0.0"
+
+
+class FakeTracerProvider:
+    def __init__(self) -> None:
+        self._active_span_processor = SimpleNamespace(_span_processors=("exporter",))
+
+
+def _response(content: str = "Hello from OpenRouter") -> ChatCompletion:
+    return ChatCompletion(
+        id="chatcmpl-openrouter-test",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(role="assistant", content=content),
+            )
+        ],
+        created=1,
+        model="openai/gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(
+            prompt_tokens=7,
+            completion_tokens=5,
+            total_tokens=12,
+        ),
+    )
+
+
+def _chunk(
+    content: str, *, usage: CompletionUsage | None = None
+) -> ChatCompletionChunk:
+    choices = (
+        [
+            ChunkChoice(
+                index=0,
+                delta=ChoiceDelta(content=content),
+                finish_reason=None,
+            )
+        ]
+        if content
+        else []
+    )
+    return ChatCompletionChunk(
+        id="chatcmpl-openrouter-stream-test",
+        choices=choices,
+        created=1,
+        model="openai/gpt-4o-mini",
+        object="chat.completion.chunk",
+        usage=usage,
+    )
+
+
+def _tool_response() -> ChatCompletion:
+    return ChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-openrouter-tool-test",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_weather",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"city":"Tokyo"}',
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+            "created": 1,
+            "model": "openai/gpt-4o-mini",
+            "object": "chat.completion",
+            "usage": {
+                "prompt_tokens": 7,
+                "completion_tokens": 5,
+                "total_tokens": 12,
+            },
+        }
+    )
+
+
+def _tool_chunk() -> ChatCompletionChunk:
+    return ChatCompletionChunk.model_validate(
+        {
+            "id": "chatcmpl-openrouter-stream-test",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_weather",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"city":"Tokyo"}',
+                                },
+                            }
+                        ]
+                    },
+                }
+            ],
+            "created": 1,
+            "model": "openai/gpt-4o-mini",
+            "object": "chat.completion.chunk",
+        }
+    )
+
+
+@pytest.fixture
+def capture_delegate_spans(monkeypatch):
+    owner = _instrumentation._ACTIVE_BRIDGE_OWNER
+    if owner is not None:
+        owner.deactivate()
+
+    provider = FakeTracerProvider()
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: provider,
+    )
+    captured: list[ReadableSpan] = []
+    instrumentor = OpenRouterInstrumentor()
+
+    def install_capture() -> None:
+        assert instrumentor._processor is not None
+
+        def inject(span: ReadableSpan) -> bool:
+            instrumentor._processor.on_end(span)
+            captured.append(span)
+            return True
+
+        monkeypatch.setattr(openai_emitter, "inject_span", inject)
+
+    yield instrumentor, captured, install_capture
+
+    instrumentor.deactivate()
+
+
+def test_current_sdk_sync_delegate_emits_one_real_readable_span(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    def create(_self, **_kwargs):
+        return _response()
+
+    monkeypatch.setattr(Completions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    result = Completions.create(
+        object(),
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    assert isinstance(result, ChatCompletion)
+    assert len(captured) == 1
+    span = captured[0]
+    assert isinstance(span, ReadableSpan)
+    assert span.attributes[GEN_AI_PROVIDER_NAME] == "openrouter"
+    assert span.attributes[SpanAttributes.LLM_SYSTEM] == "openrouter"
+    assert span.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "openai/gpt-4o-mini"
+    assert span.attributes["gen_ai.usage.input_tokens"] == 7
+    assert span.attributes["gen_ai.usage.output_tokens"] == 5
+    assert span.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_CHAT
+    assert span.attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "openrouter.chat"
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+    assert span.instrumentation_scope.name == "respan.instrumentation.openrouter"
+
+
+def test_released_delegate_without_suppression_helper_remains_supported(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    def create(_self, **_kwargs):
+        return _response("released delegate compatibility")
+
+    monkeypatch.delattr(
+        openai_instrumentation,
+        "_is_openai_instrumentation_suppressed",
+        raising=False,
+    )
+    monkeypatch.setattr(Completions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    response = Completions.create(
+        object(),
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "compatibility"}],
+    )
+
+    assert response.choices[0].message.content == "released delegate compatibility"
+    assert len(captured) == 1
+    assert captured[0].attributes[GEN_AI_PROVIDER_NAME] == "openrouter"
+
+
+def test_current_sdk_legacy_completion_uses_canonical_text_contract(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    def create(_self, **_kwargs):
+        return SimpleNamespace(
+            id="cmpl-openrouter-test",
+            model="openai/gpt-4o-mini",
+            choices=[SimpleNamespace(text="legacy completion")],
+            usage=SimpleNamespace(
+                prompt_tokens=3,
+                completion_tokens=2,
+                total_tokens=5,
+            ),
+        )
+
+    monkeypatch.setattr(LegacyCompletions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    result = LegacyCompletions.create(
+        object(), model="openai/gpt-4o-mini", prompt="complete this"
+    )
+
+    assert result.choices[0].text == "legacy completion"
+    assert len(captured) == 1
+    span = captured[0]
+    assert isinstance(span, ReadableSpan)
+    assert span.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_TEXT
+    assert span.attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == (
+        "openrouter.completion"
+    )
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+
+
+def test_current_sdk_responses_uses_canonical_chat_contract(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    def create(_self, **_kwargs):
+        return SimpleNamespace(
+            id="resp-openrouter-test",
+            model="openai/gpt-4o-mini",
+            output_text="responses output",
+            usage=SimpleNamespace(input_tokens=4, output_tokens=3, total_tokens=7),
+        )
+
+    monkeypatch.setattr(Responses, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    result = Responses.create(
+        object(), model="openai/gpt-4o-mini", input="respond to this"
+    )
+
+    assert result.output_text == "responses output"
+    assert len(captured) == 1
+    span = captured[0]
+    assert isinstance(span, ReadableSpan)
+    assert span.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_CHAT
+    assert span.attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == (
+        "openrouter.response"
+    )
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+
+
+def test_current_sdk_delegate_emits_canonical_tools_without_aliases(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    def create(_self, **_kwargs):
+        return _tool_response()
+
+    monkeypatch.setattr(Completions, "create", create)
+    instrumentor.activate()
+    install_capture()
+    tool_definition = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+    }
+
+    Completions.create(
+        object(),
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "weather"}],
+        tools=[tool_definition],
+    )
+
+    assert len(captured) == 1
+    attrs = dict(captured[0].attributes)
+    assert json.loads(attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS]) == [tool_definition]
+    assert json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]) == [
+        {
+            "id": "call_weather",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"city":"Tokyo"}',
+            },
+        }
+    ]
+    for alias in ("tools", "tool_calls", "respan.span.tools"):
+        assert alias not in attrs
+
+
+def test_stream_uses_call_time_parent_when_consumed_outside_context(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+    chunks = [_chunk("parented")]
+
+    def create(_self, **_kwargs):
+        return iter(chunks)
+
+    monkeypatch.setattr(Completions, "create", create)
+    monkeypatch.setattr(openai_instrumentation, "_is_stream", lambda _value: True)
+    instrumentor.activate()
+    install_capture()
+    parent_context = SpanContext(
+        trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+        span_id=0x1234567890ABCDEF,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        trace_state=TraceState(),
+    )
+
+    with use_span(NonRecordingSpan(parent_context)):
+        stream = Completions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "stream"}],
+            stream=True,
+        )
+    assert list(stream) == chunks
+
+    assert len(captured) == 1
+    assert captured[0].context.trace_id == parent_context.trace_id
+    assert captured[0].parent is not None
+    assert captured[0].parent.span_id == parent_context.span_id
+    assert captured[0].attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == (
+        "openrouter.chat"
+    )
+
+
+def test_sync_stream_finalizes_once_with_stream_flag(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+    chunks = [
+        _chunk("Trace "),
+        _chunk("works."),
+        _chunk(
+            "",
+            usage=CompletionUsage(
+                prompt_tokens=4,
+                completion_tokens=2,
+                total_tokens=6,
+            ),
+        ),
+    ]
+
+    def create(_self, **_kwargs):
+        return iter(chunks)
+
+    monkeypatch.setattr(Completions, "create", create)
+    monkeypatch.setattr(openai_instrumentation, "_is_stream", lambda _value: True)
+    instrumentor.activate()
+    install_capture()
+
+    stream = Completions.create(
+        object(),
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "stream"}],
+        stream=True,
+    )
+    assert list(stream) == chunks
+
+    assert len(captured) == 1
+    span = captured[0]
+    assert span.attributes[GEN_AI_REQUEST_STREAM] is True
+    assert span.attributes[SpanAttributes.LLM_IS_STREAMING] is True
+    assert span.attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        "Trace works."
+    )
+    assert span.attributes["gen_ai.usage.input_tokens"] == 4
+    assert span.attributes["gen_ai.usage.output_tokens"] == 2
+
+
+def test_long_stream_keeps_complete_bounded_content_terminal_tool_and_usage(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+    chunks = [
+        *[_chunk("x") for _ in range(150)],
+        _tool_chunk(),
+        _chunk(
+            "",
+            usage=CompletionUsage(
+                prompt_tokens=19,
+                completion_tokens=11,
+                total_tokens=30,
+            ),
+        ),
+    ]
+
+    def create(_self, **_kwargs):
+        return iter(chunks)
+
+    monkeypatch.setattr(Completions, "create", create)
+    monkeypatch.setattr(openai_instrumentation, "_is_stream", lambda _value: True)
+    instrumentor.activate()
+    install_capture()
+
+    stream = Completions.create(
+        object(),
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "long stream"}],
+        stream=True,
+    )
+    assert list(stream) == chunks
+
+    assert len(captured) == 1
+    attrs = dict(captured[0].attributes)
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "x" * 150
+    assert attrs["gen_ai.usage.input_tokens"] == 19
+    assert attrs["gen_ai.usage.output_tokens"] == 11
+    assert json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]) == [
+        {
+            "id": "call_weather",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"city":"Tokyo"}',
+            },
+        }
+    ]
+
+
+def test_sync_stream_close_finalizes_partial_output_once(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+    chunks = [_chunk("partial"), _chunk(" ignored")]
+
+    def create(_self, **_kwargs):
+        return iter(chunks)
+
+    monkeypatch.setattr(Completions, "create", create)
+    monkeypatch.setattr(openai_instrumentation, "_is_stream", lambda _value: True)
+    instrumentor.activate()
+    install_capture()
+
+    stream = Completions.create(
+        object(),
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "stream"}],
+        stream=True,
+    )
+    assert next(stream) == chunks[0]
+    stream.close()
+
+    assert len(captured) == 1
+    assert captured[0].attributes[GEN_AI_REQUEST_STREAM] is True
+    assert (
+        captured[0].attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]
+        == "partial"
+    )
+
+
+def test_sync_stream_proxy_preserves_context_manager_and_delegate_attributes(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    class ContextStream:
+        marker = "delegate-marker"
+
+        def __init__(self) -> None:
+            self.closed = False
+            self.entered = False
+            self._chunks = iter([_chunk("partial"), _chunk(" ignored")])
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._chunks)
+
+        def close(self) -> None:
+            self.closed = True
+
+        def __enter__(self):
+            self.entered = True
+            return self
+
+        def __exit__(self, _exc_type, _exc, _traceback) -> None:
+            self.close()
+
+    delegated_stream = ContextStream()
+
+    def create(_self, **_kwargs):
+        return delegated_stream
+
+    monkeypatch.setattr(Completions, "create", create)
+    monkeypatch.setattr(openai_instrumentation, "_is_stream", lambda _value: True)
+    instrumentor.activate()
+    install_capture()
+
+    with Completions.create(
+        object(),
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "stream"}],
+        stream=True,
+    ) as stream:
+        assert stream.marker == "delegate-marker"
+        assert next(stream) == _chunk("partial")
+
+    assert delegated_stream.entered is True
+    assert delegated_stream.closed is True
+    assert len(captured) == 1
+    assert captured[0].attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        "partial"
+    )
+
+
+def test_sync_provider_error_retains_precise_status(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    class RateLimited(Exception):
+        status_code = 429
+
+    def create(_self, **_kwargs):
+        raise RateLimited("Error code: 429 - deterministic provider limit")
+
+    monkeypatch.setattr(Completions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    with pytest.raises(RateLimited):
+        Completions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "fail"}],
+        )
+
+    assert len(captured) == 1
+    span = captured[0]
+    assert span.status.status_code is StatusCode.ERROR
+    assert span.attributes["http.response.status_code"] == 429
+    assert "deterministic provider limit" in span.attributes["error.message"]
+
+
+def test_nonstream_status_does_not_require_message_regex_or_exception_str(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    class HostileRateLimit(Exception):
+        status_code = 429
+
+        def __str__(self) -> str:
+            raise RuntimeError("hostile __str__ invoked")
+
+    def create(_self, **_kwargs):
+        raise HostileRateLimit("provider limit")
+
+    monkeypatch.setattr(Completions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    with pytest.raises(HostileRateLimit):
+        Completions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "fail safely"}],
+        )
+
+    assert len(captured) == 1
+    span = captured[0]
+    assert span.attributes["http.response.status_code"] == 429
+    assert span.attributes["error.message"] == "provider limit"
+    assert span.status.status_code is StatusCode.ERROR
+
+
+def test_explicit_generic_500_is_not_overridden_by_error_text(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    class ProviderFailure(Exception):
+        status_code = 500
+
+    def create(_self, **_kwargs):
+        raise ProviderFailure("OpenRouter provider cache HTTP 404 during formatting")
+
+    monkeypatch.setattr(Completions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    with pytest.raises(ProviderFailure):
+        Completions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "fail safely"}],
+        )
+
+    assert len(captured) == 1
+    assert captured[0].attributes["http.response.status_code"] == 500
+
+
+def test_hostile_status_property_never_masks_original_provider_error(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    class HostileStatus(Exception):
+        @property
+        def status_code(self):
+            raise RuntimeError("hostile status property invoked")
+
+        @property
+        def response(self):
+            raise RuntimeError("hostile response property invoked")
+
+    def create(_self, **_kwargs):
+        raise HostileStatus("safe diagnostic")
+
+    monkeypatch.setattr(Completions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    with pytest.raises(HostileStatus, match="safe diagnostic"):
+        Completions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "fail safely"}],
+        )
+
+    assert len(captured) == 1
+    assert captured[0].attributes["http.response.status_code"] == 500
+
+
+def test_async_stream_finalizes_and_preserves_error_status(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    class AsyncFailingStream:
+        def __aiter__(self):
+            async def iterate():
+                yield _chunk("partial")
+                error = RuntimeError("HTTP 503 OpenRouter unavailable")
+                error.status_code = 503
+                raise error
+
+            return iterate()
+
+    def create(_self, **_kwargs):
+        return AsyncFailingStream()
+
+    monkeypatch.setattr(AsyncCompletions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    async def consume() -> None:
+        stream = await AsyncCompletions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "stream"}],
+            stream=True,
+        )
+        with pytest.raises(RuntimeError, match="OpenRouter unavailable"):
+            async for _chunk_value in stream:
+                await asyncio.sleep(0)
+
+    asyncio.run(consume())
+
+    assert len(captured) == 1
+    span = captured[0]
+    assert span.attributes[GEN_AI_REQUEST_STREAM] is True
+    assert span.attributes["http.response.status_code"] == 503
+    assert span.status.status_code is StatusCode.ERROR
+
+
+def test_async_for_delegates_iterator_and_finalizes_full_output(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+    chunks = [
+        _chunk("async "),
+        _chunk("complete"),
+        _chunk(
+            "",
+            usage=CompletionUsage(
+                prompt_tokens=8,
+                completion_tokens=2,
+                total_tokens=10,
+            ),
+        ),
+    ]
+
+    class AsyncIterableOnly:
+        def __aiter__(self):
+            async def iterate():
+                for chunk in chunks:
+                    yield chunk
+
+            return iterate()
+
+    def create(_self, **_kwargs):
+        return AsyncIterableOnly()
+
+    monkeypatch.setattr(AsyncCompletions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    async def consume() -> list[ChatCompletionChunk]:
+        stream = await AsyncCompletions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "stream"}],
+            stream=True,
+        )
+        return [chunk async for chunk in stream]
+
+    assert asyncio.run(consume()) == chunks
+    assert len(captured) == 1
+    attrs = dict(captured[0].attributes)
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == ("async complete")
+    assert attrs["gen_ai.usage.input_tokens"] == 8
+    assert attrs["gen_ai.usage.output_tokens"] == 2
+
+
+def test_async_stream_aclose_finalizes_once_and_closes_delegate(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    class CloseAwareAsyncStream:
+        def __init__(self) -> None:
+            self.closed = False
+            self._chunks = iter([_chunk("partial"), _chunk(" ignored")])
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._chunks)
+            except StopIteration as exc:
+                raise StopAsyncIteration from exc
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    delegated_stream = CloseAwareAsyncStream()
+
+    def create(_self, **_kwargs):
+        return delegated_stream
+
+    monkeypatch.setattr(AsyncCompletions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    async def consume_one() -> None:
+        stream = await AsyncCompletions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "stream"}],
+            stream=True,
+        )
+        assert await anext(stream) == _chunk("partial")
+        await stream.aclose()
+
+    asyncio.run(consume_one())
+
+    assert delegated_stream.closed is True
+    assert len(captured) == 1
+    attrs = dict(captured[0].attributes)
+    assert attrs[GEN_AI_REQUEST_STREAM] is True
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "partial"
+
+
+def test_async_stream_proxy_preserves_context_manager(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    class AsyncContextStream:
+        def __init__(self) -> None:
+            self.entered = False
+            self.closed = False
+            self._chunks = iter([_chunk("partial"), _chunk(" ignored")])
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._chunks)
+            except StopIteration as exc:
+                raise StopAsyncIteration from exc
+
+        async def close(self) -> None:
+            self.closed = True
+
+        async def __aenter__(self):
+            self.entered = True
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _traceback) -> None:
+            await self.close()
+
+    delegated_stream = AsyncContextStream()
+
+    def create(_self, **_kwargs):
+        return delegated_stream
+
+    monkeypatch.setattr(AsyncCompletions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    async def consume() -> None:
+        stream = await AsyncCompletions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "stream"}],
+            stream=True,
+        )
+        async with stream as entered:
+            assert entered is stream
+            assert await anext(entered) == _chunk("partial")
+
+    asyncio.run(consume())
+
+    assert delegated_stream.entered is True
+    assert delegated_stream.closed is True
+    assert len(captured) == 1
+    assert captured[0].attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        "partial"
+    )
+
+
+def test_async_stream_cancellation_emits_once_and_closes_delegate(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    class CancelledStream:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise asyncio.CancelledError("consumer cancelled")
+
+        async def close(self) -> None:
+            self.closed = True
+
+    delegated_stream = CancelledStream()
+
+    def create(_self, **_kwargs):
+        return delegated_stream
+
+    monkeypatch.setattr(AsyncCompletions, "create", create)
+    instrumentor.activate()
+    install_capture()
+
+    async def consume() -> None:
+        stream = await AsyncCompletions.create(
+            object(),
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "stream"}],
+            stream=True,
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await anext(stream)
+
+    asyncio.run(consume())
+
+    assert delegated_stream.closed is True
+    assert len(captured) == 1
+    assert captured[0].status.status_code is StatusCode.ERROR
+    assert captured[0].attributes["http.response.status_code"] == 500
+    assert captured[0].attributes["error.message"] == "consumer cancelled"
+
+
+def test_later_openai_owner_join_and_leave_keeps_openrouter_active(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, captured, install_capture = capture_delegate_spans
+
+    def create(_self, **_kwargs):
+        return _response("joined owner")
+
+    monkeypatch.setattr(Completions, "create", create)
+    instrumentor.activate()
+    install_capture()
+    openrouter_wrapper = Completions.create
+    independent = DirectOpenAIInstrumentor()
+
+    independent.activate()
+    assert Completions.create is openrouter_wrapper
+    independent.deactivate()
+    assert Completions.create is openrouter_wrapper
+
+    result = Completions.create(
+        object(),
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "still traced"}],
+    )
+    assert result.choices[0].message.content == "joined owner"
+    assert len(captured) == 1
+
+
+def test_openrouter_leaves_before_independent_openai_owner_without_harming_it(
+    monkeypatch,
+    capture_delegate_spans,
+) -> None:
+    instrumentor, _captured, _install_capture = capture_delegate_spans
+
+    def create(_self, **_kwargs):
+        return _response("independent owner")
+
+    monkeypatch.setattr(Completions, "create", create)
+    instrumentor.activate()
+    independent = DirectOpenAIInstrumentor()
+    independent.activate()
+
+    instrumentor.deactivate()
+    assert Completions.create is not create
+    assert independent._is_instrumented is True
+
+    independent.deactivate()
+    assert Completions.create is create

--- a/python-sdks/instrumentations/respan-instrumentation-openrouter/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openrouter/tests/test_instrumentation.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import json
 import logging
 from types import SimpleNamespace
+from typing import ClassVar
 
 import pytest
 from opentelemetry.semconv_ai import SpanAttributes
+from respan_instrumentation_openrouter import OpenRouterInstrumentor, _instrumentation
+from respan_instrumentation_openrouter._constants import OPENROUTER_SYSTEM_NAME
+from respan_instrumentation_openrouter._processor import OpenRouterSpanProcessor
 from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
 from respan_sdk.constants.span_attributes import (
     RESPAN_LOG_TYPE,
@@ -14,14 +18,9 @@ from respan_sdk.constants.span_attributes import (
 )
 from respan_tracing.core.tracer import RespanTracer
 
-from respan_instrumentation_openrouter import OpenRouterInstrumentor
-from respan_instrumentation_openrouter import _instrumentation
-from respan_instrumentation_openrouter._constants import OPENROUTER_SYSTEM_NAME
-from respan_instrumentation_openrouter._processor import OpenRouterSpanProcessor
-
 
 class FakeOpenAIInstrumentor:
-    created: list["FakeOpenAIInstrumentor"] = []
+    created: ClassVar[list[FakeOpenAIInstrumentor]] = []
 
     def __init__(self) -> None:
         self.activated = False
@@ -49,6 +48,8 @@ class FakeTracerProvider:
 
 @pytest.fixture(autouse=True)
 def reset_fakes(monkeypatch):
+    while (owner := _instrumentation._ACTIVE_BRIDGE_OWNER) is not None:
+        owner.deactivate()
     FakeOpenAIInstrumentor.created.clear()
     RespanTracer.reset_instance()
     monkeypatch.setattr(
@@ -57,6 +58,8 @@ def reset_fakes(monkeypatch):
         FakeOpenAIInstrumentor,
     )
     yield
+    while (owner := _instrumentation._ACTIVE_BRIDGE_OWNER) is not None:
+        owner.deactivate()
     RespanTracer.reset_instance()
 
 
@@ -94,6 +97,30 @@ def test_activate_delegates_to_openai_and_inserts_processor_before_exporter(
     assert provider._active_span_processor._span_processors == ("exporter",)
 
 
+def test_foreign_same_class_processor_and_exact_order_are_preserved(
+    monkeypatch,
+) -> None:
+    foreign = OpenRouterSpanProcessor(capture_content=False)
+    provider = FakeTracerProvider(processors=(foreign, "exporter"))
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: provider,
+    )
+
+    instrumentor = OpenRouterInstrumentor()
+    instrumentor.activate()
+
+    assert provider._active_span_processor._span_processors == (
+        instrumentor._processor,
+        foreign,
+        "exporter",
+    )
+
+    instrumentor.deactivate()
+    assert provider._active_span_processor._span_processors == (foreign, "exporter")
+
+
 def test_activate_is_idempotent(monkeypatch) -> None:
     provider = FakeTracerProvider(processors=("exporter",))
     monkeypatch.setattr(
@@ -107,10 +134,154 @@ def test_activate_is_idempotent(monkeypatch) -> None:
     instrumentor.activate()
 
     assert len(FakeOpenAIInstrumentor.created) == 1
-    assert sum(
-        isinstance(processor, OpenRouterSpanProcessor)
-        for processor in provider._active_span_processor._span_processors
-    ) == 1
+    assert (
+        sum(
+            isinstance(processor, OpenRouterSpanProcessor)
+            for processor in provider._active_span_processor._span_processors
+        )
+        == 1
+    )
+
+
+def test_second_instance_with_different_capture_policy_is_rejected(monkeypatch) -> None:
+    provider = FakeTracerProvider(processors=("foreign", "exporter"))
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: provider,
+    )
+
+    first = OpenRouterInstrumentor(capture_content=True)
+    second = OpenRouterInstrumentor(capture_content=False)
+    first.activate()
+    second.activate()
+
+    assert first._is_instrumented is True
+    assert first._processor is not None
+    assert first._processor._capture_content is True
+    assert second._is_instrumented is False
+    assert second._processor is None
+    assert len(FakeOpenAIInstrumentor.created) == 1
+    assert (
+        sum(
+            isinstance(processor, OpenRouterSpanProcessor)
+            for processor in provider._active_span_processor._span_processors
+        )
+        == 1
+    )
+
+    first.deactivate()
+    assert provider._active_span_processor._span_processors == (
+        "foreign",
+        "exporter",
+    )
+
+
+def test_same_config_instances_share_runtime_until_last_release(monkeypatch) -> None:
+    provider = FakeTracerProvider(processors=("foreign", "exporter"))
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: provider,
+    )
+
+    first = OpenRouterInstrumentor(capture_content=False)
+    second = OpenRouterInstrumentor(capture_content=False)
+    first.activate()
+    second.activate()
+
+    assert first._is_instrumented is True
+    assert second._is_instrumented is True
+    assert first._runtime is second._runtime
+    assert first._processor is second._processor
+    assert len(FakeOpenAIInstrumentor.created) == 1
+
+    first.deactivate()
+    assert second._is_instrumented is True
+    assert isinstance(
+        provider._active_span_processor._span_processors[0],
+        OpenRouterSpanProcessor,
+    )
+    assert FakeOpenAIInstrumentor.created[0].deactivated is False
+
+    second.deactivate()
+    assert provider._active_span_processor._span_processors == (
+        "foreign",
+        "exporter",
+    )
+    assert FakeOpenAIInstrumentor.created[0].deactivated is True
+
+
+def test_deactivate_does_not_overwrite_foreign_delegate_change(monkeypatch) -> None:
+    provider = FakeTracerProvider(processors=("exporter",))
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: provider,
+    )
+    instrumentor = OpenRouterInstrumentor()
+    instrumentor.activate()
+
+    assert instrumentor._runtime is not None
+    original = instrumentor._runtime.delegate_kind_entries["chat"]
+    aggregate = _instrumentation.openai_instrumentation._KINDS["chat"][1]
+
+    def foreign_emit(**_kwargs):
+        return None
+
+    _instrumentation.openai_instrumentation._KINDS["chat"] = (
+        foreign_emit,
+        aggregate,
+    )
+    try:
+        instrumentor.deactivate()
+        assert _instrumentation.openai_instrumentation._KINDS["chat"][0] is foreign_emit
+        assert provider._active_span_processor._span_processors == ("exporter",)
+    finally:
+        _instrumentation.openai_instrumentation._KINDS["chat"] = original
+
+
+def test_adopts_preinstalled_openai_delegate_without_owning_teardown(
+    monkeypatch,
+) -> None:
+    class ExistingOpenAIInstrumentor(FakeOpenAIInstrumentor):
+        created: ClassVar[list[ExistingOpenAIInstrumentor]] = []
+
+        def activate(self) -> None:
+            self.activated = True
+            self._is_instrumented = False
+
+    provider = FakeTracerProvider(processors=("exporter",))
+    monkeypatch.setattr(
+        _instrumentation,
+        "OpenAIInstrumentor",
+        ExistingOpenAIInstrumentor,
+    )
+    monkeypatch.setattr(
+        _instrumentation.openai_instrumentation,
+        "_original_methods",
+        {("foreign", "create"): object()},
+    )
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: provider,
+    )
+
+    instrumentor = OpenRouterInstrumentor()
+    instrumentor.activate()
+
+    assert instrumentor._is_instrumented is True
+    assert instrumentor._runtime is not None
+    assert instrumentor._runtime.owns_delegate_patches is False
+    assert isinstance(
+        provider._active_span_processor._span_processors[0],
+        OpenRouterSpanProcessor,
+    )
+
+    instrumentor.deactivate()
+    assert ExistingOpenAIInstrumentor.created[0].deactivated is False
+    assert provider._active_span_processor._span_processors == ("exporter",)
 
 
 def test_activate_skips_when_respan_tracing_is_disabled(monkeypatch, caplog) -> None:
@@ -136,7 +307,7 @@ def test_activate_skips_when_respan_tracing_is_disabled(monkeypatch, caplog) -> 
 
 def test_activate_skips_when_openai_delegate_does_not_instrument(monkeypatch) -> None:
     class MissingOpenAIInstrumentor(FakeOpenAIInstrumentor):
-        created: list["MissingOpenAIInstrumentor"] = []
+        created: ClassVar[list[MissingOpenAIInstrumentor]] = []
 
         def activate(self) -> None:
             self.activated = True
@@ -314,12 +485,12 @@ def test_processor_promotes_new_gen_ai_output_messages_to_canonical_fields() -> 
     assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.role"] == "assistant"
     assert (
         attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]
-        == 'Tool call: lookup({"city": "Tokyo"})'
+        == 'Tool call: lookup({"city":"Tokyo"})'
     )
     assert json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]) == [
         {
             "type": "function",
-            "function": {"name": "lookup", "arguments": '{"city": "Tokyo"}'},
+            "function": {"name": "lookup", "arguments": '{"city":"Tokyo"}'},
             "id": "call_123",
         }
     ]

--- a/python-sdks/instrumentations/respan-instrumentation-openrouter/tests/test_processor_contract.py
+++ b/python-sdks/instrumentations/respan-instrumentation-openrouter/tests/test_processor_contract.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import json
+
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_REQUEST_STREAM,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import StatusCode
+from respan_instrumentation_openrouter._constants import (
+    MAX_ATTRIBUTE_BYTES,
+    OPENROUTER_INSTRUMENTATION_SCOPE,
+)
+from respan_instrumentation_openrouter._processor import (
+    OpenRouterSpanProcessor,
+    _redact_text,
+)
+from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_EMBEDDING
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_tracing.exporters.respan import _span_to_otlp_json
+from respan_tracing.utils.span_factory import build_readable_span
+
+
+def _span(attributes: dict, *, error_message: str | None = None):
+    return build_readable_span(
+        "openai.chat",
+        start_time_ns=1,
+        end_time_ns=2,
+        attributes=attributes,
+        error_message=error_message,
+        merge_propagated=False,
+    )
+
+
+def _otlp_attributes(payload: dict) -> dict:
+    result = {}
+    for item in payload["attributes"]:
+        value = item["value"]
+        primitive = next(iter(value.values()))
+        result[item["key"]] = primitive
+    return result
+
+
+def test_real_readable_span_has_openrouter_contract_and_scope() -> None:
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+            SpanAttributes.LLM_USAGE_PROMPT_TOKENS: 7,
+            SpanAttributes.LLM_USAGE_COMPLETION_TOKENS: 5,
+            SpanAttributes.LLM_USAGE_TOTAL_TOKENS: 12,
+            SpanAttributes.TRACELOOP_SPAN_KIND: "llm",
+            f"{SpanAttributes.LLM_PROMPTS}.0.role": "user",
+            f"{SpanAttributes.LLM_PROMPTS}.0.content": "hello",
+        }
+    )
+
+    OpenRouterSpanProcessor().on_end(span)
+
+    attrs = dict(span.attributes)
+    assert attrs[SpanAttributes.LLM_SYSTEM] == "openrouter"
+    assert attrs[GEN_AI_PROVIDER_NAME] == "openrouter"
+    assert attrs[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
+    assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_CHAT
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] == "openrouter.chat"
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+    assert attrs[GEN_AI_USAGE_INPUT_TOKENS] == 7
+    assert attrs[GEN_AI_USAGE_OUTPUT_TOKENS] == 5
+    assert attrs[SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS] == 12
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
+    assert span.instrumentation_scope.name == OPENROUTER_INSTRUMENTATION_SCOPE
+
+
+def test_provider_429_is_an_otel_error_in_the_real_export_payload() -> None:
+    secret = "sk-or-v1-1234567890abcdef"
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+            SpanAttributes.TRACELOOP_ENTITY_INPUT: '[{"role":"user","content":"hi"}]',
+        },
+        error_message=f"Error code: 429 - rate limited; api_key={secret}",
+    )
+
+    OpenRouterSpanProcessor().on_end(span)
+
+    assert span.status.status_code is StatusCode.ERROR
+    assert span.attributes["http.response.status_code"] == 429
+    assert secret not in span.attributes["error.message"]
+    error_output = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    assert error_output["status_code"] == 429
+    assert secret not in json.dumps(error_output)
+
+    otlp = _span_to_otlp_json(span)
+    assert otlp["status"]["code"] == 2
+    assert secret not in otlp["status"]["message"]
+    exported_attrs = _otlp_attributes(otlp)
+    assert int(exported_attrs["http.response.status_code"]) == 429
+    assert secret not in exported_attrs["error.message"]
+
+
+def test_unrelated_status_code_text_is_not_promoted_to_provider_404() -> None:
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+        },
+        error_message=(
+            "cache HTTP 404 while formatting application output; status code: 404"
+        ),
+    )
+
+    OpenRouterSpanProcessor().on_end(span)
+
+    assert span.attributes["http.response.status_code"] == 500
+
+
+def test_generic_error_code_text_is_not_promoted_without_provider_scope() -> None:
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+        },
+        error_message="application cache error code: 404 during tool execution",
+    )
+
+    OpenRouterSpanProcessor().on_end(span)
+
+    assert span.attributes["http.response.status_code"] == 500
+
+
+def test_capture_content_false_keeps_identity_usage_and_error_only() -> None:
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+            SpanAttributes.LLM_USAGE_PROMPT_TOKENS: 3,
+            SpanAttributes.TRACELOOP_ENTITY_INPUT: "secret prompt",
+            SpanAttributes.TRACELOOP_ENTITY_OUTPUT: "secret response",
+            SpanAttributes.LLM_REQUEST_FUNCTIONS: '[{"type":"function"}]',
+            f"{SpanAttributes.LLM_PROMPTS}.0.content": "secret prompt",
+            f"{SpanAttributes.LLM_COMPLETIONS}.0.content": "secret response",
+        },
+        error_message="OpenRouter error code: 401 - credential rejected",
+    )
+
+    OpenRouterSpanProcessor(capture_content=False).on_end(span)
+
+    attrs = dict(span.attributes)
+    assert attrs[GEN_AI_PROVIDER_NAME] == "openrouter"
+    assert attrs[GEN_AI_USAGE_INPUT_TOKENS] == 3
+    assert attrs["http.response.status_code"] == 401
+    assert "error.message" in attrs
+    assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in attrs
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in attrs
+    assert SpanAttributes.LLM_REQUEST_FUNCTIONS not in attrs
+    assert not any(
+        key.startswith(("gen_ai.prompt.", "gen_ai.completion.")) for key in attrs
+    )
+
+
+def test_capture_content_false_still_redacts_sensitive_url_fields() -> None:
+    secret = "plain-secret-value"
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+            "url.full": (
+                "https://user:password@openrouter.ai/api/v1/chat/completions"
+                f"?api_key={secret}&model=openai%2Fgpt-4o-mini"
+                "&client_secret=another-secret"
+            ),
+        }
+    )
+
+    OpenRouterSpanProcessor(capture_content=False).on_end(span)
+
+    url = span.attributes["url.full"]
+    assert "user:password" not in url
+    assert secret not in url
+    assert "another-secret" not in url
+    assert "api_key=%5BREDACTED%5D" in url
+    assert "model=openai%2Fgpt-4o-mini" in url
+    assert len(url.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES
+
+
+def test_quoted_and_suffix_sensitive_fields_are_redacted() -> None:
+    secret_values = {
+        "api_key": "plain-secret-value",
+        "authorization": "Basic plaintext-credential",
+        "nested_client_secret": "client-secret-value",
+        "auth_token": "auth-token-value",
+        "accessToken": "camel-access-token-value",
+        "db_password": "database-password-value",
+        "token": "plain-token-value",
+    }
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+            SpanAttributes.TRACELOOP_ENTITY_INPUT: json.dumps(secret_values),
+        }
+    )
+
+    OpenRouterSpanProcessor().on_end(span)
+
+    safe_input = span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+    parsed = json.loads(safe_input)
+    assert all(value == "[REDACTED]" for value in parsed.values())
+    assert not any(value in safe_input for value in secret_values.values())
+    assert _redact_text('{"api_key":"plain-secret-value"}') == (
+        '{"api_key":"[REDACTED]"}'
+    )
+    assert _redact_text("'authorization': 'Basic plaintext-credential'") == (
+        "'authorization': '[REDACTED]'"
+    )
+
+
+def test_content_is_private_finite_and_utf8_byte_bounded() -> None:
+    secret = "sk-or-v1-1234567890abcdef"
+    huge = "界" * (MAX_ATTRIBUTE_BYTES * 2)
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+            SpanAttributes.TRACELOOP_ENTITY_INPUT: json.dumps(
+                {
+                    "messages": [{"role": "user", "content": huge}],
+                    "authorization": f"Bearer {secret}",
+                    "temperature": float("nan"),
+                }
+            ),
+            SpanAttributes.LLM_REQUEST_FUNCTIONS: json.dumps(
+                [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"api_key": secret},
+                        },
+                    }
+                ]
+            ),
+        }
+    )
+
+    OpenRouterSpanProcessor().on_end(span)
+
+    for key in (
+        SpanAttributes.TRACELOOP_ENTITY_INPUT,
+        SpanAttributes.LLM_REQUEST_FUNCTIONS,
+    ):
+        value = span.attributes[key]
+        assert len(value.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES
+        assert secret not in value
+        assert "NaN" not in value
+        json.loads(value)
+
+
+def test_retained_model_is_redacted_and_utf8_byte_bounded() -> None:
+    secret = "plain-secret-value"
+    model = f"openai/{'界' * MAX_ATTRIBUTE_BYTES}?api_key={secret}"
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: model,
+        }
+    )
+
+    OpenRouterSpanProcessor(capture_content=False).on_end(span)
+
+    safe_model = span.attributes[SpanAttributes.LLM_REQUEST_MODEL]
+    assert safe_model.startswith("openai/")
+    assert secret not in safe_model
+    assert len(safe_model.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES
+
+
+def test_embedding_vector_is_not_truncated_by_chat_bounds() -> None:
+    vector = [0.125] * (MAX_ATTRIBUTE_BYTES + 1)
+    output = json.dumps(vector)
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/text-embedding-3-small",
+            SpanAttributes.LLM_REQUEST_TYPE: "embedding",
+            SpanAttributes.TRACELOOP_ENTITY_OUTPUT: output,
+        }
+    )
+
+    OpenRouterSpanProcessor().on_end(span)
+
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == output
+    assert span.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_EMBEDDING
+    assert span.attributes[SpanAttributes.LLM_REQUEST_TYPE] == "embedding"
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == (
+        "openrouter.embeddings"
+    )
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+
+
+def test_hostile_readable_span_status_properties_do_not_break_export() -> None:
+    class HostileStatus:
+        @property
+        def status_code(self):
+            raise RuntimeError("hostile status property invoked")
+
+        @property
+        def description(self):
+            raise RuntimeError("hostile status description invoked")
+
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+        }
+    )
+    span._status = HostileStatus()
+
+    OpenRouterSpanProcessor().on_end(span)
+
+    assert span.attributes[GEN_AI_PROVIDER_NAME] == "openrouter"
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "openrouter.chat"
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+
+
+def test_stream_flag_uses_current_and_traceloop_conventions() -> None:
+    from respan_instrumentation_openrouter._processor import (
+        openrouter_emission_context,
+    )
+
+    span = _span(
+        {
+            SpanAttributes.LLM_SYSTEM: "openai",
+            SpanAttributes.LLM_REQUEST_MODEL: "openai/gpt-4o-mini",
+        }
+    )
+    with openrouter_emission_context(
+        kind="chat",
+        request_kwargs={"stream": True},
+        error_message=None,
+        status_code=200,
+    ):
+        OpenRouterSpanProcessor().on_end(span)
+
+    assert span.attributes[GEN_AI_REQUEST_STREAM] is True
+    assert span.attributes[SpanAttributes.LLM_IS_STREAMING] is True

--- a/python-sdks/instrumentations/respan-instrumentation-pgvector/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-pgvector/README.md
@@ -20,33 +20,55 @@ pip install "respan-instrumentation-pgvector[psycopg2]"
 ## Quickstart
 
 ```python
+import os
+
 import psycopg
 import pgvector.psycopg as pgvector_psycopg
 from respan import Respan, workflow
 from respan_instrumentation_pgvector import PGVectorInstrumentor
 
 respan = Respan(instrumentations=[PGVectorInstrumentor()])
+dsn = os.environ["PGVECTOR_DSN"]
 
 
 @workflow(name="pgvector_similarity_query_workflow")
-def run_query(dsn: str):
+def run_query(query_vector: list[float], limit: int):
     with psycopg.connect(dsn) as connection:
         pgvector_psycopg.register_vector(connection)
-        return connection.execute(
-            "SELECT id, embedding FROM items ORDER BY embedding <-> %s LIMIT 3",
-            ([0.1, 0.2, 0.3],),
-        ).fetchall()
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT id, embedding FROM items ORDER BY embedding <-> %s LIMIT %s",
+                (query_vector, limit),
+            )
+            return cursor.fetchall()
 
 
-print(run_query("postgresql://localhost/postgres"))
-respan.shutdown()
+try:
+    print(run_query([0.1, 0.2, 0.3], 3))
+finally:
+    try:
+        respan.flush()
+    finally:
+        respan.shutdown()
 ```
 
 Pass `capture_content=False` to omit SQL arguments, parameters, and returned
 rows while retaining operation names, status, and PostgreSQL attributes.
 Activation/deactivation and `instrument()` / `uninstrument()` are idempotent.
+All concurrently active instrumentors must use the same `capture_content`
+setting; a conflicting activation is rejected instead of silently using the
+first instance's setting.
 SQLAlchemy applications that use the psycopg 3 driver are covered at the
 underlying connection/cursor layer.
+
+Captured values are valid JSON and capped at 16,000 UTF-8 bytes. Collections
+and vectors include at most 128 preview items plus their count/truncation
+metadata. Connection and other unsupported SDK objects are represented by a
+stable type name rather than arbitrary `repr()` output; DSNs, credentials,
+secrets, and process-specific memory addresses are redacted. Operation identity
+is retained in `traceloop.entity.name` and standard database attributes. The
+default semantic exporter displays these auto-emitted operation nodes as the
+contract-defined bare `task` span name.
 
 See `respan-example-projects/python/tracing/pgvector` for setup, distance
 operators, sync/async, mutation, bulk insert, and deterministic error examples.

--- a/python-sdks/instrumentations/respan-instrumentation-pgvector/src/respan_instrumentation_pgvector/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pgvector/src/respan_instrumentation_pgvector/_constants.py
@@ -1,5 +1,6 @@
 """pgvector and psycopg SDK-specific instrumentation constants."""
 
+from importlib.metadata import PackageNotFoundError, version
 from typing import NamedTuple
 
 
@@ -19,6 +20,10 @@ class FunctionPatchSpec(NamedTuple):
 
 
 PGVECTOR_INSTRUMENTATION_NAME = "pgvector"
+try:
+    PGVECTOR_INSTRUMENTATION_VERSION = version("respan-instrumentation-pgvector")
+except PackageNotFoundError:  # pragma: no cover - source-only imports
+    PGVECTOR_INSTRUMENTATION_VERSION = "unknown"
 
 CURSOR_OPERATIONS = (
     "execute",
@@ -92,9 +97,16 @@ FUNCTION_PATCH_SPECS = (
 
 MAX_ATTRIBUTE_CHARS = 16_000
 MAX_PREVIEW_ITEMS = 128
+MAX_SERIALIZATION_DEPTH = 7
+MAX_STRING_CHARS = 4_096
 SENSITIVE_KEY_PARTS = (
     "api_key",
     "authorization",
+    "connection_string",
+    "credential",
+    "dsn",
+    "passfile",
+    "sslkey",
     "password",
     "secret",
     "token",

--- a/python-sdks/instrumentations/respan-instrumentation-pgvector/src/respan_instrumentation_pgvector/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pgvector/src/respan_instrumentation_pgvector/_instrumentation.py
@@ -6,49 +6,236 @@ import importlib
 import inspect
 import json
 import logging
+import math
 import re
+import struct
+from array import array
 from collections.abc import Mapping, Sequence
 from contextvars import ContextVar
-from dataclasses import asdict, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass
 from enum import Enum
-from numbers import Real
-from typing import Any
+from itertools import islice
+from numbers import Integral, Real
+from threading import RLock
+from typing import Any, ClassVar
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import SpanKind, Status, StatusCode
-from respan_instrumentation_pgvector._constants import (
-    FUNCTION_PATCH_SPECS,
-    MAX_ATTRIBUTE_CHARS,
-    MAX_PREVIEW_ITEMS,
-    METHOD_PATCH_SPECS,
-    PGVECTOR_INSTRUMENTATION_NAME,
-    SENSITIVE_KEY_PARTS,
-    FunctionPatchSpec,
-    MethodPatchSpec,
-)
 from respan_sdk.constants import ERROR_MESSAGE_ATTR
 from respan_sdk.constants.llm_logging import LOG_TYPE_TASK
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
 from respan_tracing.core.tracer import RespanTracer
 from wrapt import wrap_function_wrapper
 
+from respan_instrumentation_pgvector._constants import (
+    FUNCTION_PATCH_SPECS,
+    MAX_ATTRIBUTE_CHARS,
+    MAX_PREVIEW_ITEMS,
+    MAX_SERIALIZATION_DEPTH,
+    MAX_STRING_CHARS,
+    METHOD_PATCH_SPECS,
+    PGVECTOR_INSTRUMENTATION_NAME,
+    PGVECTOR_INSTRUMENTATION_VERSION,
+    SENSITIVE_KEY_PARTS,
+    FunctionPatchSpec,
+    MethodPatchSpec,
+)
+
 logger = logging.getLogger(__name__)
 
-_SQL_OPERATION = re.compile(r"^\s*(?:/\*.*?\*/\s*)*(?:--[^\n]*\n\s*)*([A-Za-z]+)", re.S)
-
-
+_SQL_OPERATION = re.compile(
+    r"^\s*(?:/\*.*?\*/\s*)*(?:--[^\n]*\n\s*)*([A-Za-z]+)",
+    re.DOTALL,
+)
 _VECTOR_KEY_PARTS = ("embedding", "vector")
+_POSTGRES_URI = re.compile(r"(?i)\bpostgres(?:ql)?(?:\+[a-z0-9_.-]+)?://\S+")
+_URI_CREDENTIALS = re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s/@:]+:[^\s/@]+@\S+")
+_LIBPQ_DSN_KEY = re.compile(
+    r"(?i)(?:^|\s)(?:host|hostaddr|port|dbname|database|user|password|passfile|"
+    r"sslcert|sslkey|service)\s*="
+)
+_INLINE_SECRET = re.compile(
+    r"(?i)\b(password|passwd|pwd|api[_-]?key|authorization|secret|token)"
+    r"(\s*[:=]\s*)([^\s,;&]+)"
+)
+_BEARER_TOKEN = re.compile(r"(?i)\bbearer\s+[^\s,;&]+")
+_MEMORY_ADDRESS = re.compile(r"(?i)\b0x[0-9a-f]{6,}\b")
+
+
+def _safe_type_name(value: Any) -> str:
+    value_type = value if isinstance(value, type) else type(value)
+    module = getattr(value_type, "__module__", "")
+    qualname = getattr(value_type, "__qualname__", None) or getattr(
+        value_type,
+        "__name__",
+        "object",
+    )
+    candidate = f"{module}.{qualname}" if module and module != "builtins" else qualname
+    stable = re.sub(r"[^A-Za-z0-9_.-]+", ".", candidate).strip(".")
+    return (stable or "object")[:256]
+
+
+def _truncate_utf8(value: str, *, max_bytes: int = MAX_STRING_CHARS) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    suffix = "...[truncated]"
+    budget = max(0, max_bytes - len(suffix.encode("utf-8")))
+    preview = encoded[:budget].decode("utf-8", errors="ignore")
+    return f"{preview}{suffix}"
+
+
+def _safe_text(value: str) -> str:
+    """Return bounded text with credentials, DSNs, and addresses removed."""
+    text = value
+    if _POSTGRES_URI.search(text) or len(_LIBPQ_DSN_KEY.findall(text)) >= 2:
+        return "<redacted-dsn>"
+    text = _URI_CREDENTIALS.sub("<redacted-uri>", text)
+    text = _BEARER_TOKEN.sub("Bearer <redacted>", text)
+    text = _INLINE_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}<redacted>", text
+    )
+    text = _MEMORY_ADDRESS.sub("0x<redacted>", text)
+    return _truncate_utf8(text)
+
+
+def _stable_mapping_key(value: Any) -> str:
+    if isinstance(value, Enum):
+        return _stable_mapping_key(value.value)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return _safe_text(str(value))[:256]
+    return f"<{_safe_type_name(value)}>"
+
+
+def _unsupported_summary(value: Any, *, reason: str | None = None) -> dict[str, str]:
+    summary = {"type": _safe_type_name(value)}
+    if reason:
+        summary["truncated"] = reason
+    return summary
+
+
+def _trusted_collection_length(value: Any) -> int | str:
+    if type(value) in {list, tuple, dict, range, array}:
+        return len(value)
+    return f">{MAX_PREVIEW_ITEMS}"
+
+
+def _bounded_vector_result(items: list[Any], count: int) -> Any:
+    if count <= MAX_PREVIEW_ITEMS:
+        return items[:count]
+    return {
+        "count": count,
+        "items": items[:MAX_PREVIEW_ITEMS],
+        "kind": "vector",
+        "truncated": True,
+    }
+
+
+def _trusted_pgvector_preview(value: Any) -> Any | None:
+    """Read known pgvector internals without materializing a full vector."""
+
+    value_type = type(value)
+    identity = (value_type.__module__, value_type.__name__)
+    try:
+        if identity == ("pgvector.vector", "Vector"):
+            raw = getattr(value, "_value", None)
+            if type(raw) is not array:
+                return None
+            count = len(raw)
+            sample = list(islice(iter(raw), MAX_PREVIEW_ITEMS + 1))
+            return _bounded_vector_result(sample, count)
+
+        if identity == ("pgvector.halfvec", "HalfVector"):
+            raw = getattr(value, "_value", None)
+            if type(raw) is not array:
+                return None
+            count = len(raw)
+            sample = [
+                struct.unpack("e", struct.pack("H", int(item)))[0]
+                for item in islice(iter(raw), MAX_PREVIEW_ITEMS + 1)
+            ]
+            return _bounded_vector_result(sample, count)
+
+        if identity == ("pgvector.sparsevec", "SparseVector"):
+            count = getattr(value, "_dim", None)
+            indices = getattr(value, "_indices", None)
+            values = getattr(value, "_values", None)
+            if (
+                not isinstance(count, int)
+                or count < 0
+                or type(indices) is not list
+                or type(values) is not list
+            ):
+                return None
+            preview_length = min(count, MAX_PREVIEW_ITEMS)
+            sample: list[int | float] = [0.0] * preview_length
+            for index, item in islice(zip(indices, values), MAX_PREVIEW_ITEMS + 1):
+                if (
+                    isinstance(index, int)
+                    and 0 <= index < preview_length
+                    and isinstance(item, Real)
+                    and not isinstance(item, bool)
+                ):
+                    number = float(item)
+                    sample[index] = number if math.isfinite(number) else 0.0
+            return _bounded_vector_result(sample, count)
+
+        if identity == ("pgvector.bit", "Bit"):
+            count = getattr(value, "_length", None)
+            data = getattr(value, "_data", None)
+            if not isinstance(count, int) or count < 0 or type(data) is not bytes:
+                return None
+            preview_length = min(count, MAX_PREVIEW_ITEMS)
+            sample = [
+                bool(data[index // 8] & (1 << (7 - index % 8)))
+                for index in range(preview_length)
+            ]
+            return _bounded_vector_result(sample, count)
+    except Exception:  # noqa: BLE001 - corrupted vendor objects become summaries
+        return None
+    return None
+
+
+def _trusted_numpy_preview(value: Any) -> Any | None:
+    value_type = type(value)
+    if (value_type.__module__, value_type.__name__) != ("numpy", "ndarray"):
+        return None
+    try:
+        count = int(value.size)
+        sample: list[Any] = []
+        for item in islice(iter(value.flat), MAX_PREVIEW_ITEMS + 1):
+            scalar = item.item()
+            if scalar is None or isinstance(scalar, (bool, int, str)):
+                sample.append(scalar)
+            elif isinstance(scalar, Real):
+                number = float(scalar)
+                sample.append(number if math.isfinite(number) else None)
+            else:
+                sample.append(_unsupported_summary(scalar))
+        return _bounded_vector_result(sample, count)
+    except Exception:  # noqa: BLE001 - malformed arrays become summaries
+        return None
+
+
+@dataclass(frozen=True)
+class _AppliedPatch:
+    target: Any
+    attribute: str
+    installed_wrapper: Any
 
 
 def _is_numeric_vector(value: Any) -> bool:
-    return (
-        isinstance(value, Sequence)
-        and not isinstance(value, (str, bytes, bytearray))
-        and bool(value)
-        and all(isinstance(item, Real) and not isinstance(item, bool) for item in value)
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return False
+    try:
+        sample = list(islice(iter(value), MAX_PREVIEW_ITEMS + 1))
+    except Exception:  # noqa: BLE001 - hostile SDK sequences must not break calls
+        return False
+    return bool(sample) and all(
+        isinstance(item, Real) and not isinstance(item, bool) for item in sample
     )
 
 
@@ -65,10 +252,17 @@ def _jsonable(
     preserved_vector: list[bool] | None = None,
 ) -> Any:
     preserved_vector = preserved_vector if preserved_vector is not None else [False]
-    if depth > 7 and not (vector_context or _is_numeric_vector(value)):
-        return repr(value)
-    if value is None or isinstance(value, (str, int, float, bool)):
+    if depth > MAX_SERIALIZATION_DEPTH:
+        return _unsupported_summary(value, reason="max_depth")
+    if value is None or isinstance(value, bool):
         return value
+    if isinstance(value, str):
+        return _safe_text(value)
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, Real):
+        number = float(value)
+        return number if math.isfinite(number) else str(number)
     if isinstance(value, bytes):
         return {"type": "bytes", "length": len(value)}
     if isinstance(value, Enum):
@@ -79,23 +273,31 @@ def _jsonable(
             preserved_vector=preserved_vector,
         )
     if is_dataclass(value) and not isinstance(value, type):
+        try:
+            field_items = list(islice(fields(value), MAX_PREVIEW_ITEMS + 1))
+            dataclass_value = {
+                field.name: getattr(value, field.name)
+                for field in field_items[:MAX_PREVIEW_ITEMS]
+            }
+            if len(field_items) > MAX_PREVIEW_ITEMS:
+                dataclass_value["__truncated__"] = len(fields(value))
+        except Exception:  # noqa: BLE001 - hostile fields become a type summary
+            return _unsupported_summary(value)
         return _jsonable(
-            asdict(value),
+            dataclass_value,
             depth=depth + 1,
             vector_context=vector_context,
             preserved_vector=preserved_vector,
         )
     if isinstance(value, Mapping):
         result: dict[str, Any] = {}
-        omitted = 0
-        regular_items = 0
-        for key, item in value.items():
-            key_text = str(key)
+        try:
+            items = list(islice(value.items(), MAX_PREVIEW_ITEMS + 1))
+        except Exception:  # noqa: BLE001 - hostile mappings become a type summary
+            return _unsupported_summary(value)
+        for key, item in items[:MAX_PREVIEW_ITEMS]:
+            key_text = _stable_mapping_key(key)
             item_is_vector = vector_context or _is_vector_key(key_text)
-            if not item_is_vector and regular_items >= MAX_PREVIEW_ITEMS:
-                omitted += 1
-                continue
-            regular_items += int(not item_is_vector)
             result[key_text] = (
                 "<redacted>"
                 if any(part in key_text.lower() for part in SENSITIVE_KEY_PARTS)
@@ -106,64 +308,79 @@ def _jsonable(
                     preserved_vector=preserved_vector,
                 )
             )
-        if omitted:
-            result["__truncated__"] = omitted
+        if len(items) > MAX_PREVIEW_ITEMS:
+            result["__truncated__"] = _trusted_collection_length(value)
         return result
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        preserve_all = vector_context or _is_numeric_vector(value)
-        if preserve_all:
+        is_vector = vector_context or _is_numeric_vector(value)
+        if is_vector:
             preserved_vector[0] = True
-        source = value if preserve_all else value[:MAX_PREVIEW_ITEMS]
+        try:
+            source = list(islice(iter(value), MAX_PREVIEW_ITEMS + 1))
+        except Exception:  # noqa: BLE001 - hostile sequences become a type summary
+            return _unsupported_summary(value)
         items = [
             _jsonable(
                 item,
                 depth=depth + 1,
-                vector_context=vector_context,
+                vector_context=is_vector,
                 preserved_vector=preserved_vector,
             )
-            for item in source
+            for item in source[:MAX_PREVIEW_ITEMS]
         ]
-        if preserve_all:
-            return items
-        if len(value) > MAX_PREVIEW_ITEMS:
-            return {"count": len(value), "items": items, "truncated": True}
+        if len(source) > MAX_PREVIEW_ITEMS:
+            return {
+                "count": _trusted_collection_length(value),
+                "items": items,
+                "kind": "vector" if is_vector else "sequence",
+                "truncated": True,
+            }
         return items
-    for method_name in (
-        "model_dump",
-        "to_dict",
-        "dict",
-        "to_list",
-        "tolist",
-        "to_numpy",
-    ):
-        method = getattr(value, method_name, None)
-        if not callable(method):
-            continue
-        try:
-            return _jsonable(
-                method(),
-                depth=depth + 1,
-                vector_context=vector_context,
-                preserved_vector=preserved_vector,
-            )
-        except Exception:
-            continue
-    return repr(value)
+    vendor_preview = _trusted_pgvector_preview(value)
+    if vendor_preview is None:
+        vendor_preview = _trusted_numpy_preview(value)
+    if vendor_preview is not None:
+        preserved_vector[0] = True
+        return _jsonable(
+            vendor_preview,
+            depth=depth + 1,
+            vector_context=True,
+            preserved_vector=preserved_vector,
+        )
+    return _unsupported_summary(value)
 
 
 def _json_dumps(value: Any) -> str:
     preserved_vector = [False]
     text = json.dumps(
         _jsonable(value, preserved_vector=preserved_vector),
-        default=str,
+        allow_nan=False,
+        ensure_ascii=False,
         sort_keys=True,
     )
-    if preserved_vector[0] or len(text) <= MAX_ATTRIBUTE_CHARS:
+    encoded_size = len(text.encode("utf-8"))
+    if encoded_size <= MAX_ATTRIBUTE_CHARS:
         return text
-    return json.dumps(
-        {"preview": text[:MAX_ATTRIBUTE_CHARS], "truncated": True},
-        sort_keys=True,
-    )
+    low = 0
+    high = min(len(text), MAX_ATTRIBUTE_CHARS)
+    result = ""
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = json.dumps(
+            {
+                "original_bytes": encoded_size,
+                "preview": text[:midpoint],
+                "truncated": True,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        if len(candidate.encode("utf-8")) <= MAX_ATTRIBUTE_CHARS:
+            result = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return result
 
 
 def _call_input(
@@ -177,8 +394,8 @@ def _call_input(
         arguments = {
             key: value for key, value in bound.arguments.items() if key != "self"
         }
-    except Exception:
-        arguments = {"args": list(args), "kwargs": kwargs}
+    except (TypeError, ValueError):
+        arguments = {"args": args, "kwargs": kwargs}
     return {"operation": operation, **arguments}
 
 
@@ -198,9 +415,14 @@ def _db_operation(
     if method not in {"execute", "executemany"}:
         return method
     query = _query_from_call(args, kwargs)
-    if query is None:
+    if not isinstance(query, (str, bytes, bytearray)):
         return method
-    match = _SQL_OPERATION.match(str(query))
+    query_text = (
+        query.decode("utf-8", errors="replace")
+        if isinstance(query, bytes)
+        else str(query)
+    )
+    match = _SQL_OPERATION.match(query_text)
     return match.group(1).upper() if match else method
 
 
@@ -210,16 +432,36 @@ def _result_summary(value: Any) -> Any:
     summary: dict[str, Any] = {"type": type(value).__name__}
     found = False
     for key in ("rowcount", "statusmessage", "rownumber", "closed"):
-        item = getattr(value, key, None)
+        try:
+            item = getattr(value, key, None)
+        except Exception:  # noqa: BLE001, S112 - omit hostile vendor properties
+            continue
         if item is not None:
             summary[key] = item
             found = True
-    description = getattr(value, "description", None)
+    try:
+        description = getattr(value, "description", None)
+    except Exception:  # noqa: BLE001 - result properties are vendor-controlled
+        description = None
     if description:
-        summary["columns"] = [
-            str(getattr(column, "name", column[0] if column else column))
-            for column in description
-        ]
+        columns: list[str] = []
+        try:
+            description_items = islice(iter(description), MAX_PREVIEW_ITEMS)
+        except Exception:  # noqa: BLE001 - hostile descriptions are omitted
+            description_items = ()
+        for column in description_items:
+            try:
+                name = getattr(column, "name", None)
+                if name is None and isinstance(column, Sequence) and column:
+                    name = column[0]
+            except Exception:  # noqa: BLE001 - hostile columns become type names
+                name = None
+            columns.append(
+                _safe_text(name)
+                if isinstance(name, str)
+                else _safe_type_name(name or column)
+            )
+        summary["columns"] = columns
         found = True
     return summary if found else _jsonable(value)
 
@@ -227,11 +469,13 @@ def _result_summary(value: Any) -> Any:
 class PGVectorInstrumentor:
     """Trace pgvector registration and psycopg sync/async SQL operations."""
 
-    name = PGVECTOR_INSTRUMENTATION_NAME
-    _patches_applied = False
-    _activation_count = 0
-    _patched_targets: list[tuple[Any, str]] = []
-    _active_call: ContextVar[bool] = ContextVar(
+    name: ClassVar[str] = PGVECTOR_INSTRUMENTATION_NAME
+    _patches_applied: ClassVar[bool] = False
+    _activation_count: ClassVar[int] = 0
+    _patched_targets: ClassVar[list[_AppliedPatch]] = []
+    _capture_content_config: ClassVar[bool | None] = None
+    _lifecycle_lock: ClassVar[RLock] = RLock()
+    _active_call: ClassVar[ContextVar[bool]] = ContextVar(
         "respan_pgvector_active_call",
         default=False,
     )
@@ -258,11 +502,14 @@ class PGVectorInstrumentor:
         entity_name = f"pgvector.{operation}"
         span.set_attribute(RESPAN_LOG_TYPE, LOG_TYPE_TASK)
         span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_name)
+        span.set_attribute(
+            SpanAttributes.TRACELOOP_ENTITY_PATH,
+            "" if getattr(span, "parent", None) is None else entity_name,
+        )
         span.set_attribute(OTelSpanAttributes.DB_SYSTEM, "postgresql")
         span.set_attribute(
             OTelSpanAttributes.DB_OPERATION,
-            _db_operation(method, args, kwargs),
+            _db_operation(method, args, kwargs) or label,
         )
         if self._capture_content:
             span.set_attribute(
@@ -270,15 +517,40 @@ class PGVectorInstrumentor:
                 _json_dumps(_call_input(operation, wrapped, args, kwargs)),
             )
 
+    @staticmethod
+    def _exception_message(exc: Exception) -> str:
+        try:
+            arguments = exc.args
+        except Exception:  # noqa: BLE001 - hostile exception attributes are ignored
+            arguments = ()
+        for argument in arguments:
+            if isinstance(argument, str):
+                return _safe_text(argument)
+            if argument is None or isinstance(argument, (bool, int)):
+                return _safe_text(str(argument))
+            if isinstance(argument, float) and math.isfinite(argument):
+                return _safe_text(str(argument))
+        return _safe_type_name(exc)
+
     def _set_error(self, span: Any, exc: Exception) -> None:
-        span.record_exception(exc)
-        span.set_status(Status(StatusCode.ERROR, str(exc)))
+        message = self._exception_message(exc)
+        exception_type = _safe_type_name(exc)
+        add_event = getattr(span, "add_event", None)
+        if callable(add_event):
+            add_event(
+                "exception",
+                {
+                    OTelSpanAttributes.EXCEPTION_MESSAGE: message,
+                    OTelSpanAttributes.EXCEPTION_TYPE: exception_type,
+                },
+            )
+        span.set_status(Status(StatusCode.ERROR, message))
         span.set_attribute("status_code", 500)
-        span.set_attribute(ERROR_MESSAGE_ATTR, str(exc))
+        span.set_attribute(ERROR_MESSAGE_ATTR, message)
         if self._capture_content:
             span.set_attribute(
                 SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                _json_dumps({"error": type(exc).__name__, "message": str(exc)}),
+                _json_dumps({"error": exception_type, "message": message}),
             )
 
     def _trace_sync(
@@ -295,10 +567,15 @@ class PGVectorInstrumentor:
         token = active_call.set(True)
         operation = f"{label}.{method}" if method else label
         try:
-            tracer = trace.get_tracer(__name__)
+            tracer = trace.get_tracer(
+                PGVECTOR_INSTRUMENTATION_NAME,
+                PGVECTOR_INSTRUMENTATION_VERSION,
+            )
             with tracer.start_as_current_span(
                 f"pgvector.{operation}",
                 kind=SpanKind.CLIENT,
+                record_exception=False,
+                set_status_on_exception=False,
             ) as span:
                 self._set_start_attributes(span, label, method, wrapped, args, kwargs)
                 try:
@@ -330,10 +607,15 @@ class PGVectorInstrumentor:
         token = active_call.set(True)
         operation = f"{label}.{method}" if method else label
         try:
-            tracer = trace.get_tracer(__name__)
+            tracer = trace.get_tracer(
+                PGVECTOR_INSTRUMENTATION_NAME,
+                PGVECTOR_INSTRUMENTATION_VERSION,
+            )
             with tracer.start_as_current_span(
                 f"pgvector.{operation}",
                 kind=SpanKind.CLIENT,
+                record_exception=False,
+                set_status_on_exception=False,
             ) as span:
                 self._set_start_attributes(span, label, method, wrapped, args, kwargs)
                 try:
@@ -351,13 +633,52 @@ class PGVectorInstrumentor:
         finally:
             active_call.reset(token)
 
-    def _patch_method_spec(self, spec: MethodPatchSpec) -> list[tuple[Any, str]]:
+    @staticmethod
+    def _wrapper_chain_contains(current: Any, expected: Any) -> bool:
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            if current is expected:
+                return True
+            seen.add(id(current))
+            current = getattr(current, "__wrapped__", None)
+        return False
+
+    @classmethod
+    def _unwrap_targets(cls, patches: list[_AppliedPatch]) -> list[_AppliedPatch]:
+        failed: list[_AppliedPatch] = []
+        for patch in reversed(patches):
+            try:
+                current = inspect.getattr_static(patch.target, patch.attribute)
+                if current is patch.installed_wrapper:
+                    unwrap(patch.target, patch.attribute)
+                    current = inspect.getattr_static(patch.target, patch.attribute)
+                if cls._wrapper_chain_contains(current, patch.installed_wrapper):
+                    failed.append(patch)
+            except Exception:
+                failed.append(patch)
+                logger.debug(
+                    "Failed to unwrap pgvector %s.%s",
+                    getattr(
+                        patch.target,
+                        "__name__",
+                        type(patch.target).__name__,
+                    ),
+                    patch.attribute,
+                    exc_info=True,
+                )
+        failed.reverse()
+        return failed
+
+    def _patch_method_spec(
+        self,
+        spec: MethodPatchSpec,
+        patched: list[_AppliedPatch],
+    ) -> None:
         try:
             module = importlib.import_module(spec.module)
             target_class = getattr(module, spec.class_name)
         except (ImportError, AttributeError):
-            return []
-        patched: list[tuple[Any, str]] = []
+            return
         for method in spec.methods:
             if not callable(getattr(target_class, method, None)):
                 continue
@@ -372,6 +693,12 @@ class PGVectorInstrumentor:
                 _method: str = method,
                 _is_async: bool = spec.is_async,
             ) -> Any:
+                instrumentor_class = type(self)
+                if (
+                    not instrumentor_class._patches_applied
+                    or not instrumentor_class._activation_count
+                ):
+                    return wrapped(*args, **kwargs)
                 if _is_async:
                     return self._trace_async(_label, _method, wrapped, args, kwargs)
                 return self._trace_sync(_label, _method, wrapped, args, kwargs)
@@ -381,20 +708,26 @@ class PGVectorInstrumentor:
                 f"{spec.class_name}.{method}",
                 traced,
             )
-            patched.append((target_class, method))
-        return patched
+            patched.append(
+                _AppliedPatch(
+                    target_class,
+                    method,
+                    inspect.getattr_static(target_class, method),
+                )
+            )
 
     def _patch_function_spec(
         self,
         spec: FunctionPatchSpec,
-    ) -> list[tuple[Any, str]]:
+        patched: list[_AppliedPatch],
+    ) -> None:
         try:
             module = importlib.import_module(spec.module)
             original = getattr(module, spec.function_name)
         except (ImportError, AttributeError):
-            return []
+            return
         if not callable(original):
-            return []
+            return
 
         def traced(
             wrapped: Any,
@@ -402,38 +735,86 @@ class PGVectorInstrumentor:
             args: tuple[Any, ...],
             kwargs: dict[str, Any],
         ) -> Any:
+            instrumentor_class = type(self)
+            if (
+                not instrumentor_class._patches_applied
+                or not instrumentor_class._activation_count
+            ):
+                return wrapped(*args, **kwargs)
             if spec.is_async:
                 return self._trace_async(spec.label, "", wrapped, args, kwargs)
             return self._trace_sync(spec.label, "", wrapped, args, kwargs)
 
         wrap_function_wrapper(spec.module, spec.function_name, traced)
-        return [(module, spec.function_name)]
+        patched.append(
+            _AppliedPatch(
+                module,
+                spec.function_name,
+                inspect.getattr_static(module, spec.function_name),
+            )
+        )
 
     def activate(self) -> None:
         """Patch pgvector registration and psycopg operations."""
         cls = type(self)
+        with cls._lifecycle_lock:
+            self._activate_locked()
+
+    def _activate_locked(self) -> None:
+        cls = type(self)
         if self._is_instrumented or not self._tracing_enabled():
             return
+        if cls._patched_targets and not cls._patches_applied:
+            cls._patched_targets = self._unwrap_targets(cls._patched_targets)
+            if cls._patched_targets:
+                raise RuntimeError(
+                    "pgvector instrumentation could not clean up stale wrappers"
+                )
+            cls._capture_content_config = None
         if cls._patches_applied:
+            if cls._capture_content_config != self._capture_content:
+                raise ValueError(
+                    "all active PGVectorInstrumentor instances must use the same "
+                    "capture_content setting"
+                )
             cls._activation_count += 1
             self._is_instrumented = True
             return
 
-        patched_targets: list[tuple[Any, str]] = []
-        for spec in METHOD_PATCH_SPECS:
-            patched_targets.extend(self._patch_method_spec(spec))
-        for spec in FUNCTION_PATCH_SPECS:
-            patched_targets.extend(self._patch_function_spec(spec))
+        patched_targets: list[_AppliedPatch] = []
+        try:
+            for spec in METHOD_PATCH_SPECS:
+                self._patch_method_spec(spec, patched_targets)
+            for spec in FUNCTION_PATCH_SPECS:
+                self._patch_function_spec(spec, patched_targets)
+        except Exception:
+            cls._patched_targets = self._unwrap_targets(patched_targets)
+            cls._patches_applied = False
+            cls._activation_count = 0
+            cls._capture_content_config = (
+                self._capture_content if cls._patched_targets else None
+            )
+            self._is_instrumented = False
+            logger.exception("Failed to activate pgvector instrumentation")
+            raise
 
         self._is_instrumented = bool(patched_targets)
         cls._patches_applied = self._is_instrumented
         cls._activation_count = int(self._is_instrumented)
         cls._patched_targets = patched_targets
+        cls._capture_content_config = (
+            self._capture_content if self._is_instrumented else None
+        )
         if not self._is_instrumented:
             logger.warning("pgvector instrumentation found no supported methods")
 
     def deactivate(self) -> None:
         """Remove pgvector patches after the final active instance stops."""
+        cls = type(self)
+        with cls._lifecycle_lock:
+            self._deactivate_locked()
+
+    def _deactivate_locked(self) -> None:
         if not self._is_instrumented:
             return
         self._is_instrumented = False
@@ -441,18 +822,10 @@ class PGVectorInstrumentor:
         cls._activation_count = max(cls._activation_count - 1, 0)
         if cls._activation_count:
             return
-        for target, method in reversed(cls._patched_targets):
-            try:
-                unwrap(target, method)
-            except Exception:
-                logger.debug(
-                    "Failed to unwrap pgvector %s.%s",
-                    getattr(target, "__name__", type(target).__name__),
-                    method,
-                    exc_info=True,
-                )
-        cls._patched_targets = []
+        cls._patched_targets = self._unwrap_targets(cls._patched_targets)
         cls._patches_applied = False
+        if not cls._patched_targets:
+            cls._capture_content_config = None
 
     def instrument(self) -> None:
         """OpenTelemetry-style alias for :meth:`activate`."""

--- a/python-sdks/instrumentations/respan-instrumentation-pgvector/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pgvector/tests/test_instrumentation.py
@@ -1,17 +1,30 @@
 import json
+import os
 import sys
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from importlib.metadata import version
+from pathlib import Path
 from types import ModuleType
+from typing import ClassVar
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
 from opentelemetry.semconv_ai import SpanAttributes
-from opentelemetry.trace import StatusCode
-
-from respan_instrumentation_pgvector import PGVectorInstrumentor
-from respan_instrumentation_pgvector import _instrumentation
+from opentelemetry.trace import SpanKind, StatusCode
+from respan_instrumentation_pgvector import PGVectorInstrumentor, _instrumentation
 from respan_instrumentation_pgvector._constants import (
     MAX_ATTRIBUTE_CHARS,
     MAX_PREVIEW_ITEMS,
+    MAX_STRING_CHARS,
+    PGVECTOR_INSTRUMENTATION_NAME,
+    PGVECTOR_INSTRUMENTATION_VERSION,
     FunctionPatchSpec,
     MethodPatchSpec,
 )
@@ -29,12 +42,16 @@ class _FakeSpan:
         self.attributes = {}
         self.status = None
         self.exceptions = []
+        self.events = []
 
     def set_attribute(self, key, value):
         self.attributes[key] = value
 
-    def record_exception(self, exc):
-        self.exceptions.append(exc)
+    def record_exception(self, exc, attributes=None):
+        self.exceptions.append((exc, attributes or {}))
+
+    def add_event(self, name, attributes=None):
+        self.events.append((name, attributes or {}))
 
     def set_status(self, status):
         self.status = status
@@ -56,7 +73,7 @@ def _install_fake_modules(monkeypatch):
     pgvector_psycopg = ModuleType("pgvector.psycopg")
 
     class Cursor:
-        result_vector = [0.1, 0.2, 0.3]
+        result_vector: ClassVar[list[float]] = [0.1, 0.2, 0.3]
         rowcount = 2
         statusmessage = "SELECT 2"
         description = None
@@ -160,19 +177,28 @@ def reset_instrumentor():
     PGVectorInstrumentor._patches_applied = False
     PGVectorInstrumentor._activation_count = 0
     PGVectorInstrumentor._patched_targets = []
+    PGVectorInstrumentor._capture_content_config = None
     yield
-    for target, method in reversed(PGVectorInstrumentor._patched_targets):
-        _instrumentation.unwrap(target, method)
+    PGVectorInstrumentor._patched_targets = PGVectorInstrumentor._unwrap_targets(
+        PGVectorInstrumentor._patched_targets
+    )
     PGVectorInstrumentor._patches_applied = False
     PGVectorInstrumentor._activation_count = 0
     PGVectorInstrumentor._patched_targets = []
+    PGVectorInstrumentor._capture_content_config = None
 
 
 def _assert_contract(span):
     attrs = span.attributes
     assert attrs[RESPAN_LOG_TYPE] == "task"
     assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME]
-    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH]
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] in {
+        "",
+        attrs[SpanAttributes.TRACELOOP_ENTITY_NAME],
+    }
+    assert attrs[OTelSpanAttributes.DB_SYSTEM] == "postgresql"
+    assert attrs[OTelSpanAttributes.DB_OPERATION]
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
     for banned_alias in (
         "tools",
         "tool_calls",
@@ -194,10 +220,18 @@ def test_package_exports_pgvector_instrumentor():
     assert PGVectorInstrumentor.name == "pgvector"
 
 
+def test_readme_keeps_dsn_outside_the_decorated_workflow_boundary():
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text()
+    assert "def run_query(dsn" not in readme
+    assert "dsn = os.environ" in readme
+    assert "def run_query(query_vector: list[float], limit: int)" in readme
+    assert "run_query([0.1, 0.2, 0.3], 3)" in readme
+
+
 def test_registration_execute_and_fetch_emit_canonical_spans(monkeypatch):
     psycopg, pgvector_psycopg = _install_fake_modules(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     instrumentor = PGVectorInstrumentor()
     instrumentor.activate()
 
@@ -215,8 +249,16 @@ def test_registration_execute_and_fetch_emit_canonical_spans(monkeypatch):
         "pgvector.connection.execute",
         "pgvector.cursor.fetchall",
     ]
+    assert [
+        span.attributes[OTelSpanAttributes.DB_OPERATION] for span in tracer.spans
+    ] == [
+        "register_vector",
+        "SELECT",
+        "fetchall",
+    ]
     for span in tracer.spans:
         _assert_contract(span)
+        assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
         assert SpanAttributes.TRACELOOP_ENTITY_INPUT in span.attributes
         assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT in span.attributes
         assert span.status.status_code is StatusCode.OK
@@ -232,7 +274,7 @@ def test_registration_execute_and_fetch_emit_canonical_spans(monkeypatch):
 async def test_async_execute_and_fetch_are_awaited(monkeypatch):
     psycopg, pgvector_psycopg = _install_fake_modules(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     instrumentor = PGVectorInstrumentor()
     instrumentor.instrument()
 
@@ -256,7 +298,7 @@ async def test_async_execute_and_fetch_are_awaited(monkeypatch):
 def test_error_status_and_capture_content_control(monkeypatch):
     psycopg, _ = _install_fake_modules(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     instrumentor = PGVectorInstrumentor(capture_content=False)
     instrumentor.activate()
 
@@ -265,7 +307,7 @@ def test_error_status_and_capture_content_control(monkeypatch):
 
     span = tracer.spans[-1]
     assert span.status.status_code is StatusCode.ERROR
-    assert span.exceptions
+    assert span.events[0][0] == "exception"
     assert span.attributes["status_code"] == 500
     assert span.attributes["error.message"] == "invalid vector query"
     assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in span.attributes
@@ -274,10 +316,10 @@ def test_error_status_and_capture_content_control(monkeypatch):
     instrumentor.deactivate()
 
 
-def test_full_vectors_survive_canonical_input_and_output(monkeypatch):
+def test_vectors_and_other_sequences_are_bounded_in_canonical_content(monkeypatch):
     psycopg, _ = _install_fake_modules(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     instrumentor = PGVectorInstrumentor()
     instrumentor.activate()
     vector = [0.125] * (MAX_ATTRIBUTE_CHARS + 17)
@@ -297,25 +339,35 @@ def test_full_vectors_survive_canonical_input_and_output(monkeypatch):
     entity_output = json.loads(
         tracer.spans[-1].attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
     )
-    assert entity_input["params"][0] == vector
-    assert entity_output[1] == vector
-    assert len(entity_output[1]) == len(vector)
-    assert (
-        len(tracer.spans[-2].attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
-        > MAX_ATTRIBUTE_CHARS
-    )
-    assert (
-        len(tracer.spans[-1].attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
-        > MAX_ATTRIBUTE_CHARS
-    )
+    assert entity_input["params"][0] == {
+        "count": len(vector),
+        "items": vector[:MAX_PREVIEW_ITEMS],
+        "kind": "vector",
+        "truncated": True,
+    }
+    assert entity_output[1] == {
+        "count": len(vector),
+        "items": vector[:MAX_PREVIEW_ITEMS],
+        "kind": "vector",
+        "truncated": True,
+    }
     assert entity_input["params"][1]["truncated"] is True
+    for span in tracer.spans[-2:]:
+        for key in (
+            SpanAttributes.TRACELOOP_ENTITY_INPUT,
+            SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+        ):
+            value = span.attributes.get(key)
+            if value is not None:
+                assert len(value.encode("utf-8")) <= MAX_ATTRIBUTE_CHARS
+                json.loads(value)
     instrumentor.deactivate()
 
 
 def test_lifecycle_is_idempotent_and_reference_counted(monkeypatch):
     psycopg, _ = _install_fake_modules(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     first = PGVectorInstrumentor()
     second = PGVectorInstrumentor()
     first.activate()
@@ -330,3 +382,569 @@ def test_lifecycle_is_idempotent_and_reference_counted(monkeypatch):
     second.deactivate()
     psycopg.Cursor().execute("SELECT embedding FROM items")
     assert len(tracer.spans) == 2
+
+
+def test_serializer_never_uses_arbitrary_repr_and_redacts_credentials():
+    class ConnectionLike:
+        def __init__(self):
+            self.repr_calls = 0
+
+        def __repr__(self):
+            self.repr_calls += 1
+            return (
+                "<Connection postgresql://admin:secret@localhost/private at 0x1234abcd>"
+            )
+
+    connection = ConnectionLike()
+    payload = {
+        "connection": connection,
+        "dsn": "postgresql://admin:secret@localhost/private",
+        "authorization": "Bearer should-not-survive",
+        "nested": {"password": "should-not-survive"},
+        "message": "object at 0x1234abcd",
+    }
+
+    serialized = _instrumentation._json_dumps(payload)
+    decoded = json.loads(serialized)
+
+    assert connection.repr_calls == 0
+    assert decoded["connection"]["type"].endswith("ConnectionLike")
+    assert decoded["dsn"] == "<redacted>"
+    assert decoded["authorization"] == "<redacted>"
+    assert decoded["nested"]["password"] == "<redacted>"
+    assert decoded["message"] == "object at 0x<redacted>"
+    assert "secret" not in serialized
+    assert "localhost" not in serialized
+    assert "0x1234abcd" not in serialized
+    assert len(serialized.encode("utf-8")) <= MAX_ATTRIBUTE_CHARS
+
+
+def test_serializer_handles_cycles_depth_and_multibyte_bounds():
+    recursive: dict[str, object] = {}
+    recursive["self"] = recursive
+    recursive["text"] = "界" * (MAX_ATTRIBUTE_CHARS * 2)
+
+    serialized = _instrumentation._json_dumps(recursive)
+
+    assert len(serialized.encode("utf-8")) <= MAX_ATTRIBUTE_CHARS
+    assert json.loads(serialized)["truncated"] is True
+    assert "0x" not in serialized
+
+
+def test_serializer_handles_hostile_containers_and_non_finite_numbers():
+    class HostileMapping(dict):
+        def items(self):
+            raise RuntimeError("postgresql://admin:secret@localhost/private")
+
+    class HostileSequence(Sequence):
+        def __getitem__(self, _index):
+            raise RuntimeError("password=secret")
+
+        def __len__(self):
+            return MAX_PREVIEW_ITEMS + 1
+
+        def __iter__(self):
+            raise RuntimeError("password=secret")
+
+    decoded = json.loads(
+        _instrumentation._json_dumps(
+            {
+                "mapping": HostileMapping(),
+                "sequence": HostileSequence(),
+                "numbers": [float("nan"), float("inf"), float("-inf")],
+            }
+        )
+    )
+
+    assert decoded["mapping"]["type"].endswith("HostileMapping")
+    assert decoded["sequence"]["type"].endswith("HostileSequence")
+    assert decoded["numbers"] == ["nan", "inf", "-inf"]
+    assert "secret" not in json.dumps(decoded)
+
+
+def test_serializer_bounds_vendor_vectors_without_eager_conversion(monkeypatch):
+    from pgvector import Vector
+
+    vector = Vector([index / 100 for index in range(MAX_PREVIEW_ITEMS + 17)])
+    conversion_calls = 0
+
+    def forbidden_to_list(_self):
+        nonlocal conversion_calls
+        conversion_calls += 1
+        raise AssertionError("full vector conversion must not run")
+
+    monkeypatch.setattr(Vector, "to_list", forbidden_to_list)
+    payload = json.loads(_instrumentation._json_dumps({"embedding": vector}))
+
+    assert conversion_calls == 0
+    preview = payload["embedding"]
+    assert preview["count"] == MAX_PREVIEW_ITEMS + 17
+    assert preview["kind"] == "vector"
+    assert preview["truncated"] is True
+    assert preview["items"] == pytest.approx(
+        [index / 100 for index in range(MAX_PREVIEW_ITEMS)]
+    )
+
+    class VendorLookalike:
+        __module__ = "pgvector.future"
+
+        def __init__(self):
+            self.calls = 0
+
+        def to_list(self):
+            self.calls += 1
+            return list(range(MAX_PREVIEW_ITEMS * 100))
+
+    lookalike = VendorLookalike()
+    summary = json.loads(_instrumentation._json_dumps(lookalike))
+    assert lookalike.calls == 0
+    assert summary["type"].endswith("VendorLookalike")
+
+
+def test_serializer_does_not_call_custom_length_for_truncation_metadata():
+    class CountingSequence(Sequence):
+        def __init__(self):
+            self.length_calls = 0
+
+        def __getitem__(self, index):
+            if index >= MAX_PREVIEW_ITEMS + 17:
+                raise IndexError
+            return float(index)
+
+        def __len__(self):
+            self.length_calls += 1
+            raise AssertionError("custom __len__ must not run")
+
+        def __iter__(self):
+            return iter(float(index) for index in range(MAX_PREVIEW_ITEMS + 17))
+
+    sequence = CountingSequence()
+    payload = json.loads(_instrumentation._json_dumps({"vector": sequence}))
+
+    assert sequence.length_calls == 0
+    assert payload["vector"]["count"] == f">{MAX_PREVIEW_ITEMS}"
+    assert len(payload["vector"]["items"]) == MAX_PREVIEW_ITEMS
+
+
+def test_error_event_never_calls_raw_exception_recording_or_leaks_broken_str(
+    monkeypatch,
+):
+    class BrokenStringError(RuntimeError):
+        string_calls = 0
+
+        def __str__(self):
+            type(self).string_calls += 1
+            raise RuntimeError("postgresql://admin:secret@localhost/private")
+
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
+
+    def fail():
+        raise BrokenStringError()
+
+    with pytest.raises(BrokenStringError):
+        PGVectorInstrumentor()._trace_sync("cursor", "execute", fail, (), {})
+
+    span = tracer.spans[-1]
+    assert span.exceptions == []
+    assert BrokenStringError.string_calls == 0
+    assert span.events[0][0] == "exception"
+    event_attributes = span.events[0][1]
+    assert event_attributes[OTelSpanAttributes.EXCEPTION_TYPE].endswith(
+        "BrokenStringError"
+    )
+    assert event_attributes[OTelSpanAttributes.EXCEPTION_MESSAGE].endswith(
+        "BrokenStringError"
+    )
+    assert "secret" not in json.dumps(event_attributes)
+    assert "postgresql://" not in json.dumps(event_attributes)
+    assert OTelSpanAttributes.EXCEPTION_STACKTRACE not in event_attributes
+
+
+def test_real_otel_failure_event_contains_only_sanitized_content(monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("respan-pgvector-error-test")
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
+
+    def fail():
+        raise RuntimeError("postgresql://admin:secret@localhost/private at 0x1234abcd")
+
+    with pytest.raises(RuntimeError):
+        PGVectorInstrumentor()._trace_sync("cursor", "execute", fail, (), {})
+
+    provider.force_flush()
+    span = exporter.get_finished_spans()[0]
+    assert span.status.status_code is StatusCode.ERROR
+    assert span.status.description == "<redacted-dsn>"
+    assert span.attributes["error.message"] == "<redacted-dsn>"
+    assert len(span.events) == 1
+    event = span.events[0]
+    assert event.name == "exception"
+    event_text = json.dumps(dict(event.attributes))
+    assert "postgresql://" not in event_text
+    assert "secret" not in event_text
+    assert "0x1234abcd" not in event_text
+    assert OTelSpanAttributes.EXCEPTION_STACKTRACE not in event.attributes
+
+
+def test_multibyte_error_status_and_attributes_are_byte_bounded(monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("respan-pgvector-utf8-error-test")
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
+
+    def fail():
+        raise RuntimeError("😀" * (MAX_STRING_CHARS * 2))
+
+    with pytest.raises(RuntimeError):
+        PGVectorInstrumentor()._trace_sync("cursor", "execute", fail, (), {})
+
+    provider.force_flush()
+    span = exporter.get_finished_spans()[0]
+    direct_values = (
+        span.status.description,
+        span.attributes["error.message"],
+        span.events[0].attributes[OTelSpanAttributes.EXCEPTION_MESSAGE],
+    )
+    assert all(value.endswith("...[truncated]") for value in direct_values)
+    assert all(
+        len(value.encode("utf-8")) <= MAX_STRING_CHARS for value in direct_values
+    )
+    output = span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    assert len(output.encode("utf-8")) <= MAX_ATTRIBUTE_CHARS
+    json.loads(output)
+
+
+def test_activation_rolls_back_partial_patches(monkeypatch):
+    psycopg, _ = _install_fake_modules(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
+    original_wrap = _instrumentation.wrap_function_wrapper
+    calls = 0
+
+    def flaky_wrap(module, target, wrapper):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("synthetic patch failure")
+        return original_wrap(module, target, wrapper)
+
+    monkeypatch.setattr(_instrumentation, "wrap_function_wrapper", flaky_wrap)
+
+    with pytest.raises(RuntimeError, match="synthetic patch failure"):
+        PGVectorInstrumentor().activate()
+
+    psycopg.Connection().execute("SELECT 1")
+    assert not tracer.spans
+    assert PGVectorInstrumentor._patched_targets == []
+    assert PGVectorInstrumentor._patches_applied is False
+    assert PGVectorInstrumentor._activation_count == 0
+
+
+def test_concurrent_activation_and_deactivation_keep_one_wrapper(monkeypatch):
+    psycopg, _ = _install_fake_modules(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
+    instrumentors = [PGVectorInstrumentor() for _ in range(12)]
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        list(executor.map(lambda item: item.activate(), instrumentors))
+
+    assert PGVectorInstrumentor._activation_count == len(instrumentors)
+    psycopg.Cursor().execute("SELECT 1")
+    assert len(tracer.spans) == 1
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        list(executor.map(lambda item: item.deactivate(), instrumentors))
+
+    assert PGVectorInstrumentor._activation_count == 0
+    assert PGVectorInstrumentor._patched_targets == []
+    psycopg.Cursor().execute("SELECT 1")
+    assert len(tracer.spans) == 1
+
+
+def test_active_instances_reject_mismatched_capture_content(monkeypatch):
+    _install_fake_modules(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
+    without_content = PGVectorInstrumentor(capture_content=False)
+    with_content = PGVectorInstrumentor(capture_content=True)
+    without_content.activate()
+
+    with pytest.raises(ValueError, match="same capture_content setting"):
+        with_content.activate()
+
+    assert PGVectorInstrumentor._activation_count == 1
+    assert with_content._is_instrumented is False
+    without_content.deactivate()
+    with_content.activate()
+    assert PGVectorInstrumentor._capture_content_config is True
+    with_content.deactivate()
+
+
+def test_deactivation_does_not_remove_a_later_foreign_wrapper(monkeypatch):
+    psycopg, _ = _install_fake_modules(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
+    instrumentor = PGVectorInstrumentor()
+    instrumentor.activate()
+
+    def foreign_wrapper(wrapped, _instance, args, kwargs):
+        return wrapped(*args, **kwargs)
+
+    _instrumentation.wrap_function_wrapper(
+        "psycopg",
+        "Cursor.execute",
+        foreign_wrapper,
+    )
+    instrumentor.deactivate()
+
+    assert PGVectorInstrumentor._patches_applied is False
+    assert len(PGVectorInstrumentor._patched_targets) == 1
+    psycopg.Cursor().execute("SELECT 1")
+    assert len(tracer.spans) == 0
+
+    _instrumentation.unwrap(psycopg.Cursor, "execute")
+    instrumentor.activate()
+    psycopg.Cursor().execute("SELECT 1")
+    assert len(tracer.spans) == 1
+    instrumentor.deactivate()
+    assert PGVectorInstrumentor._patched_targets == []
+
+
+def test_real_otel_export_preserves_hierarchy_content_and_no_duplicates(monkeypatch):
+    psycopg, pgvector_psycopg = _install_fake_modules(monkeypatch)
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("respan-pgvector-test")
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
+    instrumentor = PGVectorInstrumentor()
+    instrumentor.activate()
+
+    with tracer.start_as_current_span("workflow"):
+        connection = psycopg.Connection()
+        pgvector_psycopg.register_vector(connection)
+        rows = connection.execute(
+            "SELECT embedding FROM items ORDER BY embedding <-> %s LIMIT 1",
+            ([0.1, 0.2, 0.3],),
+        ).fetchall()
+
+    instrumentor.deactivate()
+    provider.force_flush()
+    spans = list(exporter.get_finished_spans())
+    operation_spans = [span for span in spans if span.name.startswith("pgvector.")]
+
+    assert rows[0][1] == [0.1, 0.2, 0.3]
+    assert [span.name for span in operation_spans] == [
+        "pgvector.register_vector",
+        "pgvector.connection.execute",
+        "pgvector.cursor.fetchall",
+    ]
+    assert len({span.context.span_id for span in operation_spans}) == 3
+    workflow = next(span for span in spans if span.name == "workflow")
+    assert all(
+        span.parent.span_id == workflow.context.span_id for span in operation_spans
+    )
+    assert all(span.kind is SpanKind.CLIENT for span in operation_spans)
+    assert all(span.status.status_code is StatusCode.OK for span in operation_spans)
+    for span in operation_spans:
+        _assert_contract(span)
+        assert (
+            span.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH]
+            == span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME]
+        )
+        json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
+        json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+
+
+def test_canonical_scope_version_and_root_nested_entity_paths(monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer_calls: list[tuple[str, str]] = []
+
+    def get_tracer(name: str, instrumentation_version: str):
+        tracer_calls.append((name, instrumentation_version))
+        return provider.get_tracer(name, instrumentation_version)
+
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", get_tracer)
+    instrumentor = PGVectorInstrumentor()
+
+    def succeed():
+        return None
+
+    instrumentor._trace_sync("cursor", "fetchone", succeed, (), {})
+    outer_tracer = provider.get_tracer("pgvector-test-parent")
+    with outer_tracer.start_as_current_span("workflow"):
+        instrumentor._trace_sync("cursor", "fetchone", succeed, (), {})
+
+    provider.force_flush()
+    operation_spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if span.name == "pgvector.cursor.fetchone"
+    ]
+    assert len(operation_spans) == 2
+    root = next(span for span in operation_spans if span.parent is None)
+    nested = next(span for span in operation_spans if span.parent is not None)
+    assert root.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+    assert nested.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == (
+        "pgvector.cursor.fetchone"
+    )
+    assert tracer_calls == [
+        (PGVECTOR_INSTRUMENTATION_NAME, PGVECTOR_INSTRUMENTATION_VERSION),
+        (PGVECTOR_INSTRUMENTATION_NAME, PGVECTOR_INSTRUMENTATION_VERSION),
+    ]
+    assert PGVECTOR_INSTRUMENTATION_VERSION == version(
+        "respan-instrumentation-pgvector"
+    )
+    for span in operation_spans:
+        assert span.instrumentation_scope.name == PGVECTOR_INSTRUMENTATION_NAME
+        assert span.instrumentation_scope.version == PGVECTOR_INSTRUMENTATION_VERSION
+
+
+@pytest.mark.asyncio
+async def test_current_pgvector_and_psycopg_exports_are_wrapped_and_restored(
+    monkeypatch,
+):
+    import pgvector.psycopg as pgvector_psycopg
+    import psycopg
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("respan-pgvector-current-sdk-test")
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
+    original_register = pgvector_psycopg.register_vector
+    original_register_async = pgvector_psycopg.register_vector_async
+    original_execute = psycopg.Connection.execute
+    instrumentor = PGVectorInstrumentor()
+    instrumentor.activate()
+
+    assert pgvector_psycopg.register_vector is not original_register
+    assert pgvector_psycopg.register_vector_async is not original_register_async
+    assert psycopg.Connection.execute is not original_execute
+    with pytest.raises((AttributeError, TypeError)):
+        pgvector_psycopg.register_vector(object())
+    with pytest.raises((AttributeError, TypeError)):
+        await pgvector_psycopg.register_vector_async(object())
+
+    instrumentor.deactivate()
+    provider.force_flush()
+    spans = list(exporter.get_finished_spans())
+
+    assert pgvector_psycopg.register_vector is original_register
+    assert pgvector_psycopg.register_vector_async is original_register_async
+    assert psycopg.Connection.execute is original_execute
+    assert [span.name for span in spans] == [
+        "pgvector.register_vector",
+        "pgvector.register_vector",
+    ]
+    assert all(span.status.status_code is StatusCode.ERROR for span in spans)
+    for span in spans:
+        _assert_contract(span)
+        assert len(span.events) == 1
+        payload = span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+        assert "0x" not in payload
+        assert "postgresql://" not in payload
+        assert json.loads(payload)["context"]["type"] == "object"
+
+
+@pytest.mark.skipif(
+    not os.getenv("PGVECTOR_DSN"), reason="PGVECTOR_DSN is not configured"
+)
+def test_live_psycopg_sync_registration_server_cursor_and_rollback(monkeypatch):
+    import pgvector.psycopg as pgvector_psycopg
+    import psycopg
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer",
+        lambda *_: provider.get_tracer("respan-pgvector-live-sync"),
+    )
+    instrumentor = PGVectorInstrumentor()
+    instrumentor.activate()
+    connection = psycopg.connect(os.environ["PGVECTOR_DSN"])
+    try:
+        extension = connection.execute(
+            "SELECT 1 FROM pg_extension WHERE extname = 'vector'"
+        ).fetchone()
+        if not extension:
+            pytest.skip("the configured PostgreSQL database does not install pgvector")
+        pgvector_psycopg.register_vector(connection)
+        connection.execute(
+            "CREATE TEMP TABLE respan_pgvector_test (embedding vector(3))"
+        )
+        connection.execute(
+            "INSERT INTO respan_pgvector_test VALUES (%s)",
+            ([0.1, 0.2, 0.3],),
+        )
+        with connection.cursor(name="respan_pgvector_server_cursor") as cursor:
+            cursor.execute("SELECT embedding FROM respan_pgvector_test")
+            assert cursor.fetchall()[0][0] == [0.1, 0.2, 0.3]
+        connection.rollback()
+    finally:
+        connection.close()
+        instrumentor.deactivate()
+    provider.force_flush()
+    assert any(
+        span.attributes.get(SpanAttributes.TRACELOOP_ENTITY_NAME)
+        == "pgvector.server_cursor.fetchall"
+        for span in exporter.get_finished_spans()
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.getenv("PGVECTOR_DSN"), reason="PGVECTOR_DSN is not configured"
+)
+async def test_live_psycopg_async_registration_and_rollback(monkeypatch):
+    import pgvector.psycopg as pgvector_psycopg
+    import psycopg
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer",
+        lambda *_: provider.get_tracer("respan-pgvector-live-async"),
+    )
+    instrumentor = PGVectorInstrumentor()
+    instrumentor.activate()
+    connection = await psycopg.AsyncConnection.connect(os.environ["PGVECTOR_DSN"])
+    try:
+        extension = await connection.execute(
+            "SELECT 1 FROM pg_extension WHERE extname = 'vector'"
+        )
+        if not await extension.fetchone():
+            pytest.skip("the configured PostgreSQL database does not install pgvector")
+        await pgvector_psycopg.register_vector_async(connection)
+        await connection.execute(
+            "CREATE TEMP TABLE respan_pgvector_async_test (embedding vector(3))"
+        )
+        await connection.execute(
+            "INSERT INTO respan_pgvector_async_test VALUES (%s)",
+            ([0.4, 0.5, 0.6],),
+        )
+        cursor = await connection.execute(
+            "SELECT embedding FROM respan_pgvector_async_test"
+        )
+        assert (await cursor.fetchone())[0] == [0.4, 0.5, 0.6]
+        await connection.rollback()
+    finally:
+        await connection.close()
+        instrumentor.deactivate()
+    provider.force_flush()
+    assert any(
+        span.attributes.get(SpanAttributes.TRACELOOP_ENTITY_NAME)
+        == "pgvector.connection.execute"
+        for span in exporter.get_finished_spans()
+    )


### PR DESCRIPTION
## Summary

- Repair OpenLIT, OpenRouter, and PGVector OTel 2.x instrumentation across current SDK shapes, lifecycle ownership, streaming, tools, errors, and bounded privacy-safe serialization.
- Add current real-SDK/export regressions and a patch release intent for all three packages.
- Preserve canonical span-contract fields without compatibility aliases.

## Validation

- [x] Focused package tests: OpenLIT 30/30, OpenRouter 49/49, PGVector 22/22 plus 2 credential-gated live-database skips.
- [x] Root-scoped Ruff check and format check pass for all three package directories.
- [x] All three wheels build and pass isolated import/install checks; applicable pip check and editable direct_url.json checks pass.
- [x] Release intent and release inventory validators pass.
- [x] All 17 paired example scripts completed under `otel2-fix-py-group-21-20260817T214109Z`; the PGVector live-database script reported its intended missing-DSN skip.
- [x] Respan MCP: all 16 trace trees and all 48 full details inspected; exact roots, parents, IDs, markers, content, usage, streams, tools, errors, and privacy checked with no duplicates or credential leakage.
- [x] Real OpenRouter provider validation passed with model `openai/gpt-4o-mini`, exact output, and non-estimated 15/4/19 usage.

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- Current ingestion still projects OpenRouter provider, status, and tool convenience fields inconsistently and estimates usage on selected no-terminal-usage error or early-close records.
- Shared `@tool` input normalization, PGVector local-error classification and entity-path projection, upstream OpenAI/httpcore2 `[DONE]` teardown, and credential-gated PostgreSQL/pgvector runtime coverage remain separately tracked.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/69