### PR TITLE
fix(instrumentation-py): repair Pinecone, Pipecat, and Portkey OTel 2.x spans

### DIFF
--- a/.release-intents/20260818-pinecone-pipecat-portkey-otel2.json
+++ b/.release-intents/20260818-pinecone-pipecat-portkey-otel2.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair canonical OpenTelemetry 2.x spans, lifecycle safety, bounded content, streaming, tools, and provider errors for Pinecone, Pipecat, and Portkey instrumentations.",
+  "packages": {
+    "respan-instrumentation-pinecone": "patch",
+    "respan-instrumentation-pipecat": "patch",
+    "respan-instrumentation-portkey": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-pinecone/src/respan_instrumentation_pinecone/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pinecone/src/respan_instrumentation_pinecone/_instrumentation.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from opentelemetry.semconv_ai import SpanAttributes
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+
 from ._native_instrumentation import (
     NativeClientInstrumentor,
     PatchSpec,

--- a/python-sdks/instrumentations/respan-instrumentation-pinecone/src/respan_instrumentation_pinecone/_native_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pinecone/src/respan_instrumentation_pinecone/_native_instrumentation.py
@@ -4,27 +4,34 @@ from __future__ import annotations
 
 import importlib
 import inspect
-import json
 import logging
-from collections.abc import Mapping, Sequence
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import Any
+from threading import RLock
+from typing import Any, ClassVar
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.semconv.attributes.http_attributes import HTTP_RESPONSE_STATUS_CODE
 from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import SpanKind, Status, StatusCode
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.llm_logging import LOG_TYPE_TASK
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
 from respan_tracing.core.tracer import RespanTracer
 from wrapt import wrap_function_wrapper
 
-logger = logging.getLogger(__name__)
+from respan_instrumentation_pinecone._serialization import (
+    exception_message,
+    exception_status_code,
+    is_sensitive_key,
+    json_dumps,
+    safe_text,
+    safe_type_name,
+)
 
-_MAX_ITEMS = 12
-_MAX_CHARS = 16_000
-_SENSITIVE_PARTS = ("api_key", "authorization", "password", "secret", "token")
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -39,48 +46,6 @@ class PatchSpec:
     exclude: frozenset[str] = field(default_factory=frozenset)
 
 
-def _jsonable(value: Any, *, depth: int = 0) -> Any:
-    if depth > 5:
-        return repr(value)
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, bytes):
-        return {"type": "bytes", "length": len(value)}
-    if isinstance(value, Mapping):
-        result: dict[str, Any] = {}
-        for index, (key, item) in enumerate(value.items()):
-            if index >= _MAX_ITEMS:
-                result["__truncated__"] = max(len(value) - _MAX_ITEMS, 0)
-                break
-            key_text = str(key)
-            result[key_text] = (
-                "<redacted>"
-                if any(part in key_text.lower() for part in _SENSITIVE_PARTS)
-                else _jsonable(item, depth=depth + 1)
-            )
-        return result
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        items = [_jsonable(item, depth=depth + 1) for item in value[:_MAX_ITEMS]]
-        if len(value) > _MAX_ITEMS:
-            return {"count": len(value), "items": items, "truncated": True}
-        return items
-    for method_name in ("model_dump", "to_dict", "dict", "to_pylist"):
-        method = getattr(value, method_name, None)
-        if callable(method):
-            try:
-                return _jsonable(method(), depth=depth + 1)
-            except Exception:
-                pass
-    return repr(value)
-
-
-def _json_dumps(value: Any) -> str:
-    text = json.dumps(_jsonable(value), default=str, sort_keys=True)
-    if len(text) <= _MAX_CHARS:
-        return text
-    return json.dumps({"preview": text[:_MAX_CHARS], "truncated": True})
-
-
 def _call_input(
     wrapped: Any,
     args: tuple[Any, ...],
@@ -89,7 +54,7 @@ def _call_input(
     try:
         bound = inspect.signature(wrapped).bind_partial(*args, **kwargs)
         return {key: value for key, value in bound.arguments.items() if key != "self"}
-    except Exception:
+    except Exception:  # noqa: BLE001 - provider call signatures may be hostile
         return {"args": list(args), "kwargs": kwargs}
 
 
@@ -107,14 +72,32 @@ def _instance_identity(instance: Any) -> dict[str, str]:
         "uri",
         "_uri",
     ):
-        value = getattr(instance, key, None)
+        try:
+            value = getattr(instance, key, None)
+        except Exception:  # noqa: BLE001 - provider descriptors must not break calls
+            value = None
         if isinstance(value, (str, int)):
-            identity[key.lstrip("_")] = str(value)
-    config = getattr(instance, "_config", None)
-    host = getattr(config, "host", None)
+            identity_key = key.lstrip("_")
+            identity[identity_key] = (
+                "<redacted>"
+                if is_sensitive_key(identity_key)
+                else safe_text(str(value), endpoint=identity_key in {"uri", "host"})
+            )
+    try:
+        config = getattr(instance, "_config", None)
+        host = getattr(config, "host", None)
+    except Exception:  # noqa: BLE001 - provider config descriptors may raise
+        host = None
     if isinstance(host, str):
-        identity["host"] = host
+        identity["host"] = safe_text(host, endpoint=True)
     return identity
+
+
+@dataclass(frozen=True)
+class AppliedPatch:
+    target: type
+    attribute: str
+    installed_wrapper: Any
 
 
 class NativeClientInstrumentor:
@@ -123,15 +106,18 @@ class NativeClientInstrumentor:
     name = "native-client"
     vendor = "native-client"
     patches: tuple[PatchSpec, ...] = ()
-    _patches_applied = False
-    _activation_count = 0
-    _patched_targets: list[tuple[type, str]] = []
-    _active_call: ContextVar[bool] = ContextVar(
+    _patches_applied: ClassVar[bool] = False
+    _activation_count: ClassVar[int] = 0
+    _patched_targets: ClassVar[list[AppliedPatch]] = []
+    _capture_content_config: ClassVar[bool | None] = None
+    _lifecycle_lock: ClassVar[RLock] = RLock()
+    _active_call: ClassVar[ContextVar[bool]] = ContextVar(
         "respan_native_client_active",
         default=False,
     )
 
-    def __init__(self) -> None:
+    def __init__(self, *, capture_content: bool = True) -> None:
+        self._capture_content = capture_content
         self._is_instrumented = False
 
     @staticmethod
@@ -163,24 +149,42 @@ class NativeClientInstrumentor:
             **_instance_identity(instance),
             **_call_input(wrapped, args, kwargs),
         }
-        span.set_attribute(RESPAN_LOG_TYPE, "task")
+        span.set_attribute(RESPAN_LOG_TYPE, LOG_TYPE_TASK)
         span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_name)
         span.set_attribute(
-            SpanAttributes.TRACELOOP_ENTITY_INPUT,
-            _json_dumps(payload),
+            SpanAttributes.TRACELOOP_ENTITY_PATH,
+            "" if getattr(span, "parent", None) is None else entity_name,
         )
+        if getattr(cls, "_capture_content_config", True):
+            span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_INPUT,
+                json_dumps(payload),
+            )
         span.set_attribute(OTelSpanAttributes.DB_SYSTEM, cls.vendor)
         span.set_attribute(OTelSpanAttributes.DB_OPERATION, operation)
 
-    @staticmethod
-    def _set_error(span: Any, exc: Exception) -> None:
-        span.record_exception(exc)
-        span.set_status(Status(StatusCode.ERROR, str(exc)))
-        span.set_attribute(
-            SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-            _json_dumps({"error": type(exc).__name__, "message": str(exc)}),
-        )
+    @classmethod
+    def _set_error(cls, span: Any, exc: Exception) -> None:
+        message = exception_message(exc)
+        exception_type = safe_type_name(exc)
+        status_code = exception_status_code(exc)
+        add_event = getattr(span, "add_event", None)
+        if callable(add_event):
+            add_event(
+                "exception",
+                {
+                    OTelSpanAttributes.EXCEPTION_MESSAGE: message,
+                    OTelSpanAttributes.EXCEPTION_TYPE: exception_type,
+                },
+            )
+        span.set_status(Status(StatusCode.ERROR, message))
+        span.set_attribute(HTTP_RESPONSE_STATUS_CODE, status_code)
+        span.set_attribute(ERROR_MESSAGE_ATTR, message)
+        if cls._capture_content_config:
+            span.set_attribute(
+                SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                json_dumps({"error": exception_type, "message": message}),
+            )
 
     def _trace_sync(
         self,
@@ -195,10 +199,12 @@ class NativeClientInstrumentor:
             return wrapped(*args, **kwargs)
         token = active_call.set(True)
         try:
-            tracer = trace.get_tracer(type(self).__module__)
+            tracer = trace.get_tracer(self.name, "0.1.0")
             with tracer.start_as_current_span(
                 self._span_name(operation),
                 kind=SpanKind.CLIENT,
+                record_exception=False,
+                set_status_on_exception=False,
             ) as span:
                 self._set_start_attributes(
                     span,
@@ -214,10 +220,11 @@ class NativeClientInstrumentor:
                     self._set_error(span, exc)
                     raise
                 span.set_status(Status(StatusCode.OK))
-                span.set_attribute(
-                    SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                    _json_dumps(result),
-                )
+                if self._capture_content:
+                    span.set_attribute(
+                        SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                        json_dumps(result),
+                    )
                 return result
         finally:
             active_call.reset(token)
@@ -235,10 +242,12 @@ class NativeClientInstrumentor:
             return await wrapped(*args, **kwargs)
         token = active_call.set(True)
         try:
-            tracer = trace.get_tracer(type(self).__module__)
+            tracer = trace.get_tracer(self.name, "0.1.0")
             with tracer.start_as_current_span(
                 self._span_name(operation),
                 kind=SpanKind.CLIENT,
+                record_exception=False,
+                set_status_on_exception=False,
             ) as span:
                 self._set_start_attributes(
                     span,
@@ -254,10 +263,11 @@ class NativeClientInstrumentor:
                     self._set_error(span, exc)
                     raise
                 span.set_status(Status(StatusCode.OK))
-                span.set_attribute(
-                    SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                    _json_dumps(result),
-                )
+                if self._capture_content:
+                    span.set_attribute(
+                        SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                        json_dumps(result),
+                    )
                 return result
         finally:
             active_call.reset(token)
@@ -274,85 +284,150 @@ class NativeClientInstrumentor:
             and callable(getattr(target_class, name, None))
         )
 
-    def activate(self) -> None:
-        cls = type(self)
-        if self._is_instrumented or not self._tracing_enabled():
-            return
-        if cls._patches_applied:
-            cls._activation_count += 1
-            self._is_instrumented = True
-            return
+    @staticmethod
+    def _wrapper_chain_contains(current: Any, expected: Any) -> bool:
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            if current is expected:
+                return True
+            seen.add(id(current))
+            current = getattr(current, "__wrapped__", None)
+        return False
 
-        patched_targets: list[tuple[type, str]] = []
-        for patch in cls.patches:
+    @classmethod
+    def _remove_owned_patches(cls, patches: list[AppliedPatch]) -> list[AppliedPatch]:
+        retained: list[AppliedPatch] = []
+        for patch in reversed(patches):
             try:
-                module = importlib.import_module(patch.module)
-                target_class = getattr(module, patch.class_name)
-            except (ImportError, AttributeError):
-                continue
-            for method in self._methods_for(target_class, patch):
-                if not hasattr(target_class, method):
-                    continue
-                operation = self._operation_name(patch, method)
-
-                def traced(
-                    wrapped: Any,
-                    instance: Any,
-                    args: tuple[Any, ...],
-                    kwargs: dict[str, Any],
-                    *,
-                    _operation: str = operation,
-                    _async: bool = patch.is_async,
-                ) -> Any:
-                    if _async:
-                        return self._trace_async(
-                            _operation,
-                            wrapped,
-                            instance,
-                            args,
-                            kwargs,
-                        )
-                    return self._trace_sync(
-                        _operation,
-                        wrapped,
-                        instance,
-                        args,
-                        kwargs,
-                    )
-
-                target = f"{patch.class_name}.{method}"
-                wrap_function_wrapper(patch.module, target, traced)
-                patched_targets.append((target_class, method))
-
-        self._is_instrumented = bool(patched_targets)
-        cls._patches_applied = self._is_instrumented
-        cls._activation_count = int(self._is_instrumented)
-        cls._patched_targets = patched_targets
-        if not self._is_instrumented:
-            logger.warning(
-                "%s instrumentation found no supported methods",
-                cls.vendor,
-            )
-
-    def deactivate(self) -> None:
-        if not self._is_instrumented:
-            return
-        self._is_instrumented = False
-        cls = type(self)
-        cls._activation_count = max(cls._activation_count - 1, 0)
-        if cls._activation_count:
-            return
-
-        for target_class, method in reversed(cls._patched_targets):
-            try:
-                unwrap(target_class, method)
+                current = inspect.getattr_static(patch.target, patch.attribute)
+                if current is patch.installed_wrapper:
+                    unwrap(patch.target, patch.attribute)
+                    current = inspect.getattr_static(patch.target, patch.attribute)
+                if cls._wrapper_chain_contains(current, patch.installed_wrapper):
+                    retained.append(patch)
             except Exception:
+                retained.append(patch)
                 logger.debug(
-                    "Failed to unwrap %s.%s.%s",
-                    target_class.__module__,
-                    target_class.__qualname__,
-                    method,
+                    "Failed to remove %s.%s wrapper",
+                    getattr(patch.target, "__name__", safe_type_name(patch.target)),
+                    patch.attribute,
                     exc_info=True,
                 )
-        cls._patched_targets = []
-        cls._patches_applied = False
+        retained.reverse()
+        return retained
+
+    def activate(self) -> None:
+        cls = type(self)
+        with cls._lifecycle_lock:
+            if self._is_instrumented or not self._tracing_enabled():
+                return
+            if cls._patches_applied:
+                if cls._capture_content_config != self._capture_content:
+                    raise ValueError(
+                        "all active PineconeInstrumentor instances must use the "
+                        "same capture_content setting"
+                    )
+                cls._activation_count += 1
+                self._is_instrumented = True
+                return
+            if cls._patched_targets and all(
+                cls._wrapper_chain_contains(
+                    inspect.getattr_static(item.target, item.attribute),
+                    item.installed_wrapper,
+                )
+                for item in cls._patched_targets
+            ):
+                cls._patches_applied = True
+                cls._activation_count = 1
+                cls._capture_content_config = self._capture_content
+                self._is_instrumented = True
+                return
+
+            cls._patched_targets = cls._remove_owned_patches(cls._patched_targets)
+            if cls._patched_targets:
+                raise RuntimeError("Pinecone instrumentation has stale wrappers")
+
+            patched_targets: list[AppliedPatch] = []
+            try:
+                for patch in cls.patches:
+                    try:
+                        module = importlib.import_module(patch.module)
+                        target_class = getattr(module, patch.class_name)
+                    except (ImportError, AttributeError):
+                        continue
+                    for method in self._methods_for(target_class, patch):
+                        if not callable(getattr(target_class, method, None)):
+                            continue
+                        operation = self._operation_name(patch, method)
+
+                        def traced(
+                            wrapped: Any,
+                            instance: Any,
+                            args: tuple[Any, ...],
+                            kwargs: dict[str, Any],
+                            *,
+                            _operation: str = operation,
+                            _async: bool = patch.is_async,
+                        ) -> Any:
+                            instrumentor_class = type(self)
+                            if (
+                                not instrumentor_class._patches_applied
+                                or not instrumentor_class._activation_count
+                            ):
+                                return wrapped(*args, **kwargs)
+                            if _async:
+                                return self._trace_async(
+                                    _operation, wrapped, instance, args, kwargs
+                                )
+                            return self._trace_sync(
+                                _operation, wrapped, instance, args, kwargs
+                            )
+
+                        target = f"{patch.class_name}.{method}"
+                        wrap_function_wrapper(patch.module, target, traced)
+                        patched_targets.append(
+                            AppliedPatch(
+                                target_class,
+                                method,
+                                inspect.getattr_static(target_class, method),
+                            )
+                        )
+            except Exception:
+                cls._patched_targets = cls._remove_owned_patches(patched_targets)
+                cls._patches_applied = False
+                cls._activation_count = 0
+                cls._capture_content_config = None
+                self._is_instrumented = False
+                raise
+
+            self._is_instrumented = bool(patched_targets)
+            cls._patches_applied = self._is_instrumented
+            cls._activation_count = int(self._is_instrumented)
+            cls._patched_targets = patched_targets
+            cls._capture_content_config = (
+                self._capture_content if self._is_instrumented else None
+            )
+            if not self._is_instrumented:
+                logger.warning(
+                    "%s instrumentation found no supported methods", cls.vendor
+                )
+
+    def deactivate(self) -> None:
+        cls = type(self)
+        with cls._lifecycle_lock:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            cls._activation_count = max(cls._activation_count - 1, 0)
+            if cls._activation_count:
+                return
+            cls._patches_applied = False
+            cls._patched_targets = cls._remove_owned_patches(cls._patched_targets)
+            if not cls._patched_targets:
+                cls._capture_content_config = None
+
+    def instrument(self) -> None:
+        self.activate()
+
+    def uninstrument(self) -> None:
+        self.deactivate()

--- a/python-sdks/instrumentations/respan-instrumentation-pinecone/src/respan_instrumentation_pinecone/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pinecone/src/respan_instrumentation_pinecone/_serialization.py
@@ -1,0 +1,246 @@
+"""Bounded, privacy-safe serialization for Pinecone spans."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from enum import Enum
+from itertools import islice
+from numbers import Integral, Real
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+MAX_ATTRIBUTE_BYTES = 16_000
+MAX_ITEMS = 50
+MAX_DEPTH = 8
+MAX_TEXT_BYTES = 8_000
+
+_SENSITIVE_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "client_secret",
+    "password",
+    "secret",
+    "token",
+)
+_INLINE_SECRET = re.compile(
+    r"(?i)(api[_-]?key|authorization|client[_-]?secret|password|secret|token)"
+    r"(\s*[\"']?\s*[:=]\s*[\"']?\s*)([^\s,;&\"'}]+)"
+)
+_BEARER_TOKEN = re.compile(r"(?i)\bbearer\s+[^\s,;&]+")
+_MEMORY_ADDRESS = re.compile(r"(?i)\b0x[0-9a-f]{6,}\b")
+
+
+def safe_type_name(value: Any) -> str:
+    value_type = value if isinstance(value, type) else type(value)
+    module = getattr(value_type, "__module__", "")
+    qualname = getattr(value_type, "__qualname__", None) or getattr(
+        value_type, "__name__", "object"
+    )
+    candidate = f"{module}.{qualname}" if module and module != "builtins" else qualname
+    stable = re.sub(r"[^A-Za-z0-9_.-]+", ".", candidate).strip(".")
+    return (stable or "object")[:256]
+
+
+def truncate_utf8(value: str, max_bytes: int = MAX_TEXT_BYTES) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    suffix = "...[truncated]"
+    budget = max(0, max_bytes - len(suffix.encode("utf-8")))
+    return encoded[:budget].decode("utf-8", errors="ignore") + suffix
+
+
+def sanitize_endpoint(value: str) -> str:
+    """Strip endpoint credentials, query parameters, and fragments."""
+
+    try:
+        candidate = value if "://" in value else f"//{value}"
+        parsed = urlsplit(candidate)
+        host = parsed.hostname
+        if not host:
+            return "<redacted-endpoint>"
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        netloc = f"{host}{port}"
+        scheme = parsed.scheme if "://" in value else ""
+        sanitized = urlunsplit((scheme, netloc, parsed.path, "", ""))
+        return sanitized if scheme else sanitized.removeprefix("//")
+    except Exception:  # noqa: BLE001 - malformed endpoints are redacted
+        return "<redacted-endpoint>"
+
+
+def safe_text(value: str, *, endpoint: bool = False) -> str:
+    if endpoint:
+        value = sanitize_endpoint(value)
+    value = _BEARER_TOKEN.sub("Bearer <redacted>", value)
+    value = _INLINE_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}<redacted>", value
+    )
+    value = _MEMORY_ADDRESS.sub("0x<redacted>", value)
+    return truncate_utf8(value)
+
+
+def is_sensitive_key(value: str) -> bool:
+    normalized = value.lower().replace("-", "_")
+    return any(
+        normalized == part or normalized.endswith(f"_{part}") or part in normalized
+        for part in _SENSITIVE_PARTS
+    )
+
+
+def _stable_key(value: Any) -> str:
+    if isinstance(value, Enum):
+        return _stable_key(value.value)
+    if value is None or isinstance(value, (str, bool, int)):
+        return safe_text(str(value))[:256]
+    if isinstance(value, float) and math.isfinite(value):
+        return str(value)[:256]
+    return f"<{safe_type_name(value)}>"
+
+
+def _summary(value: Any, *, reason: str | None = None) -> dict[str, str]:
+    result = {"type": safe_type_name(value)}
+    if reason:
+        result["truncated"] = reason
+    return result
+
+
+def _trusted_pinecone_mapping(value: Any) -> Any | None:
+    value_type = type(value)
+    if not getattr(value_type, "__module__", "").startswith("pinecone"):
+        return None
+    for method_name in ("to_dict", "model_dump"):
+        try:
+            method = getattr(value, method_name, None)
+        except Exception:  # noqa: BLE001, S112 - hostile provider descriptors
+            continue
+        if callable(method):
+            try:
+                return method()
+            except Exception:  # noqa: BLE001, S112 - malformed provider models
+                continue
+    return None
+
+
+def jsonable(value: Any, *, depth: int = 0) -> Any:
+    if depth > MAX_DEPTH:
+        return _summary(value, reason="max_depth")
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return safe_text(value)
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, Real):
+        number = float(value)
+        return number if math.isfinite(number) else None
+    if isinstance(value, bytes):
+        return {"type": "bytes", "length": len(value)}
+    if isinstance(value, Enum):
+        return jsonable(value.value, depth=depth + 1)
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        try:
+            items = list(islice(value.items(), MAX_ITEMS + 1))
+        except Exception:  # noqa: BLE001 - hostile mappings become type summaries
+            return _summary(value)
+        for key, item in items[:MAX_ITEMS]:
+            key_text = _stable_key(key)
+            result[key_text] = (
+                "<redacted>"
+                if is_sensitive_key(key_text)
+                else jsonable(item, depth=depth + 1)
+            )
+        if len(items) > MAX_ITEMS:
+            result["__truncated__"] = True
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        try:
+            source = list(islice(iter(value), MAX_ITEMS + 1))
+        except Exception:  # noqa: BLE001 - hostile sequences become type summaries
+            return _summary(value)
+        items = [jsonable(item, depth=depth + 1) for item in source[:MAX_ITEMS]]
+        if len(source) > MAX_ITEMS:
+            return {
+                "items": items,
+                "truncated": True,
+                "count": f">{MAX_ITEMS}",
+            }
+        return items
+    trusted = _trusted_pinecone_mapping(value)
+    if trusted is not None:
+        return jsonable(trusted, depth=depth + 1)
+    return _summary(value)
+
+
+def json_dumps(value: Any) -> str:
+    text = json.dumps(
+        jsonable(value),
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    original_bytes = len(text.encode("utf-8"))
+    if original_bytes <= MAX_ATTRIBUTE_BYTES:
+        return text
+    low, high = 0, min(len(text), MAX_ATTRIBUTE_BYTES)
+    result = ""
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = json.dumps(
+            {
+                "original_bytes": original_bytes,
+                "preview": text[:midpoint],
+                "truncated": True,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(candidate.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES:
+            result = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return result
+
+
+def exception_message(exc: BaseException) -> str:
+    try:
+        arguments = exc.args
+    except Exception:  # noqa: BLE001 - hostile exception args are ignored
+        arguments = ()
+    for argument in arguments:
+        if isinstance(argument, str):
+            return safe_text(argument)
+        if argument is None or isinstance(argument, (bool, int)):
+            return safe_text(str(argument))
+        if isinstance(argument, float) and math.isfinite(argument):
+            return safe_text(str(argument))
+    return safe_type_name(exc)
+
+
+def exception_status_code(exc: BaseException) -> int:
+    for owner, attribute in ((exc, "status_code"), (exc, "status")):
+        try:
+            value = getattr(owner, attribute, None)
+        except Exception:  # noqa: BLE001 - hostile status properties are ignored
+            value = None
+        if isinstance(value, int) and 400 <= value <= 599:
+            return value
+    try:
+        response = getattr(exc, "response", None)
+    except Exception:  # noqa: BLE001 - hostile response properties are ignored
+        response = None
+    if response is not None:
+        try:
+            value = getattr(response, "status_code", None)
+        except Exception:  # noqa: BLE001 - hostile status properties are ignored
+            value = None
+        if isinstance(value, int) and 400 <= value <= 599:
+            return value
+    return 500

--- a/python-sdks/instrumentations/respan-instrumentation-pinecone/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pinecone/tests/test_instrumentation.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from types import ModuleType
 
 from opentelemetry.semconv_ai import SpanAttributes
-
 from respan_instrumentation_pinecone import PineconeInstrumentor
 from respan_instrumentation_pinecone import (
     _native_instrumentation as native_instrumentation,
@@ -73,7 +72,7 @@ def test_sync_async_and_embedding_operations(monkeypatch):
     inference_module.Inference = Inference
 
     tracer = _Tracer()
-    monkeypatch.setattr(native_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(native_instrumentation.trace, "get_tracer", lambda *_: tracer)
     PineconeInstrumentor._patches_applied = False
     instrumentor = PineconeInstrumentor()
     instrumentor.activate()

--- a/python-sdks/instrumentations/respan-instrumentation-pinecone/tests/test_real_pinecone.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pinecone/tests/test_real_pinecone.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import Counter
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from types import SimpleNamespace
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.semconv.attributes.http_attributes import HTTP_RESPONSE_STATUS_CODE
+from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
+from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.trace import StatusCode
+from pinecone import Index
+from pinecone.async_client.async_index import AsyncIndex
+from pinecone.exceptions import PineconeApiException
+from respan_instrumentation_pinecone import PineconeInstrumentor
+from respan_instrumentation_pinecone import (
+    _native_instrumentation as native_instrumentation,
+)
+from respan_instrumentation_pinecone._serialization import json_dumps
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "PineconeContractFixture/1.0"
+
+    def log_message(self, *_args) -> None:
+        return
+
+    def _json(self, status: int, value: object) -> None:
+        payload = json.dumps(value).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:
+        if self.path.startswith("/vectors/fetch"):
+            self._json(
+                200,
+                {
+                    "namespace": "demo",
+                    "vectors": {
+                        "doc-1": {
+                            "id": "doc-1",
+                            "values": [0.1, 0.2],
+                            "metadata": {"topic": "tracing"},
+                        }
+                    },
+                },
+            )
+            return
+        self._json(404, {"message": "not found"})
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length", "0"))
+        if length:
+            self.rfile.read(length)
+        if self.path == "/describe_index_stats":
+            self._json(
+                200,
+                {
+                    "dimension": 2,
+                    "indexFullness": 0,
+                    "namespaces": {},
+                    "totalVectorCount": 1,
+                },
+            )
+        elif self.path == "/vectors/upsert":
+            self._json(200, {"upsertedCount": 1})
+        elif self.path == "/query":
+            self._json(
+                200,
+                {
+                    "namespace": "demo",
+                    "matches": [
+                        {
+                            "id": "doc-1",
+                            "score": 0.99,
+                            "values": [0.1, 0.2],
+                            "metadata": {"topic": "tracing"},
+                        }
+                    ],
+                },
+            )
+        elif self.path == "/vectors/delete":
+            self._json(503, {"message": "deterministic Pinecone outage"})
+        else:
+            self._json(404, {"message": "not found"})
+
+
+@contextmanager
+def _server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@pytest.fixture
+def exporter(monkeypatch):
+    provider = TracerProvider()
+    span_exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    monkeypatch.setattr(native_instrumentation.trace, "get_tracer", provider.get_tracer)
+    yield provider, span_exporter
+    provider.shutdown()
+
+
+def test_real_current_sdk_exports_sync_async_and_failure(exporter):
+    provider, span_exporter = exporter
+    instrumentor = PineconeInstrumentor()
+    instrumentor.activate()
+    try:
+        with _server() as host:
+            index = Index(
+                host=host, api_key="pinecone-contract-secret", ssl_verify=False
+            )
+
+            async def async_fetch() -> object:
+                async_index = AsyncIndex(
+                    host=host,
+                    api_key="pinecone-contract-secret",
+                    ssl_verify=False,
+                )
+                try:
+                    return await async_index.fetch(ids=["doc-1"], namespace="demo")
+                finally:
+                    await async_index.close()
+
+            tracer = provider.get_tracer("pinecone.contract")
+            with tracer.start_as_current_span("root") as root:
+                index.describe_index_stats()
+                index.upsert(
+                    vectors=[{"id": "doc-1", "values": [0.1, 0.2]}],
+                    namespace="demo",
+                )
+                index.query(
+                    vector=[0.1, 0.2],
+                    top_k=1,
+                    namespace="demo",
+                    include_metadata=True,
+                    include_values=True,
+                )
+                asyncio.run(async_fetch())
+                with pytest.raises(PineconeApiException):
+                    index.delete(ids=["doc-1"], namespace="demo")
+
+            spans = span_exporter.get_finished_spans()
+            names = Counter(span.name for span in spans)
+            assert names == Counter(
+                {
+                    "root": 1,
+                    "pinecone.index.describe_index_stats": 1,
+                    "pinecone.index.upsert": 1,
+                    "pinecone.index.query": 1,
+                    "pinecone.index.fetch": 1,
+                    "pinecone.index.delete": 1,
+                }
+            )
+            assert len({span.context.span_id for span in spans}) == len(spans)
+            client_spans = [span for span in spans if span.name != "root"]
+            assert all(
+                span.parent.span_id == root.context.span_id for span in client_spans
+            )
+            assert all(
+                span.attributes[RESPAN_LOG_TYPE] == "task" for span in client_spans
+            )
+            assert all(
+                SpanAttributes.TRACELOOP_SPAN_KIND not in span.attributes
+                for span in client_spans
+            )
+            assert all(
+                span.attributes[OTelSpanAttributes.DB_SYSTEM] == "pinecone"
+                for span in client_spans
+            )
+            for span in client_spans:
+                assert json.loads(
+                    span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+                )
+                if SpanAttributes.TRACELOOP_ENTITY_OUTPUT in span.attributes:
+                    json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+
+            failed = next(span for span in client_spans if span.name.endswith("delete"))
+            assert failed.status.status_code is StatusCode.ERROR
+            assert failed.attributes[HTTP_RESPONSE_STATUS_CODE] == 503
+            assert (
+                "deterministic Pinecone outage" in failed.attributes[ERROR_MESSAGE_ATTR]
+            )
+            assert failed.events[0].name == "exception"
+            exported = json.dumps([dict(span.attributes) for span in spans])
+            assert "pinecone-contract-secret" not in exported
+            assert "0x" not in exported
+    finally:
+        instrumentor.deactivate()
+
+
+def test_serializer_is_bounded_redacted_and_never_calls_repr_or_str():
+    calls = {"repr": 0, "str": 0}
+
+    class Hostile:
+        def __repr__(self):
+            calls["repr"] += 1
+            raise AssertionError("repr must not be called")
+
+        def __str__(self):
+            calls["str"] += 1
+            raise AssertionError("str must not be called")
+
+    encoded = json_dumps(
+        {
+            "api_key": "plain-secret",
+            "client_secret": "another-secret",
+            "nested": {"auth_token": "token-value", "value": Hostile()},
+            "unicode": "😀" * 10_000,
+        }
+    )
+    assert len(encoded.encode("utf-8")) <= 16_000
+    parsed = json.loads(encoded)
+    assert parsed
+    assert "plain-secret" not in encoded
+    assert "another-secret" not in encoded
+    assert "token-value" not in encoded
+    assert calls == {"repr": 0, "str": 0}
+
+
+def test_multiple_instances_share_lifecycle_and_reject_config_mismatch(monkeypatch):
+    class IndexFixture:
+        def query(self, vector, top_k):
+            return {"matches": [], "vector": vector, "top_k": top_k}
+
+    module = SimpleNamespace(Index=IndexFixture)
+    monkeypatch.setattr(
+        native_instrumentation.importlib,
+        "import_module",
+        lambda name: (
+            module
+            if name == "pinecone.index"
+            else (_ for _ in ()).throw(ImportError(name))
+        ),
+    )
+    first = PineconeInstrumentor()
+    second = PineconeInstrumentor()
+    first.activate()
+    second.activate()
+    try:
+        assert PineconeInstrumentor._activation_count == 2
+        first.deactivate()
+        assert PineconeInstrumentor._activation_count == 1
+        assert PineconeInstrumentor._patches_applied is True
+        with pytest.raises(ValueError):
+            PineconeInstrumentor(capture_content=False).activate()
+    finally:
+        second.deactivate()
+    assert PineconeInstrumentor._activation_count == 0
+    assert PineconeInstrumentor._patches_applied is False

--- a/python-sdks/instrumentations/respan-instrumentation-pipecat/src/respan_instrumentation_pipecat/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pipecat/src/respan_instrumentation_pipecat/_instrumentation.py
@@ -1,21 +1,40 @@
 """Pipecat instrumentation plugin for Respan."""
 
+from __future__ import annotations
+
 import importlib
 import logging
+import threading
 from typing import Any
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
-
-from respan_instrumentation_pipecat._translator import PipecatOpenInferenceTranslator
 from respan_tracing.core.tracer import RespanTracer
+
+from respan_instrumentation_pipecat._observer_hooks import (
+    ObserverHook,
+    install_observer_hook,
+    remove_observer_hook,
+)
+from respan_instrumentation_pipecat._translator import PipecatOpenInferenceTranslator
 
 logger = logging.getLogger(__name__)
 
 PIPECAT_INSTRUMENTATION_NAME = "pipecat"
 OPENINFERENCE_PIPECAT_MODULE = "openinference.instrumentation.pipecat"
-OPENINFERENCE_PIPECAT_OBSERVER_MODULE = "openinference.instrumentation.pipecat._observer"
-_ORIGINAL_OBSERVER_CONTEXT_ATTR = "_respan_original_context"
+OPENINFERENCE_PIPECAT_OBSERVER_MODULE = (
+    "openinference.instrumentation.pipecat._observer"
+)
+
+_LOCK = threading.RLock()
+_REFCOUNT = 0
+_PROCESSOR: PipecatOpenInferenceTranslator | None = None
+_PROVIDER: Any = None
+_UPSTREAM: Any = None
+_OBSERVER_MODULE: Any = None
+_OBSERVER_CONTEXT_ORIGINAL: Any = None
+_OBSERVER_HOOK: ObserverHook | None = None
+_CONFIG: dict[str, Any] | None = None
 
 
 def _load_openinference_pipecat_class() -> type:
@@ -27,153 +46,204 @@ def _load_openinference_pipecat_observer_module() -> Any:
     return importlib.import_module(OPENINFERENCE_PIPECAT_OBSERVER_MODULE)
 
 
-class PipecatInstrumentor:
-    """Respan instrumentor for Pipecat.
+def _is_respan_tracing_enabled() -> bool:
+    tracer = getattr(RespanTracer, "_instance", None)
+    if tracer is None:
+        return True
+    return bool(getattr(tracer, "is_enabled", True))
 
-    Activates the upstream OpenInference Pipecat instrumentor and registers a
-    Pipecat-local translator so pipeline, LLM, STT, TTS, and tool spans reach
-    the Respan OTEL pipeline with canonical tracing attributes.
-    """
+
+def _active_processors(provider: Any) -> tuple[Any, tuple[Any, ...] | None]:
+    active = getattr(provider, "_active_span_processor", None)
+    processors = getattr(active, "_span_processors", None) if active else None
+    return active, processors
+
+
+def _register_processor(
+    provider: Any, processor: PipecatOpenInferenceTranslator
+) -> None:
+    active, processors = _active_processors(provider)
+    if active is not None and processors is not None:
+        remaining = tuple(
+            existing for existing in processors if existing is not processor
+        )
+        active._span_processors = (processor, *remaining)
+    elif hasattr(provider, "add_span_processor"):
+        provider.add_span_processor(processor)
+
+
+def _unregister_processor(
+    provider: Any, processor: PipecatOpenInferenceTranslator
+) -> None:
+    active, processors = _active_processors(provider)
+    if active is not None and processors is not None:
+        active._span_processors = tuple(
+            existing for existing in processors if existing is not processor
+        )
+
+
+def _same_config(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    if left.keys() != right.keys():
+        return False
+    for key, value in left.items():
+        if value is right[key]:
+            continue
+        try:
+            if value == right[key]:
+                continue
+        except Exception:  # noqa: BLE001 - hostile configuration equality is rejected
+            return False
+        return False
+    return True
+
+
+def _patch_observer(observer_module: Any) -> tuple[Any, ObserverHook]:
+    original_context = observer_module.Context
+    observer_module.Context = context_api.get_current
+    try:
+        hook = install_observer_hook(observer_module)
+    except Exception:
+        if observer_module.Context is context_api.get_current:
+            observer_module.Context = original_context
+        raise
+    return original_context, hook
+
+
+def _restore_observer(
+    observer_module: Any,
+    original_context: Any,
+    hook: ObserverHook | None,
+) -> None:
+    remove_observer_hook(hook)
+    if (
+        observer_module is not None
+        and observer_module.Context is context_api.get_current
+    ):
+        observer_module.Context = original_context
+
+
+class PipecatInstrumentor:
+    """Activate OpenInference Pipecat once and normalize its spans for Respan."""
 
     name = PIPECAT_INSTRUMENTATION_NAME
 
     def __init__(self, **instrumentor_kwargs: Any) -> None:
         self._instrumentor_kwargs = dict(instrumentor_kwargs)
-        self._instrumentor = None
-        self._processor = None
         self._is_instrumented = False
-        self._patched_observer_module = None
-
-    @staticmethod
-    def _is_respan_tracing_enabled() -> bool:
-        tracer = getattr(RespanTracer, "_instance", None)
-        if tracer is None:
-            return True
-        return bool(getattr(tracer, "is_enabled", True))
-
-    @staticmethod
-    def _register_processor(
-        tracer_provider,
-        processor: PipecatOpenInferenceTranslator,
-    ) -> None:
-        active_span_processor = getattr(tracer_provider, "_active_span_processor", None)
-        processors = (
-            getattr(active_span_processor, "_span_processors", None)
-            if active_span_processor is not None
-            else None
-        )
-
-        if processors is not None:
-            active_span_processor._span_processors = tuple(
-                existing_processor
-                for existing_processor in processors
-                if existing_processor is not processor
-            )
-            active_span_processor._span_processors = (
-                processor,
-                *active_span_processor._span_processors,
-            )
-            return
-
-        if hasattr(tracer_provider, "add_span_processor"):
-            tracer_provider.add_span_processor(processor)
-
-    @staticmethod
-    def _unregister_processor(
-        tracer_provider,
-        processor: PipecatOpenInferenceTranslator,
-    ) -> None:
-        active_span_processor = getattr(tracer_provider, "_active_span_processor", None)
-        processors = (
-            getattr(active_span_processor, "_span_processors", None)
-            if active_span_processor is not None
-            else None
-        )
-        if processors is None:
-            return
-        active_span_processor._span_processors = tuple(
-            existing_processor
-            for existing_processor in processors
-            if existing_processor is not processor
-        )
-
-    def _patch_observer_context(self) -> None:
-        observer_module = _load_openinference_pipecat_observer_module()
-        if not hasattr(observer_module, _ORIGINAL_OBSERVER_CONTEXT_ATTR):
-            setattr(
-                observer_module,
-                _ORIGINAL_OBSERVER_CONTEXT_ATTR,
-                observer_module.Context,
-            )
-        observer_module.Context = context_api.get_current
-        self._patched_observer_module = observer_module
-
-    def _restore_observer_context(self) -> None:
-        observer_module = self._patched_observer_module
-        if observer_module is None:
-            return
-        original_context = getattr(observer_module, _ORIGINAL_OBSERVER_CONTEXT_ATTR, None)
-        if original_context is not None:
-            observer_module.Context = original_context
-            delattr(observer_module, _ORIGINAL_OBSERVER_CONTEXT_ATTR)
-        self._patched_observer_module = None
 
     def activate(self) -> None:
-        """Instrument Pipecat via OpenInference and Pipecat's local translator."""
+        """Instrument Pipecat with shared, transactional lifecycle ownership."""
+        global _CONFIG, _OBSERVER_CONTEXT_ORIGINAL, _OBSERVER_HOOK
+        global _OBSERVER_MODULE, _PROCESSOR, _PROVIDER, _REFCOUNT, _UPSTREAM
+
         if self._is_instrumented:
             return
-
-        if not self._is_respan_tracing_enabled():
+        if not _is_respan_tracing_enabled():
             logger.info(
                 "Pipecat instrumentation skipped because Respan tracing is disabled"
             )
             return
+        with _LOCK:
+            if self._is_instrumented:
+                return
+            if _REFCOUNT:
+                if _CONFIG is None or not _same_config(
+                    _CONFIG, self._instrumentor_kwargs
+                ):
+                    logger.warning(
+                        "Pipecat instrumentation is already active with different settings"
+                    )
+                    return
+                _REFCOUNT += 1
+                self._is_instrumented = True
+                return
 
-        try:
-            pipecat_instrumentor_class = _load_openinference_pipecat_class()
-        except ImportError as exc:
-            logger.warning(
-                "Failed to activate Pipecat instrumentation — missing dependency: %s",
-                exc,
-            )
-            return
+            try:
+                instrumentor_class = _load_openinference_pipecat_class()
+                observer_module = _load_openinference_pipecat_observer_module()
+            except ImportError as exc:
+                logger.warning(
+                    "Failed to activate Pipecat instrumentation — missing dependency: %s",
+                    exc,
+                )
+                return
 
-        tracer_provider = trace.get_tracer_provider()
-        if self._processor is None:
-            self._processor = PipecatOpenInferenceTranslator()
-        self._register_processor(tracer_provider, self._processor)
+            provider = trace.get_tracer_provider()
+            processor = PipecatOpenInferenceTranslator()
+            upstream = instrumentor_class()
+            original_context: Any = None
+            hook: ObserverHook | None = None
+            registered = False
+            try:
+                _register_processor(provider, processor)
+                registered = True
+                original_context, hook = _patch_observer(observer_module)
+                upstream.instrument(
+                    tracer_provider=provider,
+                    **self._instrumentor_kwargs,
+                )
+            except Exception:
+                try:
+                    upstream.uninstrument()
+                except Exception:
+                    logger.exception("Failed to roll back Pipecat instrumentation")
+                if hook is not None or original_context is not None:
+                    _restore_observer(observer_module, original_context, hook)
+                if registered:
+                    _unregister_processor(provider, processor)
+                logger.exception("Failed to activate Pipecat instrumentation")
+                return
 
-        try:
-            self._patch_observer_context()
-            self._instrumentor = pipecat_instrumentor_class()
-            self._instrumentor.instrument(
-                tracer_provider=tracer_provider,
-                **self._instrumentor_kwargs,
-            )
+            _CONFIG = dict(self._instrumentor_kwargs)
+            _OBSERVER_CONTEXT_ORIGINAL = original_context
+            _OBSERVER_HOOK = hook
+            _OBSERVER_MODULE = observer_module
+            _PROCESSOR = processor
+            _PROVIDER = provider
+            _UPSTREAM = upstream
+            _REFCOUNT = 1
             self._is_instrumented = True
             logger.info("Pipecat instrumentation activated")
-        except Exception:
-            if self._instrumentor is not None:
-                try:
-                    self._instrumentor.uninstrument()
-                except Exception:
-                    logger.exception("Failed to clean up Pipecat instrumentation")
-            self._unregister_processor(tracer_provider, self._processor)
-            self._restore_observer_context()
-            self._instrumentor = None
-            self._is_instrumented = False
-            logger.exception("Failed to activate Pipecat instrumentation")
 
     def deactivate(self) -> None:
-        """Deactivate Pipecat instrumentation."""
-        if self._is_instrumented and self._instrumentor is not None:
-            try:
-                self._instrumentor.uninstrument()
-            except Exception:
-                logger.exception("Failed to deactivate Pipecat instrumentation")
-        if self._processor is not None:
-            self._unregister_processor(trace.get_tracer_provider(), self._processor)
-        self._restore_observer_context()
-        self._instrumentor = None
-        self._is_instrumented = False
-        logger.info("Pipecat instrumentation deactivated")
+        """Release one owner and remove only the final shared activation."""
+        global _CONFIG, _OBSERVER_CONTEXT_ORIGINAL, _OBSERVER_HOOK
+        global _OBSERVER_MODULE, _PROCESSOR, _PROVIDER, _REFCOUNT, _UPSTREAM
+
+        if not self._is_instrumented:
+            return
+        with _LOCK:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            _REFCOUNT = max(0, _REFCOUNT - 1)
+            if _REFCOUNT:
+                return
+            if _UPSTREAM is not None:
+                try:
+                    _UPSTREAM.uninstrument()
+                except Exception:
+                    logger.exception("Failed to deactivate Pipecat instrumentation")
+            if _PROCESSOR is not None and _PROVIDER is not None:
+                _unregister_processor(_PROVIDER, _PROCESSOR)
+            _restore_observer(
+                _OBSERVER_MODULE,
+                _OBSERVER_CONTEXT_ORIGINAL,
+                _OBSERVER_HOOK,
+            )
+            _CONFIG = None
+            _OBSERVER_CONTEXT_ORIGINAL = None
+            _OBSERVER_HOOK = None
+            _OBSERVER_MODULE = None
+            _PROCESSOR = None
+            _PROVIDER = None
+            _UPSTREAM = None
+            logger.info("Pipecat instrumentation deactivated")
+
+    def instrument(self) -> None:
+        """Alias used by direct OpenTelemetry-style integrations."""
+        self.activate()
+
+    def uninstrument(self) -> None:
+        """Alias used by direct OpenTelemetry-style integrations."""
+        self.deactivate()

--- a/python-sdks/instrumentations/respan-instrumentation-pipecat/src/respan_instrumentation_pipecat/_observer_hooks.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pipecat/src/respan_instrumentation_pipecat/_observer_hooks.py
@@ -1,0 +1,202 @@
+"""Small Pipecat observer compatibility hooks owned by the Respan adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from opentelemetry.trace import Status, StatusCode
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+
+from respan_instrumentation_pipecat._serialization import (
+    exception_message,
+    exception_status_code,
+    safe_text,
+    safe_type_name,
+)
+
+RESPAN_PIPECAT_ERROR_STATUS = "pipecat.respan.error_status_code"
+RESPAN_PIPECAT_ERROR_TYPE = "pipecat.respan.error_type"
+RESPAN_PIPECAT_LLM_COMPLETED = "pipecat.respan.llm_completed"
+
+
+@dataclass
+class ObserverHook:
+    observer_class: type
+    original: Callable[..., Awaitable[None]]
+    wrapper: Callable[..., Awaitable[None]]
+    active: bool = True
+
+
+def _safe_getattr(value: Any, name: str, default: Any = None) -> Any:
+    try:
+        return getattr(value, name, default)
+    except Exception:  # noqa: BLE001 - hostile provider descriptors are ignored
+        return default
+
+
+def _frame_error(frame: Any) -> tuple[str, str, int] | None:
+    if type(frame).__name__ != "ErrorFrame":
+        return None
+    exception = _safe_getattr(frame, "exception")
+    if isinstance(exception, BaseException):
+        return (
+            exception_message(exception),
+            safe_type_name(exception),
+            exception_status_code(exception),
+        )
+    raw_error = _safe_getattr(frame, "error")
+    message = (
+        safe_text(raw_error)
+        if isinstance(raw_error, str)
+        else "Pipecat operation failed"
+    )
+    return message, "PipecatError", 500
+
+
+def _mark_span(span: Any, *, message: str, error_type: str, status_code: int) -> None:
+    if span is None:
+        return
+    span.set_attribute(ERROR_MESSAGE_ATTR, message)
+    span.set_attribute(RESPAN_PIPECAT_ERROR_STATUS, status_code)
+    span.set_attribute(RESPAN_PIPECAT_ERROR_TYPE, error_type)
+    span.set_status(Status(StatusCode.ERROR, message))
+
+
+def _record_error_frame(observer: Any, data: Any) -> None:
+    frame = _safe_getattr(data, "frame")
+    error = _frame_error(frame)
+    if error is None:
+        return
+    message, error_type, status_code = error
+    candidates = (
+        _safe_getattr(frame, "processor"),
+        _safe_getattr(data, "source"),
+        _safe_getattr(data, "destination"),
+    )
+    active_spans = _safe_getattr(observer, "_active_spans", {})
+    marked: set[int] = set()
+    if isinstance(active_spans, dict):
+        for candidate in candidates:
+            span_info = (
+                active_spans.get(id(candidate)) if candidate is not None else None
+            )
+            if isinstance(span_info, dict):
+                span = span_info.get("span")
+                if span is not None and id(span) not in marked:
+                    _mark_span(
+                        span,
+                        message=message,
+                        error_type=error_type,
+                        status_code=status_code,
+                    )
+                    marked.add(id(span))
+        if not marked:
+            for span_info in active_spans.values():
+                if (
+                    not isinstance(span_info, dict)
+                    or span_info.get("service_type") != "llm"
+                ):
+                    continue
+                span = span_info.get("span")
+                if span is not None:
+                    _mark_span(
+                        span,
+                        message=message,
+                        error_type=error_type,
+                        status_code=status_code,
+                    )
+    _mark_span(
+        _safe_getattr(observer, "_turn_span"),
+        message=message,
+        error_type=error_type,
+        status_code=status_code,
+    )
+
+
+def _message_text(message: Any) -> str | None:
+    if not isinstance(message, dict) or message.get("role") != "user":
+        return None
+    content = message.get("content")
+    if isinstance(content, str):
+        return safe_text(content)
+    return None
+
+
+def _record_semantic_frame(observer: Any, data: Any) -> None:
+    frame = _safe_getattr(data, "frame")
+    frame_name = type(frame).__name__
+    turn_span = _safe_getattr(observer, "_turn_span")
+    if turn_span is None:
+        return
+    if frame_name == "LLMContextFrame":
+        observer._respan_llm_text_chunks = []
+        observer._respan_seen_llm_frame_ids = set()
+        context = _safe_getattr(frame, "context")
+        messages = _safe_getattr(context, "_messages") or _safe_getattr(
+            context, "messages", []
+        )
+        try:
+            user_text = [text for item in messages if (text := _message_text(item))]
+        except Exception:  # noqa: BLE001 - hostile context collections are ignored
+            user_text = []
+        if user_text:
+            existing = _safe_getattr(observer, "_turn_user_text", [])
+            if not existing:
+                observer._turn_user_text = list(user_text)
+            turn_span.set_attribute("input.value", " ".join(user_text))
+    elif frame_name == "LLMFullResponseEndFrame":
+        turn_span.set_attribute(RESPAN_PIPECAT_LLM_COMPLETED, True)
+    elif frame_name == "LLMTextFrame":
+        text = _safe_getattr(frame, "text")
+        if isinstance(text, str) and text:
+            frame_id = _safe_getattr(frame, "id", id(frame))
+            seen = _safe_getattr(observer, "_respan_seen_llm_frame_ids", set())
+            if not isinstance(seen, set):
+                seen = set()
+            if frame_id in seen:
+                return
+            seen.add(frame_id)
+            observer._respan_seen_llm_frame_ids = seen
+            chunks = _safe_getattr(observer, "_respan_llm_text_chunks", [])
+            if isinstance(chunks, list):
+                chunks.append(safe_text(text))
+                observer._respan_llm_text_chunks = chunks
+
+
+def _prepare_turn_end(observer: Any, data: Any) -> None:
+    frame = _safe_getattr(data, "frame")
+    if type(frame).__name__ not in {"EndFrame", "CancelFrame"}:
+        return
+    chunks = _safe_getattr(observer, "_respan_llm_text_chunks", [])
+    if isinstance(chunks, list) and chunks:
+        observer._turn_bot_text = [safe_text("".join(chunks))]
+
+
+def install_observer_hook(observer_module: Any) -> ObserverHook:
+    observer_class = observer_module.OpenInferenceObserver
+    original = observer_class.on_push_frame
+    hook: ObserverHook
+
+    async def wrapped(instance: Any, data: Any) -> None:
+        if hook.active:
+            _record_error_frame(instance, data)
+            _prepare_turn_end(instance, data)
+        await original(instance, data)
+        if hook.active:
+            _record_semantic_frame(instance, data)
+
+    hook = ObserverHook(
+        observer_class=observer_class, original=original, wrapper=wrapped
+    )
+    observer_class.on_push_frame = wrapped
+    return hook
+
+
+def remove_observer_hook(hook: ObserverHook | None) -> None:
+    if hook is None:
+        return
+    hook.active = False
+    if hook.observer_class.on_push_frame is hook.wrapper:
+        hook.observer_class.on_push_frame = hook.original

--- a/python-sdks/instrumentations/respan-instrumentation-pipecat/src/respan_instrumentation_pipecat/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pipecat/src/respan_instrumentation_pipecat/_serialization.py
@@ -1,0 +1,223 @@
+"""Bounded and privacy-safe serialization for Pipecat spans."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from numbers import Integral, Real
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+MAX_ATTRIBUTE_BYTES = 16_000
+MAX_ITEMS = 50
+MAX_DEPTH = 8
+MAX_TEXT_BYTES = 8_000
+
+_SENSITIVE_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "client_secret",
+    "password",
+    "secret",
+    "token",
+)
+_INLINE_SECRET = re.compile(
+    r"(?i)([\"']?(?:api[_-]?key|authorization|client[_-]?secret|password|secret|token)[\"']?)"
+    r"(\s*[:=]\s*[\"']?\s*)([^\s,;&\"'}]+)"
+)
+_BEARER_TOKEN = re.compile(r"(?i)\bbearer\s+[^\s,;&]+")
+_MEMORY_ADDRESS = re.compile(r"(?i)\b0x[0-9a-f]{6,}\b")
+
+
+def safe_type_name(value: Any) -> str:
+    value_type = value if isinstance(value, type) else type(value)
+    module = getattr(value_type, "__module__", "")
+    qualname = getattr(value_type, "__qualname__", None) or getattr(
+        value_type, "__name__", "object"
+    )
+    candidate = f"{module}.{qualname}" if module and module != "builtins" else qualname
+    stable = re.sub(r"[^A-Za-z0-9_.-]+", ".", candidate).strip(".")
+    return (stable or "object")[:256]
+
+
+def truncate_utf8(value: str, max_bytes: int = MAX_TEXT_BYTES) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    suffix = "...[truncated]"
+    budget = max(0, max_bytes - len(suffix.encode("utf-8")))
+    return encoded[:budget].decode("utf-8", errors="ignore") + suffix
+
+
+def is_sensitive_key(value: str) -> bool:
+    normalized = value.lower().replace("-", "_")
+    return any(
+        normalized == part or normalized.endswith(f"_{part}") or part in normalized
+        for part in _SENSITIVE_PARTS
+    )
+
+
+def sanitize_endpoint(value: str) -> str:
+    try:
+        candidate = value if "://" in value else f"//{value}"
+        parsed = urlsplit(candidate)
+        if not parsed.hostname:
+            return "<redacted-endpoint>"
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        scheme = parsed.scheme if "://" in value else ""
+        result = urlunsplit((scheme, f"{parsed.hostname}{port}", parsed.path, "", ""))
+        return result if scheme else result.removeprefix("//")
+    except Exception:  # noqa: BLE001 - malformed endpoints are fully redacted
+        return "<redacted-endpoint>"
+
+
+def safe_text(value: str, *, endpoint: bool = False) -> str:
+    if endpoint:
+        value = sanitize_endpoint(value)
+    value = _BEARER_TOKEN.sub("Bearer <redacted>", value)
+    value = _INLINE_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}<redacted>", value
+    )
+    value = _MEMORY_ADDRESS.sub("0x<redacted>", value)
+    return truncate_utf8(value)
+
+
+def _stable_key(value: Any) -> str:
+    if value is None or isinstance(value, (str, bool, int)):
+        return safe_text(str(value))[:256]
+    if isinstance(value, float) and math.isfinite(value):
+        return str(value)[:256]
+    return f"<{safe_type_name(value)}>"
+
+
+def _summary(value: Any, reason: str | None = None) -> dict[str, str]:
+    result = {"type": safe_type_name(value)}
+    if reason:
+        result["truncated"] = reason
+    return result
+
+
+def jsonable(value: Any, *, depth: int = 0) -> Any:
+    if depth > MAX_DEPTH:
+        return _summary(value, "max_depth")
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return safe_text(value)
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, Real):
+        number = float(value)
+        return number if math.isfinite(number) else None
+    if isinstance(value, bytes):
+        return {"type": "bytes", "length": len(value)}
+    if isinstance(value, Mapping):
+        try:
+            source = list(islice(value.items(), MAX_ITEMS + 1))
+        except Exception:  # noqa: BLE001 - hostile mappings become stable summaries
+            return _summary(value)
+        result: dict[str, Any] = {}
+        for key, item in source[:MAX_ITEMS]:
+            key_text = _stable_key(key)
+            result[key_text] = (
+                "<redacted>"
+                if is_sensitive_key(key_text)
+                else jsonable(item, depth=depth + 1)
+            )
+        if len(source) > MAX_ITEMS:
+            result["__truncated__"] = True
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        try:
+            source = list(islice(iter(value), MAX_ITEMS + 1))
+        except Exception:  # noqa: BLE001 - hostile sequences become stable summaries
+            return _summary(value)
+        items = [jsonable(item, depth=depth + 1) for item in source[:MAX_ITEMS]]
+        if len(source) > MAX_ITEMS:
+            return {"items": items, "truncated": True, "count": f">{MAX_ITEMS}"}
+        return items
+    return _summary(value)
+
+
+def json_dumps(value: Any) -> str:
+    text = json.dumps(
+        jsonable(value),
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    original_bytes = len(text.encode("utf-8"))
+    if original_bytes <= MAX_ATTRIBUTE_BYTES:
+        return text
+    low, high = 0, min(len(text), MAX_ATTRIBUTE_BYTES)
+    result = ""
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = json.dumps(
+            {
+                "original_bytes": original_bytes,
+                "preview": text[:midpoint],
+                "truncated": True,
+            },
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(candidate.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES:
+            result = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return result
+
+
+def parse_json(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return value
+
+
+def exception_message(exc: BaseException) -> str:
+    try:
+        arguments = exc.args
+    except Exception:  # noqa: BLE001 - hostile exceptions are summarized
+        arguments = ()
+    for argument in arguments:
+        if isinstance(argument, str):
+            return safe_text(argument)
+        if argument is None or isinstance(argument, (bool, int)):
+            return safe_text(str(argument))
+        if isinstance(argument, float) and math.isfinite(argument):
+            return safe_text(str(argument))
+    return safe_type_name(exc)
+
+
+def exception_status_code(exc: BaseException) -> int:
+    for owner, attribute in ((exc, "status_code"), (exc, "status")):
+        try:
+            value = getattr(owner, attribute, None)
+        except Exception:  # noqa: BLE001 - hostile status properties are ignored
+            value = None
+        if isinstance(value, int) and 400 <= value <= 599:
+            return value
+    try:
+        response = getattr(exc, "response", None)
+    except Exception:  # noqa: BLE001 - hostile response properties are ignored
+        response = None
+    if response is not None:
+        try:
+            value = getattr(response, "status_code", None)
+        except Exception:  # noqa: BLE001 - hostile status properties are ignored
+            value = None
+        if isinstance(value, int) and 400 <= value <= 599:
+            return value
+    return 500

--- a/python-sdks/instrumentations/respan-instrumentation-pipecat/src/respan_instrumentation_pipecat/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pipecat/src/respan_instrumentation_pipecat/_translator.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from collections import defaultdict
 from typing import Any
 
 from openinference.semconv.trace import (
     MessageAttributes,
-    SpanAttributes as OISpanAttributes,
     ToolCallAttributes,
+)
+from openinference.semconv.trace import (
+    SpanAttributes as OISpanAttributes,
 )
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 from opentelemetry.semconv._incubating.attributes import (
@@ -18,8 +19,12 @@ from opentelemetry.semconv._incubating.attributes import (
 )
 from opentelemetry.semconv_ai import (
     LLMRequestTypeValues,
+)
+from opentelemetry.semconv_ai import (
     SpanAttributes as TLSpanAttributes,
 )
+from opentelemetry.trace import Status, StatusCode
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
 from respan_sdk.constants.llm_logging import (
     LOG_TYPE_AGENT,
     LOG_TYPE_CHAT,
@@ -30,10 +35,23 @@ from respan_sdk.constants.llm_logging import (
     LOG_TYPE_TOOL,
     LOG_TYPE_TRANSCRIPTION,
     LOG_TYPE_WORKFLOW,
+    LogMethodChoices,
 )
 from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_METHOD,
     RESPAN_LOG_TYPE,
     RESPAN_SESSION_ID,
+)
+
+from respan_instrumentation_pipecat._observer_hooks import (
+    RESPAN_PIPECAT_ERROR_STATUS,
+    RESPAN_PIPECAT_ERROR_TYPE,
+    RESPAN_PIPECAT_LLM_COMPLETED,
+)
+from respan_instrumentation_pipecat._serialization import (
+    json_dumps,
+    parse_json,
+    safe_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -74,20 +92,11 @@ _OI_KIND_TO_LOG_TYPE = {
 
 
 def _safe_json_str(value: Any) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value
-    return json.dumps(value, default=str)
+    return json_dumps(parse_json(value))
 
 
 def _parse_json(value: Any) -> Any:
-    if not isinstance(value, str):
-        return value
-    try:
-        return json.loads(value)
-    except (TypeError, json.JSONDecodeError):
-        return value
+    return parse_json(value)
 
 
 def _set_nested_value(target: dict[str, Any], dotted_path: str, value: Any) -> None:
@@ -167,7 +176,7 @@ def _normalize_tool_call(tool_call: dict[str, Any]) -> dict[str, Any]:
 
 
 def _tool_call_signature(tool_call: dict[str, Any]) -> str:
-    return json.dumps(tool_call, default=str, sort_keys=True, separators=(",", ":"))
+    return json_dumps(tool_call)
 
 
 def _extract_tool_calls_from_buckets(
@@ -188,8 +197,7 @@ def _extract_tool_calls_from_buckets(
             if not parts[0].isdigit() or len(parts) == 1:
                 continue
             field = parts[1]
-            if field.startswith(_OI_TOOL_CALL_PREFIX):
-                field = field[len(_OI_TOOL_CALL_PREFIX) :]
+            field = field.removeprefix(_OI_TOOL_CALL_PREFIX)
             tool_call_buckets[int(parts[0])][field] = value
 
         for tool_call_index in sorted(tool_call_buckets):
@@ -205,7 +213,9 @@ def _extract_tool_calls_from_buckets(
                 result.append(normalized)
 
         legacy_name = raw.get(MessageAttributes.MESSAGE_FUNCTION_CALL_NAME)
-        legacy_arguments = raw.get(MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON)
+        legacy_arguments = raw.get(
+            MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON
+        )
         if legacy_name is None and legacy_arguments is None:
             continue
         legacy_tool_call = {"type": "function", "function": {}}
@@ -234,19 +244,21 @@ def _messages_to_openllmetry(
 
         role = raw.get(MessageAttributes.MESSAGE_ROLE)
         if role:
-            attrs.setdefault(f"{target}.role", role)
+            attrs[f"{target}.role"] = safe_text(str(role))
 
         content = _extract_message_content(raw)
         if content is not None:
-            attrs.setdefault(f"{target}.content", content)
+            attrs[f"{target}.content"] = (
+                safe_text(content) if isinstance(content, str) else json_dumps(content)
+            )
 
         tool_calls = _extract_tool_calls_from_buckets({index: raw})
         if tool_calls is not None:
-            attrs.setdefault(f"{target}.tool_calls", _safe_json_str(tool_calls))
+            attrs[f"{target}.tool_calls"] = json_dumps(tool_calls)
 
         finish_reason = raw.get(_OI_MESSAGE_FINISH_REASON)
         if finish_reason:
-            attrs.setdefault(f"{target}.finish_reason", finish_reason)
+            attrs[f"{target}.finish_reason"] = safe_text(str(finish_reason))
 
 
 def _normalize_tools(value: Any) -> list[dict[str, Any]] | None:
@@ -281,6 +293,74 @@ def _pipecat_log_type(attrs: dict[str, Any], oi_kind_upper: str) -> str:
     return _OI_KIND_TO_LOG_TYPE.get(oi_kind_upper, LOG_TYPE_TASK)
 
 
+def _has_parent(span: ReadableSpan) -> bool:
+    parent = getattr(span, "parent", None)
+    return bool(parent and getattr(parent, "span_id", 0))
+
+
+def _status_message(span: ReadableSpan, attrs: dict[str, Any]) -> str | None:
+    direct = attrs.get(ERROR_MESSAGE_ATTR)
+    if isinstance(direct, str) and direct:
+        return safe_text(direct)
+    status = getattr(span, "status", None)
+    description = getattr(status, "description", None)
+    if isinstance(description, str) and description:
+        return safe_text(description)
+    for event in getattr(span, "events", ()) or ():
+        event_attrs = getattr(event, "attributes", None) or {}
+        message = event_attrs.get("exception.message")
+        if isinstance(message, str) and message:
+            return safe_text(message)
+    return None
+
+
+def _normalize_status(
+    span: ReadableSpan, attrs: dict[str, Any], *, is_chat: bool
+) -> None:
+    internal_code = attrs.pop(RESPAN_PIPECAT_ERROR_STATUS, None)
+    error_type = attrs.pop(RESPAN_PIPECAT_ERROR_TYPE, None)
+    status = getattr(span, "status", None)
+    is_error = getattr(status, "status_code", None) is StatusCode.ERROR or isinstance(
+        internal_code, int
+    )
+    if not is_error:
+        return
+    code = internal_code if isinstance(internal_code, int) else None
+    if code is None:
+        for key in ("http.response.status_code", "http.status_code", "status_code"):
+            candidate = attrs.get(key)
+            if isinstance(candidate, int) and 400 <= candidate <= 599:
+                code = candidate
+                break
+    message = _status_message(span, attrs) or "Pipecat operation failed"
+    if code is None and is_chat:
+        import re
+
+        match = re.search(
+            r"(?i)\b(?:error|status)(?:\s+code)?\s*[:=]?\s*([45]\d\d)\b",
+            message,
+        )
+        if match:
+            code = int(match.group(1))
+    code = code or 500
+    attrs[ERROR_MESSAGE_ATTR] = message
+    attrs["status_code"] = code
+    attrs["http.response.status_code"] = code
+    attrs["error.type"] = safe_text(str(error_type or "PipecatError"))
+    attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_dumps(
+        {"status": "error", "type": error_type or "PipecatError", "message": message}
+    )
+    try:
+        span._status = Status(StatusCode.ERROR, message)
+    except Exception:
+        logger.debug("Could not replace Pipecat span status", exc_info=True)
+    if hasattr(span, "_events"):
+        try:
+            span._events = ()
+        except Exception:
+            logger.debug("Could not sanitize Pipecat span events", exc_info=True)
+
+
 class PipecatOpenInferenceTranslator(SpanProcessor):
     """SpanProcessor for OpenInference spans emitted by Pipecat."""
 
@@ -302,59 +382,85 @@ class PipecatOpenInferenceTranslator(SpanProcessor):
         is_chat = log_type == LOG_TYPE_CHAT
         logger.debug("[Pipecat OI] Translating %s span: %s", oi_kind_upper, span.name)
 
-        attrs.setdefault(RESPAN_LOG_TYPE, log_type)
-        attrs.setdefault(
-            TLSpanAttributes.TRACELOOP_ENTITY_NAME,
-            attrs.get(OISpanAttributes.AGENT_NAME) or span.name,
+        entity_name = safe_text(
+            str(attrs.get(OISpanAttributes.AGENT_NAME) or span.name or "pipecat")
         )
-        attrs.setdefault(TLSpanAttributes.TRACELOOP_ENTITY_PATH, "")
+        attrs[RESPAN_LOG_METHOD] = LogMethodChoices.TRACING_INTEGRATION.value
+        attrs[RESPAN_LOG_TYPE] = log_type
+        attrs[TLSpanAttributes.TRACELOOP_ENTITY_NAME] = entity_name
+        attrs[TLSpanAttributes.TRACELOOP_ENTITY_PATH] = (
+            entity_name if _has_parent(span) else ""
+        )
 
         session_id = attrs.get(OISpanAttributes.SESSION_ID)
         if session_id:
-            attrs.setdefault(RESPAN_SESSION_ID, session_id)
+            attrs[RESPAN_SESSION_ID] = safe_text(str(session_id))
 
         input_value = attrs.get(OISpanAttributes.INPUT_VALUE)
         if input_value is not None:
-            attrs.setdefault(
-                TLSpanAttributes.TRACELOOP_ENTITY_INPUT,
-                _safe_json_str(input_value),
-            )
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json_str(input_value)
 
         output_value = attrs.get(OISpanAttributes.OUTPUT_VALUE)
         if output_value is not None:
-            attrs.setdefault(
-                TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                _safe_json_str(output_value),
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json_str(
+                output_value
             )
 
         if log_type == LOG_TYPE_TOOL:
             tool_input = attrs.get(OISpanAttributes.TOOL_PARAMETERS)
+            tool_name = attrs.get(OISpanAttributes.TOOL_NAME)
             if tool_input is not None:
-                attrs.setdefault(
-                    TLSpanAttributes.TRACELOOP_ENTITY_INPUT,
-                    _safe_json_str(tool_input),
+                attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = json_dumps(
+                    {
+                        "name": tool_name or span.name,
+                        "arguments": parse_json(tool_input),
+                    }
                 )
             tool_output = attrs.get(_PIPECAT_TOOL_RESULT)
             if tool_output is not None:
-                attrs.setdefault(
-                    TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                    _safe_json_str(tool_output),
+                attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _safe_json_str(
+                    tool_output
                 )
-            tool_name = attrs.get(OISpanAttributes.TOOL_NAME)
             if tool_name:
-                attrs.setdefault(
-                    TLSpanAttributes.TRACELOOP_ENTITY_NAME,
-                    f"pipecat.tool.{tool_name}",
+                tool_entity = safe_text(f"pipecat.tool.{tool_name}")
+                attrs[TLSpanAttributes.TRACELOOP_ENTITY_NAME] = tool_entity
+                attrs[TLSpanAttributes.TRACELOOP_ENTITY_PATH] = (
+                    tool_entity if _has_parent(span) else ""
                 )
 
         if is_chat:
             self._translate_chat(attrs)
 
+        llm_completed = attrs.pop(RESPAN_PIPECAT_LLM_COMPLETED, False) is True
+        if llm_completed and not attrs.get(RESPAN_PIPECAT_ERROR_STATUS):
+            attrs["conversation.end_reason"] = "completed"
+            attrs["conversation.was_interrupted"] = False
+
+        _normalize_status(span, attrs, is_chat=is_chat)
         self._remove_raw_attrs(attrs)
+        attrs.pop(TLSpanAttributes.TRACELOOP_SPAN_KIND, None)
+        for key in list(attrs):
+            if key.startswith(("frame.", "service.")):
+                attrs.pop(key, None)
+            elif (
+                isinstance(attrs.get(key), str)
+                and key
+                not in {
+                    TLSpanAttributes.TRACELOOP_ENTITY_INPUT,
+                    TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                    TLSpanAttributes.LLM_REQUEST_FUNCTIONS,
+                    _GEN_AI_COMPLETION_TOOL_CALLS,
+                }
+                and not key.endswith(".tool_calls")
+            ):
+                attrs[key] = safe_text(
+                    attrs[key],
+                    endpoint="url" in key.lower() or "endpoint" in key.lower(),
+                )
         span._attributes = attrs
 
     def _translate_chat(self, attrs: dict[str, Any]) -> None:
-        attrs.setdefault(TLSpanAttributes.LLM_REQUEST_TYPE, LLMRequestTypeValues.CHAT.value)
+        attrs[TLSpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
 
         model = attrs.get(TLSpanAttributes.LLM_REQUEST_MODEL) or attrs.get(
             OISpanAttributes.LLM_MODEL_NAME
@@ -363,36 +469,30 @@ class PipecatOpenInferenceTranslator(SpanProcessor):
         if _is_unknown_model(model) and not _is_unknown_model(settings_model):
             model = settings_model
         if not _is_unknown_model(model):
-            attrs[TLSpanAttributes.LLM_REQUEST_MODEL] = model
+            attrs[TLSpanAttributes.LLM_REQUEST_MODEL] = safe_text(str(model))
 
         provider = attrs.get(OISpanAttributes.LLM_PROVIDER)
         if provider:
-            provider_name = str(provider).lower()
-            attrs.setdefault(GenAIAttributes.GEN_AI_PROVIDER_NAME, provider_name)
-            attrs.setdefault(TLSpanAttributes.LLM_SYSTEM, provider_name)
+            provider_name = safe_text(str(provider).lower())
+            attrs[GenAIAttributes.GEN_AI_PROVIDER_NAME] = provider_name
+            attrs[TLSpanAttributes.LLM_SYSTEM] = provider_name
         system = attrs.get(OISpanAttributes.LLM_SYSTEM)
         if system:
-            attrs.setdefault(TLSpanAttributes.LLM_SYSTEM, str(system).lower())
+            attrs[TLSpanAttributes.LLM_SYSTEM] = safe_text(str(system).lower())
 
         prompt_tokens = attrs.get(OISpanAttributes.LLM_TOKEN_COUNT_PROMPT)
         if prompt_tokens is not None:
-            attrs.setdefault(TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS, prompt_tokens)
-            attrs.setdefault(GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS, prompt_tokens)
+            attrs[TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS] = prompt_tokens
+            attrs[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] = prompt_tokens
 
         completion_tokens = attrs.get(OISpanAttributes.LLM_TOKEN_COUNT_COMPLETION)
         if completion_tokens is not None:
-            attrs.setdefault(
-                TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
-                completion_tokens,
-            )
-            attrs.setdefault(
-                GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS,
-                completion_tokens,
-            )
+            attrs[TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = completion_tokens
+            attrs[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] = completion_tokens
 
         total_tokens = attrs.get(OISpanAttributes.LLM_TOKEN_COUNT_TOTAL)
         if total_tokens is not None:
-            attrs.setdefault(TLSpanAttributes.LLM_USAGE_TOTAL_TOKENS, total_tokens)
+            attrs[TLSpanAttributes.LLM_USAGE_TOTAL_TOKENS] = total_tokens
 
         _messages_to_openllmetry(
             attrs,
@@ -409,24 +509,24 @@ class PipecatOpenInferenceTranslator(SpanProcessor):
             _collect_message_buckets(attrs, _OI_OUTPUT_MESSAGES_PREFIX)
         )
         if tool_calls is not None:
-            attrs.setdefault(_GEN_AI_COMPLETION_TOOL_CALLS, _safe_json_str(tool_calls))
+            attrs[_GEN_AI_COMPLETION_TOOL_CALLS] = json_dumps(tool_calls)
 
         tools = _normalize_tools(attrs.get(OISpanAttributes.LLM_TOOLS))
         if tools is None:
             tools = _normalize_tools(attrs.get(_PIPECAT_TOOLS_DEFINITIONS))
         if tools is not None:
-            tools_json = _safe_json_str(tools)
-            attrs.setdefault(TLSpanAttributes.LLM_REQUEST_FUNCTIONS, tools_json)
+            attrs[TLSpanAttributes.LLM_REQUEST_FUNCTIONS] = json_dumps(tools)
 
         invocation_parameters = _parse_json(
             attrs.get(OISpanAttributes.LLM_INVOCATION_PARAMETERS)
         )
         if isinstance(invocation_parameters, dict):
             if invocation_parameters.get("model"):
-                attrs.setdefault(
-                    TLSpanAttributes.LLM_REQUEST_MODEL,
-                    invocation_parameters["model"],
+                attrs[TLSpanAttributes.LLM_REQUEST_MODEL] = safe_text(
+                    str(invocation_parameters["model"])
                 )
+            if invocation_parameters.get("stream") is True:
+                attrs[TLSpanAttributes.LLM_IS_STREAMING] = True
 
     @staticmethod
     def _remove_raw_attrs(attrs: dict[str, Any]) -> None:
@@ -444,6 +544,7 @@ class PipecatOpenInferenceTranslator(SpanProcessor):
             OISpanAttributes.LLM_TOKEN_COUNT_COMPLETION,
             OISpanAttributes.LLM_TOKEN_COUNT_TOTAL,
             OISpanAttributes.LLM_TOOLS,
+            OISpanAttributes.METADATA,
             OISpanAttributes.AGENT_NAME,
             OISpanAttributes.SESSION_ID,
             OISpanAttributes.TOOL_NAME,
@@ -451,6 +552,15 @@ class PipecatOpenInferenceTranslator(SpanProcessor):
             OISpanAttributes.TOOL_DESCRIPTION,
             _PIPECAT_TOOLS_DEFINITIONS,
             _PIPECAT_TOOL_RESULT,
+            "tools",
+            "tool_calls",
+            "model",
+            "prompt_tokens",
+            "completion_tokens",
+            "total_request_tokens",
+            "span_tools",
+            "has_tool_calls",
+            "parallel_tool_calls",
         }
         prefixes_to_remove = (
             _OI_INPUT_MESSAGES_PREFIX,

--- a/python-sdks/instrumentations/respan-instrumentation-pipecat/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pipecat/tests/test_instrumentation.py
@@ -2,15 +2,14 @@ import json
 import logging
 import sys
 from types import ModuleType, SimpleNamespace
+from typing import ClassVar
 
 import pytest
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
-
-from respan_instrumentation_pipecat import PipecatInstrumentor
-from respan_instrumentation_pipecat import _instrumentation
+from respan_instrumentation_pipecat import PipecatInstrumentor, _instrumentation
 from respan_instrumentation_pipecat._instrumentation import (
     OPENINFERENCE_PIPECAT_MODULE,
     OPENINFERENCE_PIPECAT_OBSERVER_MODULE,
@@ -60,7 +59,7 @@ def _install_fake_modules(monkeypatch, *, activate_raises=False):
         pass
 
     class FakePipecatInstrumentor:
-        created = []
+        created: ClassVar[list] = []
 
         def __init__(self):
             self.instrument_kwargs = None
@@ -75,6 +74,10 @@ def _install_fake_modules(monkeypatch, *, activate_raises=False):
         def uninstrument(self):
             self.uninstrument_called = True
 
+    class FakeOpenInferenceObserver:
+        async def on_push_frame(self, data):
+            return None
+
     openinference_module = ModuleType("openinference")
     openinference_instrumentation_module = ModuleType("openinference.instrumentation")
     openinference_pipecat_module = ModuleType(OPENINFERENCE_PIPECAT_MODULE)
@@ -83,6 +86,9 @@ def _install_fake_modules(monkeypatch, *, activate_raises=False):
         OPENINFERENCE_PIPECAT_OBSERVER_MODULE
     )
     openinference_pipecat_observer_module.Context = FakeObserverContext
+    openinference_pipecat_observer_module.OpenInferenceObserver = (
+        FakeOpenInferenceObserver
+    )
     openinference_instrumentation_module.pipecat = openinference_pipecat_module
 
     monkeypatch.setitem(sys.modules, "openinference", openinference_module)
@@ -127,6 +133,14 @@ def _make_span(attrs: dict, name: str = "pipecat.llm"):
 @pytest.fixture(autouse=True)
 def reset_tracer():
     RespanTracer.reset_instance()
+    _instrumentation._REFCOUNT = 0
+    _instrumentation._PROCESSOR = None
+    _instrumentation._PROVIDER = None
+    _instrumentation._UPSTREAM = None
+    _instrumentation._OBSERVER_MODULE = None
+    _instrumentation._OBSERVER_CONTEXT_ORIGINAL = None
+    _instrumentation._OBSERVER_HOOK = None
+    _instrumentation._CONFIG = None
     yield
     RespanTracer.reset_instance()
 
@@ -184,6 +198,53 @@ def test_activate_passes_custom_openinference_kwargs(monkeypatch):
     }
 
 
+def test_multiple_instances_share_one_runtime_and_last_owner_cleans_up(monkeypatch):
+    fake = _install_fake_modules(monkeypatch)
+    first = PipecatInstrumentor()
+    second = PipecatInstrumentor()
+
+    first.activate()
+    second.activate()
+
+    assert len(fake.pipecat_instrumentor_class.created) == 1
+    assert (
+        len(
+            [
+                processor
+                for processor in fake.tracer_provider._active_span_processor._span_processors
+                if isinstance(processor, PipecatOpenInferenceTranslator)
+            ]
+        )
+        == 1
+    )
+    upstream = fake.pipecat_instrumentor_class.created[0]
+
+    first.deactivate()
+    assert upstream.uninstrument_called is False
+    assert second._is_instrumented is True
+    assert fake.observer_module.Context is _instrumentation.context_api.get_current
+
+    second.deactivate()
+    assert upstream.uninstrument_called is True
+    assert fake.observer_module.Context is fake.observer_context_class
+    assert fake.tracer_provider._active_span_processor._span_processors == ("exporter",)
+
+
+def test_active_runtime_rejects_mismatched_configuration(monkeypatch, caplog):
+    fake = _install_fake_modules(monkeypatch)
+    first = PipecatInstrumentor(debug_log_filename="one.log")
+    second = PipecatInstrumentor(debug_log_filename="two.log")
+
+    first.activate()
+    with caplog.at_level(logging.WARNING):
+        second.activate()
+
+    assert second._is_instrumented is False
+    assert len(fake.pipecat_instrumentor_class.created) == 1
+    assert "already active with different settings" in caplog.text
+    first.deactivate()
+
+
 def test_activate_cleans_up_when_activation_fails(monkeypatch, caplog):
     fake = _install_fake_modules(monkeypatch, activate_raises=True)
 
@@ -195,7 +256,6 @@ def test_activate_cleans_up_when_activation_fails(monkeypatch, caplog):
     assert upstream.uninstrument_called is True
     assert fake.observer_module.Context is fake.observer_context_class
     assert fake.tracer_provider._active_span_processor._span_processors == ("exporter",)
-    assert instrumentor._instrumentor is None
     assert instrumentor._is_instrumented is False
     assert "Failed to activate Pipecat instrumentation" in caplog.text
 
@@ -257,8 +317,13 @@ def test_translator_maps_pipecat_turn_span():
         span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_NAME]
         == "pipecat.conversation.turn"
     )
-    assert span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] == "hello"
-    assert span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] == "world"
+    assert (
+        json.loads(span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_INPUT]) == "hello"
+    )
+    assert (
+        json.loads(span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+        == "world"
+    )
     assert span._attributes[RESPAN_SESSION_ID] == "session-1"
     assert "openinference.span.kind" not in span._attributes
 
@@ -341,13 +406,14 @@ def test_translator_maps_stt_and_tts_service_types():
     assert stt_span._attributes[RESPAN_LOG_TYPE] == LOG_TYPE_TRANSCRIPTION
     assert TLSpanAttributes.TRACELOOP_SPAN_KIND not in stt_span._attributes
     assert (
-        stt_span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] == "spoken text"
+        json.loads(stt_span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_INPUT])
+        == "spoken text"
     )
     assert TLSpanAttributes.LLM_REQUEST_TYPE not in stt_span._attributes
     assert tts_span._attributes[RESPAN_LOG_TYPE] == LOG_TYPE_SPEECH
     assert TLSpanAttributes.TRACELOOP_SPAN_KIND not in tts_span._attributes
     assert (
-        tts_span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+        json.loads(tts_span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT])
         == "spoken response"
     )
     assert TLSpanAttributes.LLM_REQUEST_TYPE not in tts_span._attributes
@@ -373,13 +439,13 @@ def test_translator_maps_tool_span():
         span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_NAME]
         == "pipecat.tool.lookup"
     )
-    assert (
-        span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] == '{"city":"Tokyo"}'
-    )
-    assert (
-        span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]
-        == '{"weather":"sunny"}'
-    )
+    assert json.loads(span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "name": "lookup",
+        "arguments": {"city": "Tokyo"},
+    }
+    assert json.loads(span._attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "weather": "sunny"
+    }
     for attr_name in _OFF_CONTRACT_ALIAS_ATTRS:
         assert attr_name not in span._attributes
     assert "tool.name" not in span._attributes

--- a/python-sdks/instrumentations/respan-instrumentation-pipecat/tests/test_real_pipecat.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pipecat/tests/test_real_pipecat.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import Counter
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from opentelemetry.trace import StatusCode
+from pipecat.frames.frames import (
+    EndFrame,
+    ErrorFrame,
+    Frame,
+    LLMContextFrame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    LLMTextFrame,
+)
+from pipecat.metrics.metrics import LLMTokenUsage
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.llm_service import LLMService, LLMSettings
+from pipecat.workers.runner import WorkerRunner
+from respan_instrumentation_pipecat import PipecatInstrumentor, _instrumentation
+from respan_instrumentation_pipecat._serialization import json_dumps
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+
+
+class OfflineLLMService(LLMService):
+    def __init__(self, *, fail: bool = False) -> None:
+        super().__init__(
+            name="OfflineLLMService",
+            settings=LLMSettings(
+                model="offline-pipecat",
+                system_instruction=None,
+                temperature=None,
+                max_tokens=None,
+                top_p=None,
+                top_k=None,
+                frequency_penalty=None,
+                presence_penalty=None,
+                seed=None,
+                filter_incomplete_user_turns=False,
+                user_turn_completion_config=None,
+            ),
+        )
+        self._fail = fail
+
+    def can_generate_metrics(self) -> bool:
+        return True
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if not isinstance(frame, LLMContextFrame):
+            await self.push_frame(frame, direction)
+            return
+        await self.push_frame(LLMFullResponseStartFrame())
+        if self._fail:
+            error = ProviderAuthError("provider rejected request", status_code=401)
+            await self.push_frame(
+                ErrorFrame(
+                    error="provider rejected request",
+                    exception=error,
+                    processor=self,
+                )
+            )
+            return
+        for chunk in ("Pi", "pecat tracing ", "is connected."):
+            await self.push_frame(LLMTextFrame(chunk))
+        await self.start_llm_usage_metrics(
+            LLMTokenUsage(prompt_tokens=7, completion_tokens=5, total_tokens=12)
+        )
+        await self.push_frame(LLMFullResponseEndFrame())
+
+
+class ProviderAuthError(RuntimeError):
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class Collector(FrameProcessor):
+    def __init__(self) -> None:
+        super().__init__(name="collector", enable_direct_mode=True)
+        self.done = asyncio.Event()
+        self.text: list[str] = []
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, LLMTextFrame):
+            self.text.append(frame.text)
+        if isinstance(frame, (LLMFullResponseEndFrame, ErrorFrame)):
+            self.done.set()
+        await self.push_frame(frame, direction)
+
+
+async def _run_pipeline(*, fail: bool) -> None:
+    collector = Collector()
+    worker = PipelineWorker(
+        Pipeline([OfflineLLMService(fail=fail), collector]),
+        cancel_on_idle_timeout=False,
+        enable_rtvi=False,
+        conversation_id="pipecat-real-test",
+        params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+    )
+    runner = WorkerRunner(handle_sigint=False)
+    await runner.add_workers(worker)
+
+    async def drive() -> None:
+        await asyncio.sleep(0.05)
+        await worker.queue_frame(
+            LLMContextFrame(
+                LLMContext(
+                    messages=[{"role": "user", "content": "Trace a real Pipecat turn."}]
+                )
+            )
+        )
+        await asyncio.wait_for(collector.done.wait(), timeout=10)
+        await worker.queue_frame(EndFrame())
+
+    await asyncio.wait_for(asyncio.gather(runner.run(), drive()), timeout=15)
+
+
+@pytest.mark.asyncio
+async def test_real_current_pipecat_exports_success_and_provider_failure(monkeypatch):
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer_provider", lambda: provider)
+    instrumentor = PipecatInstrumentor()
+    instrumentor.activate()
+    tracer = provider.get_tracer("respan.pipecat.test")
+    try:
+        with tracer.start_as_current_span("success.root"):
+            await _run_pipeline(fail=False)
+        with tracer.start_as_current_span("failure.root"):
+            await _run_pipeline(fail=True)
+    finally:
+        instrumentor.deactivate()
+        provider.force_flush()
+
+    spans = list(exporter.get_finished_spans())
+    names = Counter(span.name for span in spans)
+    assert names == Counter(
+        {
+            "success.root": 1,
+            "failure.root": 1,
+            "pipecat.conversation.turn": 2,
+            "pipecat.llm": 2,
+        }
+    )
+    assert len({span.context.span_id for span in spans}) == len(spans)
+    by_name: dict[str, list[Any]] = {}
+    for span in spans:
+        by_name.setdefault(span.name, []).append(span)
+
+    roots = {span.name: span for span in spans if span.parent is None}
+    assert set(roots) == {"success.root", "failure.root"}
+    all_ids = {span.context.span_id for span in spans}
+    for span in spans:
+        if span.parent is not None:
+            assert span.parent.span_id in all_ids
+
+    turns = by_name["pipecat.conversation.turn"]
+    success_turn = next(
+        span for span in turns if span.status.status_code is not StatusCode.ERROR
+    )
+    failure_turn = next(
+        span for span in turns if span.status.status_code is StatusCode.ERROR
+    )
+    assert success_turn.attributes[RESPAN_LOG_TYPE] == "workflow"
+    assert (
+        json.loads(success_turn.attributes[TLSpanAttributes.TRACELOOP_ENTITY_INPUT])
+        == "Trace a real Pipecat turn."
+    )
+    assert (
+        json.loads(success_turn.attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+        == "Pipecat tracing is connected."
+    )
+    assert success_turn.attributes["conversation.end_reason"] == "completed"
+    assert success_turn.attributes["conversation.was_interrupted"] is False
+
+    success_llm = next(
+        span
+        for span in by_name["pipecat.llm"]
+        if span.status.status_code is not StatusCode.ERROR
+    )
+    assert success_llm.attributes.get(TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS) == 7, (
+        success_llm.attributes
+    )
+    assert success_llm.attributes[TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 5
+
+    assert failure_turn.attributes["http.response.status_code"] == 401
+    assert failure_turn.attributes["status_code"] == 401
+    assert failure_turn.attributes[ERROR_MESSAGE_ATTR] == "provider rejected request"
+    failure_llm = next(
+        span
+        for span in by_name["pipecat.llm"]
+        if span.status.status_code is StatusCode.ERROR
+    )
+    assert failure_llm.attributes["http.response.status_code"] == 401
+    assert failure_llm.attributes[RESPAN_LOG_TYPE] == "chat"
+    assert (
+        json.loads(failure_llm.attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT])[
+            "message"
+        ]
+        == "provider rejected request"
+    )
+    assert all(
+        TLSpanAttributes.TRACELOOP_SPAN_KIND not in span.attributes for span in turns
+    )
+
+    provider.shutdown()
+
+
+def test_serializer_is_bounded_redacted_and_never_calls_hostile_repr():
+    class Hostile:
+        def __repr__(self) -> str:
+            raise AssertionError("repr must not run")
+
+        def __str__(self) -> str:
+            raise AssertionError("str must not run")
+
+    value = {
+        "client_secret": "plain-secret",
+        "nested": {"auth_token": "token-value"},
+        "hostile": Hostile(),
+        "unicode": "😀" * 20_000,
+    }
+    encoded = json_dumps(value)
+    parsed = json.loads(encoded)
+    assert len(encoded.encode("utf-8")) <= 16_000
+    assert "plain-secret" not in encoded
+    assert "token-value" not in encoded
+    assert parsed

--- a/python-sdks/instrumentations/respan-instrumentation-portkey/src/respan_instrumentation_portkey/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-portkey/src/respan_instrumentation_portkey/_instrumentation.py
@@ -1,11 +1,13 @@
-"""Portkey instrumentation plugin for Respan."""
+"""Lifecycle for Portkey's OpenInference adapter and Respan contract layer."""
+
+from __future__ import annotations
 
 import importlib
 import logging
+import threading
 from typing import Any
 
 from opentelemetry import trace
-
 from respan_instrumentation_openinference import OpenInferenceInstrumentor
 from respan_instrumentation_openinference._translator import OpenInferenceTranslator
 from respan_tracing.core.tracer import RespanTracer
@@ -15,156 +17,197 @@ from respan_instrumentation_portkey._constants import (
     PORTKEY_INSTRUMENTATION_NAME,
 )
 from respan_instrumentation_portkey._processor import PortkeySpanContractProcessor
+from respan_instrumentation_portkey._streaming import (
+    StreamHooks,
+    install_stream_hooks,
+    remove_stream_hooks,
+)
 
 logger = logging.getLogger(__name__)
 
+_LOCK = threading.RLock()
+_REFCOUNT = 0
+_CONFIG: dict[str, Any] | None = None
+_DELEGATE: OpenInferenceInstrumentor | None = None
+_PROCESSOR: PortkeySpanContractProcessor | None = None
+_PROVIDER: Any = None
+_STREAM_HOOKS: StreamHooks | None = None
+
 
 def _load_openinference_portkey_class() -> type:
-    portkey_module = importlib.import_module(OPENINFERENCE_PORTKEY_MODULE)
-    return portkey_module.PortkeyInstrumentor
+    return importlib.import_module(OPENINFERENCE_PORTKEY_MODULE).PortkeyInstrumentor
 
 
-def _get_active_span_processors(tracer_provider) -> tuple[Any, ...] | None:
-    active_span_processor = getattr(tracer_provider, "_active_span_processor", None)
-    processors = (
-        getattr(active_span_processor, "_span_processors", None)
-        if active_span_processor is not None
-        else None
-    )
-    if processors is None:
-        return None
-    return tuple(processors)
+def _processors(provider: Any) -> tuple[Any, ...] | None:
+    active = getattr(provider, "_active_span_processor", None)
+    current = getattr(active, "_span_processors", None) if active else None
+    return tuple(current) if current is not None else None
 
 
-def _set_active_span_processors(tracer_provider, processors: tuple[Any, ...]) -> bool:
-    active_span_processor = getattr(tracer_provider, "_active_span_processor", None)
-    if active_span_processor is None:
+def _set_processors(provider: Any, processors: tuple[Any, ...]) -> bool:
+    active = getattr(provider, "_active_span_processor", None)
+    if active is None or getattr(active, "_span_processors", None) is None:
         return False
-    if getattr(active_span_processor, "_span_processors", None) is None:
-        return False
-    active_span_processor._span_processors = processors
+    active._span_processors = processors
     return True
 
 
-def _register_processor_after_translator(tracer_provider, processor) -> None:
-    processors = _get_active_span_processors(tracer_provider)
+def _register_after_translator(provider: Any, processor: Any) -> None:
+    processors = _processors(provider)
     if processors is None:
-        if hasattr(tracer_provider, "add_span_processor"):
-            tracer_provider.add_span_processor(processor)
+        if hasattr(provider, "add_span_processor"):
+            provider.add_span_processor(processor)
         return
-
-    processors = tuple(
-        existing_processor
-        for existing_processor in processors
-        if existing_processor is not processor
-    )
-
-    for index, existing_processor in enumerate(processors):
-        if isinstance(existing_processor, OpenInferenceTranslator):
-            _set_active_span_processors(
-                tracer_provider=tracer_provider,
-                processors=(
-                    *processors[: index + 1],
-                    processor,
-                    *processors[index + 1 :],
-                ),
+    remaining = tuple(item for item in processors if item is not processor)
+    for index, item in enumerate(remaining):
+        if isinstance(item, OpenInferenceTranslator):
+            _set_processors(
+                provider,
+                (*remaining[: index + 1], processor, *remaining[index + 1 :]),
             )
             return
-
-    _set_active_span_processors(
-        tracer_provider=tracer_provider,
-        processors=(*processors, processor),
-    )
+    _set_processors(provider, (*remaining, processor))
 
 
-def _unregister_processor(tracer_provider, processor) -> None:
-    processors = _get_active_span_processors(tracer_provider)
-    if processors is None:
-        return
-    _set_active_span_processors(
-        tracer_provider=tracer_provider,
-        processors=tuple(
-            existing_processor
-            for existing_processor in processors
-            if existing_processor is not processor
-        ),
-    )
+def _unregister(provider: Any, processor: Any) -> None:
+    processors = _processors(provider)
+    if processors is not None:
+        _set_processors(
+            provider, tuple(item for item in processors if item is not processor)
+        )
+
+
+def _same_config(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    if left.keys() != right.keys():
+        return False
+    for key, value in left.items():
+        if value is right[key]:
+            continue
+        try:
+            if value == right[key]:
+                continue
+        except Exception:  # noqa: BLE001
+            return False
+        return False
+    return True
+
+
+def _tracing_enabled() -> bool:
+    tracer = getattr(RespanTracer, "_instance", None)
+    return tracer is None or bool(getattr(tracer, "is_enabled", True))
 
 
 class PortkeyInstrumentor:
-    """Respan instrumentor for Portkey.
-
-    Activates the OpenInference Portkey instrumentor and registers Respan's
-    OpenInference translator so Portkey spans reach the Respan OTLP pipeline
-    with canonical tracing fields.
-    """
+    """Activate one shared Portkey runtime per process."""
 
     name = PORTKEY_INSTRUMENTATION_NAME
 
     def __init__(self, **instrumentor_kwargs: Any) -> None:
-        self._instrumentor_kwargs = instrumentor_kwargs
-        self._delegate = None
-        self._contract_processor = PortkeySpanContractProcessor()
+        self._instrumentor_kwargs = dict(instrumentor_kwargs)
+        self._delegate: OpenInferenceInstrumentor | None = None
+        self._contract_processor: PortkeySpanContractProcessor | None = None
         self._is_instrumented = False
-
-    @staticmethod
-    def _is_respan_tracing_enabled() -> bool:
-        tracer = getattr(RespanTracer, "_instance", None)
-        if tracer is None:
-            return True
-        return bool(getattr(tracer, "is_enabled", True))
 
     def activate(self) -> None:
-        """Instrument Portkey through OpenInference and Respan's translator."""
+        global _CONFIG, _DELEGATE, _PROCESSOR, _PROVIDER, _REFCOUNT, _STREAM_HOOKS
+
         if self._is_instrumented:
             return
-
-        if not self._is_respan_tracing_enabled():
-            logger.info("Portkey instrumentation skipped because Respan tracing is disabled")
-            return
-
-        try:
-            portkey_instrumentor_class = _load_openinference_portkey_class()
-        except ImportError as exc:
-            logger.warning(
-                "Failed to activate Portkey instrumentation - missing dependency: %s",
-                exc,
+        if not _tracing_enabled():
+            logger.info(
+                "Portkey instrumentation skipped because Respan tracing is disabled"
             )
             return
+        with _LOCK:
+            if self._is_instrumented:
+                return
+            if _REFCOUNT:
+                if _CONFIG is None or not _same_config(
+                    _CONFIG, self._instrumentor_kwargs
+                ):
+                    logger.warning(
+                        "Portkey instrumentation is already active with different settings"
+                    )
+                    return
+                _REFCOUNT += 1
+                self._delegate = _DELEGATE
+                self._contract_processor = _PROCESSOR
+                self._is_instrumented = True
+                return
+            try:
+                instrumentor_class = _load_openinference_portkey_class()
+            except ImportError as exc:
+                logger.warning(
+                    "Failed to activate Portkey instrumentation - missing dependency: %s",
+                    exc,
+                )
+                return
 
-        try:
-            self._delegate = OpenInferenceInstrumentor(
-                portkey_instrumentor_class,
-                **self._instrumentor_kwargs,
+            provider = trace.get_tracer_provider()
+            delegate = OpenInferenceInstrumentor(
+                instrumentor_class, **self._instrumentor_kwargs
             )
-            self._delegate.activate()
-            _register_processor_after_translator(
-                tracer_provider=trace.get_tracer_provider(),
-                processor=self._contract_processor,
-            )
+            processor = PortkeySpanContractProcessor()
+            hooks: StreamHooks | None = None
+            registered = False
+            try:
+                delegate.activate()
+                _register_after_translator(provider, processor)
+                registered = True
+                hooks = install_stream_hooks(provider)
+            except Exception:
+                remove_stream_hooks(hooks)
+                if registered:
+                    _unregister(provider, processor)
+                try:
+                    delegate.deactivate()
+                except Exception:
+                    logger.exception("Failed to roll back Portkey instrumentation")
+                logger.exception("Failed to activate Portkey instrumentation")
+                return
+
+            _CONFIG = dict(self._instrumentor_kwargs)
+            _DELEGATE = delegate
+            _PROCESSOR = processor
+            _PROVIDER = provider
+            _REFCOUNT = 1
+            _STREAM_HOOKS = hooks
+            self._delegate = delegate
+            self._contract_processor = processor
             self._is_instrumented = True
             logger.info("Portkey instrumentation activated")
-        except Exception:
-            if self._delegate is not None:
-                try:
-                    self._delegate.deactivate()
-                except Exception:
-                    logger.exception("Failed to clean up Portkey instrumentation")
-            self._delegate = None
-            self._is_instrumented = False
-            logger.exception("Failed to activate Portkey instrumentation")
 
     def deactivate(self) -> None:
-        """Deactivate the instrumentation."""
-        _unregister_processor(
-            tracer_provider=trace.get_tracer_provider(),
-            processor=self._contract_processor,
-        )
-        if self._is_instrumented and self._delegate is not None:
-            try:
-                self._delegate.deactivate()
-            except Exception:
-                logger.exception("Failed to deactivate Portkey instrumentation")
-        self._delegate = None
-        self._is_instrumented = False
-        logger.info("Portkey instrumentation deactivated")
+        global _CONFIG, _DELEGATE, _PROCESSOR, _PROVIDER, _REFCOUNT, _STREAM_HOOKS
+
+        if not self._is_instrumented:
+            return
+        with _LOCK:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            self._delegate = None
+            self._contract_processor = None
+            _REFCOUNT = max(0, _REFCOUNT - 1)
+            if _REFCOUNT:
+                return
+            remove_stream_hooks(_STREAM_HOOKS)
+            if _PROCESSOR is not None and _PROVIDER is not None:
+                _unregister(_PROVIDER, _PROCESSOR)
+            if _DELEGATE is not None:
+                try:
+                    _DELEGATE.deactivate()
+                except Exception:
+                    logger.exception("Failed to deactivate Portkey instrumentation")
+            _CONFIG = None
+            _DELEGATE = None
+            _PROCESSOR = None
+            _PROVIDER = None
+            _STREAM_HOOKS = None
+            logger.info("Portkey instrumentation deactivated")
+
+    def instrument(self) -> None:
+        self.activate()
+
+    def uninstrument(self) -> None:
+        self.deactivate()

--- a/python-sdks/instrumentations/respan-instrumentation-portkey/src/respan_instrumentation_portkey/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-portkey/src/respan_instrumentation_portkey/_processor.py
@@ -1,23 +1,37 @@
-"""Portkey-specific span cleanup for the Respan OTLP pipeline."""
+"""Portkey-specific contract normalization after OpenInference translation."""
 
 from __future__ import annotations
 
-import json
+import re
 from typing import Any
 
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.semconv_ai import LLMRequestTypeValues
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from opentelemetry.trace import Status, StatusCode
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LogMethodChoices
 from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_METHOD,
+    RESPAN_LOG_TYPE,
     RESPAN_SPAN_HANDOFFS,
     RESPAN_SPAN_TOOL_CALLS,
     RESPAN_SPAN_TOOLS,
 )
 
 from respan_instrumentation_portkey._constants import OPENINFERENCE_PORTKEY_MODULE
+from respan_instrumentation_portkey._serialization import (
+    json_dumps,
+    parse_json,
+    safe_text,
+    sanitize_endpoint,
+)
+from respan_instrumentation_portkey._streaming import current_request
 
 OTEL_SCOPE_NAME = "otel.scope.name"
 GEN_AI_COMPLETION_TOOL_CALLS_ATTR = f"{TLSpanAttributes.LLM_COMPLETIONS}.0.tool_calls"
 LLM_REQUEST_FUNCTIONS_ATTR = TLSpanAttributes.LLM_REQUEST_FUNCTIONS
+GEN_AI_PROVIDER_NAME = "gen_ai.provider.name"
 
 _OFF_CONTRACT_ALIAS_ATTRS = frozenset(
     {
@@ -36,69 +50,173 @@ _OFF_CONTRACT_ALIAS_ATTRS = frozenset(
     }
 )
 _OPENAI_OMIT_VALUE_PREFIX = "<openai.Omit object"
+_JSON_ATTRS = {
+    TLSpanAttributes.TRACELOOP_ENTITY_INPUT,
+    TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+    LLM_REQUEST_FUNCTIONS_ATTR,
+    GEN_AI_COMPLETION_TOOL_CALLS_ATTR,
+}
 
 
 def _is_portkey_span(span: ReadableSpan, attrs: dict[str, Any]) -> bool:
     if attrs.get(OTEL_SCOPE_NAME) == OPENINFERENCE_PORTKEY_MODULE:
         return True
+    scope = getattr(span, "instrumentation_scope", None)
+    return getattr(scope, "name", None) == OPENINFERENCE_PORTKEY_MODULE
 
-    instrumentation_scope = getattr(span, "instrumentation_scope", None)
-    return getattr(instrumentation_scope, "name", None) == OPENINFERENCE_PORTKEY_MODULE
+
+def _has_parent(span: ReadableSpan) -> bool:
+    parent = getattr(span, "parent", None)
+    return bool(parent and getattr(parent, "span_id", 0))
 
 
-def _json_string(value: Any) -> str | None:
-    if value is None:
+def _dict(value: Any) -> dict[str, Any] | None:
+    parsed = parse_json(value)
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _response_tool_calls(output: dict[str, Any] | None) -> list[dict[str, Any]] | None:
+    if output is None:
         return None
-    if isinstance(value, str):
-        return value
-    return json.dumps(value, default=str)
+    choices = output.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        return None
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        return None
+    calls = message.get("tool_calls")
+    if not isinstance(calls, list):
+        return None
+    return [call for call in calls[:50] if isinstance(call, dict)] or None
 
 
-def _strip_placeholder_values(attrs: dict[str, Any]) -> None:
-    for key, value in list(attrs.items()):
-        if isinstance(value, str) and value.startswith(_OPENAI_OMIT_VALUE_PREFIX):
-            attrs.pop(key, None)
+def _status_message(span: ReadableSpan, attrs: dict[str, Any]) -> str:
+    message = attrs.get(ERROR_MESSAGE_ATTR)
+    if isinstance(message, str) and message:
+        return safe_text(message)
+    description = getattr(getattr(span, "status", None), "description", None)
+    if isinstance(description, str) and description:
+        return safe_text(description)
+    for event in getattr(span, "events", ()) or ():
+        event_attrs = getattr(event, "attributes", None) or {}
+        message = event_attrs.get("exception.message")
+        if isinstance(message, str) and message:
+            return safe_text(message)
+    return "Portkey operation failed"
 
 
-def _normalize_structured_contract_attrs(attrs: dict[str, Any]) -> None:
-    tools_json = _json_string(attrs.get(LLM_REQUEST_FUNCTIONS_ATTR))
-    if tools_json:
-        attrs[LLM_REQUEST_FUNCTIONS_ATTR] = tools_json
-    else:
-        helper_tools_json = _json_string(attrs.get(RESPAN_SPAN_TOOLS))
-        if helper_tools_json:
-            attrs[LLM_REQUEST_FUNCTIONS_ATTR] = helper_tools_json
-
-    tool_calls_json = _json_string(attrs.get(GEN_AI_COMPLETION_TOOL_CALLS_ATTR))
-    if tool_calls_json:
-        attrs[GEN_AI_COMPLETION_TOOL_CALLS_ATTR] = tool_calls_json
-    else:
-        helper_tool_calls_json = _json_string(attrs.get(RESPAN_SPAN_TOOL_CALLS))
-        if helper_tool_calls_json:
-            attrs[GEN_AI_COMPLETION_TOOL_CALLS_ATTR] = helper_tool_calls_json
+def _normalize_status(span: ReadableSpan, attrs: dict[str, Any]) -> None:
+    is_error = (
+        getattr(getattr(span, "status", None), "status_code", None) is StatusCode.ERROR
+    )
+    explicit = None
+    for key in ("http.response.status_code", "http.status_code", "status_code"):
+        value = attrs.get(key)
+        if isinstance(value, int) and 400 <= value <= 599:
+            explicit = value
+            break
+    if not is_error and explicit is None:
+        return
+    message = _status_message(span, attrs)
+    if explicit is None:
+        match = re.search(
+            r"(?i)\b(?:error|status)(?:\s+code)?\s*[:=]?\s*([45]\d\d)\b",
+            message,
+        )
+        explicit = int(match.group(1)) if match else None
+    code = explicit or 500
+    attrs[ERROR_MESSAGE_ATTR] = message
+    attrs["status_code"] = code
+    attrs["http.response.status_code"] = code
+    attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_dumps(
+        {"status": "error", "type": "PortkeyError", "message": message}
+    )
+    try:
+        span._status = Status(StatusCode.ERROR, message)
+        span._events = ()
+    except Exception:  # noqa: BLE001 - fake/immutable spans keep sanitized attrs
+        return
 
 
 class PortkeySpanContractProcessor(SpanProcessor):
-    """Normalize Portkey spans after OpenInference translation."""
+    """Normalize final Portkey spans into the current Respan contract."""
 
     def on_start(self, span: Any, parent_context: Any = None) -> None:
         pass
 
     def on_end(self, span: ReadableSpan) -> None:
-        original_attrs = getattr(span, "_attributes", None)
-        if original_attrs is None:
+        original = getattr(span, "_attributes", None)
+        if original is None:
+            return
+        attrs = dict(original)
+        if not _is_portkey_span(span, attrs):
             return
 
-        attrs = dict(original_attrs)
-        if not _is_portkey_span(span=span, attrs=attrs):
-            return
+        for key, value in list(attrs.items()):
+            if isinstance(value, str) and value.startswith(_OPENAI_OMIT_VALUE_PREFIX):
+                attrs.pop(key, None)
 
-        _normalize_structured_contract_attrs(attrs)
-        _strip_placeholder_values(attrs)
+        entity_name = safe_text(
+            str(attrs.get(TLSpanAttributes.TRACELOOP_ENTITY_NAME) or "portkey.chat")
+        )
+        attrs[RESPAN_LOG_METHOD] = LogMethodChoices.TRACING_INTEGRATION.value
+        attrs[RESPAN_LOG_TYPE] = LOG_TYPE_CHAT
+        attrs[TLSpanAttributes.TRACELOOP_ENTITY_NAME] = entity_name
+        attrs[TLSpanAttributes.TRACELOOP_ENTITY_PATH] = (
+            entity_name if _has_parent(span) else ""
+        )
+        attrs[TLSpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
+        attrs[TLSpanAttributes.LLM_SYSTEM] = "portkey"
+        attrs[GEN_AI_PROVIDER_NAME] = "portkey"
+        attrs.pop(TLSpanAttributes.TRACELOOP_SPAN_KIND, None)
 
-        for alias_attr in _OFF_CONTRACT_ALIAS_ATTRS:
-            attrs.pop(alias_attr, None)
+        input_payload = _dict(attrs.get(TLSpanAttributes.TRACELOOP_ENTITY_INPUT))
+        active_request = current_request()
+        if input_payload is None and active_request is not None:
+            input_payload = active_request
+        elif input_payload is not None and active_request is not None:
+            input_payload = {**input_payload, **active_request}
+        output_payload = _dict(attrs.get(TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT))
+        if input_payload is not None:
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = json_dumps(input_payload)
+        if output_payload is not None:
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_dumps(output_payload)
 
+        tools = input_payload.get("tools") if input_payload is not None else None
+        if not isinstance(tools, list):
+            tools = parse_json(attrs.get(LLM_REQUEST_FUNCTIONS_ATTR))
+        if not isinstance(tools, list):
+            tools = parse_json(attrs.get(RESPAN_SPAN_TOOLS))
+        if isinstance(tools, list) and tools:
+            attrs[LLM_REQUEST_FUNCTIONS_ATTR] = json_dumps(tools)
+
+        calls = _response_tool_calls(output_payload)
+        if calls is None:
+            parsed_calls = parse_json(attrs.get(GEN_AI_COMPLETION_TOOL_CALLS_ATTR))
+            calls = parsed_calls if isinstance(parsed_calls, list) else None
+        if calls is None:
+            parsed_calls = parse_json(attrs.get(RESPAN_SPAN_TOOL_CALLS))
+            calls = parsed_calls if isinstance(parsed_calls, list) else None
+        if calls:
+            attrs[GEN_AI_COMPLETION_TOOL_CALLS_ATTR] = json_dumps(calls)
+
+        if input_payload is not None and input_payload.get("stream") is True:
+            attrs[TLSpanAttributes.LLM_IS_STREAMING] = True
+
+        _normalize_status(span, attrs)
+        for alias in _OFF_CONTRACT_ALIAS_ATTRS:
+            attrs.pop(alias, None)
+        attrs.pop(OTEL_SCOPE_NAME, None)
+
+        for key, value in list(attrs.items()):
+            if key in _JSON_ATTRS and value is not None:
+                attrs[key] = json_dumps(parse_json(value))
+            elif isinstance(value, str):
+                attrs[key] = (
+                    sanitize_endpoint(value)
+                    if "url" in key.lower() or "endpoint" in key.lower()
+                    else safe_text(value)
+                )
         span._attributes = attrs
 
     def shutdown(self) -> None:

--- a/python-sdks/instrumentations/respan-instrumentation-portkey/src/respan_instrumentation_portkey/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-portkey/src/respan_instrumentation_portkey/_serialization.py
@@ -1,0 +1,211 @@
+"""Bounded privacy-safe values for Portkey spans."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from numbers import Integral, Real
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+MAX_BYTES = 16_000
+MAX_TEXT_BYTES = 8_000
+MAX_ITEMS = 50
+MAX_DEPTH = 8
+_SECRET_PARTS = ("api_key", "apikey", "authorization", "password", "secret", "token")
+_USAGE_TOKEN_KEYS = frozenset(
+    {
+        "audio_tokens",
+        "cached_tokens",
+        "completion_tokens",
+        "input_tokens",
+        "output_tokens",
+        "prompt_tokens",
+        "reasoning_tokens",
+        "total_tokens",
+    }
+)
+_INLINE_SECRET = re.compile(
+    r"(?i)([\"']?(?:api[_-]?key|authorization|password|secret|token)[\"']?)"
+    r"(\s*[:=]\s*[\"']?\s*)([^\s,;&\"'}]+)"
+)
+_BEARER = re.compile(r"(?i)\bbearer\s+[^\s,;&]+")
+_ADDRESS = re.compile(r"(?i)\b0x[0-9a-f]{6,}\b")
+
+
+def truncate_utf8(value: str, limit: int = MAX_TEXT_BYTES) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit:
+        return value
+    suffix = "...[truncated]"
+    budget = max(0, limit - len(suffix.encode()))
+    return encoded[:budget].decode("utf-8", errors="ignore") + suffix
+
+
+def safe_text(value: str) -> str:
+    value = _BEARER.sub("Bearer <redacted>", value)
+    value = _INLINE_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}<redacted>", value
+    )
+    return truncate_utf8(_ADDRESS.sub("0x<redacted>", value))
+
+
+def safe_type_name(value: Any) -> str:
+    value_type = value if isinstance(value, type) else type(value)
+    module = getattr(value_type, "__module__", "")
+    name = getattr(value_type, "__qualname__", None) or getattr(
+        value_type, "__name__", "object"
+    )
+    result = f"{module}.{name}" if module and module != "builtins" else name
+    return re.sub(r"[^A-Za-z0-9_.-]+", ".", result).strip(".")[:256] or "object"
+
+
+def is_sensitive_key(value: str) -> bool:
+    normalized = value.lower().replace("-", "_")
+    if normalized in _USAGE_TOKEN_KEYS:
+        return False
+    return any(
+        normalized == part or normalized.endswith(f"_{part}") or part in normalized
+        for part in _SECRET_PARTS
+    )
+
+
+def sanitize_endpoint(value: str) -> str:
+    try:
+        candidate = value if "://" in value else f"//{value}"
+        parsed = urlsplit(candidate)
+        if not parsed.hostname:
+            return "<redacted-endpoint>"
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        scheme = parsed.scheme if "://" in value else ""
+        result = urlunsplit((scheme, f"{parsed.hostname}{port}", parsed.path, "", ""))
+        return result if scheme else result.removeprefix("//")
+    except Exception:  # noqa: BLE001
+        return "<redacted-endpoint>"
+
+
+def _key(value: Any) -> str:
+    if value is None or isinstance(value, (str, bool, int)):
+        return safe_text(str(value))[:256]
+    return f"<{safe_type_name(value)}>"
+
+
+def jsonable(value: Any, *, depth: int = 0) -> Any:
+    if depth > MAX_DEPTH:
+        return {"type": safe_type_name(value), "truncated": "max_depth"}
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return safe_text(value)
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, Real):
+        number = float(value)
+        return number if math.isfinite(number) else None
+    if isinstance(value, bytes):
+        return {"type": "bytes", "length": len(value)}
+    if isinstance(value, Mapping):
+        try:
+            source = list(islice(value.items(), MAX_ITEMS + 1))
+        except Exception:  # noqa: BLE001
+            return {"type": safe_type_name(value)}
+        result: dict[str, Any] = {}
+        for key, item in source[:MAX_ITEMS]:
+            key_text = _key(key)
+            result[key_text] = (
+                "<redacted>"
+                if is_sensitive_key(key_text)
+                else jsonable(item, depth=depth + 1)
+            )
+        if len(source) > MAX_ITEMS:
+            result["__truncated__"] = True
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        try:
+            source = list(islice(iter(value), MAX_ITEMS + 1))
+        except Exception:  # noqa: BLE001
+            return {"type": safe_type_name(value)}
+        values = [jsonable(item, depth=depth + 1) for item in source[:MAX_ITEMS]]
+        if len(source) > MAX_ITEMS:
+            return {"items": values, "truncated": True, "count": f">{MAX_ITEMS}"}
+        return values
+    module = getattr(type(value), "__module__", "")
+    if module.startswith(("portkey_ai", "openai")):
+        for method_name in ("model_dump", "to_dict"):
+            try:
+                method = getattr(value, method_name, None)
+                if callable(method):
+                    return jsonable(method(), depth=depth + 1)
+            except Exception:  # noqa: BLE001, S112
+                continue
+    return {"type": safe_type_name(value)}
+
+
+def json_dumps(value: Any) -> str:
+    text = json.dumps(
+        jsonable(value),
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    original_bytes = len(text.encode("utf-8"))
+    if original_bytes <= MAX_BYTES:
+        return text
+    low, high, result = 0, min(len(text), MAX_BYTES), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = json.dumps(
+            {
+                "original_bytes": original_bytes,
+                "preview": text[:middle],
+                "truncated": True,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(candidate.encode("utf-8")) <= MAX_BYTES:
+            result, low = candidate, middle + 1
+        else:
+            high = middle - 1
+    return result
+
+
+def parse_json(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return value
+
+
+def exception_message(exc: BaseException) -> str:
+    try:
+        args = exc.args
+    except Exception:  # noqa: BLE001
+        args = ()
+    for value in args:
+        if isinstance(value, str):
+            return safe_text(value)
+    return safe_type_name(exc)
+
+
+def exception_status(exc: BaseException) -> int:
+    for owner, name in ((exc, "status_code"), (exc, "status")):
+        try:
+            value = getattr(owner, name, None)
+        except Exception:  # noqa: BLE001
+            value = None
+        if isinstance(value, int) and 400 <= value <= 599:
+            return value
+    try:
+        response = getattr(exc, "response", None)
+        value = getattr(response, "status_code", None)
+    except Exception:  # noqa: BLE001
+        value = None
+    return value if isinstance(value, int) and 400 <= value <= 599 else 500

--- a/python-sdks/instrumentations/respan-instrumentation-portkey/src/respan_instrumentation_portkey/_streaming.py
+++ b/python-sdks/instrumentations/respan-instrumentation-portkey/src/respan_instrumentation_portkey/_streaming.py
@@ -1,0 +1,385 @@
+"""Completion stream support missing from the upstream Portkey instrumentor."""
+
+from __future__ import annotations
+
+import inspect
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Any
+
+from opentelemetry import context as context_api
+from opentelemetry.trace import Status, StatusCode
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+
+from respan_instrumentation_portkey._constants import OPENINFERENCE_PORTKEY_MODULE
+from respan_instrumentation_portkey._serialization import (
+    exception_message,
+    exception_status,
+    json_dumps,
+    jsonable,
+    safe_text,
+)
+
+_REQUEST_CONTEXT: ContextVar[dict[str, Any] | None] = ContextVar(
+    "respan_portkey_request", default=None
+)
+
+
+def current_request() -> dict[str, Any] | None:
+    """Return the request active while an upstream Portkey span is ending."""
+
+    request = _REQUEST_CONTEXT.get()
+    return dict(request) if request is not None else None
+
+
+def _attach_request(kwargs: dict[str, Any]) -> Token[dict[str, Any] | None]:
+    return _REQUEST_CONTEXT.set(dict(kwargs))
+
+
+def _getattr(value: Any, name: str, default: Any = None) -> Any:
+    try:
+        return getattr(value, name, default)
+    except Exception:  # noqa: BLE001 - provider-owned descriptors are untrusted
+        return default
+
+
+def _bound(method: Any, instance: Any) -> Any:
+    descriptor = _getattr(method, "__get__")
+    return descriptor(instance, type(instance)) if callable(descriptor) else method
+
+
+def _request_attrs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    attrs: dict[str, Any] = {
+        "openinference.span.kind": "LLM",
+        "input.value": json_dumps(kwargs),
+        "input.mime_type": "application/json",
+        "llm.invocation_parameters": json_dumps(
+            {
+                key: value
+                for key, value in kwargs.items()
+                if key not in {"messages", "tools"}
+            }
+        ),
+    }
+    model = kwargs.get("model")
+    if isinstance(model, str):
+        attrs["llm.model_name"] = safe_text(model)
+    messages = kwargs.get("messages")
+    if isinstance(messages, list):
+        for index, message in enumerate(messages[:50]):
+            if not isinstance(message, dict):
+                continue
+            role = message.get("role")
+            content = message.get("content")
+            if isinstance(role, str):
+                attrs[f"llm.input_messages.{index}.message.role"] = safe_text(role)
+            if isinstance(content, str):
+                attrs[f"llm.input_messages.{index}.message.content"] = safe_text(
+                    content
+                )
+    tools = kwargs.get("tools")
+    if isinstance(tools, list):
+        for index, tool in enumerate(tools[:50]):
+            attrs[f"llm.tools.{index}.tool.json_schema"] = json_dumps(tool)
+    return attrs
+
+
+class StreamAccumulator:
+    def __init__(self) -> None:
+        self.content = ""
+        self.model: str | None = None
+        self.response_id: str | None = None
+        self.usage: Any = None
+        self.tool_calls: dict[int, dict[str, Any]] = {}
+
+    def add(self, item: Any) -> None:
+        model = _getattr(item, "model")
+        if isinstance(model, str):
+            self.model = safe_text(model)
+        response_id = _getattr(item, "id")
+        if isinstance(response_id, str):
+            self.response_id = safe_text(response_id)
+        usage = _getattr(item, "usage")
+        if usage is not None:
+            self.usage = usage
+        choices = _getattr(item, "choices")
+        if not isinstance(choices, (list, tuple)) or not choices:
+            return
+        delta = _getattr(choices[0], "delta")
+        content = _getattr(delta, "content")
+        if isinstance(content, str):
+            self.content = safe_text(self.content + content)
+        calls = _getattr(delta, "tool_calls")
+        if not isinstance(calls, (list, tuple)):
+            return
+        for call in calls[:50]:
+            index = _getattr(call, "index", 0)
+            if not isinstance(index, int) or index < 0:
+                index = 0
+            slot = self.tool_calls.setdefault(
+                index,
+                {
+                    "id": None,
+                    "type": "function",
+                    "function": {"name": "", "arguments": ""},
+                },
+            )
+            call_id = _getattr(call, "id")
+            if isinstance(call_id, str):
+                slot["id"] = safe_text(call_id)
+            function = _getattr(call, "function")
+            name = _getattr(function, "name")
+            arguments = _getattr(function, "arguments")
+            if isinstance(name, str):
+                slot["function"]["name"] = safe_text(name)
+            if isinstance(arguments, str):
+                slot["function"]["arguments"] = safe_text(
+                    slot["function"]["arguments"] + arguments
+                )
+
+    def response(self) -> dict[str, Any]:
+        message: dict[str, Any] = {"role": "assistant", "content": self.content or None}
+        if self.tool_calls:
+            message["tool_calls"] = [
+                self.tool_calls[index] for index in sorted(self.tool_calls)
+            ]
+        return {
+            "id": self.response_id,
+            "model": self.model,
+            "choices": [{"index": 0, "message": message}],
+            "usage": jsonable(self.usage),
+        }
+
+    def finish(self, span: Any, error: BaseException | None = None) -> None:
+        if not span.is_recording():
+            return
+        response = self.response()
+        if self.model:
+            span.set_attribute("llm.model_name", self.model)
+        span.set_attribute("output.value", json_dumps(response))
+        span.set_attribute("output.mime_type", "application/json")
+        span.set_attribute("llm.output_messages.0.message.role", "assistant")
+        if self.content:
+            span.set_attribute("llm.output_messages.0.message.content", self.content)
+        if self.tool_calls:
+            for index, call in enumerate(
+                response["choices"][0]["message"]["tool_calls"]
+            ):
+                prefix = f"llm.output_messages.0.message.tool_calls.{index}.tool_call"
+                if call.get("id"):
+                    span.set_attribute(f"{prefix}.id", call["id"])
+                span.set_attribute(f"{prefix}.function.name", call["function"]["name"])
+                span.set_attribute(
+                    f"{prefix}.function.arguments", call["function"]["arguments"]
+                )
+        usage = jsonable(self.usage)
+        if isinstance(usage, dict):
+            for source, target in (
+                ("prompt_tokens", "llm.token_count.prompt"),
+                ("completion_tokens", "llm.token_count.completion"),
+                ("total_tokens", "llm.token_count.total"),
+            ):
+                value = usage.get(source)
+                if isinstance(value, int):
+                    span.set_attribute(target, value)
+        if error is not None:
+            message = exception_message(error)
+            code = exception_status(error)
+            span.set_attribute(ERROR_MESSAGE_ATTR, message)
+            span.set_attribute("http.response.status_code", code)
+            span.set_attribute("status_code", code)
+            span.set_status(Status(StatusCode.ERROR, message))
+        else:
+            span.set_status(Status(StatusCode.OK))
+        span.end()
+
+
+class SyncStreamProxy:
+    def __init__(self, stream: Any, span: Any) -> None:
+        self._stream = stream
+        self._span = span
+        self._accumulator = StreamAccumulator()
+        self._done = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            item = next(self._stream)
+        except StopIteration:
+            self._finish()
+            raise
+        except BaseException as exc:
+            self._finish(exc)
+            raise
+        self._accumulator.add(item)
+        return item
+
+    def _finish(self, error: BaseException | None = None) -> None:
+        if self._done:
+            return
+        self._done = True
+        self._accumulator.finish(self._span, error)
+
+    def close(self) -> None:
+        try:
+            close = _getattr(self._stream, "close")
+            if callable(close):
+                close()
+        finally:
+            self._finish()
+
+    def __enter__(self):
+        enter = _getattr(self._stream, "__enter__")
+        if callable(enter):
+            enter()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        try:
+            exit_method = _getattr(self._stream, "__exit__")
+            if callable(exit_method):
+                return exit_method(exc_type, exc, traceback)
+            return False
+        finally:
+            self._finish(exc)
+
+
+class AsyncStreamProxy:
+    def __init__(self, stream: Any, span: Any) -> None:
+        self._stream = stream
+        self._iterator = stream.__aiter__()
+        self._span = span
+        self._accumulator = StreamAccumulator()
+        self._done = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            item = await self._iterator.__anext__()
+        except StopAsyncIteration:
+            self._finish()
+            raise
+        except BaseException as exc:
+            self._finish(exc)
+            raise
+        self._accumulator.add(item)
+        return item
+
+    def _finish(self, error: BaseException | None = None) -> None:
+        if self._done:
+            return
+        self._done = True
+        self._accumulator.finish(self._span, error)
+
+    async def aclose(self) -> None:
+        try:
+            close = _getattr(self._stream, "aclose") or _getattr(self._stream, "close")
+            if callable(close):
+                result = close()
+                if inspect.isawaitable(result):
+                    await result
+        finally:
+            self._finish()
+
+    async def __aenter__(self):
+        enter = _getattr(self._stream, "__aenter__")
+        if callable(enter):
+            result = enter()
+            if inspect.isawaitable(result):
+                await result
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        try:
+            exit_method = _getattr(self._stream, "__aexit__")
+            if callable(exit_method):
+                result = exit_method(exc_type, exc, traceback)
+                return await result if inspect.isawaitable(result) else result
+            return False
+        finally:
+            self._finish(exc)
+
+
+@dataclass
+class StreamHooks:
+    sync_class: type
+    async_class: type
+    sync_original: Any
+    async_original: Any
+    sync_wrapper: Any
+    async_wrapper: Any
+
+
+def install_stream_hooks(provider: Any) -> StreamHooks:
+    module = __import__("portkey_ai.api_resources.apis.chat_complete", fromlist=["x"])
+    sync_class = module.Completions
+    async_class = module.AsyncCompletions
+    sync_original = sync_class.create
+    async_original = async_class.create
+    tracer = provider.get_tracer(OPENINFERENCE_PORTKEY_MODULE, "0.1.0")
+
+    def sync_wrapper(instance: Any, *args: Any, **kwargs: Any) -> Any:
+        if kwargs.get("stream") is not True:
+            request_token = _attach_request(kwargs)
+            try:
+                return _bound(sync_original, instance)(*args, **kwargs)
+            finally:
+                _REQUEST_CONTEXT.reset(request_token)
+        span = tracer.start_span("Completions", attributes=_request_attrs(dict(kwargs)))
+        token = context_api.attach(
+            context_api.set_value(context_api._SUPPRESS_INSTRUMENTATION_KEY, True)
+        )
+        try:
+            stream = _bound(sync_original, instance)(*args, **kwargs)
+        except BaseException as exc:
+            StreamAccumulator().finish(span, exc)
+            raise
+        finally:
+            context_api.detach(token)
+        return SyncStreamProxy(stream, span)
+
+    async def async_wrapper(instance: Any, *args: Any, **kwargs: Any) -> Any:
+        if kwargs.get("stream") is not True:
+            request_token = _attach_request(kwargs)
+            try:
+                return await _bound(async_original, instance)(*args, **kwargs)
+            finally:
+                _REQUEST_CONTEXT.reset(request_token)
+        span = tracer.start_span(
+            "AsyncCompletions", attributes=_request_attrs(dict(kwargs))
+        )
+        token = context_api.attach(
+            context_api.set_value(context_api._SUPPRESS_INSTRUMENTATION_KEY, True)
+        )
+        try:
+            stream = await _bound(async_original, instance)(*args, **kwargs)
+        except BaseException as exc:
+            StreamAccumulator().finish(span, exc)
+            raise
+        finally:
+            context_api.detach(token)
+        return AsyncStreamProxy(stream, span)
+
+    sync_class.create = sync_wrapper
+    async_class.create = async_wrapper
+    return StreamHooks(
+        sync_class,
+        async_class,
+        sync_original,
+        async_original,
+        sync_wrapper,
+        async_wrapper,
+    )
+
+
+def remove_stream_hooks(hooks: StreamHooks | None) -> None:
+    if hooks is None:
+        return
+    if hooks.sync_class.create is hooks.sync_wrapper:
+        hooks.sync_class.create = hooks.sync_original
+    if hooks.async_class.create is hooks.async_wrapper:
+        hooks.async_class.create = hooks.async_original

--- a/python-sdks/instrumentations/respan-instrumentation-portkey/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-portkey/tests/test_instrumentation.py
@@ -1,17 +1,12 @@
+import json
 import logging
 import sys
 from types import ModuleType, SimpleNamespace
+from typing import ClassVar
 
 import pytest
 from respan_instrumentation_openinference._translator import OpenInferenceTranslator
-from respan_sdk.constants.span_attributes import (
-    RESPAN_SPAN_TOOL_CALLS,
-    RESPAN_SPAN_TOOLS,
-)
-from respan_tracing.core.tracer import RespanTracer
-
-from respan_instrumentation_portkey import PortkeyInstrumentor
-from respan_instrumentation_portkey import _instrumentation
+from respan_instrumentation_portkey import PortkeyInstrumentor, _instrumentation
 from respan_instrumentation_portkey._constants import OPENINFERENCE_PORTKEY_MODULE
 from respan_instrumentation_portkey._processor import (
     GEN_AI_COMPLETION_TOOL_CALLS_ATTR,
@@ -19,6 +14,12 @@ from respan_instrumentation_portkey._processor import (
     OTEL_SCOPE_NAME,
     PortkeySpanContractProcessor,
 )
+from respan_instrumentation_portkey._serialization import json_dumps
+from respan_sdk.constants.span_attributes import (
+    RESPAN_SPAN_TOOL_CALLS,
+    RESPAN_SPAN_TOOLS,
+)
+from respan_tracing.core.tracer import RespanTracer
 
 
 def _install_fake_modules(monkeypatch):
@@ -26,7 +27,7 @@ def _install_fake_modules(monkeypatch):
         pass
 
     class FakeOpenInferenceInstrumentor:
-        created = []
+        created: ClassVar[list] = []
 
         def __init__(self, instrumentor_class, **kwargs):
             self.instrumentor_class = instrumentor_class
@@ -64,6 +65,12 @@ def _install_fake_modules(monkeypatch):
         "OpenInferenceInstrumentor",
         FakeOpenInferenceInstrumentor,
     )
+    monkeypatch.setattr(
+        _instrumentation,
+        "install_stream_hooks",
+        lambda provider: SimpleNamespace(provider=provider),
+    )
+    monkeypatch.setattr(_instrumentation, "remove_stream_hooks", lambda hooks: None)
 
     return SimpleNamespace(
         portkey_instrumentor_class=FakePortkeyInstrumentor,
@@ -81,6 +88,12 @@ def _make_fake_tracer_provider(processors=()):
 @pytest.fixture(autouse=True)
 def reset_tracer():
     RespanTracer.reset_instance()
+    _instrumentation._REFCOUNT = 0
+    _instrumentation._CONFIG = None
+    _instrumentation._DELEGATE = None
+    _instrumentation._PROCESSOR = None
+    _instrumentation._PROVIDER = None
+    _instrumentation._STREAM_HOOKS = None
     yield
     RespanTracer.reset_instance()
 
@@ -145,6 +158,53 @@ def test_activate_is_idempotent(monkeypatch):
     instrumentor.activate()
 
     assert len(fake.openinference_instrumentor_class.created) == 1
+
+
+def test_two_instances_share_runtime_until_last_deactivate(monkeypatch):
+    fake = _install_fake_modules(monkeypatch)
+    tracer_provider = _make_fake_tracer_provider()
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: tracer_provider,
+    )
+    first = PortkeyInstrumentor()
+    second = PortkeyInstrumentor()
+
+    first.activate()
+    second.activate()
+
+    delegate = fake.openinference_instrumentor_class.created[0]
+    assert len(fake.openinference_instrumentor_class.created) == 1
+    assert _instrumentation._REFCOUNT == 2
+    first.deactivate()
+    assert delegate.is_deactivated is False
+    assert second._is_instrumented is True
+    second.deactivate()
+    assert delegate.is_deactivated is True
+    assert _instrumentation._REFCOUNT == 0
+
+
+def test_second_instance_rejects_mismatched_config(monkeypatch, caplog):
+    fake = _install_fake_modules(monkeypatch)
+    tracer_provider = _make_fake_tracer_provider()
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer_provider",
+        lambda: tracer_provider,
+    )
+    first = PortkeyInstrumentor(trace_content=True)
+    second = PortkeyInstrumentor(trace_content=False)
+
+    first.activate()
+    with caplog.at_level(logging.WARNING):
+        second.activate()
+
+    assert len(fake.openinference_instrumentor_class.created) == 1
+    assert _instrumentation._REFCOUNT == 1
+    assert second._is_instrumented is False
+    assert "already active with different settings" in caplog.text
+    first.deactivate()
 
 
 def test_activate_cleans_up_delegate_when_activation_fails(monkeypatch, caplog):
@@ -256,9 +316,37 @@ def test_contract_processor_ignores_non_portkey_spans():
     processor = PortkeySpanContractProcessor()
     span = SimpleNamespace(
         _attributes={"model": "gpt-4o-mini"},
-        instrumentation_scope=SimpleNamespace(name="openinference.instrumentation.other"),
+        instrumentation_scope=SimpleNamespace(
+            name="openinference.instrumentation.other"
+        ),
     )
 
     processor.on_end(span)
 
     assert span._attributes == {"model": "gpt-4o-mini"}
+
+
+def test_serializer_is_bounded_redacted_and_never_calls_repr():
+    class Hostile:
+        def __repr__(self):
+            raise AssertionError("repr must not run")
+
+        def __str__(self):
+            raise AssertionError("str must not run")
+
+    encoded = json_dumps(
+        {
+            "api_key": "plain-secret",
+            "auth_token": "session-secret",
+            "prompt_tokens": 17,
+            "hostile": Hostile(),
+            "text": "😀" * 10_000,
+        }
+    )
+    parsed = json.loads(encoded)
+
+    assert len(encoded.encode("utf-8")) <= 16_000
+    assert "plain-secret" not in encoded
+    assert "session-secret" not in encoded
+    assert '"prompt_tokens":17' in encoded
+    assert "[truncated]" in encoded or parsed.get("truncated") is True

--- a/python-sdks/instrumentations/respan-instrumentation-portkey/tests/test_real_portkey.py
+++ b/python-sdks/instrumentations/respan-instrumentation-portkey/tests/test_real_portkey.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+
+import httpx
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from opentelemetry.trace import StatusCode
+from portkey_ai import AsyncPortkey, Portkey
+from portkey_ai._vendor.openai import AuthenticationError
+from respan_instrumentation_openinference import OpenInferenceInstrumentor
+from respan_instrumentation_portkey import PortkeyInstrumentor, _instrumentation
+from respan_sdk.constants import ERROR_MESSAGE_ATTR
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+
+
+def _payload(request: httpx.Request) -> dict:
+    return json.loads(request.content.decode())
+
+
+def _response(request: httpx.Request) -> httpx.Response:
+    body = _payload(request)
+    model = body.get("model", "local-model")
+    if model == "error-401":
+        return httpx.Response(
+            401,
+            json={"error": {"message": "deterministic authorization failure"}},
+            request=request,
+        )
+    if body.get("stream"):
+        events = [
+            {
+                "id": "stream-1",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": model,
+                "choices": [
+                    {"index": 0, "delta": {"role": "assistant", "content": "Portkey "}}
+                ],
+            },
+            {
+                "id": "stream-1",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "stream."},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+            {
+                "id": "stream-1",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": model,
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 3,
+                    "total_tokens": 10,
+                },
+            },
+        ]
+        content = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+        content += "data: [DONE]\n\n"
+        return httpx.Response(
+            200,
+            text=content,
+            headers={"content-type": "text/event-stream"},
+            request=request,
+        )
+    message: dict = {"role": "assistant", "content": "Portkey response."}
+    finish = "stop"
+    if body.get("tools"):
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "weather-1",
+                    "type": "function",
+                    "function": {"name": "weather", "arguments": '{"city":"Tokyo"}'},
+                }
+            ],
+        }
+        finish = "tool_calls"
+    return httpx.Response(
+        200,
+        json={
+            "id": "chat-1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": model,
+            "choices": [{"index": 0, "message": message, "finish_reason": finish}],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 9, "total_tokens": 21},
+        },
+        request=request,
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_current_portkey_sync_async_stream_tool_and_error(monkeypatch):
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer_provider", lambda: provider)
+    OpenInferenceInstrumentor._translator_registered = False
+    OpenInferenceInstrumentor._translator = None
+    OpenInferenceInstrumentor._active_span_processors = []
+    instrumentor = PortkeyInstrumentor()
+    instrumentor.activate()
+    tracer = provider.get_tracer("respan.portkey.test")
+    sync_http = httpx.Client(transport=httpx.MockTransport(_response))
+    async_http = httpx.AsyncClient(transport=httpx.MockTransport(_response))
+    sync_client = Portkey(
+        api_key="local-key", base_url="https://portkey.test", http_client=sync_http
+    )
+    async_client = AsyncPortkey(
+        api_key="local-key", base_url="https://portkey.test", http_client=async_http
+    )
+    try:
+        with tracer.start_as_current_span("sync.root"):
+            sync_client.chat.completions.create(
+                model="local-model", messages=[{"role": "user", "content": "sync"}]
+            )
+        with tracer.start_as_current_span("async.root"):
+            await async_client.chat.completions.create(
+                model="local-model", messages=[{"role": "user", "content": "async"}]
+            )
+        with tracer.start_as_current_span("stream.root"):
+            stream = sync_client.chat.completions.create(
+                model="local-model",
+                messages=[{"role": "user", "content": "stream"}],
+                stream=True,
+                stream_options={"include_usage": True},
+            )
+            assert (
+                "".join(
+                    chunk.choices[0].delta.content or ""
+                    for chunk in stream
+                    if chunk.choices
+                )
+                == "Portkey stream."
+            )
+        with tracer.start_as_current_span("tool.root"):
+            sync_client.chat.completions.create(
+                model="local-model",
+                messages=[{"role": "user", "content": "weather"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "weather",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            )
+        with (
+            tracer.start_as_current_span("error.root"),
+            pytest.raises(AuthenticationError),
+        ):
+            sync_client.chat.completions.create(
+                model="error-401", messages=[{"role": "user", "content": "fail"}]
+            )
+    finally:
+        sync_client.close()
+        await async_client.close()
+        instrumentor.deactivate()
+        provider.force_flush()
+
+    spans = list(exporter.get_finished_spans())
+    names = Counter(span.name for span in spans)
+    assert names == Counter(
+        {
+            "sync.root": 1,
+            "async.root": 1,
+            "stream.root": 1,
+            "tool.root": 1,
+            "error.root": 1,
+            "Completions": 4,
+            "AsyncCompletions": 1,
+        }
+    )
+    assert len({span.context.span_id for span in spans}) == len(spans)
+    all_ids = {span.context.span_id for span in spans}
+    for span in spans:
+        if span.parent is not None:
+            assert span.parent.span_id in all_ids
+
+    chats = [span for span in spans if span.name in {"Completions", "AsyncCompletions"}]
+    assert all(span.attributes[RESPAN_LOG_TYPE] == "chat" for span in chats)
+    assert all(span.attributes["gen_ai.provider.name"] == "portkey" for span in chats)
+    assert all(
+        TLSpanAttributes.TRACELOOP_SPAN_KIND not in span.attributes for span in chats
+    )
+    stream_span = next(
+        span
+        for span in chats
+        if span.attributes.get(TLSpanAttributes.LLM_IS_STREAMING) is True
+    )
+    assert stream_span.attributes.get(TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS) == 7, (
+        stream_span.attributes
+    )
+    assert stream_span.attributes[TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 3
+    assert (
+        "Portkey stream."
+        in stream_span.attributes[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    )
+    tool_candidates = [
+        span
+        for span in chats
+        if TLSpanAttributes.LLM_REQUEST_FUNCTIONS in span.attributes
+    ]
+    assert tool_candidates, [dict(span.attributes) for span in chats]
+    tool_span = tool_candidates[0]
+    assert (
+        json.loads(tool_span.attributes[TLSpanAttributes.LLM_REQUEST_FUNCTIONS])[0][
+            "function"
+        ]["name"]
+        == "weather"
+    )
+    calls = json.loads(
+        tool_span.attributes[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]
+    )
+    assert calls[0]["id"] == "weather-1"
+    error_span = next(
+        span for span in chats if span.status.status_code is StatusCode.ERROR
+    )
+    assert error_span.attributes["status_code"] == 401
+    assert error_span.attributes["http.response.status_code"] == 401
+    assert "authorization failure" in error_span.attributes[ERROR_MESSAGE_ATTR]
+    provider.shutdown()


### PR DESCRIPTION
## Summary

- Repair Pinecone, Pipecat, and Portkey translation, lifecycle, streaming, error, bounded-serialization, privacy, and canonical semantic-convention behavior on the current OTel Python stack.
- Add real current-SDK exported-span regressions for Pinecone 9.1, Pipecat 1.7/OpenInference 2.0.1, and Portkey 2.3.4.
- Add the patch release intent for exactly these three instrumentation packages.

## Validation

- [x] Focused package tests pass: Pinecone 4/4, Pipecat 13/13, Portkey 12/12 (29/29).
- [x] Root-config Ruff check and format check pass for all changed package source and tests.
- [x] All three wheels build and import from isolated install targets: Pinecone `6d3f2895…96a0`, Pipecat `ed916fa4…4f92`, Portkey `74ebb454…994b`.
- [x] Release inventory, release-intent validation, missing-intent validation, and diff checks pass.
- [x] Companion locally linked examples pass all 11 executed scenarios under `otel2-fix-py-group-22-20260817T230705Z`.
- [x] Respan MCP returned exactly 11 traces / 31 full records; every tree and detail was inspected for roots, parents, IDs, content, model/provider, exact/non-estimated success usage, streaming, tools, failures, grouping, payload bounds, aliases, and credential leakage.
- [x] Pipecat success usage is provider-supplied and non-estimated at offline `8/6/14` and live `18/7/25`; Portkey streaming is `stream=true` with exact `7/5/12`.

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- Current ingestion still projects Pinecone's native OTel 503 as success/200 and leaves the outer decorated Pipecat/Portkey failure roots success/200 while package-owned descendants are correctly failed/401.
- Portkey convenience `tools`/`tool_calls` and provider ID remain incomplete despite canonical attributes, current-turn call content, and a connected tool child.
- Error-only Pipecat/Portkey records receive backend-estimated tokens when no provider terminal usage exists.
- Pinecone operation nodes remain visibly named `task` per the contribution task-display contract; exact operation identity remains canonical in entity/database attributes.
- Live Portkey gateway-specific coverage remains credential-gated.

## Companion examples

- [respan-example-projects #70](https://github.com/respanai/respan-example-projects/pull/70)