### PR TITLE
fix(instrumentation-py): repair Pydantic AI, Pytest, and Qdrant OTel 2.x spans

### DIFF
--- a/.release-intents/20260818-pydantic-ai-pytest-qdrant-otel2.json
+++ b/.release-intents/20260818-pydantic-ai-pytest-qdrant-otel2.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair Pydantic AI, Pytest, and Qdrant OpenTelemetry 2.x span normalization, lifecycle ownership, bounded content capture, and real-runtime coverage.",
+  "packages": {
+    "respan-instrumentation-pydantic-ai": "patch",
+    "respan-instrumentation-pytest": "patch",
+    "respan-instrumentation-qdrant": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_constants.py
@@ -7,7 +7,6 @@ This module separates:
 
 from opentelemetry.semconv_ai import SpanAttributes
 
-
 # PydanticAI native / vendor attributes
 PYDANTIC_AI_AGENT_NAME_ATTR = "gen_ai.agent.name"
 PYDANTIC_AI_OPERATION_NAME_ATTR = "gen_ai.operation.name"
@@ -24,7 +23,9 @@ PYDANTIC_AI_RESPONSE_FINISH_REASONS_ATTR = "gen_ai.response.finish_reasons"
 PYDANTIC_AI_USAGE_INPUT_TOKENS_ATTR = "gen_ai.usage.input_tokens"
 PYDANTIC_AI_USAGE_OUTPUT_TOKENS_ATTR = "gen_ai.usage.output_tokens"
 PYDANTIC_AI_AGGREGATED_USAGE_INPUT_TOKENS_ATTR = "gen_ai.aggregated_usage.input_tokens"
-PYDANTIC_AI_AGGREGATED_USAGE_OUTPUT_TOKENS_ATTR = "gen_ai.aggregated_usage.output_tokens"
+PYDANTIC_AI_AGGREGATED_USAGE_OUTPUT_TOKENS_ATTR = (
+    "gen_ai.aggregated_usage.output_tokens"
+)
 PYDANTIC_AI_AGGREGATED_USAGE_TOTAL_TOKENS_ATTR = "gen_ai.aggregated_usage.total_tokens"
 PYDANTIC_AI_USAGE_DETAILS_INPUT_TOKENS_ATTR = "gen_ai.usage.details.input_tokens"
 PYDANTIC_AI_USAGE_DETAILS_OUTPUT_TOKENS_ATTR = "gen_ai.usage.details.output_tokens"
@@ -80,8 +81,6 @@ PYDANTIC_AI_STRIP_ATTRS = frozenset(
         PYDANTIC_AI_RESPONSE_ID_ATTR,
         PYDANTIC_AI_RESPONSE_FINISH_REASONS_ATTR,
         SpanAttributes.GEN_AI_OPENAI_API_BASE,
-        PYDANTIC_AI_USAGE_INPUT_TOKENS_ATTR,
-        PYDANTIC_AI_USAGE_OUTPUT_TOKENS_ATTR,
         SpanAttributes.GEN_AI_USAGE_TOTAL_TOKENS,
         PYDANTIC_AI_AGGREGATED_USAGE_INPUT_TOKENS_ATTR,
         PYDANTIC_AI_AGGREGATED_USAGE_OUTPUT_TOKENS_ATTR,

--- a/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_instrumentation.py
@@ -1,7 +1,10 @@
 """Respan plugin for direct PydanticAI span instrumentation."""
 
+from __future__ import annotations
+
 import logging
-from typing import Any
+from threading import RLock
+from typing import Any, ClassVar
 
 from opentelemetry import trace
 
@@ -13,14 +16,18 @@ _UNSET = object()
 
 
 class PydanticAIInstrumentor:
-    """Respan instrumentor for PydanticAI.
-
-    Enables PydanticAI's OpenTelemetry emission and registers a local
-    processor that maps native PydanticAI attributes directly into the
-    Respan/Traceloop conventions used by the OTLP pipeline.
-    """
+    """Enable native Pydantic AI telemetry and normalize its ended spans."""
 
     name = "pydantic-ai"
+    _lifecycle_lock: ClassVar[RLock] = RLock()
+    _shared_processor: ClassVar[PydanticAISpanProcessor | None] = None
+    _shared_provider: ClassVar[Any | None] = None
+    _processor_refcount: ClassVar[int] = 0
+    _global_refcount: ClassVar[int] = 0
+    _global_config: ClassVar[tuple[bool, bool, int] | None] = None
+    _global_agent_class: ClassVar[Any | None] = None
+    _global_previous: ClassVar[Any] = _UNSET
+    _specific_agents: ClassVar[dict[int, dict[str, Any]]] = {}
 
     def __init__(
         self,
@@ -34,15 +41,21 @@ class PydanticAIInstrumentor:
         self._include_content = include_content
         self._include_binary_content = include_binary_content
         self._version = version
-        self._agent_class = None
-        self._processor = None
         self._is_instrumented = False
-        self._previous_agent_instrument: Any = _UNSET
-        self._previous_global_instrument: Any = _UNSET
+        self._activation_mode: tuple[str, int | None] | None = None
+
+    @property
+    def _config(self) -> tuple[bool, bool, int]:
+        return (
+            self._include_content,
+            self._include_binary_content,
+            self._version,
+        )
 
     @staticmethod
     def _register_processor(
-        tracer_provider, processor: PydanticAISpanProcessor
+        tracer_provider: Any,
+        processor: PydanticAISpanProcessor,
     ) -> None:
         active_span_processor = getattr(tracer_provider, "_active_span_processor", None)
         processors = (
@@ -50,25 +63,18 @@ class PydanticAIInstrumentor:
             if active_span_processor is not None
             else None
         )
-
         if processors is not None:
-            active_span_processor._span_processors = tuple(
-                existing_processor
-                for existing_processor in processors
-                if existing_processor is not processor
-            )
-            active_span_processor._span_processors = (
-                *active_span_processor._span_processors,
-                processor,
-            )
+            if any(existing is processor for existing in processors):
+                return
+            active_span_processor._span_processors = (processor, *processors)
             return
-
         if hasattr(tracer_provider, "add_span_processor"):
             tracer_provider.add_span_processor(processor)
 
     @staticmethod
     def _unregister_processor(
-        tracer_provider, processor: PydanticAISpanProcessor
+        tracer_provider: Any,
+        processor: PydanticAISpanProcessor,
     ) -> None:
         active_span_processor = getattr(tracer_provider, "_active_span_processor", None)
         processors = (
@@ -79,15 +85,41 @@ class PydanticAIInstrumentor:
         if processors is None:
             return
         active_span_processor._span_processors = tuple(
-            existing_processor
-            for existing_processor in processors
-            if existing_processor is not processor
+            existing for existing in processors if existing is not processor
         )
+
+    @classmethod
+    def _acquire_processor(cls, tracer_provider: Any) -> None:
+        if cls._processor_refcount:
+            if cls._shared_provider is not tracer_provider:
+                raise RuntimeError(
+                    "all active PydanticAIInstrumentor instances must use the same "
+                    "tracer provider"
+                )
+            cls._processor_refcount += 1
+            return
+
+        processor = PydanticAISpanProcessor()
+        cls._register_processor(tracer_provider, processor)
+        cls._shared_processor = processor
+        cls._shared_provider = tracer_provider
+        cls._processor_refcount = 1
+
+    @classmethod
+    def _release_processor(cls) -> None:
+        if not cls._processor_refcount:
+            return
+        cls._processor_refcount -= 1
+        if cls._processor_refcount:
+            return
+        if cls._shared_processor is not None and cls._shared_provider is not None:
+            cls._unregister_processor(cls._shared_provider, cls._shared_processor)
+        cls._shared_processor = None
+        cls._shared_provider = None
 
     def activate(self) -> None:
         if self._is_instrumented:
             return
-
         try:
             from pydantic_ai.agent import Agent
             from pydantic_ai.models.instrumented import InstrumentationSettings
@@ -98,50 +130,95 @@ class PydanticAIInstrumentor:
             )
             return
 
-        if self._processor is None:
-            self._processor = PydanticAISpanProcessor()
-        self._register_processor(trace.get_tracer_provider(), self._processor)
-
-        self._agent_class = Agent
+        cls = type(self)
+        tracer_provider = trace.get_tracer_provider()
         settings = InstrumentationSettings(
-            tracer_provider=trace.get_tracer_provider(),
+            tracer_provider=tracer_provider,
             include_content=self._include_content,
             include_binary_content=self._include_binary_content,
             version=self._version,
         )
-
-        if self._agent is None:
-            self._previous_global_instrument = getattr(Agent, "_instrument_default", _UNSET)
-            Agent.instrument_all(instrument=settings)
-        else:
-            self._previous_agent_instrument = getattr(self._agent, "instrument", _UNSET)
-            self._agent.instrument = settings
-
-        self._is_instrumented = True
+        with cls._lifecycle_lock:
+            if self._is_instrumented:
+                return
+            cls._acquire_processor(tracer_provider)
+            try:
+                if self._agent is None:
+                    if cls._global_refcount:
+                        if cls._global_config != self._config:
+                            raise ValueError(
+                                "all active global PydanticAIInstrumentor instances "
+                                "must use the same content and version settings"
+                            )
+                        cls._global_refcount += 1
+                    else:
+                        previous = getattr(Agent, "_instrument_default", _UNSET)
+                        Agent.instrument_all(instrument=settings)
+                        cls._global_previous = previous
+                        cls._global_agent_class = Agent
+                        cls._global_config = self._config
+                        cls._global_refcount = 1
+                    self._activation_mode = ("global", None)
+                else:
+                    key = id(self._agent)
+                    active = cls._specific_agents.get(key)
+                    if active is not None:
+                        if (
+                            active["agent"] is not self._agent
+                            or active["config"] != self._config
+                        ):
+                            raise ValueError(
+                                "all active instrumentors for one Pydantic AI agent "
+                                "must use the same settings"
+                            )
+                        active["count"] += 1
+                    else:
+                        previous = getattr(self._agent, "instrument", _UNSET)
+                        self._agent.instrument = settings
+                        cls._specific_agents[key] = {
+                            "agent": self._agent,
+                            "config": self._config,
+                            "count": 1,
+                            "previous": previous,
+                        }
+                    self._activation_mode = ("agent", key)
+            except Exception:
+                cls._release_processor()
+                raise
+            self._is_instrumented = True
         logger.info("PydanticAI instrumentation activated")
 
     def deactivate(self) -> None:
-        if not self._is_instrumented:
-            return
-
-        try:
-            if self._agent is None and self._agent_class is not None:
-                previous_instrument = (
-                    False
-                    if self._previous_global_instrument is _UNSET
-                    else self._previous_global_instrument
-                )
-                self._agent_class.instrument_all(instrument=previous_instrument)
-            elif self._agent is not None:
-                previous_instrument = (
-                    None
-                    if self._previous_agent_instrument is _UNSET
-                    else self._previous_agent_instrument
-                )
-                self._agent.instrument = previous_instrument
-        finally:
-            if self._processor is not None:
-                self._unregister_processor(trace.get_tracer_provider(), self._processor)
-
-        self._is_instrumented = False
+        cls = type(self)
+        with cls._lifecycle_lock:
+            if not self._is_instrumented:
+                return
+            mode = self._activation_mode
+            try:
+                if mode == ("global", None):
+                    cls._global_refcount = max(cls._global_refcount - 1, 0)
+                    if not cls._global_refcount and cls._global_agent_class is not None:
+                        previous = (
+                            False
+                            if cls._global_previous is _UNSET
+                            else cls._global_previous
+                        )
+                        cls._global_agent_class.instrument_all(instrument=previous)
+                        cls._global_agent_class = None
+                        cls._global_previous = _UNSET
+                        cls._global_config = None
+                elif mode is not None and mode[0] == "agent" and mode[1] is not None:
+                    active = cls._specific_agents.get(mode[1])
+                    if active is not None:
+                        active["count"] = max(active["count"] - 1, 0)
+                        if not active["count"]:
+                            previous = active["previous"]
+                            active["agent"].instrument = (
+                                None if previous is _UNSET else previous
+                            )
+                            cls._specific_agents.pop(mode[1], None)
+            finally:
+                cls._release_processor()
+                self._is_instrumented = False
+                self._activation_mode = None
         logger.info("PydanticAI instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_processor.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
-import json
 import logging
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_AGENT,
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_SPEECH,
+    LOG_TYPE_TASK,
+    LOG_TYPE_TOOL,
+    LOG_TYPE_TRANSCRIPTION,
+    LogMethodChoices,
+)
+from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_METHOD,
+    RESPAN_LOG_TYPE,
+)
 
 from respan_instrumentation_pydantic_ai._constants import (
     FINAL_RESULT_ATTR,
@@ -35,19 +49,11 @@ from respan_instrumentation_pydantic_ai._constants import (
     RESPAN_OVERRIDE_MODEL_ATTR,
     RESPAN_RESPONSE_FORMAT_ATTR,
 )
-from respan_sdk.constants.llm_logging import (
-    LOG_TYPE_AGENT,
-    LOG_TYPE_CHAT,
-    LOG_TYPE_EMBEDDING,
-    LOG_TYPE_SPEECH,
-    LOG_TYPE_TASK,
-    LOG_TYPE_TOOL,
-    LOG_TYPE_TRANSCRIPTION,
-    LogMethodChoices,
-)
-from respan_sdk.constants.span_attributes import (
-    RESPAN_LOG_METHOD,
-    RESPAN_LOG_TYPE,
+from respan_instrumentation_pydantic_ai._serialization import (
+    json_string,
+    json_value,
+    parse_json,
+    safe_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -64,13 +70,10 @@ _USAGE_LOG_TYPES = frozenset(
         LOG_TYPE_CHAT,
         LOG_TYPE_EMBEDDING,
         LOG_TYPE_SPEECH,
-        LOG_TYPE_TOOL,
         LOG_TYPE_TRANSCRIPTION,
     }
 )
-_NESTED_PROVIDER_USAGE_SUPPRESSIBLE_LOG_TYPES = frozenset(
-    _USAGE_LOG_TYPES - {LOG_TYPE_TOOL}
-)
+_NESTED_PROVIDER_USAGE_SUPPRESSIBLE_LOG_TYPES = frozenset(_USAGE_LOG_TYPES)
 _RAW_USAGE_ATTRIBUTE_NAMES = frozenset(
     {
         PYDANTIC_AI_USAGE_INPUT_TOKENS_ATTR,
@@ -100,24 +103,21 @@ _PRIMITIVE_ATTR_TYPES = (str, bool, int, float, bytes)
 
 
 def _safe_json_loads(value: Any) -> Any:
-    if not isinstance(value, str):
-        return value
-    try:
-        return json.loads(value)
-    except json.JSONDecodeError:
-        return None
+    parsed = parse_json(value)
+    return None if parsed is value and isinstance(value, str) else parsed
 
 
 def _json_string(value: Any) -> str | None:
     if value is None:
         return None
-    if isinstance(value, str):
-        return value
-    return json.dumps(value, default=str)
+    parsed = parse_json(value)
+    return json_string(parsed)
 
 
 def _extract_request_parameters(attrs: Mapping[str, Any]) -> dict[str, Any] | None:
-    request_parameters = _safe_json_loads(attrs.get(PYDANTIC_AI_REQUEST_PARAMETERS_ATTR))
+    request_parameters = _safe_json_loads(
+        attrs.get(PYDANTIC_AI_REQUEST_PARAMETERS_ATTR)
+    )
     if isinstance(request_parameters, dict):
         return request_parameters
     return None
@@ -158,7 +158,7 @@ def _content_to_text(value: Any) -> str:
     if value is None:
         return ""
     if isinstance(value, str):
-        return value
+        return safe_text(value)
     if isinstance(value, list):
         parts = [_content_to_text(item) for item in value]
         return "\n".join(part for part in parts if part)
@@ -167,8 +167,37 @@ def _content_to_text(value: Any) -> str:
             nested = value.get(key)
             if nested not in (None, "", (), []):
                 return _content_to_text(nested)
-        return json.dumps(value, default=str)
-    return str(value)
+        return json_string(value)
+    return safe_text(value)
+
+
+def _normalize_tool_call(part: Mapping[str, Any]) -> dict[str, Any] | None:
+    name = part.get("name") or part.get("tool_name")
+    if not isinstance(name, str) or not name:
+        return None
+    call_id = part.get("id") or part.get("tool_call_id")
+    arguments = part.get("arguments", part.get("args", {}))
+    normalized: dict[str, Any] = {
+        "type": "function",
+        "function": {
+            "name": safe_text(name),
+            "arguments": json_string(parse_json(arguments)),
+        },
+    }
+    if isinstance(call_id, str) and call_id:
+        normalized["id"] = safe_text(call_id)
+    return normalized
+
+
+def _normalize_tool_result(part: Mapping[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {"result": json_value(part.get("result"))}
+    name = part.get("name") or part.get("tool_name")
+    call_id = part.get("id") or part.get("tool_call_id")
+    if isinstance(name, str) and name:
+        payload["name"] = safe_text(name)
+    if isinstance(call_id, str) and call_id:
+        payload["tool_call_id"] = safe_text(call_id)
+    return payload
 
 
 def _messages_from_parts(
@@ -176,12 +205,13 @@ def _messages_from_parts(
     default_role: str,
     *,
     allow_part_roles: bool,
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     if not isinstance(parts, list):
         content = _content_to_text(parts)
         return [{"role": default_role, "content": content}] if content else []
 
-    messages = []
+    messages: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
     for part in parts:
         role = default_role
         if allow_part_roles and isinstance(part, Mapping):
@@ -192,22 +222,62 @@ def _messages_from_parts(
                 or part.get("type"),
                 default_role,
             )
+        part_type = (
+            safe_text(
+                part.get("type") or part.get("part_kind") or part.get("kind") or ""
+            ).lower()
+            if isinstance(part, Mapping)
+            else ""
+        )
+        if isinstance(part, Mapping) and part_type in {
+            "tool-call",
+            "tool_call",
+            "toolcall",
+        }:
+            tool_call = _normalize_tool_call(part)
+            if tool_call is not None:
+                if current is None or current.get("role") != "assistant":
+                    current = {"role": "assistant"}
+                    messages.append(current)
+                current.setdefault("tool_calls", []).append(tool_call)
+            continue
+        if isinstance(part, Mapping) and part_type in {
+            "tool-call-response",
+            "tool_call_response",
+            "tool-return",
+            "tool_return",
+        }:
+            messages.append(
+                {"role": "tool", "content": json_string(_normalize_tool_result(part))}
+            )
+            current = None
+            continue
         content = _content_to_text(part)
         if content:
-            messages.append({"role": role, "content": content})
+            if (
+                current is not None
+                and current.get("role") == role
+                and "content" not in current
+            ):
+                current["content"] = content
+            else:
+                current = {"role": role, "content": content}
+                messages.append(current)
     return messages
 
 
 def _message_to_chat_messages(
     message: Any,
     default_role: str,
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     if not isinstance(message, Mapping):
         content = _content_to_text(message)
         return [{"role": default_role, "content": content}] if content else []
 
     explicit_role = _is_chat_role(message.get("role"))
-    role = _normalize_chat_role(message.get("role") or message.get("kind"), default_role)
+    role = _normalize_chat_role(
+        message.get("role") or message.get("kind"), default_role
+    )
     content = message.get("content")
     if content in (None, "", (), []) and "parts" in message:
         return _messages_from_parts(
@@ -223,7 +293,7 @@ def _message_to_chat_messages(
 def _normalize_chat_messages(
     messages: list[Any] | None,
     default_role: str,
-) -> list[dict[str, str]] | None:
+) -> list[dict[str, Any]] | None:
     if messages is None:
         return None
 
@@ -233,7 +303,7 @@ def _normalize_chat_messages(
     return normalized_messages or None
 
 
-def _chat_output_value(messages: list[dict[str, str]]) -> Any:
+def _chat_output_value(messages: list[dict[str, Any]]) -> Any:
     if len(messages) == 1:
         return messages[0]
     return messages
@@ -255,7 +325,7 @@ def _coerce_otel_attribute_value(value: Any) -> Any:
         return value
     if _is_homogeneous_primitive_array(value):
         return value
-    return json.dumps(value, default=str)
+    return json_string(value)
 
 
 def _extract_tool_names(attrs: Mapping[str, Any]) -> list[str] | None:
@@ -266,17 +336,19 @@ def _extract_tool_names(attrs: Mapping[str, Any]) -> list[str] | None:
     return tool_names or None
 
 
-def _normalize_tool_definition(tool_definition: Mapping[str, Any]) -> dict[str, Any] | None:
+def _normalize_tool_definition(
+    tool_definition: Mapping[str, Any],
+) -> dict[str, Any] | None:
     function_payload = tool_definition.get("function")
     if isinstance(function_payload, Mapping):
         normalized = {
             "type": tool_definition.get("type", "function"),
-            "function": {"name": function_payload.get("name")},
+            "function": {"name": safe_text(function_payload.get("name"))},
         }
         for key in ("description", "parameters", "strict"):
             value = function_payload.get(key)
             if value is not None:
-                normalized["function"][key] = value
+                normalized["function"][key] = json_value(value)
         if normalized["function"].get("name"):
             return normalized
         return None
@@ -285,15 +357,15 @@ def _normalize_tool_definition(tool_definition: Mapping[str, Any]) -> dict[str, 
     if not isinstance(tool_name, str) or not tool_name:
         return None
 
-    normalized_function: dict[str, Any] = {"name": tool_name}
+    normalized_function: dict[str, Any] = {"name": safe_text(tool_name)}
     description = tool_definition.get("description")
     if description is not None:
-        normalized_function["description"] = description
+        normalized_function["description"] = safe_text(description)
     parameters = tool_definition.get("parameters") or tool_definition.get(
         "parameters_json_schema"
     )
     if parameters is not None:
-        normalized_function["parameters"] = parameters
+        normalized_function["parameters"] = json_value(parameters)
     strict = tool_definition.get("strict")
     if strict is not None:
         normalized_function["strict"] = strict
@@ -361,7 +433,11 @@ def _extract_response_format(attrs: Mapping[str, Any]) -> dict[str, Any] | None:
 
 
 def _extract_model(attrs: Mapping[str, Any]) -> str | None:
-    for key in (SpanAttributes.LLM_REQUEST_MODEL, MODEL_NAME_ATTR, RESPAN_OVERRIDE_MODEL_ATTR):
+    for key in (
+        SpanAttributes.LLM_REQUEST_MODEL,
+        MODEL_NAME_ATTR,
+        RESPAN_OVERRIDE_MODEL_ATTR,
+    ):
         value = attrs.get(key)
         if isinstance(value, str) and value:
             return value
@@ -376,7 +452,9 @@ def _get_int_attr(attrs: Mapping[str, Any], *keys: str) -> int | None:
     return None
 
 
-def _extract_usage(attrs: Mapping[str, Any]) -> tuple[int | None, int | None, int | None]:
+def _extract_usage(
+    attrs: Mapping[str, Any],
+) -> tuple[int | None, int | None, int | None]:
     prompt_tokens = _get_int_attr(
         attrs,
         PYDANTIC_AI_USAGE_INPUT_TOKENS_ATTR,
@@ -402,18 +480,45 @@ def _extract_usage(attrs: Mapping[str, Any]) -> tuple[int | None, int | None, in
 def _set_message_attrs(
     attrs: dict[str, Any],
     prefix: str,
-    messages: list[dict[str, str]],
+    messages: list[dict[str, Any]],
 ) -> None:
     for index, message in enumerate(messages):
         message_prefix = f"{prefix}.{index}"
         _set_if_missing(attrs, f"{message_prefix}.role", message["role"])
-        _set_if_missing(attrs, f"{message_prefix}.content", message["content"])
+        content = message.get("content")
+        if content not in (None, ""):
+            _set_if_missing(attrs, f"{message_prefix}.content", content)
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            _set_if_missing(
+                attrs,
+                f"{message_prefix}.tool_calls",
+                json_string(tool_calls),
+            )
+
+
+def _entity_path(span: ReadableSpan, entity_name: str) -> str:
+    return "" if getattr(span, "parent", None) is None else entity_name
+
+
+def _agent_content(attrs: Mapping[str, Any]) -> tuple[Any | None, Any | None]:
+    all_messages = _safe_json_loads(attrs.get("pydantic_ai.all_messages"))
+    normalized = _normalize_chat_messages(
+        all_messages if isinstance(all_messages, list) else None,
+        "user",
+    )
+    output = parse_json(attrs.get(FINAL_RESULT_ATTR))
+    if output is None and normalized and normalized[-1].get("role") == "assistant":
+        output = normalized[-1]
+    if normalized and normalized[-1].get("role") == "assistant":
+        normalized = normalized[:-1]
+    return normalized or None, output
 
 
 def _get_span_key(span: Any) -> tuple[int, int] | None:
     try:
         span_context = span.get_span_context()
-    except Exception:
+    except Exception:  # noqa: BLE001 - vendor span objects may expose hostile hooks.
         return None
 
     trace_id = getattr(span_context, "trace_id", None)
@@ -444,12 +549,10 @@ def _should_map_usage_fields(
 ) -> bool:
     if log_type not in _USAGE_LOG_TYPES:
         return False
-    if (
+    return not (
         suppress_nested_provider_usage
         and log_type in _NESTED_PROVIDER_USAGE_SUPPRESSIBLE_LOG_TYPES
-    ):
-        return False
-    return True
+    )
 
 
 def _enrich_nested_provider_span(
@@ -465,14 +568,18 @@ def _enrich_nested_provider_span(
     if log_type not in _NESTED_PROVIDER_USAGE_SUPPRESSIBLE_LOG_TYPES:
         return
 
-    _set_if_missing(attrs, RESPAN_LOG_METHOD, LogMethodChoices.TRACING_INTEGRATION.value)
+    _set_if_missing(
+        attrs, RESPAN_LOG_METHOD, LogMethodChoices.TRACING_INTEGRATION.value
+    )
     _set_if_missing(attrs, RESPAN_LOG_TYPE, log_type)
 
     prompt_tokens, completion_tokens, total_tokens = _extract_usage(attrs)
     if prompt_tokens is not None:
         _set_if_missing(attrs, SpanAttributes.LLM_USAGE_PROMPT_TOKENS, prompt_tokens)
     if completion_tokens is not None:
-        _set_if_missing(attrs, SpanAttributes.LLM_USAGE_COMPLETION_TOKENS, completion_tokens)
+        _set_if_missing(
+            attrs, SpanAttributes.LLM_USAGE_COMPLETION_TOKENS, completion_tokens
+        )
     if total_tokens is not None:
         _set_if_missing(attrs, SpanAttributes.LLM_USAGE_TOTAL_TOKENS, total_tokens)
 
@@ -542,12 +649,15 @@ def enrich_pydantic_ai_span(
     if log_type is None:
         return
 
-    _set_if_missing(attrs, RESPAN_LOG_METHOD, LogMethodChoices.TRACING_INTEGRATION.value)
+    _set_if_missing(
+        attrs, RESPAN_LOG_METHOD, LogMethodChoices.TRACING_INTEGRATION.value
+    )
     _set_if_missing(attrs, RESPAN_LOG_TYPE, log_type)
 
-    model = _extract_model(attrs)
-    if model is not None:
-        _set_if_missing(attrs, SpanAttributes.LLM_REQUEST_MODEL, model)
+    if log_type in _USAGE_LOG_TYPES:
+        model = _extract_model(attrs)
+        if model is not None:
+            _set_if_missing(attrs, SpanAttributes.LLM_REQUEST_MODEL, model)
 
     if _should_map_usage_fields(
         log_type,
@@ -555,23 +665,34 @@ def enrich_pydantic_ai_span(
     ):
         prompt_tokens, completion_tokens, total_tokens = _extract_usage(attrs)
         if prompt_tokens is not None:
-            _set_if_missing(attrs, SpanAttributes.LLM_USAGE_PROMPT_TOKENS, prompt_tokens)
+            _set_if_missing(attrs, PYDANTIC_AI_USAGE_INPUT_TOKENS_ATTR, prompt_tokens)
+            _set_if_missing(
+                attrs, SpanAttributes.LLM_USAGE_PROMPT_TOKENS, prompt_tokens
+            )
         if completion_tokens is not None:
-            _set_if_missing(attrs, SpanAttributes.LLM_USAGE_COMPLETION_TOKENS, completion_tokens)
+            _set_if_missing(
+                attrs,
+                PYDANTIC_AI_USAGE_OUTPUT_TOKENS_ATTR,
+                completion_tokens,
+            )
+            _set_if_missing(
+                attrs, SpanAttributes.LLM_USAGE_COMPLETION_TOKENS, completion_tokens
+            )
         if total_tokens is not None:
             _set_if_missing(attrs, SpanAttributes.LLM_USAGE_TOTAL_TOKENS, total_tokens)
 
-    response_format = _extract_response_format(attrs)
-    if response_format is not None:
-        attrs[RESPAN_RESPONSE_FORMAT_ATTR] = json.dumps(response_format, default=str)
+    if log_type == LOG_TYPE_CHAT:
+        response_format = _extract_response_format(attrs)
+        if response_format is not None:
+            attrs[RESPAN_RESPONSE_FORMAT_ATTR] = json_string(response_format)
 
-    tools = _extract_tools(attrs)
-    if tools is not None:
-        _set_if_missing(
-            attrs,
-            SpanAttributes.LLM_REQUEST_FUNCTIONS,
-            json.dumps(tools, default=str),
-        )
+        tools = _extract_tools(attrs)
+        if tools is not None:
+            _set_if_missing(
+                attrs,
+                SpanAttributes.LLM_REQUEST_FUNCTIONS,
+                json_string(tools),
+            )
 
     tool_name = attrs.get(PYDANTIC_AI_TOOL_NAME_ATTR)
     tool_name = tool_name if isinstance(tool_name, str) else None
@@ -582,22 +703,59 @@ def enrich_pydantic_ai_span(
 
     tool_input = _json_string(
         attrs.get(
-            PYDANTIC_AI_TOOL_CALL_ARGUMENTS_ATTR, attrs.get(PYDANTIC_AI_LEGACY_TOOL_ARGUMENTS_ATTR)
+            PYDANTIC_AI_TOOL_CALL_ARGUMENTS_ATTR,
+            attrs.get(PYDANTIC_AI_LEGACY_TOOL_ARGUMENTS_ATTR),
         )
     )
     tool_output = _json_string(
         attrs.get(
-            PYDANTIC_AI_TOOL_CALL_RESULT_ATTR, attrs.get(PYDANTIC_AI_LEGACY_TOOL_RESULT_ATTR)
+            PYDANTIC_AI_TOOL_CALL_RESULT_ATTR,
+            attrs.get(PYDANTIC_AI_LEGACY_TOOL_RESULT_ATTR),
         )
     )
 
+    if log_type in {LOG_TYPE_AGENT, LOG_TYPE_TASK, LOG_TYPE_TOOL}:
+        for key in (
+            SpanAttributes.LLM_SYSTEM,
+            SpanAttributes.LLM_REQUEST_MODEL,
+            SpanAttributes.LLM_REQUEST_FUNCTIONS,
+            SpanAttributes.LLM_USAGE_PROMPT_TOKENS,
+            SpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
+            SpanAttributes.LLM_USAGE_TOTAL_TOKENS,
+            PYDANTIC_AI_USAGE_INPUT_TOKENS_ATTR,
+            PYDANTIC_AI_USAGE_OUTPUT_TOKENS_ATTR,
+            RESPAN_RESPONSE_FORMAT_ATTR,
+            "gen_ai.system_instructions",
+        ):
+            attrs.pop(key, None)
+
     if log_type == LOG_TYPE_TOOL and tool_name is not None:
         _set_if_missing(attrs, SpanAttributes.TRACELOOP_ENTITY_NAME, tool_name)
-        _set_if_missing(attrs, SpanAttributes.TRACELOOP_ENTITY_PATH, tool_name)
-        _set_if_missing(attrs, SpanAttributes.TRACELOOP_ENTITY_INPUT, tool_input)
+        _set_if_missing(
+            attrs,
+            SpanAttributes.TRACELOOP_ENTITY_PATH,
+            _entity_path(span, tool_name),
+        )
+        _set_if_missing(
+            attrs,
+            SpanAttributes.TRACELOOP_ENTITY_INPUT,
+            json_string(
+                {
+                    "name": tool_name,
+                    "arguments": parse_json(tool_input),
+                }
+            ),
+        )
         _set_if_missing(attrs, SpanAttributes.TRACELOOP_ENTITY_OUTPUT, tool_output)
 
     if log_type == LOG_TYPE_CHAT:
+        entity_name = "pydantic_ai.chat"
+        _set_if_missing(attrs, SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
+        _set_if_missing(
+            attrs,
+            SpanAttributes.TRACELOOP_ENTITY_PATH,
+            _entity_path(span, entity_name),
+        )
         _set_if_missing(
             attrs,
             SpanAttributes.LLM_REQUEST_TYPE,
@@ -615,25 +773,46 @@ def enrich_pydantic_ai_span(
             _set_if_missing(
                 attrs,
                 SpanAttributes.TRACELOOP_ENTITY_INPUT,
-                json.dumps(input_messages, default=str),
+                json_string(input_messages),
             )
             _set_message_attrs(attrs, SpanAttributes.LLM_PROMPTS, input_messages)
         if output_messages is not None:
             _set_if_missing(
                 attrs,
                 SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                json.dumps(_chat_output_value(output_messages), default=str),
+                json_string(_chat_output_value(output_messages)),
             )
             _set_message_attrs(attrs, SpanAttributes.LLM_COMPLETIONS, output_messages)
 
     if log_type == LOG_TYPE_AGENT and agent_name is not None:
         _set_if_missing(attrs, SpanAttributes.TRACELOOP_ENTITY_NAME, agent_name)
-        _set_if_missing(attrs, SpanAttributes.TRACELOOP_ENTITY_PATH, agent_name)
+        _set_if_missing(
+            attrs,
+            SpanAttributes.TRACELOOP_ENTITY_PATH,
+            _entity_path(span, agent_name),
+        )
         _set_if_missing(attrs, SpanAttributes.TRACELOOP_WORKFLOW_NAME, agent_name)
+        agent_input, agent_output = _agent_content(attrs)
+        if agent_input is not None:
+            _set_if_missing(
+                attrs,
+                SpanAttributes.TRACELOOP_ENTITY_INPUT,
+                json_string(agent_input),
+            )
+        if agent_output is not None:
+            _set_if_missing(
+                attrs,
+                SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
+                json_string(agent_output),
+            )
 
     if log_type == LOG_TYPE_TASK and span.name == PYDANTIC_AI_RUNNING_TOOLS_SPAN_NAME:
         _set_if_missing(attrs, SpanAttributes.TRACELOOP_ENTITY_NAME, "running_tools")
-        _set_if_missing(attrs, SpanAttributes.TRACELOOP_ENTITY_PATH, "running_tools")
+        _set_if_missing(
+            attrs,
+            SpanAttributes.TRACELOOP_ENTITY_PATH,
+            _entity_path(span, "running_tools"),
+        )
 
     span._attributes = {
         key: _coerce_otel_attribute_value(value)
@@ -655,9 +834,8 @@ class PydanticAISpanProcessor(SpanProcessor):
         attrs = dict(getattr(span, "_attributes", None) or {})
         _enrich_nested_provider_span(span, attrs)
         span._attributes = attrs
-        if (
-            not is_pydantic_ai_span(span, attrs)
-            and _span_has_raw_usage_attributes(attrs)
+        if not is_pydantic_ai_span(span, attrs) and _span_has_raw_usage_attributes(
+            attrs
         ):
             parent_span_key = _get_parent_span_key(span)
             if parent_span_key is not None:

--- a/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/src/respan_instrumentation_pydantic_ai/_serialization.py
@@ -1,0 +1,212 @@
+"""Bounded, privacy-safe serialization for Pydantic AI span attributes."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from typing import Any
+
+MAX_ATTRIBUTE_BYTES = 16_000
+MAX_COLLECTION_ITEMS = 50
+MAX_DEPTH = 8
+MAX_STRING_BYTES = 8_000
+REDACTED = "[REDACTED]"
+
+_SENSITIVE_KEYS = {
+    "apikey",
+    "authorization",
+    "authtoken",
+    "clientsecret",
+    "cookie",
+    "credential",
+    "credentials",
+    "password",
+    "passwd",
+    "privatekey",
+    "refreshtoken",
+    "secret",
+    "sessioncookie",
+    "sessiontoken",
+    "token",
+}
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b"),
+)
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)([\"']?(?:api[_-]?key|authorization|password|secret|session[_-]?token|token)[\"']?)"
+    r"(\s*[:=]\s*)([\"']?)([^\s,;}\"']+)([\"']?)"
+)
+
+
+def _truncate_utf8(value: str, limit: int = MAX_STRING_BYTES) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit:
+        return value
+    suffix = "...[truncated]"
+    budget = max(0, limit - len(suffix.encode("utf-8")))
+    return f"{encoded[:budget].decode('utf-8', errors='ignore')}{suffix}"
+
+
+def safe_text(value: Any, *, default: str = "") -> str:
+    """Render a safe scalar without calling arbitrary ``str`` or ``repr`` hooks."""
+    if isinstance(value, str):
+        text = value
+        for pattern in _SECRET_PATTERNS:
+            text = pattern.sub(REDACTED, text)
+        text = _SECRET_ASSIGNMENT.sub(
+            lambda match: (
+                f"{match.group(1)}{match.group(2)}{match.group(3)}"
+                f"{REDACTED}{match.group(5)}"
+            ),
+            text,
+        )
+        return _truncate_utf8(text)
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and math.isfinite(value):
+        return str(value)
+    return f"<{type(value).__name__}>"
+
+
+def is_sensitive_key(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    normalized = re.sub(r"[^a-z0-9]", "", key.lower())
+    return normalized in _SENSITIVE_KEYS or normalized.endswith(
+        ("apikey", "password", "secret", "token")
+    )
+
+
+def _key_text(key: Any) -> str:
+    if isinstance(key, str):
+        return safe_text(key)[:256]
+    if key is None or isinstance(key, bool | int):
+        return safe_text(key)[:256]
+    if isinstance(key, float) and math.isfinite(key):
+        return safe_text(key)[:256]
+    return f"<{type(key).__name__}>"
+
+
+def json_value(
+    value: Any,
+    *,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> Any:
+    """Convert untrusted SDK data to bounded JSON without arbitrary conversions."""
+    if value is None or isinstance(value, bool | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return safe_text(value)
+    if isinstance(value, bytes | bytearray | memoryview):
+        return {"length": len(value), "type": type(value).__name__}
+    if depth >= MAX_DEPTH:
+        return {"truncated": "max_depth", "type": type(value).__name__}
+
+    active = seen if seen is not None else set()
+    identity = id(value)
+    if identity in active:
+        return "<cycle>"
+    active.add(identity)
+    try:
+        if isinstance(value, Mapping):
+            result: dict[str, Any] = {}
+            items = list(islice(value.items(), MAX_COLLECTION_ITEMS + 1))
+            for key, item in items[:MAX_COLLECTION_ITEMS]:
+                rendered_key = _key_text(key)
+                result[rendered_key] = (
+                    REDACTED
+                    if is_sensitive_key(key)
+                    else json_value(item, depth=depth + 1, seen=active)
+                )
+            if len(items) > MAX_COLLECTION_ITEMS:
+                result["__truncated_items__"] = True
+            return result
+
+        if isinstance(value, Sequence) and not isinstance(
+            value, str | bytes | bytearray
+        ):
+            items = list(islice(iter(value), MAX_COLLECTION_ITEMS + 1))
+            result = [
+                json_value(item, depth=depth + 1, seen=active)
+                for item in items[:MAX_COLLECTION_ITEMS]
+            ]
+            if len(items) > MAX_COLLECTION_ITEMS:
+                result.append({"__truncated_items__": True})
+            return result
+
+        for method_name in ("model_dump", "to_dict", "dict"):
+            try:
+                method = getattr(value, method_name, None)
+            except Exception:  # noqa: BLE001 - hostile SDK objects are summarized.
+                method = None
+            if not callable(method):
+                continue
+            try:
+                converted = method()
+            except Exception:  # noqa: BLE001,S112 - vendor conversion hooks are untrusted.
+                continue
+            if isinstance(converted, Mapping):
+                return json_value(converted, depth=depth + 1, seen=active)
+
+        return {"type": type(value).__name__}
+    except Exception:  # noqa: BLE001 - serialization must never break the SDK call.
+        return {"type": type(value).__name__, "unserializable": True}
+    finally:
+        active.discard(identity)
+
+
+def json_string(value: Any) -> str:
+    """Return valid JSON whose UTF-8 representation fits the attribute budget."""
+    normalized = json_value(value)
+    encoded = json.dumps(
+        normalized,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    encoded_bytes = len(encoded.encode("utf-8"))
+    if encoded_bytes <= MAX_ATTRIBUTE_BYTES:
+        return encoded
+
+    low = 0
+    high = min(len(encoded), MAX_ATTRIBUTE_BYTES)
+    result = ""
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = json.dumps(
+            {
+                "original_bytes": encoded_bytes,
+                "preview": encoded[:midpoint],
+                "truncated": True,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(candidate.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES:
+            result = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return result
+
+
+def parse_json(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return value

--- a/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pydantic-ai/tests/test_instrumentation.py
@@ -3,14 +3,28 @@ import json
 import logging
 import sys
 from types import ModuleType, SimpleNamespace
+from typing import ClassVar
 
+import pytest
 from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from opentelemetry.semconv_ai import SpanAttributes
-
-from respan_instrumentation_pydantic_ai import PydanticAIInstrumentor, _processor
+from respan_instrumentation_pydantic_ai import (
+    PydanticAIInstrumentor,
+    _instrumentation,
+    _processor,
+)
 from respan_instrumentation_pydantic_ai._processor import (
     PydanticAISpanProcessor,
     enrich_pydantic_ai_span,
+)
+from respan_instrumentation_pydantic_ai._serialization import (
+    MAX_ATTRIBUTE_BYTES,
+    json_string,
 )
 
 _BANNED_ALIASES = {
@@ -31,6 +45,27 @@ _BANNED_ALIASES = {
     "has_tool_calls",
     "parallel_tool_calls",
 }
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_lifecycle():
+    PydanticAIInstrumentor._shared_processor = None
+    PydanticAIInstrumentor._shared_provider = None
+    PydanticAIInstrumentor._processor_refcount = 0
+    PydanticAIInstrumentor._global_refcount = 0
+    PydanticAIInstrumentor._global_config = None
+    PydanticAIInstrumentor._global_agent_class = None
+    PydanticAIInstrumentor._global_previous = _instrumentation._UNSET
+    PydanticAIInstrumentor._specific_agents = {}
+    yield
+    PydanticAIInstrumentor._shared_processor = None
+    PydanticAIInstrumentor._shared_provider = None
+    PydanticAIInstrumentor._processor_refcount = 0
+    PydanticAIInstrumentor._global_refcount = 0
+    PydanticAIInstrumentor._global_config = None
+    PydanticAIInstrumentor._global_agent_class = None
+    PydanticAIInstrumentor._global_previous = _instrumentation._UNSET
+    PydanticAIInstrumentor._specific_agents = {}
 
 
 def _assert_otel_safe_attrs(attrs):
@@ -63,7 +98,7 @@ def _install_fake_modules(monkeypatch):
 
     class FakeAgent:
         _instrument_default = "existing-default"
-        instrument_all_calls = []
+        instrument_all_calls: ClassVar[list[object]] = []
 
         @classmethod
         def instrument_all(cls, instrument):
@@ -168,18 +203,23 @@ def test_enrich_pydantic_ai_tool_span_maps_tool_fields():
     assert span._attributes["respan.entity.log_type"] == "tool"
     assert span._attributes["respan.entity.log_method"] == "tracing_integration"
     assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "add"
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == "add"
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] == '{"a":1,"b":2}'
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == "3"
-    assert span._attributes[SpanAttributes.LLM_REQUEST_MODEL] == "gpt-4o-mini"
-    assert span._attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 11
-    assert span._attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 7
-    assert span._attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 18
+    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+    assert json.loads(span._attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "name": "add",
+        "arguments": {"a": 1, "b": 2},
+    }
+    assert json.loads(span._attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == 3
+    assert SpanAttributes.LLM_REQUEST_MODEL not in span._attributes
+    assert SpanAttributes.LLM_USAGE_PROMPT_TOKENS not in span._attributes
+    assert SpanAttributes.LLM_USAGE_COMPLETION_TOKENS not in span._attributes
+    assert SpanAttributes.LLM_USAGE_TOTAL_TOKENS not in span._attributes
+    assert "gen_ai.usage.input_tokens" not in span._attributes
+    assert "gen_ai.usage.output_tokens" not in span._attributes
     assert "gen_ai.tool.name" not in span._attributes
     _assert_no_banned_aliases(span._attributes)
 
 
-def test_enrich_pydantic_ai_agent_span_sets_workflow_name_and_response_format():
+def test_enrich_pydantic_ai_agent_span_stays_common_only():
     span = SimpleNamespace(
         name="invoke_agent weather",
         _attributes={
@@ -209,26 +249,11 @@ def test_enrich_pydantic_ai_agent_span_sets_workflow_name_and_response_format():
 
     assert span._attributes["respan.entity.log_type"] == "agent"
     assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "weather"
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == "weather"
+    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
     assert span._attributes[SpanAttributes.TRACELOOP_WORKFLOW_NAME] == "weather"
-    assert span._attributes[SpanAttributes.LLM_REQUEST_MODEL] == "gpt-4o-mini"
-    assert json.loads(span._attributes[SpanAttributes.LLM_REQUEST_FUNCTIONS]) == [
-        {
-            "type": "function",
-            "function": {
-                "name": "lookup_weather",
-                "description": "Look up the weather.",
-                "parameters": {"type": "object"},
-            },
-        }
-    ]
-    assert json.loads(span._attributes["response_format"]) == {
-        "type": "json_schema",
-        "json_schema": {
-            "schema": {"type": "object"},
-            "name": "WeatherAnswer",
-        },
-    }
+    assert SpanAttributes.LLM_REQUEST_MODEL not in span._attributes
+    assert SpanAttributes.LLM_REQUEST_FUNCTIONS not in span._attributes
+    assert "response_format" not in span._attributes
     assert "gen_ai.agent.name" not in span._attributes
     _assert_no_banned_aliases(span._attributes)
 
@@ -248,12 +273,13 @@ def test_enrich_pydantic_ai_chat_span_maps_messages():
 
     assert span._attributes["respan.entity.log_type"] == "chat"
     assert span._attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] == (
-        '[{"role": "user", "content": "hi"}]'
-    )
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == (
-        '{"role": "assistant", "content": "hello"}'
-    )
+    assert json.loads(span._attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == [
+        {"role": "user", "content": "hi"}
+    ]
+    assert json.loads(span._attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "role": "assistant",
+        "content": "hello",
+    }
     assert span._attributes[f"{SpanAttributes.LLM_PROMPTS}.0.role"] == "user"
     assert span._attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"] == "hi"
     assert span._attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.role"] == "assistant"
@@ -322,9 +348,7 @@ def test_enrich_pydantic_ai_chat_span_flattens_structured_message_parts():
     assert span._attributes[f"{SpanAttributes.LLM_PROMPTS}.1.content"] == (
         "What is the capital of France?"
     )
-    assert span._attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.role"] == (
-        "assistant"
-    )
+    assert span._attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.role"] == ("assistant")
     assert span._attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
         "The capital of France is Paris."
     )
@@ -347,12 +371,13 @@ def test_enrich_pydantic_ai_response_operation_maps_as_chat_span():
 
     assert span._attributes["respan.entity.log_type"] == "chat"
     assert span._attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] == (
-        '[{"role": "user", "content": "hi"}]'
-    )
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == (
-        '{"role": "assistant", "content": "hello"}'
-    )
+    assert json.loads(span._attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == [
+        {"role": "user", "content": "hi"}
+    ]
+    assert json.loads(span._attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
+        "role": "assistant",
+        "content": "hello",
+    }
     _assert_no_banned_aliases(span._attributes)
 
 
@@ -369,7 +394,7 @@ def test_enrich_pydantic_ai_running_tools_span_maps_task_fields():
 
     assert span._attributes["respan.entity.log_type"] == "task"
     assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "running_tools"
-    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == "running_tools"
+    assert span._attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
     _assert_no_banned_aliases(span._attributes)
 
 
@@ -399,3 +424,151 @@ def test_activate_logs_warning_when_dependencies_are_missing(monkeypatch, caplog
         instrumentor.activate()
 
     assert "Failed to activate PydanticAI instrumentation" in caplog.text
+
+
+def test_global_lifecycle_is_shared_and_config_mismatch_is_rejected(monkeypatch):
+    tracer_provider = _make_fake_tracer_provider()
+    tracer_provider._active_span_processor._span_processors = ("exporter",)
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: tracer_provider)
+    fake = _install_fake_modules(monkeypatch)
+    first = PydanticAIInstrumentor()
+    second = PydanticAIInstrumentor()
+
+    first.activate()
+    second.activate()
+    assert len(fake.agent_class.instrument_all_calls) == 1
+    processors = tracer_provider._active_span_processor._span_processors
+    assert isinstance(processors[0], PydanticAISpanProcessor)
+    assert processors[1:] == ("exporter",)
+
+    mismatch = PydanticAIInstrumentor(include_content=False)
+    with pytest.raises(ValueError, match="same content and version"):
+        mismatch.activate()
+
+    first.deactivate()
+    assert (
+        fake.agent_class._instrument_default is fake.agent_class.instrument_all_calls[0]
+    )
+    second.deactivate()
+    assert fake.agent_class._instrument_default == "existing-default"
+    assert tracer_provider._active_span_processor._span_processors == ("exporter",)
+
+
+def test_serializer_is_bounded_redacting_and_never_calls_hostile_string_hooks():
+    class Hostile:
+        def __str__(self):
+            raise AssertionError("hostile __str__ called")
+
+        def __repr__(self):
+            raise AssertionError("hostile __repr__ called")
+
+    encoded = json_string(
+        {
+            "api_key": "plain-secret",
+            "nested": {"client_secret": "also-secret"},
+            "hostile": Hostile(),
+            "unicode": "😀" * 10_000,
+        }
+    )
+    assert len(encoded.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES
+    assert "plain-secret" not in encoded
+    assert "also-secret" not in encoded
+    assert json.loads(encoded)
+
+
+def test_real_pydantic_ai_tool_round_exports_canonical_connected_spans(monkeypatch):
+    from pydantic_ai import Agent
+    from pydantic_ai.models.test import TestModel
+
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: tracer_provider)
+    instrumentor = PydanticAIInstrumentor()
+    instrumentor.activate()
+
+    agent = Agent(TestModel(), name="calculator", instructions="Use the add tool.")
+
+    @agent.tool_plain
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    result = agent.run_sync("Use add for 15 plus 27.")
+    assert result.output == '{"add":0}'
+    assert tracer_provider.force_flush()
+
+    spans = list(exporter.get_finished_spans())
+    assert len(spans) == 4
+    assert len({span.context.span_id for span in spans}) == 4
+    agent_span = next(span for span in spans if span.name == "invoke_agent calculator")
+    chats = [span for span in spans if span.name == "chat test"]
+    tool_span = next(span for span in spans if span.name == "execute_tool add")
+    assert len(chats) == 2
+    assert all(span.parent.span_id == agent_span.context.span_id for span in chats)
+    assert tool_span.parent.span_id == agent_span.context.span_id
+
+    agent_attrs = agent_span.attributes
+    assert agent_attrs["respan.entity.log_type"] == "agent"
+    assert agent_attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+    assert json.loads(agent_attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT])[0] == {
+        "content": "Use add for 15 plus 27.",
+        "role": "user",
+    }
+    assert json.loads(agent_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {"add": 0}
+    assert SpanAttributes.LLM_REQUEST_MODEL not in agent_attrs
+    assert SpanAttributes.LLM_USAGE_TOTAL_TOKENS not in agent_attrs
+
+    first_chat, second_chat = sorted(chats, key=lambda span: span.start_time)
+    first_attrs = first_chat.attributes
+    first_calls = json.loads(
+        first_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]
+    )
+    assert first_calls == [
+        {
+            "function": {
+                "arguments": '{"a":0,"b":0}',
+                "name": "add",
+            },
+            "id": "pyd_ai_tool_call_id__add",
+            "type": "function",
+        }
+    ]
+    assert (
+        json.loads(first_attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"][
+            "name"
+        ]
+        == "add"
+    )
+    assert first_attrs["gen_ai.usage.input_tokens"] > 0
+    assert first_attrs["gen_ai.usage.output_tokens"] > 0
+    assert (
+        first_attrs["gen_ai.usage.input_tokens"]
+        == first_attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS]
+    )
+    assert (
+        first_attrs["gen_ai.usage.output_tokens"]
+        == first_attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS]
+    )
+
+    second_attrs = second_chat.attributes
+    assert second_attrs[f"{SpanAttributes.LLM_PROMPTS}.1.role"] == "assistant"
+    assert (
+        json.loads(second_attrs[f"{SpanAttributes.LLM_PROMPTS}.1.tool_calls"])
+        == first_calls
+    )
+    assert second_attrs[f"{SpanAttributes.LLM_PROMPTS}.2.role"] == "tool"
+    assert json.loads(second_attrs[f"{SpanAttributes.LLM_PROMPTS}.2.content"]) == {
+        "name": "add",
+        "result": 0,
+        "tool_call_id": "pyd_ai_tool_call_id__add",
+    }
+    assert json.loads(tool_span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == {
+        "arguments": {"a": 0, "b": 0},
+        "name": "add",
+    }
+    _assert_no_banned_aliases(agent_attrs)
+    for span in (*chats, tool_span):
+        _assert_no_banned_aliases(span.attributes)
+
+    instrumentor.deactivate()
+    tracer_provider.shutdown()

--- a/python-sdks/instrumentations/respan-instrumentation-pytest/src/respan_instrumentation_pytest/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pytest/src/respan_instrumentation_pytest/_constants.py
@@ -2,7 +2,6 @@
 
 from respan_sdk.constants.llm_logging import LOG_TYPE_TASK, LOG_TYPE_WORKFLOW
 
-
 PYTEST_INSTRUMENTATION_NAME = "pytest"
 PYTEST_RUNTIME_PLUGIN_NAME = "respan-pytest-runtime"
 

--- a/python-sdks/instrumentations/respan-instrumentation-pytest/src/respan_instrumentation_pytest/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pytest/src/respan_instrumentation_pytest/_instrumentation.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from collections import Counter
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -15,14 +13,6 @@ from uuid import uuid4
 from opentelemetry import trace
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import SpanKind
-from respan_instrumentation_pytest._constants import (
-    ENV_EXAMPLE_RUN_ID,
-    MAX_ATTRIBUTE_CHARS,
-    MAX_COLLECTION_ITEMS,
-    MAX_SERIALIZATION_DEPTH,
-    PYTEST_INSTRUMENTATION_NAME,
-    WORKFLOW_LOG_TYPE,
-)
 from respan_sdk.constants.span_attributes import (
     RESPAN_LOG_TYPE,
     RESPAN_METADATA,
@@ -31,63 +21,32 @@ from respan_sdk.constants.span_attributes import (
 )
 from respan_tracing import RespanTelemetry
 from respan_tracing.core.tracer import RespanTracer
+from respan_tracing.exporters import propagate_attributes
+
+from respan_instrumentation_pytest._constants import (
+    ENV_EXAMPLE_RUN_ID,
+    MAX_ATTRIBUTE_CHARS,
+    PYTEST_INSTRUMENTATION_NAME,
+    WORKFLOW_LOG_TYPE,
+)
+from respan_instrumentation_pytest._serialization import (
+    json_dumps as _json_dumps,
+)
+from respan_instrumentation_pytest._serialization import (
+    safe_text,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _to_jsonable(value: Any, *, depth: int = 0) -> Any:
-    if depth > MAX_SERIALIZATION_DEPTH:
-        return repr(value)
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, bytes):
-        return {"type": "bytes", "length": len(value)}
-    if isinstance(value, Path):
-        return str(value)
-    if isinstance(value, Mapping):
-        items = list(value.items())
-        payload = {
-            str(key): _to_jsonable(item, depth=depth + 1)
-            for key, item in items[:MAX_COLLECTION_ITEMS]
-        }
-        if len(items) > MAX_COLLECTION_ITEMS:
-            payload["_respan_truncated_items"] = len(items) - MAX_COLLECTION_ITEMS
-        return payload
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        items = list(value)
-        payload = [
-            _to_jsonable(item, depth=depth + 1) for item in items[:MAX_COLLECTION_ITEMS]
-        ]
-        if len(items) > MAX_COLLECTION_ITEMS:
-            payload.append(
-                {"_respan_truncated_items": len(items) - MAX_COLLECTION_ITEMS}
-            )
-        return payload
-    return repr(value)
-
-
-def _json_dumps(value: Any, *, max_chars: int = MAX_ATTRIBUTE_CHARS) -> str:
-    serialized = json.dumps(
-        _to_jsonable(value),
-        default=str,
-        ensure_ascii=False,
-        sort_keys=True,
-    )
-    if len(serialized) <= max_chars:
-        return serialized
-    return json.dumps(
-        {
-            "truncated": True,
-            "original_characters": len(serialized),
-            "preview": serialized[:max_chars],
-        },
-        ensure_ascii=False,
-        sort_keys=True,
-    )
-
-
 def _safe_name(value: str) -> str:
-    return "_".join(value.strip().split())[:160] or "pytest_session"
+    return "_".join(safe_text(value).strip().split())[:160] or "pytest_session"
+
+
+def _safe_rootpath(value: Any) -> str:
+    if isinstance(value, Path):
+        return safe_text(value.name or ".")
+    return safe_text(value)
 
 
 @dataclass
@@ -122,6 +81,7 @@ class PytestInstrumentor:
         self._is_instrumented = False
         self._session_span: Any = None
         self._session_context_manager: Any = None
+        self._propagation_context_manager: Any = None
         self._session: Any = None
         self._test_states: dict[str, _TestState] = {}
         self._outcome_counts: Counter[str] = Counter()
@@ -164,11 +124,14 @@ class PytestInstrumentor:
         self._session_context_manager = None
         self._session_span = None
         self._session = None
+        self._exit_propagation()
         if self._telemetry is not None:
             try:
                 self._telemetry.flush()
             except Exception:
                 logger.debug("Failed to flush Pytest telemetry", exc_info=True)
+            RespanTracer.reset_instance()
+            self._telemetry = None
         self._is_instrumented = False
         logger.info("Pytest instrumentation deactivated")
 
@@ -178,16 +141,6 @@ class PytestInstrumentor:
         rootpath = getattr(config, "rootpath", Path.cwd())
         root_name = Path(rootpath).name or "tests"
         return _safe_name(f"pytest_{root_name}_workflow")
-
-    def _metadata(self, *, worker_id: str | None = None) -> str:
-        metadata = {
-            "integration": "pytest",
-            "workflow_name": self._workflow_name,
-            "example_run_id": self._run_id,
-        }
-        if worker_id:
-            metadata["worker_id"] = worker_id
-        return _json_dumps(metadata, max_chars=self._max_attribute_chars)
 
     def _set_common_attributes(
         self,
@@ -204,11 +157,47 @@ class PytestInstrumentor:
         span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_path)
         span.set_attribute(
             SpanAttributes.TRACELOOP_ENTITY_INPUT,
-            _json_dumps(input_payload, max_chars=self._max_attribute_chars),
+            _json_dumps(input_payload, max_bytes=self._max_attribute_chars),
         )
-        if self._workflow_name:
-            span.set_attribute(RESPAN_TRACE_GROUP_ID, self._workflow_name)
-        span.set_attribute(RESPAN_METADATA, self._metadata(worker_id=worker_id))
+        workflow_name = self._workflow_name or "pytest"
+        span.set_attribute(RESPAN_TRACE_GROUP_ID, workflow_name)
+        span.set_attribute(SpanAttributes.TRACELOOP_WORKFLOW_NAME, workflow_name)
+        metadata = self._run_metadata(worker_id)
+        span.set_attribute(
+            RESPAN_METADATA,
+            _json_dumps(metadata, max_bytes=self._max_attribute_chars),
+        )
+        for key, value in metadata.items():
+            span.set_attribute(f"{RESPAN_METADATA}.{key}", safe_text(value))
+
+    def _run_metadata(self, worker_id: str | None = None) -> dict[str, str]:
+        workflow_name = self._workflow_name or "pytest"
+        metadata = {
+            "integration": "pytest",
+            "workflow_name": workflow_name,
+            "example_run_id": self._run_id,
+            "run_id": self._run_id,
+        }
+        if worker_id:
+            metadata["worker_id"] = worker_id
+        return metadata
+
+    def _enter_propagation(self, worker_id: str | None = None) -> None:
+        if self._propagation_context_manager is not None:
+            return
+        self._propagation_context_manager = propagate_attributes(
+            group_identifier=self._workflow_name,
+            metadata=self._run_metadata(worker_id),
+        )
+        self._propagation_context_manager.__enter__()
+
+    def _exit_propagation(self) -> None:
+        if self._propagation_context_manager is None:
+            return
+        try:
+            self._propagation_context_manager.__exit__(None, None, None)
+        finally:
+            self._propagation_context_manager = None
 
     def pytest_sessionstart(self, session: Any) -> None:
         if not self._is_instrumented or self._session_span is not None:
@@ -217,6 +206,7 @@ class PytestInstrumentor:
             self._session = session
             self._workflow_name = self._resolved_workflow_name(session.config)
             worker_id = os.getenv("PYTEST_XDIST_WORKER")
+            self._enter_propagation(worker_id)
             self._session_context_manager = self._tracer.start_as_current_span(
                 "pytest.session", kind=SpanKind.INTERNAL
             )
@@ -227,7 +217,7 @@ class PytestInstrumentor:
                 entity_name=self._workflow_name,
                 entity_path="",
                 input_payload={
-                    "rootpath": str(getattr(session.config, "rootpath", "")),
+                    "rootpath": _safe_rootpath(getattr(session.config, "rootpath", "")),
                     "arguments": (
                         list(getattr(session.config, "args", ()) or ())
                         if self._capture_content
@@ -246,25 +236,28 @@ class PytestInstrumentor:
             logger.exception("Failed to start Pytest session span")
             self._session_context_manager = None
             self._session_span = None
+            self._exit_propagation()
 
     def pytest_collection_finish(self, session: Any) -> None:
         if self._session_span is None:
             return
         items = list(getattr(session, "items", ()) or ())
         payload: dict[str, Any] = {
-            "rootpath": str(getattr(session.config, "rootpath", "")),
+            "rootpath": _safe_rootpath(getattr(session.config, "rootpath", "")),
             "collected": len(items),
             "content_captured": self._capture_content,
         }
         if self._capture_content:
-            payload["tests"] = [getattr(item, "nodeid", str(item)) for item in items]
+            payload["tests"] = [
+                safe_text(getattr(item, "nodeid", None)) for item in items
+            ]
         self._session_span.set_attribute(
             SpanAttributes.TRACELOOP_ENTITY_INPUT,
-            _json_dumps(payload, max_chars=self._max_attribute_chars),
+            _json_dumps(payload, max_bytes=self._max_attribute_chars),
         )
 
     def _test_nodeid(self, item: Any) -> str:
-        nodeid = str(item.nodeid)
+        nodeid = safe_text(getattr(item, "nodeid", None), default="pytest.test")
         return nodeid if self._capture_content else nodeid.split("[", 1)[0]
 
     def _test_input(self, item: Any) -> dict[str, Any]:

--- a/python-sdks/instrumentations/respan-instrumentation-pytest/src/respan_instrumentation_pytest/_runtime.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pytest/src/respan_instrumentation_pytest/_runtime.py
@@ -7,17 +7,30 @@ import os
 from typing import Any
 
 import pytest
+from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import SpanKind, Status, StatusCode
 
 from respan_instrumentation_pytest._constants import TASK_LOG_TYPE
 from respan_instrumentation_pytest._instrumentation import (
     PytestInstrumentor,
-    _TestState,
     _json_dumps,
+    _TestState,
 )
+from respan_instrumentation_pytest._serialization import safe_text
 
 logger = logging.getLogger(__name__)
+
+
+def _exception_message(exception: BaseException) -> str:
+    try:
+        arguments = exception.args
+    except Exception:  # noqa: BLE001 - hostile exception attributes are ignored.
+        arguments = ()
+    for argument in arguments:
+        if isinstance(argument, str | bool | int | float):
+            return safe_text(argument)
+    return type(exception).__name__
 
 
 class PytestRuntimePlugin(PytestInstrumentor):
@@ -87,13 +100,23 @@ class PytestRuntimePlugin(PytestInstrumentor):
                 if isinstance(exception, BaseException):
                     state.error = exception
                     state.error_when = report.when
-                    if isinstance(exception, Exception) and self._capture_content:
-                        state.span.record_exception(exception)
                     message = (
-                        str(exception)
+                        _exception_message(exception)
                         if self._capture_content
                         else type(exception).__name__
                     )
+                    if self._capture_content:
+                        add_event = getattr(state.span, "add_event", None)
+                        if callable(add_event):
+                            add_event(
+                                "exception",
+                                {
+                                    OTelSpanAttributes.EXCEPTION_MESSAGE: message,
+                                    OTelSpanAttributes.EXCEPTION_TYPE: type(
+                                        exception
+                                    ).__name__,
+                                },
+                            )
                 else:
                     state.error_when = report.when
                     message = "Pytest phase failed"
@@ -135,13 +158,13 @@ class PytestRuntimePlugin(PytestInstrumentor):
                 "phase": state.error_when,
             }
             if self._capture_content:
-                error["message"] = str(state.error)
+                error["message"] = _exception_message(state.error)
             output["error"] = error
         if outcome != "failed":
             state.span.set_attribute("status_code", 200)
         state.span.set_attribute(
             SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-            _json_dumps(output, max_chars=self._max_attribute_chars),
+            _json_dumps(output, max_bytes=self._max_attribute_chars),
         )
 
     def _finish_session_span(self, exitstatus: Any) -> None:
@@ -159,7 +182,7 @@ class PytestRuntimePlugin(PytestInstrumentor):
         }
         self._session_span.set_attribute(
             SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-            _json_dumps(output, max_chars=self._max_attribute_chars),
+            _json_dumps(output, max_bytes=self._max_attribute_chars),
         )
         if failed:
             message = f"Pytest exited with status {numeric_status}"
@@ -178,6 +201,7 @@ class PytestRuntimePlugin(PytestInstrumentor):
             self._session_context_manager.__exit__(None, None, None)
             self._session_context_manager = None
             self._session_span = None
+            self._exit_propagation()
             if self._telemetry is not None:
                 try:
                     self._telemetry.flush()

--- a/python-sdks/instrumentations/respan-instrumentation-pytest/src/respan_instrumentation_pytest/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pytest/src/respan_instrumentation_pytest/_serialization.py
@@ -1,0 +1,170 @@
+"""Bounded, privacy-safe JSON helpers for Pytest telemetry."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from pathlib import Path
+from typing import Any
+
+from respan_instrumentation_pytest._constants import (
+    MAX_ATTRIBUTE_CHARS,
+    MAX_COLLECTION_ITEMS,
+    MAX_SERIALIZATION_DEPTH,
+)
+
+REDACTED = "[REDACTED]"
+_MAX_STRING_BYTES = 4_000
+_SENSITIVE_KEY_SUFFIXES = ("apikey", "password", "secret", "token")
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)([\"']?(?:api[_-]?key|authorization|password|secret|session[_-]?token|token)[\"']?)"
+    r"(\s*[:=]\s*)([\"']?)([^\s,;}\"']+)([\"']?)"
+)
+_BEARER_TOKEN = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+")
+
+
+def _truncate_utf8(value: str, limit: int = _MAX_STRING_BYTES) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit:
+        return value
+    suffix = "...[truncated]"
+    budget = max(0, limit - len(suffix.encode("utf-8")))
+    return f"{encoded[:budget].decode('utf-8', errors='ignore')}{suffix}"
+
+
+def safe_text(value: Any, *, default: str = "") -> str:
+    if isinstance(value, str):
+        value = _BEARER_TOKEN.sub(REDACTED, value)
+        value = _SECRET_ASSIGNMENT.sub(
+            lambda match: (
+                f"{match.group(1)}{match.group(2)}{match.group(3)}"
+                f"{REDACTED}{match.group(5)}"
+            ),
+            value,
+        )
+        return _truncate_utf8(value)
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and math.isfinite(value):
+        return str(value)
+    return f"<{type(value).__name__}>"
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    normalized = re.sub(r"[^a-z0-9]", "", key.lower())
+    return normalized in {
+        "authorization",
+        "cookie",
+        "credential",
+        "credentials",
+        "privatekey",
+    } or normalized.endswith(_SENSITIVE_KEY_SUFFIXES)
+
+
+def _key_text(key: Any) -> str:
+    if isinstance(key, str):
+        return safe_text(key)[:256]
+    if key is None or isinstance(key, bool | int):
+        return safe_text(key)[:256]
+    if isinstance(key, float) and math.isfinite(key):
+        return safe_text(key)[:256]
+    return f"<{type(key).__name__}>"
+
+
+def to_jsonable(
+    value: Any,
+    *,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> Any:
+    if value is None or isinstance(value, bool | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return safe_text(value)
+    if isinstance(value, bytes | bytearray | memoryview):
+        return {"length": len(value), "type": type(value).__name__}
+    if isinstance(value, Path):
+        return safe_text(value.as_posix())
+    if depth >= MAX_SERIALIZATION_DEPTH:
+        return {"truncated": "max_depth", "type": type(value).__name__}
+
+    active = seen if seen is not None else set()
+    identity = id(value)
+    if identity in active:
+        return "<cycle>"
+    active.add(identity)
+    try:
+        if isinstance(value, Mapping):
+            result: dict[str, Any] = {}
+            items = list(islice(value.items(), MAX_COLLECTION_ITEMS + 1))
+            for key, item in items[:MAX_COLLECTION_ITEMS]:
+                key_text = _key_text(key)
+                result[key_text] = (
+                    REDACTED
+                    if _is_sensitive_key(key)
+                    else to_jsonable(item, depth=depth + 1, seen=active)
+                )
+            if len(items) > MAX_COLLECTION_ITEMS:
+                result["__truncated_items__"] = True
+            return result
+        if isinstance(value, Sequence) and not isinstance(
+            value, str | bytes | bytearray
+        ):
+            items = list(islice(iter(value), MAX_COLLECTION_ITEMS + 1))
+            result = [
+                to_jsonable(item, depth=depth + 1, seen=active)
+                for item in items[:MAX_COLLECTION_ITEMS]
+            ]
+            if len(items) > MAX_COLLECTION_ITEMS:
+                result.append({"__truncated_items__": True})
+            return result
+        return {"type": type(value).__name__}
+    except Exception:  # noqa: BLE001 - hostile test parameters must not break Pytest.
+        return {"type": type(value).__name__, "unserializable": True}
+    finally:
+        active.discard(identity)
+
+
+def json_dumps(value: Any, *, max_bytes: int = MAX_ATTRIBUTE_CHARS) -> str:
+    encoded = json.dumps(
+        to_jsonable(value),
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    encoded_bytes = len(encoded.encode("utf-8"))
+    if encoded_bytes <= max_bytes:
+        return encoded
+    low = 0
+    high = min(len(encoded), max_bytes)
+    result = ""
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = json.dumps(
+            {
+                "original_bytes": encoded_bytes,
+                "preview": encoded[:midpoint],
+                "truncated": True,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(candidate.encode("utf-8")) <= max_bytes:
+            result = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return result

--- a/python-sdks/instrumentations/respan-instrumentation-pytest/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-pytest/tests/test_instrumentation.py
@@ -1,12 +1,23 @@
+import json
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import StatusCode
-
 from respan_instrumentation_pytest._runtime import PytestRuntimePlugin
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_instrumentation_pytest._serialization import json_dumps
+from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_TYPE,
+    RESPAN_METADATA,
+    RESPAN_TRACE_GROUP_ID,
+)
+from respan_tracing.utils.span_factory import read_propagated_attributes
 
 
 class FakeSpan:
@@ -15,6 +26,7 @@ class FakeSpan:
         self.attributes = {}
         self.status = None
         self.exceptions = []
+        self.events = []
         self.ended = False
 
     def set_attribute(self, key, value):
@@ -25,6 +37,9 @@ class FakeSpan:
 
     def record_exception(self, exc):
         self.exceptions.append(exc)
+
+    def add_event(self, name, attributes=None):
+        self.events.append((name, attributes or {}))
 
 
 class FakeTracer:
@@ -98,6 +113,10 @@ def assert_contract(attrs, log_type):
     assert SpanAttributes.TRACELOOP_ENTITY_PATH in attrs
     assert SpanAttributes.TRACELOOP_ENTITY_INPUT in attrs
     assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT in attrs
+    assert attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME]
+    assert attrs[RESPAN_TRACE_GROUP_ID]
+    assert attrs[f"{RESPAN_METADATA}.integration"] == "pytest"
+    assert attrs[f"{RESPAN_METADATA}.example_run_id"]
     for banned in (
         "tools",
         "tool_calls",
@@ -121,6 +140,15 @@ def test_session_and_passing_test_emit_contract_spans():
     plugin.activate()
     session = make_session()
     plugin.pytest_sessionstart(session)
+    propagated = read_propagated_attributes()
+    assert propagated[f"{RESPAN_METADATA}.example_run_id"]
+    assert (
+        propagated[f"{RESPAN_METADATA}.run_id"]
+        == propagated[f"{RESPAN_METADATA}.example_run_id"]
+    )
+    assert propagated[f"{RESPAN_METADATA}.workflow_name"] == (
+        "checkout_pytest_workflow"
+    )
     item = make_item()
     protocol = plugin.pytest_runtest_protocol(item, None)
     next(protocol)
@@ -135,12 +163,16 @@ def test_session_and_passing_test_emit_contract_spans():
     assert_contract(test_span.attributes, "task")
     assert test_span.attributes["status_code"] == 200
     assert (
-        '"outcome": "passed"'
-        in test_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+        json.loads(test_span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])[
+            "outcome"
+        ]
+        == "passed"
     )
     assert (
-        '"currency": "usd"'
-        in test_span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+        json.loads(test_span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])[
+            "parameters"
+        ]["currency"]
+        == "usd"
     )
     assert session_span.ended and test_span.ended
 
@@ -170,8 +202,15 @@ def test_failure_records_status_error_and_phase():
     assert span.status.status_code is StatusCode.ERROR
     assert span.attributes["status_code"] == 500
     assert span.attributes["error.message"] == "expected 42, got 41"
-    assert '"phase": "call"' in span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    assert (
+        json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])["error"][
+            "phase"
+        ]
+        == "call"
+    )
+    assert span.events[0][0] == "exception"
     plugin.pytest_sessionfinish(session, 1)
+    assert read_propagated_attributes() == {}
     assert tracer.spans[0].status.status_code is StatusCode.ERROR
 
 
@@ -212,3 +251,84 @@ def test_lifecycle_is_idempotent():
     plugin.deactivate()
     plugin.deactivate()
     assert not plugin._is_instrumented
+
+
+def test_serializer_is_bounded_redacting_and_hostile_safe():
+    class Hostile:
+        def __str__(self):
+            raise AssertionError("hostile __str__ called")
+
+        def __repr__(self):
+            raise AssertionError("hostile __repr__ called")
+
+    encoded = json_dumps(
+        {
+            "api_key": "plain-secret",
+            "nested": {"session_token": "nested-secret"},
+            "hostile": Hostile(),
+            "unicode": "😀" * 10_000,
+        }
+    )
+    assert len(encoded.encode("utf-8")) <= 16_000
+    assert "plain-secret" not in encoded
+    assert "nested-secret" not in encoded
+    assert json.loads(encoded)
+
+
+def test_real_otel_export_preserves_metadata_grouping_parentage_and_failure():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    plugin = PytestRuntimePlugin(
+        tracer=provider.get_tracer("pytest-contract"),
+        workflow_name="checkout_pytest_workflow",
+    )
+    plugin.activate()
+    session = make_session()
+    plugin.pytest_sessionstart(session)
+    item = make_item()
+    protocol = plugin.pytest_runtest_protocol(item, None)
+    next(protocol)
+    add_report(plugin, item, when="setup", outcome="passed")
+    add_report(
+        plugin,
+        item,
+        when="call",
+        outcome="failed",
+        exc=AssertionError("expected 42, got 41"),
+    )
+    add_report(plugin, item, when="teardown", outcome="passed")
+    finish_protocol(protocol)
+    plugin.pytest_sessionfinish(session, 1)
+    assert provider.force_flush()
+
+    spans = list(exporter.get_finished_spans())
+    assert [span.name for span in spans] == ["pytest.test", "pytest.session"]
+    test_span, session_span = spans
+    assert test_span.parent.span_id == session_span.context.span_id
+    assert test_span.context.trace_id == session_span.context.trace_id
+    assert session_span.parent is None
+    assert (
+        json.loads(session_span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])[
+            "rootpath"
+        ]
+        == "demo-suite"
+    )
+    assert len({span.context.span_id for span in spans}) == 2
+    for span in spans:
+        attrs = span.attributes
+        assert attrs[f"{RESPAN_METADATA}.integration"] == "pytest"
+        assert attrs[f"{RESPAN_METADATA}.workflow_name"] == ("checkout_pytest_workflow")
+        assert attrs[f"{RESPAN_METADATA}.example_run_id"]
+        assert (
+            attrs[f"{RESPAN_METADATA}.run_id"]
+            == attrs[f"{RESPAN_METADATA}.example_run_id"]
+        )
+        assert attrs[RESPAN_TRACE_GROUP_ID] == "checkout_pytest_workflow"
+        assert attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] == (
+            "checkout_pytest_workflow"
+        )
+        assert span.status.status_code is StatusCode.ERROR
+    assert test_span.events[0].name == "exception"
+    assert test_span.events[0].attributes["exception.type"] == "AssertionError"
+    provider.shutdown()

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_constants.py
@@ -1,6 +1,7 @@
 """Qdrant SDK-specific instrumentation constants."""
 
 QDRANT_INSTRUMENTATION_NAME = "qdrant"
+QDRANT_INSTRUMENTATION_VERSION = "0.1.0"
 
 # Public operations that issue work against Qdrant. Local model-selection and
 # introspection helpers are intentionally excluded because they do not perform
@@ -69,6 +70,8 @@ QDRANT_OPERATIONS = (
 
 MAX_ATTRIBUTE_CHARS = 16_000
 MAX_PREVIEW_ITEMS = 64
+MAX_SERIALIZATION_DEPTH = 8
+MAX_STRING_BYTES = 4_000
 SENSITIVE_KEY_PARTS = (
     "api_key",
     "authorization",

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_instrumentation.py
@@ -4,153 +4,41 @@ from __future__ import annotations
 
 import importlib
 import inspect
-import json
 import logging
-from collections.abc import Mapping, Sequence
 from contextvars import ContextVar
-from dataclasses import asdict, is_dataclass
-from enum import Enum
-from numbers import Real
-from typing import Any
+from dataclasses import dataclass
+from threading import RLock
+from typing import Any, ClassVar
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import SpanKind, Status, StatusCode
-from respan_instrumentation_qdrant._constants import (
-    MAX_ATTRIBUTE_CHARS,
-    MAX_PREVIEW_ITEMS,
-    QDRANT_INSTRUMENTATION_NAME,
-    QDRANT_OPERATIONS,
-    SENSITIVE_KEY_PARTS,
-)
 from respan_sdk.constants import ERROR_MESSAGE_ATTR
 from respan_sdk.constants.llm_logging import LOG_TYPE_TASK
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
 from respan_tracing.core.tracer import RespanTracer
 from wrapt import wrap_function_wrapper
 
+from respan_instrumentation_qdrant._constants import (
+    QDRANT_INSTRUMENTATION_NAME,
+    QDRANT_INSTRUMENTATION_VERSION,
+    QDRANT_OPERATIONS,
+)
+from respan_instrumentation_qdrant._serialization import (
+    exception_message,
+    json_dumps,
+)
+
 logger = logging.getLogger(__name__)
 
 
-_VECTOR_KEY_PARTS = ("embedding", "vector")
-
-
-def _is_numeric_vector(value: Any) -> bool:
-    return (
-        isinstance(value, Sequence)
-        and not isinstance(value, (str, bytes, bytearray))
-        and bool(value)
-        and all(isinstance(item, Real) and not isinstance(item, bool) for item in value)
-    )
-
-
-def _is_vector_key(value: str) -> bool:
-    normalized = value.lower()
-    return any(part in normalized for part in _VECTOR_KEY_PARTS)
-
-
-def _jsonable(
-    value: Any,
-    *,
-    depth: int = 0,
-    vector_context: bool = False,
-    preserved_vector: list[bool] | None = None,
-) -> Any:
-    preserved_vector = preserved_vector if preserved_vector is not None else [False]
-    if depth > 7 and not (vector_context or _is_numeric_vector(value)):
-        return repr(value)
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, bytes):
-        return {"type": "bytes", "length": len(value)}
-    if isinstance(value, Enum):
-        return _jsonable(
-            value.value,
-            depth=depth + 1,
-            vector_context=vector_context,
-            preserved_vector=preserved_vector,
-        )
-    if is_dataclass(value) and not isinstance(value, type):
-        return _jsonable(
-            asdict(value),
-            depth=depth + 1,
-            vector_context=vector_context,
-            preserved_vector=preserved_vector,
-        )
-    if isinstance(value, Mapping):
-        result: dict[str, Any] = {}
-        omitted = 0
-        regular_items = 0
-        for key, item in value.items():
-            key_text = str(key)
-            item_is_vector = vector_context or _is_vector_key(key_text)
-            if not item_is_vector and regular_items >= MAX_PREVIEW_ITEMS:
-                omitted += 1
-                continue
-            regular_items += int(not item_is_vector)
-            result[key_text] = (
-                "<redacted>"
-                if any(part in key_text.lower() for part in SENSITIVE_KEY_PARTS)
-                else _jsonable(
-                    item,
-                    depth=depth + 1,
-                    vector_context=item_is_vector,
-                    preserved_vector=preserved_vector,
-                )
-            )
-        if omitted:
-            result["__truncated__"] = omitted
-        return result
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        preserve_all = vector_context or _is_numeric_vector(value)
-        if preserve_all:
-            preserved_vector[0] = True
-        source = value if preserve_all else value[:MAX_PREVIEW_ITEMS]
-        items = [
-            _jsonable(
-                item,
-                depth=depth + 1,
-                vector_context=vector_context,
-                preserved_vector=preserved_vector,
-            )
-            for item in source
-        ]
-        if preserve_all:
-            return items
-        if len(value) > MAX_PREVIEW_ITEMS:
-            return {"count": len(value), "items": items, "truncated": True}
-        return items
-    for method_name in ("model_dump", "to_dict", "dict", "tolist"):
-        method = getattr(value, method_name, None)
-        if not callable(method):
-            continue
-        try:
-            return _jsonable(
-                method(),
-                depth=depth + 1,
-                vector_context=vector_context,
-                preserved_vector=preserved_vector,
-            )
-        except Exception:
-            continue
-    return repr(value)
-
-
-def _json_dumps(value: Any) -> str:
-    preserved_vector = [False]
-    text = json.dumps(
-        _jsonable(value, preserved_vector=preserved_vector),
-        default=str,
-        sort_keys=True,
-    )
-    if preserved_vector[0] or len(text) <= MAX_ATTRIBUTE_CHARS:
-        return text
-    return json.dumps(
-        {"preview": text[:MAX_ATTRIBUTE_CHARS], "truncated": True},
-        sort_keys=True,
-    )
+@dataclass(frozen=True)
+class _AppliedPatch:
+    target: Any
+    attribute: str
+    installed_wrapper: Any
 
 
 def _call_input(
@@ -164,19 +52,39 @@ def _call_input(
         arguments = {
             key: value for key, value in bound.arguments.items() if key != "self"
         }
-    except Exception:
-        arguments = {"args": list(args), "kwargs": kwargs}
+    except (TypeError, ValueError):
+        arguments = {"args": args, "kwargs": kwargs}
     return {"operation": operation, **arguments}
+
+
+def _http_status_code(exc: BaseException) -> int | None:
+    candidates: list[Any] = [exc]
+    for name in ("response", "__cause__"):
+        try:
+            candidates.append(getattr(exc, name, None))
+        except Exception:  # noqa: BLE001,S112 - hostile properties are ignored.
+            continue
+    for candidate in candidates:
+        for name in ("status_code", "status"):
+            try:
+                value = getattr(candidate, name, None)
+            except Exception:  # noqa: BLE001,S112 - hostile properties are ignored.
+                continue
+            if isinstance(value, int) and 400 <= value <= 599:
+                return value
+    return None
 
 
 class QdrantInstrumentor:
     """Trace synchronous and asynchronous Qdrant operations as task spans."""
 
-    name = QDRANT_INSTRUMENTATION_NAME
-    _patches_applied = False
-    _activation_count = 0
-    _patched_targets: list[tuple[type, str]] = []
-    _active_call: ContextVar[bool] = ContextVar(
+    name: ClassVar[str] = QDRANT_INSTRUMENTATION_NAME
+    _patches_applied: ClassVar[bool] = False
+    _activation_count: ClassVar[int] = 0
+    _patched_targets: ClassVar[list[_AppliedPatch]] = []
+    _capture_content_config: ClassVar[bool | None] = None
+    _lifecycle_lock: ClassVar[RLock] = RLock()
+    _active_call: ClassVar[ContextVar[bool]] = ContextVar(
         "respan_qdrant_active_call",
         default=False,
     )
@@ -201,24 +109,46 @@ class QdrantInstrumentor:
         entity_name = f"qdrant.{operation}"
         span.set_attribute(RESPAN_LOG_TYPE, LOG_TYPE_TASK)
         span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_name)
+        span.set_attribute(
+            SpanAttributes.TRACELOOP_ENTITY_PATH,
+            "" if getattr(span, "parent", None) is None else entity_name,
+        )
         span.set_attribute(OTelSpanAttributes.DB_SYSTEM, "qdrant")
         span.set_attribute(OTelSpanAttributes.DB_OPERATION, operation)
         if self._capture_content:
             span.set_attribute(
                 SpanAttributes.TRACELOOP_ENTITY_INPUT,
-                _json_dumps(_call_input(operation, wrapped, args, kwargs)),
+                json_dumps(_call_input(operation, wrapped, args, kwargs)),
             )
 
     def _set_error(self, span: Any, exc: Exception) -> None:
-        span.record_exception(exc)
-        span.set_status(Status(StatusCode.ERROR, str(exc)))
-        span.set_attribute("status_code", 500)
-        span.set_attribute(ERROR_MESSAGE_ATTR, str(exc))
+        message = exception_message(exc)
+        exception_type = type(exc).__name__
+        add_event = getattr(span, "add_event", None)
+        if callable(add_event):
+            add_event(
+                "exception",
+                {
+                    OTelSpanAttributes.EXCEPTION_MESSAGE: message,
+                    OTelSpanAttributes.EXCEPTION_TYPE: exception_type,
+                },
+            )
+        status_code = _http_status_code(exc) or 500
+        span.set_status(Status(StatusCode.ERROR, message))
+        span.set_attribute("status_code", status_code)
+        span.set_attribute(ERROR_MESSAGE_ATTR, message)
+        if status_code != 500:
+            span.set_attribute("http.response.status_code", status_code)
         if self._capture_content:
             span.set_attribute(
                 SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                _json_dumps({"error": type(exc).__name__, "message": str(exc)}),
+                json_dumps(
+                    {
+                        "error": exception_type,
+                        "message": message,
+                        "status_code": status_code,
+                    }
+                ),
             )
 
     def _trace_sync(
@@ -233,10 +163,15 @@ class QdrantInstrumentor:
             return wrapped(*args, **kwargs)
         token = active_call.set(True)
         try:
-            tracer = trace.get_tracer(__name__)
+            tracer = trace.get_tracer(
+                QDRANT_INSTRUMENTATION_NAME,
+                QDRANT_INSTRUMENTATION_VERSION,
+            )
             with tracer.start_as_current_span(
                 f"qdrant.{operation}",
                 kind=SpanKind.CLIENT,
+                record_exception=False,
+                set_status_on_exception=False,
             ) as span:
                 self._set_start_attributes(span, operation, wrapped, args, kwargs)
                 try:
@@ -245,10 +180,11 @@ class QdrantInstrumentor:
                     self._set_error(span, exc)
                     raise
                 span.set_status(Status(StatusCode.OK))
+                span.set_attribute("status_code", 200)
                 if self._capture_content:
                     span.set_attribute(
                         SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                        _json_dumps(result),
+                        json_dumps(result),
                     )
                 return result
         finally:
@@ -266,10 +202,15 @@ class QdrantInstrumentor:
             return await wrapped(*args, **kwargs)
         token = active_call.set(True)
         try:
-            tracer = trace.get_tracer(__name__)
+            tracer = trace.get_tracer(
+                QDRANT_INSTRUMENTATION_NAME,
+                QDRANT_INSTRUMENTATION_VERSION,
+            )
             with tracer.start_as_current_span(
                 f"qdrant.{operation}",
                 kind=SpanKind.CLIENT,
+                record_exception=False,
+                set_status_on_exception=False,
             ) as span:
                 self._set_start_attributes(span, operation, wrapped, args, kwargs)
                 try:
@@ -278,95 +219,181 @@ class QdrantInstrumentor:
                     self._set_error(span, exc)
                     raise
                 span.set_status(Status(StatusCode.OK))
+                span.set_attribute("status_code", 200)
                 if self._capture_content:
                     span.set_attribute(
                         SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                        _json_dumps(result),
+                        json_dumps(result),
                     )
                 return result
         finally:
             active_call.reset(token)
 
-    def activate(self) -> None:
-        """Patch supported Qdrant client methods."""
-        cls = type(self)
-        if self._is_instrumented or not self._tracing_enabled():
-            return
-        if cls._patches_applied:
-            cls._activation_count += 1
-            self._is_instrumented = True
-            return
+    @staticmethod
+    def _wrapper_chain_contains(current: Any, expected: Any) -> bool:
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            if current is expected:
+                return True
+            seen.add(id(current))
+            current = getattr(current, "__wrapped__", None)
+        return False
 
-        try:
-            module = importlib.import_module("qdrant_client")
-        except ImportError as exc:
-            logger.warning("Qdrant instrumentation dependency is unavailable: %s", exc)
-            return
-
-        patched_targets: list[tuple[type, str]] = []
-        for class_name in ("QdrantClient", "AsyncQdrantClient"):
-            target_class = getattr(module, class_name, None)
-            if target_class is None:
-                continue
-            for operation in QDRANT_OPERATIONS:
-                original = getattr(target_class, operation, None)
-                if not callable(original):
-                    continue
-                is_async = inspect.iscoroutinefunction(original)
-
-                def traced(
-                    wrapped: Any,
-                    _instance: Any,
-                    args: tuple[Any, ...],
-                    kwargs: dict[str, Any],
-                    *,
-                    _operation: str = operation,
-                    _is_async: bool = is_async,
-                ) -> Any:
-                    if _is_async:
-                        return self._trace_async(_operation, wrapped, args, kwargs)
-                    return self._trace_sync(_operation, wrapped, args, kwargs)
-
-                wrap_function_wrapper(
-                    "qdrant_client",
-                    f"{class_name}.{operation}",
-                    traced,
-                )
-                patched_targets.append((target_class, operation))
-
-        self._is_instrumented = bool(patched_targets)
-        cls._patches_applied = self._is_instrumented
-        cls._activation_count = int(self._is_instrumented)
-        cls._patched_targets = patched_targets
-        if not self._is_instrumented:
-            logger.warning("Qdrant instrumentation found no supported client methods")
-
-    def deactivate(self) -> None:
-        """Remove Qdrant patches after the last active instrumentor stops."""
-        if not self._is_instrumented:
-            return
-        self._is_instrumented = False
-        cls = type(self)
-        cls._activation_count = max(cls._activation_count - 1, 0)
-        if cls._activation_count:
-            return
-        for target_class, operation in reversed(cls._patched_targets):
+    @classmethod
+    def _unwrap_targets(cls, patches: list[_AppliedPatch]) -> list[_AppliedPatch]:
+        retained: list[_AppliedPatch] = []
+        for patch in reversed(patches):
             try:
-                unwrap(target_class, operation)
+                current = inspect.getattr_static(patch.target, patch.attribute)
+                if current is patch.installed_wrapper:
+                    unwrap(patch.target, patch.attribute)
+                    current = inspect.getattr_static(patch.target, patch.attribute)
+                if cls._wrapper_chain_contains(current, patch.installed_wrapper):
+                    retained.append(patch)
             except Exception:
+                retained.append(patch)
                 logger.debug(
                     "Failed to unwrap Qdrant %s.%s",
-                    target_class.__name__,
-                    operation,
+                    getattr(patch.target, "__name__", type(patch.target).__name__),
+                    patch.attribute,
                     exc_info=True,
                 )
-        cls._patched_targets = []
-        cls._patches_applied = False
+        retained.reverse()
+        return retained
+
+    def _patch_targets(self) -> list[_AppliedPatch]:
+        module = importlib.import_module("qdrant_client")
+        patched: list[_AppliedPatch] = []
+        try:
+            for class_name in ("QdrantClient", "AsyncQdrantClient"):
+                target_class = getattr(module, class_name, None)
+                if target_class is None:
+                    continue
+                for operation in QDRANT_OPERATIONS:
+                    original = getattr(target_class, operation, None)
+                    if not callable(original):
+                        continue
+                    is_async = inspect.iscoroutinefunction(original)
+
+                    def traced(
+                        wrapped: Any,
+                        _instance: Any,
+                        args: tuple[Any, ...],
+                        kwargs: dict[str, Any],
+                        *,
+                        _operation: str = operation,
+                        _is_async: bool = is_async,
+                    ) -> Any:
+                        cls = type(self)
+                        if not cls._patches_applied or not cls._activation_count:
+                            return wrapped(*args, **kwargs)
+                        if _is_async:
+                            return self._trace_async(_operation, wrapped, args, kwargs)
+                        return self._trace_sync(_operation, wrapped, args, kwargs)
+
+                    wrap_function_wrapper(
+                        "qdrant_client",
+                        f"{class_name}.{operation}",
+                        traced,
+                    )
+                    patched.append(
+                        _AppliedPatch(
+                            target_class,
+                            operation,
+                            inspect.getattr_static(target_class, operation),
+                        )
+                    )
+        except Exception:
+            type(self)._patched_targets = type(self)._unwrap_targets(patched)
+            raise
+        return patched
+
+    def activate(self) -> None:
+        """Patch supported Qdrant client methods transactionally."""
+        cls = type(self)
+        with cls._lifecycle_lock:
+            if self._is_instrumented or not self._tracing_enabled():
+                return
+            if cls._patches_applied:
+                if cls._capture_content_config != self._capture_content:
+                    raise ValueError(
+                        "all active QdrantInstrumentor instances must use the same "
+                        "capture_content setting"
+                    )
+                cls._activation_count += 1
+                self._is_instrumented = True
+                return
+
+            if cls._patched_targets:
+                retained = [
+                    patch
+                    for patch in cls._patched_targets
+                    if cls._wrapper_chain_contains(
+                        inspect.getattr_static(patch.target, patch.attribute),
+                        patch.installed_wrapper,
+                    )
+                ]
+                if len(retained) == len(cls._patched_targets):
+                    if cls._capture_content_config != self._capture_content:
+                        raise ValueError(
+                            "reactivated Qdrant instrumentation must retain its "
+                            "capture_content setting while foreign wrappers own the chain"
+                        )
+                    cls._patches_applied = True
+                    cls._activation_count = 1
+                    self._is_instrumented = True
+                    return
+                cls._patched_targets = cls._unwrap_targets(cls._patched_targets)
+                if cls._patched_targets:
+                    raise RuntimeError(
+                        "Qdrant instrumentation could not reconcile stale wrappers"
+                    )
+                cls._capture_content_config = None
+
+            try:
+                patched = self._patch_targets()
+            except ImportError as exc:
+                logger.warning(
+                    "Qdrant instrumentation dependency is unavailable: %s", exc
+                )
+                return
+            except Exception:
+                cls._patches_applied = False
+                cls._activation_count = 0
+                cls._capture_content_config = (
+                    self._capture_content if cls._patched_targets else None
+                )
+                raise
+
+            self._is_instrumented = bool(patched)
+            cls._patches_applied = self._is_instrumented
+            cls._activation_count = int(self._is_instrumented)
+            cls._patched_targets = patched
+            cls._capture_content_config = (
+                self._capture_content if self._is_instrumented else None
+            )
+            if not self._is_instrumented:
+                logger.warning(
+                    "Qdrant instrumentation found no supported client methods"
+                )
+
+    def deactivate(self) -> None:
+        """Remove owned Qdrant patches after the final active instance stops."""
+        cls = type(self)
+        with cls._lifecycle_lock:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            cls._activation_count = max(cls._activation_count - 1, 0)
+            if cls._activation_count:
+                return
+            cls._patched_targets = cls._unwrap_targets(cls._patched_targets)
+            cls._patches_applied = False
+            if not cls._patched_targets:
+                cls._capture_content_config = None
 
     def instrument(self) -> None:
-        """OpenTelemetry-style alias for :meth:`activate`."""
         self.activate()
 
     def uninstrument(self) -> None:
-        """OpenTelemetry-style alias for :meth:`deactivate`."""
         self.deactivate()

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/src/respan_instrumentation_qdrant/_serialization.py
@@ -1,0 +1,277 @@
+"""Bounded, privacy-safe serialization for Qdrant calls and results."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import fields, is_dataclass
+from enum import Enum
+from itertools import islice
+from numbers import Integral, Real
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from respan_instrumentation_qdrant._constants import (
+    MAX_ATTRIBUTE_CHARS,
+    MAX_PREVIEW_ITEMS,
+    MAX_SERIALIZATION_DEPTH,
+    MAX_STRING_BYTES,
+    SENSITIVE_KEY_PARTS,
+)
+
+REDACTED = "[REDACTED]"
+_VECTOR_KEY_PARTS = ("embedding", "vector")
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)([\"']?(?:api[_-]?key|authorization|password|secret|session[_-]?token|token)[\"']?)"
+    r"(\s*[:=]\s*)([\"']?)([^\s,;}\"']+)([\"']?)"
+)
+_BEARER_TOKEN = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+")
+_MEMORY_ADDRESS = re.compile(r"(?i)\b0x[0-9a-f]{6,}\b")
+
+
+def _truncate_utf8(value: str, limit: int = MAX_STRING_BYTES) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit:
+        return value
+    suffix = "...[truncated]"
+    budget = max(0, limit - len(suffix.encode("utf-8")))
+    return f"{encoded[:budget].decode('utf-8', errors='ignore')}{suffix}"
+
+
+def _sanitize_url(value: str) -> str:
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "<redacted-endpoint>"
+    if not parsed.scheme or not parsed.netloc:
+        return value
+    hostname = parsed.hostname
+    if not hostname:
+        return "<redacted-endpoint>"
+    netloc = hostname
+    if ":" in hostname and not hostname.startswith("["):
+        netloc = f"[{hostname}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        return "<redacted-endpoint>"
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+
+
+def safe_text(value: Any, *, default: str = "") -> str:
+    if isinstance(value, str):
+        if "://" in value:
+            value = _sanitize_url(value)
+        value = _BEARER_TOKEN.sub(REDACTED, value)
+        value = _SECRET_ASSIGNMENT.sub(
+            lambda match: (
+                f"{match.group(1)}{match.group(2)}{match.group(3)}"
+                f"{REDACTED}{match.group(5)}"
+            ),
+            value,
+        )
+        value = _MEMORY_ADDRESS.sub("0x<redacted>", value)
+        return _truncate_utf8(value)
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, Integral):
+        return str(int(value))
+    if isinstance(value, Real) and math.isfinite(float(value)):
+        return str(float(value))
+    return f"<{type(value).__name__}>"
+
+
+def _key_text(key: Any) -> str:
+    if isinstance(key, Enum):
+        return _key_text(key.value)
+    return safe_text(key)[:256]
+
+
+def _sensitive_key(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    normalized = re.sub(r"[^a-z0-9]", "", key.lower())
+    return any(
+        normalized.endswith(re.sub(r"[^a-z0-9]", "", part.lower()))
+        for part in SENSITIVE_KEY_PARTS
+    )
+
+
+def _vector_key(key: str) -> bool:
+    normalized = key.lower()
+    return any(part in normalized for part in _VECTOR_KEY_PARTS)
+
+
+def _trusted_length(value: Any) -> int | str:
+    if type(value) in {list, tuple, dict, range}:
+        return len(value)
+    return f">{MAX_PREVIEW_ITEMS}"
+
+
+def _is_numeric_vector(value: Any) -> bool:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes | bytearray):
+        return False
+    try:
+        sample = list(islice(iter(value), MAX_PREVIEW_ITEMS + 1))
+    except Exception:  # noqa: BLE001 - hostile sequences become summaries.
+        return False
+    return bool(sample) and all(
+        isinstance(item, Real) and not isinstance(item, bool) for item in sample
+    )
+
+
+def json_value(
+    value: Any,
+    *,
+    depth: int = 0,
+    vector_context: bool = False,
+    seen: set[int] | None = None,
+) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return safe_text(value)
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, Real):
+        number = float(value)
+        return number if math.isfinite(number) else None
+    if isinstance(value, bytes | bytearray | memoryview):
+        return {"length": len(value), "type": type(value).__name__}
+    if isinstance(value, Enum):
+        return json_value(
+            value.value,
+            depth=depth + 1,
+            vector_context=vector_context,
+            seen=seen,
+        )
+    if depth >= MAX_SERIALIZATION_DEPTH:
+        return {"truncated": "max_depth", "type": type(value).__name__}
+
+    active = seen if seen is not None else set()
+    identity = id(value)
+    if identity in active:
+        return "<cycle>"
+    active.add(identity)
+    try:
+        if is_dataclass(value) and not isinstance(value, type):
+            selected = list(islice(fields(value), MAX_PREVIEW_ITEMS + 1))
+            converted = {
+                field.name: getattr(value, field.name)
+                for field in selected[:MAX_PREVIEW_ITEMS]
+            }
+            if len(selected) > MAX_PREVIEW_ITEMS:
+                converted["__truncated_items__"] = True
+            return json_value(converted, depth=depth + 1, seen=active)
+
+        if isinstance(value, Mapping):
+            result: dict[str, Any] = {}
+            items = list(islice(value.items(), MAX_PREVIEW_ITEMS + 1))
+            for key, item in items[:MAX_PREVIEW_ITEMS]:
+                key_text = _key_text(key)
+                result[key_text] = (
+                    REDACTED
+                    if _sensitive_key(key)
+                    else json_value(
+                        item,
+                        depth=depth + 1,
+                        vector_context=vector_context or _vector_key(key_text),
+                        seen=active,
+                    )
+                )
+            if len(items) > MAX_PREVIEW_ITEMS:
+                result["__truncated_items__"] = True
+            return result
+
+        if isinstance(value, Sequence) and not isinstance(
+            value, str | bytes | bytearray
+        ):
+            is_vector = vector_context or _is_numeric_vector(value)
+            items = list(islice(iter(value), MAX_PREVIEW_ITEMS + 1))
+            converted = [
+                json_value(
+                    item,
+                    depth=depth + 1,
+                    vector_context=is_vector,
+                    seen=active,
+                )
+                for item in items[:MAX_PREVIEW_ITEMS]
+            ]
+            if len(items) > MAX_PREVIEW_ITEMS:
+                return {
+                    "count": _trusted_length(value),
+                    "items": converted,
+                    "kind": "vector" if is_vector else "sequence",
+                    "truncated": True,
+                }
+            return converted
+
+        for method_name in ("model_dump", "to_dict", "dict"):
+            try:
+                method = getattr(value, method_name, None)
+            except Exception:  # noqa: BLE001 - hostile vendor objects are summarized.
+                method = None
+            if not callable(method):
+                continue
+            try:
+                converted = method()
+            except Exception:  # noqa: BLE001,S112 - conversion hooks are untrusted.
+                continue
+            if isinstance(converted, Mapping):
+                return json_value(converted, depth=depth + 1, seen=active)
+        return {"type": type(value).__name__}
+    except Exception:  # noqa: BLE001 - serialization must not break Qdrant.
+        return {"type": type(value).__name__, "unserializable": True}
+    finally:
+        active.discard(identity)
+
+
+def json_dumps(value: Any) -> str:
+    encoded = json.dumps(
+        json_value(value),
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    encoded_bytes = len(encoded.encode("utf-8"))
+    if encoded_bytes <= MAX_ATTRIBUTE_CHARS:
+        return encoded
+    low = 0
+    high = min(len(encoded), MAX_ATTRIBUTE_CHARS)
+    result = ""
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = json.dumps(
+            {
+                "original_bytes": encoded_bytes,
+                "preview": encoded[:midpoint],
+                "truncated": True,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(candidate.encode("utf-8")) <= MAX_ATTRIBUTE_CHARS:
+            result = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return result
+
+
+def exception_message(exc: BaseException) -> str:
+    try:
+        arguments = exc.args
+    except Exception:  # noqa: BLE001 - hostile exception attributes are ignored.
+        arguments = ()
+    for argument in arguments:
+        if isinstance(argument, str | bool | int | float):
+            return safe_text(argument)
+    return type(exc).__name__

--- a/python-sdks/instrumentations/respan-instrumentation-qdrant/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-qdrant/tests/test_instrumentation.py
@@ -1,18 +1,23 @@
 import json
 import sys
+from collections import Counter
 from contextlib import contextmanager
 from types import ModuleType
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import StatusCode
-
-from respan_instrumentation_qdrant import QdrantInstrumentor
-from respan_instrumentation_qdrant import _instrumentation
+from respan_instrumentation_qdrant import QdrantInstrumentor, _instrumentation
 from respan_instrumentation_qdrant._constants import (
     MAX_ATTRIBUTE_CHARS,
     MAX_PREVIEW_ITEMS,
 )
+from respan_instrumentation_qdrant._serialization import json_dumps
 from respan_sdk.constants.span_attributes import (
     RESPAN_LOG_TYPE,
     RESPAN_SPAN_HANDOFFS,
@@ -27,6 +32,8 @@ class _FakeSpan:
         self.attributes = {}
         self.status = None
         self.exceptions = []
+        self.events = []
+        self.parent = None
 
     def set_attribute(self, key, value):
         self.attributes[key] = value
@@ -36,6 +43,9 @@ class _FakeSpan:
 
     def set_status(self, status):
         self.status = status
+
+    def add_event(self, name, attributes=None):
+        self.events.append((name, attributes or {}))
 
 
 class _FakeTracer:
@@ -82,19 +92,24 @@ def reset_instrumentor():
     QdrantInstrumentor._patches_applied = False
     QdrantInstrumentor._activation_count = 0
     QdrantInstrumentor._patched_targets = []
+    QdrantInstrumentor._capture_content_config = None
     yield
-    for target, method in reversed(QdrantInstrumentor._patched_targets):
-        _instrumentation.unwrap(target, method)
+    for patch in reversed(QdrantInstrumentor._patched_targets):
+        try:
+            _instrumentation.unwrap(patch.target, patch.attribute)
+        except Exception:  # noqa: BLE001,S110 - test cleanup must be best effort.
+            pass
     QdrantInstrumentor._patches_applied = False
     QdrantInstrumentor._activation_count = 0
     QdrantInstrumentor._patched_targets = []
+    QdrantInstrumentor._capture_content_config = None
 
 
 def _assert_contract(span):
     attrs = span.attributes
     assert attrs[RESPAN_LOG_TYPE] == "task"
     assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME]
-    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH]
+    assert SpanAttributes.TRACELOOP_ENTITY_PATH in attrs
     for banned_alias in (
         "tools",
         "tool_calls",
@@ -119,7 +134,7 @@ def test_package_exports_qdrant_instrumentor():
 def test_sync_operations_emit_canonical_task_spans(monkeypatch):
     QdrantClient, _ = _install_fake_qdrant(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     instrumentor = QdrantInstrumentor()
     instrumentor.instrument()
 
@@ -144,7 +159,7 @@ def test_sync_operations_emit_canonical_task_spans(monkeypatch):
         assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT in span.attributes
         assert span.status.status_code is StatusCode.OK
     assert (
-        "<redacted>"
+        "[REDACTED]"
         in tracer.spans[1].attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]
     )
     instrumentor.uninstrument()
@@ -154,7 +169,7 @@ def test_sync_operations_emit_canonical_task_spans(monkeypatch):
 async def test_async_operations_are_awaited_and_traced(monkeypatch):
     _, AsyncQdrantClient = _install_fake_qdrant(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     instrumentor = QdrantInstrumentor()
     instrumentor.activate()
 
@@ -172,7 +187,7 @@ async def test_async_operations_are_awaited_and_traced(monkeypatch):
 def test_errors_are_recorded_and_reraised(monkeypatch):
     QdrantClient, _ = _install_fake_qdrant(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     instrumentor = QdrantInstrumentor()
     instrumentor.activate()
 
@@ -181,7 +196,8 @@ def test_errors_are_recorded_and_reraised(monkeypatch):
 
     span = tracer.spans[-1]
     assert span.status.status_code is StatusCode.ERROR
-    assert span.exceptions
+    assert not span.exceptions
+    assert span.events[0][0] == "exception"
     assert span.attributes["status_code"] == 500
     assert span.attributes["error.message"] == "collection does not exist"
     assert (
@@ -194,7 +210,7 @@ def test_errors_are_recorded_and_reraised(monkeypatch):
 def test_capture_content_false_omits_inputs_and_outputs(monkeypatch):
     QdrantClient, _ = _install_fake_qdrant(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     instrumentor = QdrantInstrumentor(capture_content=False)
     instrumentor.activate()
 
@@ -207,10 +223,10 @@ def test_capture_content_false_omits_inputs_and_outputs(monkeypatch):
     instrumentor.deactivate()
 
 
-def test_full_vectors_survive_canonical_input_and_output(monkeypatch):
+def test_large_vectors_are_bounded_with_stable_previews(monkeypatch):
     QdrantClient, _ = _install_fake_qdrant(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     instrumentor = QdrantInstrumentor()
     instrumentor.activate()
     vector = [0.125] * (MAX_ATTRIBUTE_CHARS + 17)
@@ -224,16 +240,16 @@ def test_full_vectors_survive_canonical_input_and_output(monkeypatch):
     span = tracer.spans[-1]
     entity_input = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
     entity_output = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
-    assert entity_input["points"][0]["vector"] == vector
-    assert entity_output["points"][0]["vector"] == vector
-    assert len(entity_input["points"][0]["vector"]) == len(vector)
+    assert entity_input["points"][0]["vector"]["count"] == len(vector)
+    assert len(entity_input["points"][0]["vector"]["items"]) == MAX_PREVIEW_ITEMS
+    assert entity_output["points"][0]["vector"]["count"] == len(vector)
     assert (
-        len(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
-        > MAX_ATTRIBUTE_CHARS
+        len(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT].encode("utf-8"))
+        <= MAX_ATTRIBUTE_CHARS
     )
     assert (
-        len(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
-        > MAX_ATTRIBUTE_CHARS
+        len(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT].encode("utf-8"))
+        <= MAX_ATTRIBUTE_CHARS
     )
     assert entity_input["points"][0]["payload"]["tags"]["truncated"] is True
     instrumentor.deactivate()
@@ -242,7 +258,7 @@ def test_full_vectors_survive_canonical_input_and_output(monkeypatch):
 def test_lifecycle_is_idempotent_and_reference_counted(monkeypatch):
     QdrantClient, _ = _install_fake_qdrant(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda *_: tracer)
     first = QdrantInstrumentor()
     second = QdrantInstrumentor()
 
@@ -259,3 +275,138 @@ def test_lifecycle_is_idempotent_and_reference_counted(monkeypatch):
     second.deactivate()
     QdrantClient().query_points("docs", [0.1, 0.2, 0.3])
     assert len(tracer.spans) == 2
+
+
+def test_active_instances_reject_capture_mismatch(monkeypatch):
+    _install_fake_qdrant(monkeypatch)
+    first = QdrantInstrumentor(capture_content=True)
+    second = QdrantInstrumentor(capture_content=False)
+    first.activate()
+    with pytest.raises(ValueError, match="same capture_content"):
+        second.activate()
+    first.deactivate()
+
+
+def test_serializer_is_bounded_redacting_and_hostile_safe():
+    class Hostile:
+        def __str__(self):
+            raise AssertionError("hostile __str__ called")
+
+        def __repr__(self):
+            raise AssertionError("hostile __repr__ called")
+
+    encoded = json_dumps(
+        {
+            "api_key": "plain-secret",
+            "nested": {"client_secret": "nested-secret"},
+            "endpoint": "https://user:pass@example.test/v1?api_key=query-secret",
+            "hostile": Hostile(),
+            "unicode": "😀" * 10_000,
+        }
+    )
+    assert len(encoded.encode("utf-8")) <= MAX_ATTRIBUTE_CHARS
+    for secret in ("plain-secret", "nested-secret", "query-secret", "user:pass"):
+        assert secret not in encoded
+    assert json.loads(encoded)
+
+
+@pytest.mark.asyncio
+async def test_real_current_clients_export_sync_async_success_and_failure(monkeypatch):
+    from qdrant_client import AsyncQdrantClient, QdrantClient, models
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer",
+        lambda name, version=None: provider.get_tracer(name, version),
+    )
+    instrumentor = QdrantInstrumentor()
+    instrumentor.activate()
+    root_tracer = provider.get_tracer("qdrant-real-contract")
+
+    with root_tracer.start_as_current_span("sync.root") as sync_root:
+        client = QdrantClient(":memory:")
+        client.create_collection(
+            "docs",
+            vectors_config=models.VectorParams(
+                size=3,
+                distance=models.Distance.COSINE,
+            ),
+        )
+        client.upsert(
+            "docs",
+            points=[
+                models.PointStruct(
+                    id=1,
+                    vector=[0.1, 0.2, 0.3],
+                    payload={"topic": "tracing"},
+                )
+            ],
+        )
+        query = client.query_points("docs", query=[0.1, 0.2, 0.3], limit=1)
+        assert query.points[0].id == 1
+        assert client.retrieve("docs", ids=[1])[0].payload == {"topic": "tracing"}
+        assert client.scroll("docs", limit=1)[0][0].id == 1
+        with pytest.raises(ValueError, match="missing_collection"):
+            client.get_collection("missing_collection")
+        client.close()
+
+    with root_tracer.start_as_current_span("async.root") as async_root:
+        async_client = AsyncQdrantClient(":memory:")
+        await async_client.create_collection(
+            "async_docs",
+            vectors_config=models.VectorParams(
+                size=3,
+                distance=models.Distance.DOT,
+            ),
+        )
+        await async_client.upsert(
+            "async_docs",
+            points=[models.PointStruct(id=2, vector=[0.3, 0.2, 0.1])],
+        )
+        async_query = await async_client.query_points(
+            "async_docs",
+            query=[0.3, 0.2, 0.1],
+            limit=1,
+        )
+        assert async_query.points[0].id == 2
+        await async_client.close()
+
+    assert provider.force_flush()
+    spans = list(exporter.get_finished_spans())
+    qdrant_spans = [
+        span for span in spans if span.instrumentation_scope.name == "qdrant"
+    ]
+    names = Counter(span.name for span in qdrant_spans)
+    assert names == Counter(
+        {
+            "qdrant.create_collection": 2,
+            "qdrant.upsert": 2,
+            "qdrant.query_points": 2,
+            "qdrant.retrieve": 1,
+            "qdrant.scroll": 1,
+            "qdrant.get_collection": 1,
+        }
+    )
+    assert len({span.context.span_id for span in qdrant_spans}) == 9
+    sync_parent = sync_root.get_span_context().span_id
+    async_parent = async_root.get_span_context().span_id
+    assert all(
+        span.parent.span_id in {sync_parent, async_parent} for span in qdrant_spans
+    )
+    failed = next(span for span in qdrant_spans if span.name == "qdrant.get_collection")
+    assert failed.status.status_code is StatusCode.ERROR
+    assert failed.attributes["status_code"] == 500
+    assert failed.events[0].attributes["exception.type"] == "ValueError"
+    for span in qdrant_spans:
+        _assert_contract(span)
+        assert span.instrumentation_scope.version == "0.1.0"
+        assert span.attributes["db.system"] == "qdrant"
+        assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
+        assert json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+        assert SpanAttributes.TRACELOOP_SPAN_KIND not in span.attributes
+
+    instrumentor.deactivate()
+    provider.shutdown()


### PR DESCRIPTION
## Summary

- Repair the Pydantic AI, Pytest, and Qdrant Python instrumentations for the OTel 2.x span contract.
- Add bounded, redacted serialization; canonical content, tool, status, path, and lifecycle behavior; and real current-SDK exported-span coverage.
- Add a patch release intent for exactly `respan-instrumentation-pydantic-ai`, `respan-instrumentation-pytest`, and `respan-instrumentation-qdrant`.

## Validation

- [x] Focused package tests: Pydantic AI 13/13, Pytest 6/6, Qdrant 10/10 (29/29).
- [x] Root-scoped Ruff check and format-check pass for every changed package source and test file.
- [x] All three wheels build, install in isolated targets, and import successfully.
- [x] Release inventory, release-intent validation, missing-intent check, and diff checks pass.
- [x] Corresponding examples completed 12/12 expected process/session contracts under exact marker `otel2-fix-py-group-23-20260818T080200Z`.
- [x] Respan MCP audit opened all 12 trace trees and all 43 full records; each tree has one root, all parents resolve, all log/span IDs are unique, and marker/content/tool/error/privacy fields were inspected.

- [x] Full source and paired-example diffs were audited against every applicable document under `contribution/`; canonical span fields, OTel attribute shapes, release-intent/version ownership, and package boundaries have no remaining package-owned violation.

## External follow-ups

- Current ingestion leaves top-level convenience tool arrays empty despite canonical function definitions/current-turn calls.
- Pydantic AI agent rows show `unknown-model` because agent spans remain common-only; model/provider/usage are correctly owned by child chat spans.
- Backend classification labels local Pytest and Qdrant failures as `provider_down`, and Qdrant task display remains generic despite canonical operation identity.
- Optional live Pydantic provider calls remain provider-credential/credit gated; deterministic real-runtime coverage passes.

## Companion examples

- [respan-example-projects #71](https://github.com/respanai/respan-example-projects/pull/71)