### PR TITLE
fix(instrumentation-py): repair Together, Vertex AI, and Watson Orchestrate ADK OTel 2.x spans

### DIFF
--- a/.release-intents/20260818-together-vertexai-watson-orchestrate-otel2.json
+++ b/.release-intents/20260818-together-vertexai-watson-orchestrate-otel2.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair Together, Vertex AI, and Watson Orchestrate ADK Python instrumentation for the OpenTelemetry 2.x span contract",
+  "packages": {
+    "respan-instrumentation-together": "patch",
+    "respan-instrumentation-vertexai": "patch",
+    "respan-instrumentation-watson-orchestrate-adk": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_instrumentation.py
@@ -3,9 +3,21 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import time
-from typing import Any
+from collections.abc import Callable
+from dataclasses import dataclass
+from threading import RLock
+from types import TracebackType
+from typing import Any, Self
+
+from opentelemetry import trace
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.core.tracer import RespanTracer
 
 from respan_instrumentation_together._constants import (
     ASYNC_COMPLETIONS_RESOURCE_CLASS_NAME,
@@ -27,36 +39,49 @@ from respan_instrumentation_together._constants import (
     TOGETHER_TEXT_COMPLETIONS_MODULE,
 )
 from respan_instrumentation_together._otel_emitter import emit_together_span
-from respan_tracing.core.tracer import RespanTracer
+from respan_instrumentation_together._serialization import (
+    provider_status_code,
+    safe_exception_message,
+)
 
 logger = logging.getLogger(__name__)
 
-_original_sync_chat_create = None
-_original_async_chat_create = None
-_original_sync_completion_create = None
-_original_async_completion_create = None
-_original_sync_embedding_create = None
-_original_async_embedding_create = None
-_original_sync_image_generate = None
-_original_async_image_generate = None
-_original_sync_rerank_create = None
-_original_async_rerank_create = None
+_LOCK = RLock()
+_ACTIVATION_COUNT = 0
+_MAX_STREAM_CHUNKS = 50
+
+
+@dataclass(frozen=True)
+class _Patch:
+    cls: type[Any]
+    method_name: str
+    original: Any
+    wrapper: Any
+
+
+_PATCHES: list[_Patch] = []
 
 
 def _get_module_attr(module_path: str, attr_name: str) -> Any:
     module = importlib.import_module(module_path)
-    attr_value = getattr(module, attr_name, None)
-    if attr_value is None:
+    value = getattr(module, attr_name, None)
+    if value is None:
         raise AttributeError(f"{module_path}.{attr_name}")
-    return attr_value
+    return value
 
 
 def _load_class(module_path: str, class_name: str) -> type[Any]:
-    return _get_module_attr(module_path=module_path, attr_name=class_name)
+    return _get_module_attr(module_path, class_name)
 
 
-def _is_stream_requested(kwargs: dict[str, Any]) -> bool:
-    return kwargs.get(STREAM_KEY) is True
+def _current_trace_parent_ids() -> tuple[str | None, str | None]:
+    try:
+        context = trace.get_current_span().get_span_context()
+        if not context.is_valid:
+            return None, None
+        return format_trace_id(context.trace_id), format_span_id(context.span_id)
+    except BaseException:  # noqa: BLE001
+        return None, None
 
 
 def _emit_span_safely(
@@ -64,185 +89,217 @@ def _emit_span_safely(
     operation: str,
     kwargs: dict[str, Any],
     start_ns: int,
+    trace_id: str | None,
+    parent_id: str | None,
     response_or_chunks: Any = None,
-    error_message: str | None = None,
-    status_code: int = 200,
+    error: BaseException | None = None,
 ) -> None:
+    error_message = safe_exception_message(error) if error is not None else None
     emit_together_span(
         operation=operation,
         request_kwargs=dict(kwargs),
         start_ns=start_ns,
         response_or_chunks=response_or_chunks,
         error_message=error_message,
-        status_code=status_code,
+        status_code=provider_status_code(error) if error is not None else 200,
+        trace_id=trace_id,
+        parent_id=parent_id,
     )
 
 
-class _InstrumentedStream:
-    def __init__(self, *, stream: Any, operation: str, kwargs: dict[str, Any], start_ns: int) -> None:
-        self._stream = stream
-        self._operation = operation
-        self._kwargs = dict(kwargs)
-        self._start_ns = start_ns
-        self._chunks: list[Any] = []
-        self._emitted = False
+class _StreamState:
+    def __init__(
+        self,
+        *,
+        operation: str,
+        kwargs: dict[str, Any],
+        start_ns: int,
+        trace_id: str | None,
+        parent_id: str | None,
+    ) -> None:
+        self.operation = operation
+        self.kwargs = dict(kwargs)
+        self.start_ns = start_ns
+        self.trace_id = trace_id
+        self.parent_id = parent_id
+        self.chunks: list[Any] = []
+        self.emitted = False
 
-    def __iter__(self) -> "_InstrumentedStream":
+    def capture(self, chunk: Any) -> None:
+        if len(self.chunks) < _MAX_STREAM_CHUNKS:
+            self.chunks.append(chunk)
+        else:
+            self.chunks[-1] = chunk
+
+    def emit(self, error: BaseException | None = None) -> None:
+        if self.emitted:
+            return
+        self.emitted = True
+        _emit_span_safely(
+            operation=self.operation,
+            kwargs=self.kwargs,
+            start_ns=self.start_ns,
+            trace_id=self.trace_id,
+            parent_id=self.parent_id,
+            response_or_chunks=self.chunks,
+            error=error,
+        )
+
+
+class _InstrumentedStream:
+    def __init__(self, *, stream: Any, state: _StreamState) -> None:
+        self._stream = stream
+        self._state = state
+
+    def __iter__(self) -> _InstrumentedStream:
         return self
 
     def __next__(self) -> Any:
         try:
             chunk = next(self._stream)
         except StopIteration:
-            self._emit_once()
+            self._state.emit()
             raise
-        except Exception as exc:
-            self._emit_once(error_message=str(exc), status_code=500)
+        except BaseException as exc:
+            self._state.emit(exc)
             raise
-        self._chunks.append(chunk)
+        self._state.capture(chunk)
         return chunk
 
-    def __enter__(self) -> "_InstrumentedStream":
+    def __enter__(self) -> Self:
         enter = getattr(self._stream, "__enter__", None)
         if callable(enter):
             enter()
         return self
 
-    def __exit__(self, exc_type: Any, exc: Any, exc_tb: Any) -> Any:
-        if exc is not None:
-            self._emit_once(error_message=str(exc), status_code=500)
-        else:
-            self._emit_once()
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Any:
         exit_method = getattr(self._stream, "__exit__", None)
-        if callable(exit_method):
-            return exit_method(exc_type, exc, exc_tb)
-        return None
+        try:
+            result = exit_method(exc_type, exc, tb) if callable(exit_method) else None
+        except BaseException as close_error:
+            self._state.emit(close_error)
+            raise
+        self._state.emit(exc)
+        return result
 
     def close(self) -> None:
-        self._emit_once()
         close = getattr(self._stream, "close", None)
-        if callable(close):
-            close()
-
-    def _emit_once(
-        self,
-        *,
-        error_message: str | None = None,
-        status_code: int = 200,
-    ) -> None:
-        if self._emitted:
-            return
-        self._emitted = True
-        _emit_span_safely(
-            operation=self._operation,
-            kwargs=self._kwargs,
-            start_ns=self._start_ns,
-            response_or_chunks=self._chunks,
-            error_message=error_message,
-            status_code=status_code,
-        )
+        try:
+            if callable(close):
+                close()
+        except BaseException as exc:
+            self._state.emit(exc)
+            raise
+        self._state.emit()
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._stream, name)
 
 
 class _InstrumentedAsyncStream:
-    def __init__(self, *, stream: Any, operation: str, kwargs: dict[str, Any], start_ns: int) -> None:
+    def __init__(self, *, stream: Any, state: _StreamState) -> None:
         self._stream = stream
-        self._operation = operation
-        self._kwargs = dict(kwargs)
-        self._start_ns = start_ns
-        self._chunks: list[Any] = []
-        self._emitted = False
+        self._state = state
 
-    def __aiter__(self) -> "_InstrumentedAsyncStream":
+    def __aiter__(self) -> _InstrumentedAsyncStream:
         return self
 
     async def __anext__(self) -> Any:
         try:
             chunk = await self._stream.__anext__()
         except StopAsyncIteration:
-            self._emit_once()
+            self._state.emit()
             raise
-        except Exception as exc:
-            self._emit_once(error_message=str(exc), status_code=500)
+        except BaseException as exc:
+            self._state.emit(exc)
             raise
-        self._chunks.append(chunk)
+        self._state.capture(chunk)
         return chunk
 
-    async def __aenter__(self) -> "_InstrumentedAsyncStream":
+    async def __aenter__(self) -> Self:
         enter = getattr(self._stream, "__aenter__", None)
         if callable(enter):
             await enter()
         return self
 
-    async def __aexit__(self, exc_type: Any, exc: Any, exc_tb: Any) -> Any:
-        if exc is not None:
-            self._emit_once(error_message=str(exc), status_code=500)
-        else:
-            self._emit_once()
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Any:
         exit_method = getattr(self._stream, "__aexit__", None)
-        if callable(exit_method):
-            return await exit_method(exc_type, exc, exc_tb)
-        return None
+        try:
+            result = (
+                await exit_method(exc_type, exc, tb) if callable(exit_method) else None
+            )
+        except BaseException as close_error:
+            self._state.emit(close_error)
+            raise
+        self._state.emit(exc)
+        return result
+
+    async def aclose(self) -> None:
+        close = getattr(self._stream, "aclose", None)
+        if not callable(close):
+            close = getattr(self._stream, "close", None)
+        try:
+            if callable(close):
+                result = close()
+                if inspect.isawaitable(result):
+                    await result
+        except BaseException as exc:
+            self._state.emit(exc)
+            raise
+        self._state.emit()
 
     async def close(self) -> None:
-        self._emit_once()
-        close = getattr(self._stream, "close", None)
-        if callable(close):
-            result = close()
-            if hasattr(result, "__await__"):
-                await result
-
-    def _emit_once(
-        self,
-        *,
-        error_message: str | None = None,
-        status_code: int = 200,
-    ) -> None:
-        if self._emitted:
-            return
-        self._emitted = True
-        _emit_span_safely(
-            operation=self._operation,
-            kwargs=self._kwargs,
-            start_ns=self._start_ns,
-            response_or_chunks=self._chunks,
-            error_message=error_message,
-            status_code=status_code,
-        )
+        await self.aclose()
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._stream, name)
 
 
-def _wrap_sync_create(original: Any, *, operation: str) -> Any:
+def _wrap_sync_create(
+    original: Callable[..., Any], *, operation: str
+) -> Callable[..., Any]:
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = _current_trace_parent_ids()
         try:
             response = original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _emit_span_safely(
                 operation=operation,
                 kwargs=kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                trace_id=trace_id,
+                parent_id=parent_id,
+                error=exc,
             )
             raise
-
-        if _is_stream_requested(kwargs):
+        if kwargs.get(STREAM_KEY) is True:
             return _InstrumentedStream(
                 stream=response,
-                operation=operation,
-                kwargs=kwargs,
-                start_ns=start_ns,
+                state=_StreamState(
+                    operation=operation,
+                    kwargs=kwargs,
+                    start_ns=start_ns,
+                    trace_id=trace_id,
+                    parent_id=parent_id,
+                ),
             )
-
         _emit_span_safely(
             operation=operation,
             kwargs=kwargs,
             start_ns=start_ns,
+            trace_id=trace_id,
+            parent_id=parent_id,
             response_or_chunks=response,
         )
         return response
@@ -250,38 +307,121 @@ def _wrap_sync_create(original: Any, *, operation: str) -> Any:
     return wrapper
 
 
-def _wrap_async_create(original: Any, *, operation: str) -> Any:
+def _wrap_async_create(
+    original: Callable[..., Any], *, operation: str
+) -> Callable[..., Any]:
     async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = _current_trace_parent_ids()
         try:
             response = await original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _emit_span_safely(
                 operation=operation,
                 kwargs=kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                trace_id=trace_id,
+                parent_id=parent_id,
+                error=exc,
             )
             raise
-
-        if _is_stream_requested(kwargs):
+        if kwargs.get(STREAM_KEY) is True:
             return _InstrumentedAsyncStream(
                 stream=response,
-                operation=operation,
-                kwargs=kwargs,
-                start_ns=start_ns,
+                state=_StreamState(
+                    operation=operation,
+                    kwargs=kwargs,
+                    start_ns=start_ns,
+                    trace_id=trace_id,
+                    parent_id=parent_id,
+                ),
             )
-
         _emit_span_safely(
             operation=operation,
             kwargs=kwargs,
             start_ns=start_ns,
+            trace_id=trace_id,
+            parent_id=parent_id,
             response_or_chunks=response,
         )
         return response
 
     return wrapper
+
+
+def _targets() -> list[tuple[type[Any], str, str, bool]]:
+    return [
+        (
+            _load_class(
+                TOGETHER_CHAT_COMPLETIONS_MODULE, COMPLETIONS_RESOURCE_CLASS_NAME
+            ),
+            CREATE_METHOD_NAME,
+            "chat",
+            False,
+        ),
+        (
+            _load_class(
+                TOGETHER_CHAT_COMPLETIONS_MODULE, ASYNC_COMPLETIONS_RESOURCE_CLASS_NAME
+            ),
+            CREATE_METHOD_NAME,
+            "chat",
+            True,
+        ),
+        (
+            _load_class(
+                TOGETHER_TEXT_COMPLETIONS_MODULE, COMPLETIONS_RESOURCE_CLASS_NAME
+            ),
+            CREATE_METHOD_NAME,
+            "completion",
+            False,
+        ),
+        (
+            _load_class(
+                TOGETHER_TEXT_COMPLETIONS_MODULE, ASYNC_COMPLETIONS_RESOURCE_CLASS_NAME
+            ),
+            CREATE_METHOD_NAME,
+            "completion",
+            True,
+        ),
+        (
+            _load_class(TOGETHER_EMBEDDINGS_MODULE, EMBEDDINGS_RESOURCE_CLASS_NAME),
+            CREATE_METHOD_NAME,
+            "embedding",
+            False,
+        ),
+        (
+            _load_class(
+                TOGETHER_EMBEDDINGS_MODULE, ASYNC_EMBEDDINGS_RESOURCE_CLASS_NAME
+            ),
+            CREATE_METHOD_NAME,
+            "embedding",
+            True,
+        ),
+        (
+            _load_class(TOGETHER_IMAGES_MODULE, IMAGES_RESOURCE_CLASS_NAME),
+            GENERATE_METHOD_NAME,
+            "image",
+            False,
+        ),
+        (
+            _load_class(TOGETHER_IMAGES_MODULE, ASYNC_IMAGES_RESOURCE_CLASS_NAME),
+            GENERATE_METHOD_NAME,
+            "image",
+            True,
+        ),
+        (
+            _load_class(TOGETHER_RERANK_MODULE, RERANK_RESOURCE_CLASS_NAME),
+            CREATE_METHOD_NAME,
+            "rerank",
+            False,
+        ),
+        (
+            _load_class(TOGETHER_RERANK_MODULE, ASYNC_RERANK_RESOURCE_CLASS_NAME),
+            CREATE_METHOD_NAME,
+            "rerank",
+            True,
+        ),
+    ]
 
 
 class TogetherInstrumentor:
@@ -295,249 +435,66 @@ class TogetherInstrumentor:
     @staticmethod
     def _is_respan_tracing_enabled() -> bool:
         tracer = getattr(RespanTracer, "_instance", None)
-        if tracer is None:
-            return True
-        return bool(getattr(tracer, "is_enabled", True))
+        return tracer is None or bool(getattr(tracer, "is_enabled", True))
 
     def activate(self) -> None:
-        """Monkey-patch Together SDK resources."""
-        global _original_sync_chat_create, _original_async_chat_create
-        global _original_sync_completion_create, _original_async_completion_create
-        global _original_sync_embedding_create, _original_async_embedding_create
-        global _original_sync_image_generate, _original_async_image_generate
-        global _original_sync_rerank_create, _original_async_rerank_create
-
-        if self._is_instrumented:
-            return
-
-        if not self._is_respan_tracing_enabled():
-            logger.info("Together instrumentation skipped because Respan tracing is disabled")
-            return
-
-        try:
-            SyncChatCompletions = _load_class(
-                TOGETHER_CHAT_COMPLETIONS_MODULE,
-                COMPLETIONS_RESOURCE_CLASS_NAME,
-            )
-            AsyncChatCompletions = _load_class(
-                TOGETHER_CHAT_COMPLETIONS_MODULE,
-                ASYNC_COMPLETIONS_RESOURCE_CLASS_NAME,
-            )
-            SyncCompletions = _load_class(
-                TOGETHER_TEXT_COMPLETIONS_MODULE,
-                COMPLETIONS_RESOURCE_CLASS_NAME,
-            )
-            AsyncCompletions = _load_class(
-                TOGETHER_TEXT_COMPLETIONS_MODULE,
-                ASYNC_COMPLETIONS_RESOURCE_CLASS_NAME,
-            )
-            SyncEmbeddings = _load_class(
-                TOGETHER_EMBEDDINGS_MODULE,
-                EMBEDDINGS_RESOURCE_CLASS_NAME,
-            )
-            AsyncEmbeddings = _load_class(
-                TOGETHER_EMBEDDINGS_MODULE,
-                ASYNC_EMBEDDINGS_RESOURCE_CLASS_NAME,
-            )
-            SyncImages = _load_class(
-                TOGETHER_IMAGES_MODULE,
-                IMAGES_RESOURCE_CLASS_NAME,
-            )
-            AsyncImages = _load_class(
-                TOGETHER_IMAGES_MODULE,
-                ASYNC_IMAGES_RESOURCE_CLASS_NAME,
-            )
-            SyncRerank = _load_class(
-                TOGETHER_RERANK_MODULE,
-                RERANK_RESOURCE_CLASS_NAME,
-            )
-            AsyncRerank = _load_class(
-                TOGETHER_RERANK_MODULE,
-                ASYNC_RERANK_RESOURCE_CLASS_NAME,
-            )
-        except ImportError as exc:
-            # SDK genuinely absent - expected when the app doesn't use Together
-            # (the together SDK is an optional extra).
-            logger.debug(
-                "Together instrumentation inactive - missing dependency: %s",
-                exc,
-            )
-            return
-        except AttributeError as exc:
-            # SDK installed but incompatible (a class moved/renamed) - surface it
-            # so a broken install isn't silently left untraced.
-            logger.warning(
-                "together is installed but incompatible - instrumentation inactive: %s",
-                exc,
-            )
-            return
-        except Exception as exc:
-            logger.warning("Failed to activate Together instrumentation: %s", exc)
-            return
-
-        try:
-            if _original_sync_chat_create is None:
-                _original_sync_chat_create = getattr(SyncChatCompletions, CREATE_METHOD_NAME)
-            setattr(
-                SyncChatCompletions,
-                CREATE_METHOD_NAME,
-                _wrap_sync_create(_original_sync_chat_create, operation="chat"),
-            )
-
-            if _original_async_chat_create is None:
-                _original_async_chat_create = getattr(AsyncChatCompletions, CREATE_METHOD_NAME)
-            setattr(
-                AsyncChatCompletions,
-                CREATE_METHOD_NAME,
-                _wrap_async_create(_original_async_chat_create, operation="chat"),
-            )
-
-            if _original_sync_completion_create is None:
-                _original_sync_completion_create = getattr(SyncCompletions, CREATE_METHOD_NAME)
-            setattr(
-                SyncCompletions,
-                CREATE_METHOD_NAME,
-                _wrap_sync_create(_original_sync_completion_create, operation="completion"),
-            )
-
-            if _original_async_completion_create is None:
-                _original_async_completion_create = getattr(AsyncCompletions, CREATE_METHOD_NAME)
-            setattr(
-                AsyncCompletions,
-                CREATE_METHOD_NAME,
-                _wrap_async_create(_original_async_completion_create, operation="completion"),
-            )
-
-            if _original_sync_embedding_create is None:
-                _original_sync_embedding_create = getattr(SyncEmbeddings, CREATE_METHOD_NAME)
-            setattr(
-                SyncEmbeddings,
-                CREATE_METHOD_NAME,
-                _wrap_sync_create(_original_sync_embedding_create, operation="embedding"),
-            )
-
-            if _original_async_embedding_create is None:
-                _original_async_embedding_create = getattr(AsyncEmbeddings, CREATE_METHOD_NAME)
-            setattr(
-                AsyncEmbeddings,
-                CREATE_METHOD_NAME,
-                _wrap_async_create(_original_async_embedding_create, operation="embedding"),
-            )
-
-            if _original_sync_image_generate is None:
-                _original_sync_image_generate = getattr(SyncImages, GENERATE_METHOD_NAME)
-            setattr(
-                SyncImages,
-                GENERATE_METHOD_NAME,
-                _wrap_sync_create(_original_sync_image_generate, operation="image"),
-            )
-
-            if _original_async_image_generate is None:
-                _original_async_image_generate = getattr(AsyncImages, GENERATE_METHOD_NAME)
-            setattr(
-                AsyncImages,
-                GENERATE_METHOD_NAME,
-                _wrap_async_create(_original_async_image_generate, operation="image"),
-            )
-
-            if _original_sync_rerank_create is None:
-                _original_sync_rerank_create = getattr(SyncRerank, CREATE_METHOD_NAME)
-            setattr(
-                SyncRerank,
-                CREATE_METHOD_NAME,
-                _wrap_sync_create(_original_sync_rerank_create, operation="rerank"),
-            )
-
-            if _original_async_rerank_create is None:
-                _original_async_rerank_create = getattr(AsyncRerank, CREATE_METHOD_NAME)
-            setattr(
-                AsyncRerank,
-                CREATE_METHOD_NAME,
-                _wrap_async_create(_original_async_rerank_create, operation="rerank"),
-            )
-        except Exception as exc:
-            logger.warning("Failed to activate Together instrumentation: %s", exc)
-            self.deactivate()
-            return
-
-        self._is_instrumented = True
-        logger.info("Together instrumentation activated")
+        global _ACTIVATION_COUNT
+        with _LOCK:
+            if self._is_instrumented:
+                return
+            if not self._is_respan_tracing_enabled():
+                return
+            if _ACTIVATION_COUNT:
+                _ACTIVATION_COUNT += 1
+                self._is_instrumented = True
+                return
+            installed: list[_Patch] = []
+            try:
+                for cls, method_name, operation, is_async in _targets():
+                    original = getattr(cls, method_name)
+                    wrapper = (
+                        _wrap_async_create(original, operation=operation)
+                        if is_async
+                        else _wrap_sync_create(original, operation=operation)
+                    )
+                    setattr(cls, method_name, wrapper)
+                    installed.append(_Patch(cls, method_name, original, wrapper))
+            except (ImportError, AttributeError) as exc:
+                for patch in reversed(installed):
+                    if getattr(patch.cls, patch.method_name, None) is patch.wrapper:
+                        setattr(patch.cls, patch.method_name, patch.original)
+                logger.warning("Together instrumentation inactive: %s", exc)
+                return
+            except BaseException:
+                for patch in reversed(installed):
+                    if getattr(patch.cls, patch.method_name, None) is patch.wrapper:
+                        setattr(patch.cls, patch.method_name, patch.original)
+                raise
+            _PATCHES[:] = installed
+            _ACTIVATION_COUNT = 1
+            self._is_instrumented = True
 
     def deactivate(self) -> None:
-        """Restore original Together SDK methods."""
-        global _original_sync_chat_create, _original_async_chat_create
-        global _original_sync_completion_create, _original_async_completion_create
-        global _original_sync_embedding_create, _original_async_embedding_create
-        global _original_sync_image_generate, _original_async_image_generate
-        global _original_sync_rerank_create, _original_async_rerank_create
-
-        if not self._is_instrumented:
-            return
-
-        try:
-            SyncChatCompletions = _load_class(
-                TOGETHER_CHAT_COMPLETIONS_MODULE,
-                COMPLETIONS_RESOURCE_CLASS_NAME,
-            )
-            AsyncChatCompletions = _load_class(
-                TOGETHER_CHAT_COMPLETIONS_MODULE,
-                ASYNC_COMPLETIONS_RESOURCE_CLASS_NAME,
-            )
-            SyncCompletions = _load_class(
-                TOGETHER_TEXT_COMPLETIONS_MODULE,
-                COMPLETIONS_RESOURCE_CLASS_NAME,
-            )
-            AsyncCompletions = _load_class(
-                TOGETHER_TEXT_COMPLETIONS_MODULE,
-                ASYNC_COMPLETIONS_RESOURCE_CLASS_NAME,
-            )
-            SyncEmbeddings = _load_class(
-                TOGETHER_EMBEDDINGS_MODULE,
-                EMBEDDINGS_RESOURCE_CLASS_NAME,
-            )
-            AsyncEmbeddings = _load_class(
-                TOGETHER_EMBEDDINGS_MODULE,
-                ASYNC_EMBEDDINGS_RESOURCE_CLASS_NAME,
-            )
-            SyncImages = _load_class(
-                TOGETHER_IMAGES_MODULE,
-                IMAGES_RESOURCE_CLASS_NAME,
-            )
-            AsyncImages = _load_class(
-                TOGETHER_IMAGES_MODULE,
-                ASYNC_IMAGES_RESOURCE_CLASS_NAME,
-            )
-            SyncRerank = _load_class(
-                TOGETHER_RERANK_MODULE,
-                RERANK_RESOURCE_CLASS_NAME,
-            )
-            AsyncRerank = _load_class(
-                TOGETHER_RERANK_MODULE,
-                ASYNC_RERANK_RESOURCE_CLASS_NAME,
-            )
-
-            if _original_sync_chat_create is not None:
-                setattr(SyncChatCompletions, CREATE_METHOD_NAME, _original_sync_chat_create)
-            if _original_async_chat_create is not None:
-                setattr(AsyncChatCompletions, CREATE_METHOD_NAME, _original_async_chat_create)
-            if _original_sync_completion_create is not None:
-                setattr(SyncCompletions, CREATE_METHOD_NAME, _original_sync_completion_create)
-            if _original_async_completion_create is not None:
-                setattr(AsyncCompletions, CREATE_METHOD_NAME, _original_async_completion_create)
-            if _original_sync_embedding_create is not None:
-                setattr(SyncEmbeddings, CREATE_METHOD_NAME, _original_sync_embedding_create)
-            if _original_async_embedding_create is not None:
-                setattr(AsyncEmbeddings, CREATE_METHOD_NAME, _original_async_embedding_create)
-            if _original_sync_image_generate is not None:
-                setattr(SyncImages, GENERATE_METHOD_NAME, _original_sync_image_generate)
-            if _original_async_image_generate is not None:
-                setattr(AsyncImages, GENERATE_METHOD_NAME, _original_async_image_generate)
-            if _original_sync_rerank_create is not None:
-                setattr(SyncRerank, CREATE_METHOD_NAME, _original_sync_rerank_create)
-            if _original_async_rerank_create is not None:
-                setattr(AsyncRerank, CREATE_METHOD_NAME, _original_async_rerank_create)
-        except Exception as exc:
-            logger.warning("Failed to deactivate Together instrumentation cleanly: %s", exc)
-        finally:
+        global _ACTIVATION_COUNT
+        with _LOCK:
+            if not self._is_instrumented:
+                return
             self._is_instrumented = False
-            logger.info("Together instrumentation deactivated")
+            _ACTIVATION_COUNT = max(0, _ACTIVATION_COUNT - 1)
+            if _ACTIVATION_COUNT:
+                return
+            for patch in reversed(_PATCHES):
+                if getattr(patch.cls, patch.method_name, None) is patch.wrapper:
+                    setattr(patch.cls, patch.method_name, patch.original)
+            _PATCHES.clear()
+
+
+def _reset_runtime_for_tests() -> None:
+    """Restore owned methods and reset shared state for isolated tests."""
+    global _ACTIVATION_COUNT
+    with _LOCK:
+        for patch in reversed(_PATCHES):
+            if getattr(patch.cls, patch.method_name, None) is patch.wrapper:
+                setattr(patch.cls, patch.method_name, patch.original)
+        _PATCHES.clear()
+        _ACTIVATION_COUNT = 0

--- a/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_otel_emitter.py
@@ -8,13 +8,26 @@ from typing import Any
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_TEXT,
+)
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 from respan_instrumentation_together._constants import (
     ASSISTANT_ROLE,
     BANNED_ALIAS_ATTRS,
     CONTENT_KEY,
-    MODEL_KEY,
     ROLE_KEY,
     TOGETHER_CHAT_SPAN_NAME,
     TOGETHER_COMPLETION_SPAN_NAME,
@@ -31,7 +44,7 @@ from respan_instrumentation_together._translator import (
     chat_input_messages,
     chat_output,
     embedding_input,
-    embedding_summary,
+    embedding_output,
     extract_tool_calls,
     extract_usage,
     finish_reason,
@@ -46,14 +59,6 @@ from respan_instrumentation_together._translator import (
     text_completion_output,
     to_json_attr,
 )
-from respan_sdk.constants.llm_logging import (
-    LOG_TYPE_CHAT,
-    LOG_TYPE_EMBEDDING,
-    LOG_TYPE_TEXT,
-)
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
-from respan_sdk.utils.data_processing.id_processing import format_span_id, format_trace_id
-from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +67,7 @@ def _current_trace_parent_ids() -> tuple[str | None, str | None]:
     try:
         current_span = trace.get_current_span()
         span_context = current_span.get_span_context()
-    except Exception:
+    except BaseException:  # noqa: BLE001
         return None, None
 
     trace_id = getattr(span_context, "trace_id", 0) or 0
@@ -80,6 +85,7 @@ def _base_attrs(
 ) -> dict[str, Any]:
     attrs = {
         SpanAttributes.LLM_SYSTEM: TOGETHER_SYSTEM_NAME,
+        GenAIAttributes.GEN_AI_PROVIDER_NAME: TOGETHER_SYSTEM_NAME,
         SpanAttributes.LLM_REQUEST_TYPE: request_type,
         SpanAttributes.TRACELOOP_ENTITY_NAME: span_name,
         SpanAttributes.TRACELOOP_ENTITY_PATH: span_name,
@@ -91,7 +97,9 @@ def _base_attrs(
     return attrs
 
 
-def _set_model(attrs: dict[str, Any], request_kwargs: dict[str, Any], response: Any) -> None:
+def _set_model(
+    attrs: dict[str, Any], request_kwargs: dict[str, Any], response: Any
+) -> None:
     model = request_model(request_kwargs=request_kwargs, response=response)
     if model:
         attrs[SpanAttributes.LLM_REQUEST_MODEL] = model
@@ -101,13 +109,17 @@ def _set_usage(attrs: dict[str, Any], response_or_chunks: Any) -> None:
     usage = extract_usage(response_or_chunks=response_or_chunks)
     if "prompt_tokens" in usage:
         attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = usage["prompt_tokens"]
+        attrs[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] = usage["prompt_tokens"]
     if "completion_tokens" in usage:
         attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = usage["completion_tokens"]
+        attrs[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] = usage["completion_tokens"]
     if "total_tokens" in usage:
         attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = usage["total_tokens"]
 
 
-def _set_chat_input_attrs(attrs: dict[str, Any], request_kwargs: dict[str, Any]) -> None:
+def _set_chat_input_attrs(
+    attrs: dict[str, Any], request_kwargs: dict[str, Any]
+) -> None:
     messages = chat_input_messages(request_kwargs=request_kwargs)
     attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = chat_input(request_kwargs)
     for index, message in enumerate(messages):
@@ -115,7 +127,7 @@ def _set_chat_input_attrs(attrs: dict[str, Any], request_kwargs: dict[str, Any])
         role = message.get(ROLE_KEY)
         content = message.get(CONTENT_KEY)
         if role is not None:
-            attrs[f"{prefix}.role"] = str(role)
+            attrs[f"{prefix}.role"] = to_json_attr(role)
         if content is not None:
             attrs[f"{prefix}.content"] = to_json_attr(content)
         tool_calls = message.get(TOOL_CALLS_KEY)
@@ -173,7 +185,7 @@ def build_completion_attrs(
     attrs = _base_attrs(
         span_name=TOGETHER_COMPLETION_SPAN_NAME,
         log_type=LOG_TYPE_TEXT,
-        request_type=LLMRequestTypeValues.COMPLETION.value,
+        request_type=LLMRequestTypeValues.CHAT.value,
     )
     _set_model(attrs=attrs, request_kwargs=request_kwargs, response=response_or_chunks)
     prompt = text_completion_input(request_kwargs)
@@ -207,8 +219,7 @@ def build_embedding_attrs(
     attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = embedding_input(request_kwargs)
     attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"] = embedding_input(request_kwargs)
     if response is not None:
-        summary = embedding_summary(response)
-        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(summary)
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = embedding_output(response)
     _assert_no_banned_aliases(attrs)
     return attrs
 
@@ -221,7 +232,7 @@ def build_rerank_attrs(
     attrs = _base_attrs(
         span_name=TOGETHER_RERANK_SPAN_NAME,
         log_type=LOG_TYPE_TEXT,
-        request_type=LLMRequestTypeValues.RERANK.value,
+        request_type=LLMRequestTypeValues.CHAT.value,
     )
     _set_model(attrs=attrs, request_kwargs=request_kwargs, response=response)
     attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = rerank_input(request_kwargs)
@@ -240,7 +251,7 @@ def build_image_attrs(
     attrs = _base_attrs(
         span_name=TOGETHER_IMAGE_SPAN_NAME,
         log_type=LOG_TYPE_TEXT,
-        request_type=LLMRequestTypeValues.UNKNOWN.value,
+        request_type=LLMRequestTypeValues.CHAT.value,
     )
     _set_model(attrs=attrs, request_kwargs=request_kwargs, response=response)
     attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = image_input(request_kwargs)
@@ -266,31 +277,35 @@ def build_attrs(
     response_or_chunks: Any = None,
 ) -> dict[str, Any]:
     if operation == "chat":
-        return build_chat_attrs(
+        attrs = build_chat_attrs(
             request_kwargs=request_kwargs,
             response_or_chunks=response_or_chunks,
         )
-    if operation == "completion":
-        return build_completion_attrs(
+    elif operation == "completion":
+        attrs = build_completion_attrs(
             request_kwargs=request_kwargs,
             response_or_chunks=response_or_chunks,
         )
-    if operation == "embedding":
-        return build_embedding_attrs(
+    elif operation == "embedding":
+        attrs = build_embedding_attrs(
             request_kwargs=request_kwargs,
             response=response_or_chunks,
         )
-    if operation == "rerank":
-        return build_rerank_attrs(
+    elif operation == "rerank":
+        attrs = build_rerank_attrs(
             request_kwargs=request_kwargs,
             response=response_or_chunks,
         )
-    if operation == "image":
-        return build_image_attrs(
+    elif operation == "image":
+        attrs = build_image_attrs(
             request_kwargs=request_kwargs,
             response=response_or_chunks,
         )
-    raise ValueError(f"Unsupported Together operation: {operation}")
+    else:
+        raise ValueError(f"Unsupported Together operation: {operation}")
+    if operation in {"chat", "completion"} and request_kwargs.get("stream") is True:
+        attrs[SpanAttributes.LLM_IS_STREAMING] = True
+    return attrs
 
 
 def emit_together_span(
@@ -301,6 +316,8 @@ def emit_together_span(
     response_or_chunks: Any = None,
     error_message: str | None = None,
     status_code: int = 200,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
     """Build a ReadableSpan for a Together SDK call and inject it."""
     try:
@@ -311,9 +328,22 @@ def emit_together_span(
         )
         if error_message:
             attrs["error.message"] = error_message
-            attrs.setdefault("status_code", status_code if status_code >= 400 else 500)
+            attrs["http.response.status_code"] = (
+                status_code if status_code >= 400 else 500
+            )
+            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(
+                {
+                    "error": {
+                        "message": error_message,
+                        "status_code": status_code if status_code >= 400 else 500,
+                    }
+                }
+            )
 
-        trace_id, parent_id = _current_trace_parent_ids()
+        if trace_id is None or parent_id is None:
+            current_trace_id, current_parent_id = _current_trace_parent_ids()
+            trace_id = trace_id or current_trace_id
+            parent_id = parent_id or current_parent_id
         span_name = str(attrs[SpanAttributes.TRACELOOP_ENTITY_NAME])
         span = build_readable_span(
             name=span_name,

--- a/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_serialization.py
@@ -1,0 +1,239 @@
+"""Bounded, privacy-safe serialization for Together telemetry."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+MAX_JSON_BYTES = 16_000
+MAX_TEXT_BYTES = 4_000
+MAX_ITEMS = 50
+MAX_DEPTH = 8
+
+_SENSITIVE_KEY = re.compile(
+    r"(^|[._-])(api[_-]?key|authorization|cookie|password|secret|token)([._-]|$)",
+    re.IGNORECASE,
+)
+_ASSIGNMENT_SECRET = re.compile(
+    r"(?i)([a-z0-9_.-]*(?:api[_-]?key|authorization|cookie|password|secret|token))"
+    r"\s*[:=]\s*([^\s,;]+)"
+)
+_QUOTED_SECRET = re.compile(
+    r"""(?i)(["'][^"']*(?:api[_-]?key|authorization|cookie|password|secret|token)["']\s*:\s*)(["'])(.*?)\2"""
+)
+_BEARER_SECRET = re.compile(r"(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")
+
+
+def safe_type_name(value: Any) -> str:
+    return type(value).__name__[:120]
+
+
+def redact_text(value: str) -> str:
+    value = _BEARER_SECRET.sub(lambda match: f"{match.group(1)} [REDACTED]", value)
+    value = _QUOTED_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]{match.group(2)}",
+        value,
+    )
+    value = _ASSIGNMENT_SECRET.sub(
+        lambda match: f"{match.group(1)}=[REDACTED]",
+        value,
+    )
+    return value
+
+
+def safe_text(value: Any, *, max_bytes: int = MAX_TEXT_BYTES) -> str:
+    if isinstance(value, str):
+        text = redact_text(value)
+    elif value is None:
+        text = ""
+    elif isinstance(value, bool):
+        text = "true" if value else "false"
+    elif isinstance(value, int) or isinstance(value, float) and math.isfinite(value):
+        text = str(value)
+    else:
+        text = f"<{safe_type_name(value)}>"
+    if len(text.encode("utf-8")) <= max_bytes:
+        return text
+    low, high, best = 0, len(text), ""
+    suffix = "…[truncated]"
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = f"{text[:middle]}{suffix}"
+        if len(candidate.encode("utf-8")) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or "[truncated]"
+
+
+def safe_exception_message(exc: BaseException) -> str:
+    try:
+        raw_args = exc.args
+    except BaseException:  # noqa: BLE001
+        raw_args = ()
+    parts: list[str] = []
+    if isinstance(raw_args, tuple):
+        for value in raw_args[:4]:
+            if isinstance(value, (str, bool, int, float)) or value is None:
+                rendered = safe_text(value, max_bytes=1_000)
+                if rendered:
+                    parts.append(rendered)
+    detail = "; ".join(parts)
+    name = safe_type_name(exc)
+    return safe_text(f"{name}: {detail}" if detail else name)
+
+
+def provider_status_code(exc: BaseException) -> int:
+    candidates: list[Any] = []
+    for name in ("status_code", "status"):
+        try:
+            candidates.append(getattr(exc, name, None))
+        except BaseException:  # noqa: BLE001, S112
+            continue
+    try:
+        response = getattr(exc, "response", None)
+    except BaseException:  # noqa: BLE001
+        response = None
+    if response is not None:
+        for name in ("status_code", "status"):
+            try:
+                candidates.append(getattr(response, name, None))
+            except BaseException:  # noqa: BLE001, S112
+                continue
+    for value in candidates:
+        if (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 400 <= value <= 599
+        ):
+            return value
+    return 500
+
+
+def _safe_key(value: Any) -> str:
+    if isinstance(value, str):
+        return safe_text(value, max_bytes=256)
+    if isinstance(value, (int, bool)) or value is None:
+        return json.dumps(value)
+    return f"<{safe_type_name(value)}>"
+
+
+def to_jsonable(value: Any, *, depth: int = 0) -> Any:
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else safe_text(value)
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        try:
+            length = len(value)
+        except BaseException:  # noqa: BLE001
+            length = None
+        return {"type": "bytes", "length": length}
+    if depth >= MAX_DEPTH:
+        return {"type": safe_type_name(value), "truncated": True}
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        truncated = False
+        try:
+            for key, item in islice(iter(value.items()), MAX_ITEMS + 1):
+                if len(result) >= MAX_ITEMS:
+                    truncated = True
+                    break
+                rendered_key = _safe_key(key)
+                result[rendered_key] = (
+                    "[REDACTED]"
+                    if _SENSITIVE_KEY.search(rendered_key)
+                    else to_jsonable(item, depth=depth + 1)
+                )
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if truncated:
+            result["_respan_truncated_items"] = True
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items: list[Any] = []
+        truncated = False
+        try:
+            for item in islice(iter(value), MAX_ITEMS + 1):
+                if len(items) >= MAX_ITEMS:
+                    truncated = True
+                    break
+                items.append(to_jsonable(item, depth=depth + 1))
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if truncated:
+            items.append({"_respan_truncated_items": True})
+        return items
+    for method_name in ("model_dump", "to_dict"):
+        try:
+            method = getattr(value, method_name, None)
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if callable(method):
+            try:
+                dumped = (
+                    method(mode="json") if method_name == "model_dump" else method()
+                )
+            except TypeError:
+                try:
+                    dumped = method()
+                except BaseException:  # noqa: BLE001, S112
+                    continue
+            except BaseException:  # noqa: BLE001, S112
+                continue
+            return to_jsonable(dumped, depth=depth + 1)
+    return {"type": safe_type_name(value)}
+
+
+def json_dumps(value: Any, *, max_bytes: int = MAX_JSON_BYTES) -> str:
+    serialized = json.dumps(
+        to_jsonable(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    if len(serialized.encode("utf-8")) <= max_bytes:
+        return serialized
+    low, high, best = 0, len(serialized), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = json.dumps(
+            {"preview": serialized[:middle], "truncated": True},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        if len(candidate.encode("utf-8")) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or '{"truncated":true}'
+
+
+def sanitize_url(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = safe_text(value)
+    try:
+        parsed = urlsplit(text if "://" in text else f"//{text}")
+        host = parsed.hostname or ""
+        if not host:
+            return "[REDACTED-ENDPOINT]"
+        netloc = host
+        if ":" in host and not host.startswith("["):
+            netloc = f"[{host}]"
+        if parsed.port is not None:
+            netloc = f"{netloc}:{parsed.port}"
+        return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+    except (TypeError, ValueError):
+        return "[REDACTED-ENDPOINT]"

--- a/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-together/src/respan_instrumentation_together/_translator.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Iterable
+import math
+from itertools import islice
+from typing import Any
 
 from respan_instrumentation_together._constants import (
     ARGUMENTS_KEY,
-    ASSISTANT_ROLE,
     B64_JSON_KEY,
     CHOICES_KEY,
     CONTENT_KEY,
@@ -35,74 +36,51 @@ from respan_instrumentation_together._constants import (
     RESULTS_KEY,
     ROLE_KEY,
     TEXT_KEY,
-    TOOLS_KEY,
     TOOL_CALL_ID_KEY,
     TOOL_CALLS_KEY,
     TYPE_KEY,
     URL_KEY,
     USAGE_KEY,
 )
-from respan_sdk.utils.serialization import serialize_value
+from respan_instrumentation_together._serialization import (
+    json_dumps,
+    safe_text,
+    to_jsonable,
+)
 
 
 def safe_json(value: Any) -> str:
-    """JSON-encode a value after applying the SDK serializer."""
-    try:
-        return json.dumps(serialize_value(value=value), default=str)
-    except Exception:
-        return str(value)
+    """JSON-encode a value with the instrumentation capture policy."""
+    return json_dumps(value)
 
 
 def to_json_attr(value: Any) -> str:
     if isinstance(value, str):
-        return value
+        return safe_text(value)
     return safe_json(value=value)
 
 
 def field(value: Any, name: str, default: Any = None) -> Any:
     if isinstance(value, dict):
         return value.get(name, default)
-    return getattr(value, name, default)
+    try:
+        return getattr(value, name, default)
+    except BaseException:  # noqa: BLE001
+        return default
 
 
 def _is_omitted(value: Any) -> bool:
     value_type = type(value)
-    return (
-        value_type.__module__.startswith("together.")
-        and value_type.__name__ in {"Omit", "NotGiven"}
-    )
+    return value_type.__module__.startswith("together.") and value_type.__name__ in {
+        "Omit",
+        "NotGiven",
+    }
 
 
 def dump_value(value: Any) -> Any:
-    if value is None or _is_omitted(value):
+    if _is_omitted(value):
         return None
-    if isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, dict):
-        return {
-            str(key): dump_value(nested_value)
-            for key, nested_value in value.items()
-            if dump_value(nested_value) is not None
-        }
-    if isinstance(value, (list, tuple, set)):
-        return [
-            dumped_item
-            for item in value
-            if (dumped_item := dump_value(item)) is not None
-        ]
-    to_dict = getattr(value, "to_dict", None)
-    if callable(to_dict):
-        try:
-            return to_dict()
-        except Exception:
-            pass
-    model_dump = getattr(value, "model_dump", None)
-    if callable(model_dump):
-        try:
-            return model_dump(exclude_none=True)
-        except TypeError:
-            return model_dump()
-    return serialize_value(value=value)
+    return to_jsonable(value)
 
 
 def sequence_value(value: Any) -> list[Any]:
@@ -115,8 +93,8 @@ def sequence_value(value: Any) -> list[Any]:
     if isinstance(value, (str, bytes, dict)):
         return [value]
     try:
-        return list(value)
-    except TypeError:
+        return list(islice(iter(value), 50))
+    except (TypeError, RuntimeError):
         return [value]
 
 
@@ -125,7 +103,7 @@ def normalize_message(message: Any) -> dict[str, Any]:
     role = field(message, ROLE_KEY)
     content = field(message, CONTENT_KEY)
     if role is not None:
-        normalized[ROLE_KEY] = role
+        normalized[ROLE_KEY] = safe_text(role, max_bytes=256)
     if content is not None:
         normalized[CONTENT_KEY] = dump_value(content)
 
@@ -139,7 +117,7 @@ def normalize_message(message: Any) -> dict[str, Any]:
 
     tool_call_id = field(message, TOOL_CALL_ID_KEY)
     if tool_call_id:
-        normalized[TOOL_CALL_ID_KEY] = str(tool_call_id)
+        normalized[TOOL_CALL_ID_KEY] = safe_text(tool_call_id, max_bytes=256)
 
     return normalized
 
@@ -155,7 +133,7 @@ def normalize_function_call(function_call: Any) -> dict[str, Any]:
     arguments = field(function_call, ARGUMENTS_KEY)
     result: dict[str, Any] = {}
     if name:
-        result[NAME_KEY] = str(name)
+        result[NAME_KEY] = safe_text(name, max_bytes=256)
     if arguments is not None:
         result[ARGUMENTS_KEY] = (
             arguments if isinstance(arguments, str) else safe_json(arguments)
@@ -175,7 +153,7 @@ def _normalize_tool_call(tool_call: Any) -> dict[str, Any]:
     }
     call_id = field(tool_call, ID_KEY)
     if call_id:
-        normalized[ID_KEY] = str(call_id)
+        normalized[ID_KEY] = safe_text(call_id, max_bytes=256)
     return normalized
 
 
@@ -204,15 +182,20 @@ def normalize_tools(tools: Any) -> list[dict[str, Any]]:
         function_name = field(function, NAME_KEY)
         if not function_name:
             continue
-        normalized_function: dict[str, Any] = {NAME_KEY: str(function_name)}
+        normalized_function: dict[str, Any] = {
+            NAME_KEY: safe_text(function_name, max_bytes=256)
+        }
         description = field(function, DESCRIPTION_KEY)
         if description is not None:
-            normalized_function[DESCRIPTION_KEY] = str(description)
+            normalized_function[DESCRIPTION_KEY] = safe_text(description)
         parameters = field(function, PARAMETERS_KEY)
         if parameters is not None:
             normalized_function[PARAMETERS_KEY] = dump_value(parameters)
         normalized_tools.append(
-            {TYPE_KEY: str(tool_type), FUNCTION_KEY: normalized_function}
+            {
+                TYPE_KEY: safe_text(tool_type, max_bytes=64),
+                FUNCTION_KEY: normalized_function,
+            }
         )
     return normalized_tools
 
@@ -288,7 +271,11 @@ def text_completion_output(response_or_chunks: Any) -> str:
 
 def extract_tool_calls(response_or_chunks: Any) -> list[dict[str, Any]]:
     raw_calls: list[Any] = []
-    chunks = response_or_chunks if isinstance(response_or_chunks, list) else [response_or_chunks]
+    chunks = (
+        response_or_chunks
+        if isinstance(response_or_chunks, list)
+        else [response_or_chunks]
+    )
     for response in chunks:
         choice = _first_choice(response)
         message = _choice_message(choice)
@@ -316,7 +303,11 @@ def extract_tool_calls(response_or_chunks: Any) -> list[dict[str, Any]]:
 
 
 def finish_reason(response_or_chunks: Any) -> str | None:
-    chunks = response_or_chunks if isinstance(response_or_chunks, list) else [response_or_chunks]
+    chunks = (
+        response_or_chunks
+        if isinstance(response_or_chunks, list)
+        else [response_or_chunks]
+    )
     for response in reversed(chunks):
         for choice in reversed(field(response, CHOICES_KEY, []) or []):
             reason = field(choice, FINISH_REASON_KEY)
@@ -326,7 +317,11 @@ def finish_reason(response_or_chunks: Any) -> str | None:
 
 
 def extract_usage(response_or_chunks: Any) -> dict[str, int]:
-    chunks = response_or_chunks if isinstance(response_or_chunks, list) else [response_or_chunks]
+    chunks = (
+        response_or_chunks
+        if isinstance(response_or_chunks, list)
+        else [response_or_chunks]
+    )
     for response in reversed(chunks):
         usage = field(response, USAGE_KEY)
         if usage is None:
@@ -349,18 +344,42 @@ def embedding_input(request_kwargs: dict[str, Any]) -> str:
     return to_json_attr(request_kwargs.get(INPUT_KEY))
 
 
-def embedding_summary(response: Any) -> dict[str, Any]:
-    data = field(response, DATA_KEY, []) or []
-    first_embedding = None
-    for item in data:
-        embedding = field(item, EMBEDDING_KEY)
-        if isinstance(embedding, list):
-            first_embedding = embedding
-            break
-    summary: dict[str, Any] = {"embedding_count": len(data)}
-    if first_embedding is not None:
-        summary["embedding_dimensions"] = len(first_embedding)
-    return summary
+def embedding_output(response: Any) -> str:
+    """Retain complete numeric vectors as required by the span contract."""
+    entries: list[dict[str, Any]] = []
+    data = field(response, DATA_KEY, [])
+    try:
+        iterator = iter(data)
+    except TypeError:
+        iterator = iter(())
+    for item in iterator:
+        raw_embedding = field(item, EMBEDDING_KEY)
+        if not isinstance(raw_embedding, (list, tuple)):
+            continue
+        vector: list[int | float] = []
+        valid = True
+        for value in raw_embedding:
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                valid = False
+                break
+            if isinstance(value, float) and not math.isfinite(value):
+                valid = False
+                break
+            vector.append(value)
+        if not valid:
+            continue
+        entry: dict[str, Any] = {EMBEDDING_KEY: vector}
+        index = field(item, INDEX_KEY)
+        if isinstance(index, int) and not isinstance(index, bool):
+            entry[INDEX_KEY] = index
+        entries.append(entry)
+    return json.dumps(
+        {DATA_KEY: entries},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
 
 
 def rerank_input(request_kwargs: dict[str, Any]) -> str:
@@ -416,7 +435,9 @@ def image_output(response: Any) -> str:
                 "present": bool(value),
                 "length": len(value) if isinstance(value, str) else 0,
             }
-        images.append({key: value for key, value in normalized.items() if value is not None})
+        images.append(
+            {key: value for key, value in normalized.items() if value is not None}
+        )
     return safe_json({"image_count": len(images), "images": images})
 
 
@@ -425,4 +446,4 @@ def request_model(request_kwargs: dict[str, Any], response: Any = None) -> str |
     if isinstance(model, str) and model:
         return model
     response_model = field(response, MODEL_KEY)
-    return response_model if isinstance(response_model, str) and response_model else None
+    return safe_text(response_model, max_bytes=512) if response_model else None

--- a/python-sdks/instrumentations/respan-instrumentation-together/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-together/tests/test_instrumentation.py
@@ -9,9 +9,7 @@ from typing import Any
 import pytest
 from opentelemetry import context as context_api
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
-
-from respan_instrumentation_together import TogetherInstrumentor
-from respan_instrumentation_together import _instrumentation
+from respan_instrumentation_together import TogetherInstrumentor, _instrumentation
 from respan_instrumentation_together._constants import (
     ASYNC_COMPLETIONS_RESOURCE_CLASS_NAME,
     ASYNC_EMBEDDINGS_RESOURCE_CLASS_NAME,
@@ -21,7 +19,6 @@ from respan_instrumentation_together._constants import (
     COMPLETIONS_RESOURCE_CLASS_NAME,
     CREATE_METHOD_NAME,
     EMBEDDINGS_RESOURCE_CLASS_NAME,
-    GENERATE_METHOD_NAME,
     IMAGES_RESOURCE_CLASS_NAME,
     RERANK_RESOURCE_CLASS_NAME,
     TOGETHER_CHAT_COMPLETIONS_MODULE,
@@ -37,7 +34,11 @@ from respan_instrumentation_together._otel_emitter import (
     build_image_attrs,
     build_rerank_attrs,
 )
-from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_EMBEDDING, LOG_TYPE_TEXT
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_TEXT,
+)
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
 
 
@@ -53,7 +54,9 @@ def usage(prompt_tokens: int = 3, completion_tokens: int = 4) -> SimpleNamespace
     )
 
 
-def chat_response(*, content: str = "hello", tool_calls: list[Any] | None = None) -> Any:
+def chat_response(
+    *, content: str = "hello", tool_calls: list[Any] | None = None
+) -> Any:
     return obj(
         model="openai/gpt-oss-20b",
         choices=[
@@ -112,7 +115,7 @@ class AsyncIterator:
     def __init__(self, chunks: list[Any]) -> None:
         self._chunks = iter(chunks)
 
-    def __aiter__(self) -> "AsyncIterator":
+    def __aiter__(self) -> AsyncIterator:
         return self
 
     async def __anext__(self) -> Any:
@@ -123,17 +126,10 @@ class AsyncIterator:
 
 
 @pytest.fixture(autouse=True)
-def reset_instrumentation_globals() -> None:
-    _instrumentation._original_sync_chat_create = None
-    _instrumentation._original_async_chat_create = None
-    _instrumentation._original_sync_completion_create = None
-    _instrumentation._original_async_completion_create = None
-    _instrumentation._original_sync_embedding_create = None
-    _instrumentation._original_async_embedding_create = None
-    _instrumentation._original_sync_image_generate = None
-    _instrumentation._original_async_image_generate = None
-    _instrumentation._original_sync_rerank_create = None
-    _instrumentation._original_async_rerank_create = None
+def reset_instrumentation_globals() -> Any:
+    _instrumentation._reset_runtime_for_tests()
+    yield
+    _instrumentation._reset_runtime_for_tests()
 
 
 @pytest.fixture()
@@ -149,19 +145,27 @@ def captured_spans(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
 @pytest.fixture()
 def fake_together_modules(monkeypatch: pytest.MonkeyPatch) -> dict[str, type[Any]]:
     class ChatCompletionsResource:
-        def create(self, *, model: str, messages: Any, tools: Any = None, stream: bool = False) -> Any:
+        def create(
+            self, *, model: str, messages: Any, tools: Any = None, stream: bool = False
+        ) -> Any:
             if stream:
                 return iter(
                     [
                         obj(
                             choices=[
-                                obj(delta=obj(role="assistant", content="hello "), finish_reason=None)
+                                obj(
+                                    delta=obj(role="assistant", content="hello "),
+                                    finish_reason=None,
+                                )
                             ],
                             usage=None,
                         ),
                         obj(
                             choices=[
-                                obj(delta=obj(role="assistant", content="stream"), finish_reason="stop")
+                                obj(
+                                    delta=obj(role="assistant", content="stream"),
+                                    finish_reason="stop",
+                                )
                             ],
                             usage=usage(8, 9),
                         ),
@@ -170,12 +174,21 @@ def fake_together_modules(monkeypatch: pytest.MonkeyPatch) -> dict[str, type[Any
             return chat_response(content=f"{model}: {messages[0]['content']}")
 
     class AsyncChatCompletionsResource:
-        async def create(self, *, model: str, messages: Any, stream: bool = False) -> Any:
+        async def create(
+            self, *, model: str, messages: Any, stream: bool = False
+        ) -> Any:
             if stream:
                 return AsyncIterator(
                     [
-                        obj(choices=[obj(delta=obj(role="assistant", content="async "))]),
-                        obj(choices=[obj(delta=obj(role="assistant", content="stream"))], usage=usage(10, 11)),
+                        obj(
+                            choices=[obj(delta=obj(role="assistant", content="async "))]
+                        ),
+                        obj(
+                            choices=[
+                                obj(delta=obj(role="assistant", content="stream"))
+                            ],
+                            usage=usage(10, 11),
+                        ),
                     ]
                 )
             return chat_response(content=f"async {messages[0]['content']}")
@@ -205,11 +218,15 @@ def fake_together_modules(monkeypatch: pytest.MonkeyPatch) -> dict[str, type[Any
             return image_response()
 
     class RerankResource:
-        def create(self, *, documents: Any, model: str, query: str, **kwargs: Any) -> Any:
+        def create(
+            self, *, documents: Any, model: str, query: str, **kwargs: Any
+        ) -> Any:
             return rerank_response()
 
     class AsyncRerankResource:
-        async def create(self, *, documents: Any, model: str, query: str, **kwargs: Any) -> Any:
+        async def create(
+            self, *, documents: Any, model: str, query: str, **kwargs: Any
+        ) -> Any:
             return rerank_response()
 
     modules = {
@@ -289,8 +306,16 @@ def test_build_chat_attrs_uses_canonical_fields_without_aliases() -> None:
     assert attrs[SpanAttributes.LLM_REQUEST_TYPE] == LLMRequestTypeValues.CHAT.value
     assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "openai/gpt-oss-20b"
     assert attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"] == "Weather in Tokyo?"
-    assert json.loads(attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"]["name"] == "get_weather"
-    assert json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])[0]["function"]["name"] == "get_weather"
+    assert (
+        json.loads(attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"]["name"]
+        == "get_weather"
+    )
+    assert (
+        json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])[0][
+            "function"
+        ]["name"]
+        == "get_weather"
+    )
     assert_no_banned_aliases(attrs)
 
 
@@ -300,9 +325,15 @@ def test_build_non_chat_attrs_cover_completion_embedding_rerank_and_image() -> N
         response_or_chunks=text_response(),
     )
     assert completion_attrs[RESPAN_LOG_TYPE] == LOG_TYPE_TEXT
-    assert completion_attrs[SpanAttributes.LLM_REQUEST_TYPE] == LLMRequestTypeValues.COMPLETION.value
+    assert (
+        completion_attrs[SpanAttributes.LLM_REQUEST_TYPE]
+        == LLMRequestTypeValues.CHAT.value
+    )
     assert completion_attrs[SpanAttributes.LLM_REQUEST_MODEL] == "code"
-    assert completion_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == " completed text"
+    assert (
+        completion_attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]
+        == " completed text"
+    )
     assert_no_banned_aliases(completion_attrs)
 
     embedding_attrs = build_embedding_attrs(
@@ -310,13 +341,17 @@ def test_build_non_chat_attrs_cover_completion_embedding_rerank_and_image() -> N
         response=embedding_response(),
     )
     assert embedding_attrs[RESPAN_LOG_TYPE] == LOG_TYPE_EMBEDDING
-    assert embedding_attrs[SpanAttributes.LLM_REQUEST_TYPE] == LLMRequestTypeValues.EMBEDDING.value
+    assert (
+        embedding_attrs[SpanAttributes.LLM_REQUEST_TYPE]
+        == LLMRequestTypeValues.EMBEDDING.value
+    )
     assert embedding_attrs[SpanAttributes.LLM_REQUEST_MODEL] == "embed"
     assert json.loads(embedding_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
-        "embedding_count": 2,
-        "embedding_dimensions": 3,
+        "data": [
+            {"embedding": [0.1, 0.2, 0.3], "index": 0},
+            {"embedding": [0.4, 0.5, 0.6], "index": 1},
+        ]
     }
-    assert "0.1" not in embedding_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
     assert_no_banned_aliases(embedding_attrs)
 
     rerank_attrs = build_rerank_attrs(
@@ -327,18 +362,28 @@ def test_build_non_chat_attrs_cover_completion_embedding_rerank_and_image() -> N
         },
         response=rerank_response(),
     )
-    assert rerank_attrs[SpanAttributes.LLM_REQUEST_TYPE] == LLMRequestTypeValues.RERANK.value
+    assert (
+        rerank_attrs[SpanAttributes.LLM_REQUEST_TYPE] == LLMRequestTypeValues.CHAT.value
+    )
     assert rerank_attrs[SpanAttributes.LLM_REQUEST_MODEL] == "rank"
-    assert json.loads(rerank_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])[0]["index"] == 1
+    assert (
+        json.loads(rerank_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])[0]["index"]
+        == 1
+    )
     assert_no_banned_aliases(rerank_attrs)
 
     image_attrs = build_image_attrs(
         request_kwargs={"model": "flux", "prompt": "a small robot"},
         response=image_response(),
     )
-    assert image_attrs[SpanAttributes.LLM_REQUEST_TYPE] == LLMRequestTypeValues.UNKNOWN.value
+    assert (
+        image_attrs[SpanAttributes.LLM_REQUEST_TYPE] == LLMRequestTypeValues.CHAT.value
+    )
     assert image_attrs[SpanAttributes.LLM_REQUEST_MODEL] == "flux"
-    assert json.loads(image_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])["image_count"] == 1
+    assert (
+        json.loads(image_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])["image_count"]
+        == 1
+    )
     assert_no_banned_aliases(image_attrs)
 
 
@@ -359,7 +404,10 @@ def test_activate_patches_sync_chat_and_emits_span(
     assert len(captured_spans) == 1
     attrs = captured_spans[0]._attributes
     assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "openai/gpt-oss-20b"
-    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "openai/gpt-oss-20b: Say hello"
+    assert (
+        attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]
+        == "openai/gpt-oss-20b: Say hello"
+    )
     assert_no_banned_aliases(attrs)
 
     instrumentor.deactivate()
@@ -408,7 +456,10 @@ def test_async_chat_emits_span(
 
         assert response.choices[0].message.content == "async Async"
         assert len(captured_spans) == 1
-        assert captured_spans[0]._attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "async Async"
+        assert (
+            captured_spans[0]._attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"]
+            == "async Async"
+        )
 
         instrumentor.deactivate()
 
@@ -436,7 +487,9 @@ def test_active_workflow_name_is_attached_to_injected_span() -> None:
     assert attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] == "together_chat_completion"
 
 
-def test_deactivate_restores_original_methods(fake_together_modules: dict[str, type[Any]]) -> None:
+def test_deactivate_restores_original_methods(
+    fake_together_modules: dict[str, type[Any]],
+) -> None:
     ChatCompletionsResource = fake_together_modules["chat"]
     AsyncChatCompletionsResource = fake_together_modules["async_chat"]
     original_sync = getattr(ChatCompletionsResource, CREATE_METHOD_NAME)
@@ -445,7 +498,9 @@ def test_deactivate_restores_original_methods(fake_together_modules: dict[str, t
     instrumentor = TogetherInstrumentor()
     instrumentor.activate()
     assert getattr(ChatCompletionsResource, CREATE_METHOD_NAME) is not original_sync
-    assert getattr(AsyncChatCompletionsResource, CREATE_METHOD_NAME) is not original_async
+    assert (
+        getattr(AsyncChatCompletionsResource, CREATE_METHOD_NAME) is not original_async
+    )
 
     instrumentor.deactivate()
     assert getattr(ChatCompletionsResource, CREATE_METHOD_NAME) is original_sync

--- a/python-sdks/instrumentations/respan-instrumentation-together/tests/test_otel2_contract.py
+++ b/python-sdks/instrumentations/respan-instrumentation-together/tests/test_otel2_contract.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_instrumentation_together import TogetherInstrumentor, _instrumentation
+from respan_instrumentation_together._constants import (
+    COMPLETIONS_RESOURCE_CLASS_NAME,
+    CREATE_METHOD_NAME,
+    TOGETHER_CHAT_COMPLETIONS_MODULE,
+)
+from respan_instrumentation_together._serialization import json_dumps
+
+
+def _obj(**values: Any) -> SimpleNamespace:
+    return SimpleNamespace(**values)
+
+
+@pytest.fixture(autouse=True)
+def _clean_runtime() -> Any:
+    _instrumentation._reset_runtime_for_tests()
+    yield
+    _instrumentation._reset_runtime_for_tests()
+
+
+def _current_chat_class() -> type[Any]:
+    module = pytest.importorskip(TOGETHER_CHAT_COMPLETIONS_MODULE)
+    return getattr(module, COMPLETIONS_RESOURCE_CLASS_NAME)
+
+
+def test_real_current_together_stream_exports_canonical_readable_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chat_class = _current_chat_class()
+    emitted: list[Any] = []
+    monkeypatch.setattr(
+        "respan_instrumentation_together._otel_emitter.inject_span",
+        lambda span: emitted.append(span),
+    )
+
+    def fake_create(self: Any, **kwargs: Any) -> Any:
+        del self, kwargs
+        return iter(
+            [
+                _obj(
+                    choices=[_obj(delta=_obj(content="Together "), finish_reason=None)],
+                    usage=None,
+                ),
+                _obj(
+                    choices=[
+                        _obj(delta=_obj(content="streamed."), finish_reason="stop")
+                    ],
+                    usage=_obj(
+                        prompt_tokens=9,
+                        completion_tokens=4,
+                        total_tokens=13,
+                    ),
+                ),
+            ]
+        )
+
+    monkeypatch.setattr(chat_class, CREATE_METHOD_NAME, fake_create)
+    instrumentor = TogetherInstrumentor()
+    instrumentor.activate()
+    resource = object.__new__(chat_class)
+    provider = TracerProvider()
+    with provider.get_tracer(__name__).start_as_current_span("parent") as parent:
+        stream = resource.create(
+            model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            messages=[{"role": "user", "content": "Say streamed."}],
+            stream=True,
+        )
+        assert [chunk for chunk in stream]
+        parent_context = parent.get_span_context()
+    instrumentor.deactivate()
+
+    assert len(emitted) == 1
+    span = emitted[0]
+    attrs = span.attributes
+    assert span.parent.span_id == parent_context.span_id
+    assert attrs[SpanAttributes.LLM_IS_STREAMING] is True
+    assert attrs[gen_ai_attributes.GEN_AI_PROVIDER_NAME] == "together"
+    assert attrs[gen_ai_attributes.GEN_AI_USAGE_INPUT_TOKENS] == 9
+    assert attrs[gen_ai_attributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 4
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "Together streamed."
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
+
+
+def test_real_current_together_lifecycle_is_shared_and_foreign_safe() -> None:
+    chat_class = _current_chat_class()
+    original = getattr(chat_class, CREATE_METHOD_NAME)
+    first = TogetherInstrumentor()
+    second = TogetherInstrumentor()
+    first.activate()
+    installed = getattr(chat_class, CREATE_METHOD_NAME)
+    second.activate()
+    first.deactivate()
+    assert getattr(chat_class, CREATE_METHOD_NAME) is installed
+    second.deactivate()
+    assert getattr(chat_class, CREATE_METHOD_NAME) is original
+
+    first.activate()
+    installed = getattr(chat_class, CREATE_METHOD_NAME)
+
+    def foreign(self: Any, *args: Any, **kwargs: Any) -> Any:
+        return installed(self, *args, **kwargs)
+
+    setattr(chat_class, CREATE_METHOD_NAME, foreign)
+    first.deactivate()
+    assert getattr(chat_class, CREATE_METHOD_NAME) is foreign
+    setattr(chat_class, CREATE_METHOD_NAME, original)
+
+
+def test_provider_error_keeps_precise_status_without_calling_hostile_str(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chat_class = _current_chat_class()
+    emitted: list[Any] = []
+    monkeypatch.setattr(
+        "respan_instrumentation_together._otel_emitter.inject_span",
+        lambda span: emitted.append(span),
+    )
+
+    class ProviderError(Exception):
+        status_code = 429
+
+        def __str__(self) -> str:
+            raise AssertionError("instrumentation called hostile __str__")
+
+    error = ProviderError('{"api_key":"plain-secret","message":"limited"}')
+
+    def fail(self: Any, **kwargs: Any) -> Any:
+        del self, kwargs
+        raise error
+
+    monkeypatch.setattr(chat_class, CREATE_METHOD_NAME, fail)
+    instrumentor = TogetherInstrumentor()
+    instrumentor.activate()
+    with pytest.raises(ProviderError) as caught:
+        object.__new__(chat_class).create(
+            model="model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+    instrumentor.deactivate()
+    assert caught.value is error
+    assert len(emitted) == 1
+    span = emitted[0]
+    assert span.status.status_code.name == "ERROR"
+    assert span.attributes["http.response.status_code"] == 429
+    serialized = json.dumps(dict(span.attributes), sort_keys=True)
+    assert "plain-secret" not in serialized
+
+
+def test_bounded_json_redacts_nested_secrets_and_never_uses_repr() -> None:
+    class Hostile:
+        def __str__(self) -> str:
+            raise AssertionError
+
+        __repr__ = __str__
+
+    serialized = json_dumps(
+        {
+            "client_secret": "plain-secret",
+            "nested": {"authorization": "Basic abcdef", "object": Hostile()},
+            "unicode": "😀" * 20_000,
+        }
+    )
+    assert len(serialized.encode("utf-8")) <= 16_000
+    assert "plain-secret" not in serialized
+    assert "abcdef" not in serialized
+    assert json.loads(serialized)

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_instrumentation.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import time
-from collections.abc import AsyncIterator, Iterator
-from typing import Any
+from collections.abc import Callable
+from dataclasses import dataclass
+from threading import RLock
+from types import TracebackType
+from typing import Any, Self
+
+from opentelemetry import trace
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.core.tracer import RespanTracer
 
 from respan_instrumentation_vertexai._constants import (
     CHAT_SESSION_CLASS_NAME,
@@ -21,23 +32,36 @@ from respan_instrumentation_vertexai._constants import (
     VERTEXAI_INSTRUMENTATION_NAME,
 )
 from respan_instrumentation_vertexai._otel_emitter import emit_generate_content_span
+from respan_instrumentation_vertexai._serialization import (
+    provider_status_code,
+    safe_exception_message,
+)
 from respan_instrumentation_vertexai._translator import request_payload_from_call
-from respan_tracing.core.tracer import RespanTracer
 
 logger = logging.getLogger(__name__)
 
-_original_generate_content = None
-_original_generate_content_async = None
-_original_send_message = None
-_original_send_message_async = None
+_LOCK = RLock()
+_ACTIVATION_COUNT = 0
+_MAX_STREAM_CHUNKS = 50
+
+
+@dataclass(frozen=True)
+class _Patch:
+    cls: type[Any]
+    method_name: str
+    original: Any
+    wrapper: Any
+
+
+_PATCHES: list[_Patch] = []
 
 
 def _get_module_attr(module_path: str, attr_name: str) -> Any:
     module = importlib.import_module(module_path)
-    attr_value = getattr(module, attr_name, None)
-    if attr_value is None:
+    value = getattr(module, attr_name, None)
+    if value is None:
         raise AttributeError(f"{module_path}.{attr_name}")
-    return attr_value
+    return value
 
 
 def _load_vertexai_classes() -> tuple[type[Any], type[Any]]:
@@ -49,148 +73,241 @@ def _load_vertexai_classes() -> tuple[type[Any], type[Any]]:
     )
 
 
-def _emit_span_safely(
+def _current_trace_parent_ids() -> tuple[str | None, str | None]:
+    try:
+        context = trace.get_current_span().get_span_context()
+        if not context.is_valid:
+            return None, None
+        return format_trace_id(context.trace_id), format_span_id(context.span_id)
+    except BaseException:  # noqa: BLE001
+        return None, None
+
+
+def _emit(
     *,
-    instance: Any,
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
+    request_payload: dict[str, Any],
     start_ns: int,
     span_name: str,
+    trace_id: str | None,
+    parent_id: str | None,
     response_or_chunks: Any = None,
-    error_message: str | None = None,
-    status_code: int = 200,
+    error: BaseException | None = None,
 ) -> None:
     emit_generate_content_span(
-        request_payload=request_payload_from_call(
-            instance=instance,
-            args=args,
-            kwargs=kwargs,
-        ),
+        request_payload=request_payload,
         start_ns=start_ns,
         response_or_chunks=response_or_chunks,
         span_name=span_name,
-        error_message=error_message,
-        status_code=status_code,
+        error_message=safe_exception_message(error) if error is not None else None,
+        status_code=provider_status_code(error) if error is not None else 200,
+        trace_id=trace_id,
+        parent_id=parent_id,
     )
 
 
-def _wrap_sync_iterator(
-    *,
-    iterator: Iterator[Any],
-    instance: Any,
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-    start_ns: int,
-    span_name: str,
-) -> Iterator[Any]:
-    chunks: list[Any] = []
-    try:
-        for chunk in iterator:
-            chunks.append(chunk)
-            yield chunk
-    except Exception as exc:
-        _emit_span_safely(
-            instance=instance,
-            args=args,
-            kwargs=kwargs,
-            start_ns=start_ns,
-            span_name=span_name,
-            response_or_chunks=chunks,
-            error_message=str(exc),
-            status_code=500,
-        )
-        raise
-    else:
-        _emit_span_safely(
-            instance=instance,
-            args=args,
-            kwargs=kwargs,
-            start_ns=start_ns,
-            span_name=span_name,
-            response_or_chunks=chunks,
+class _StreamState:
+    def __init__(
+        self,
+        *,
+        request_payload: dict[str, Any],
+        start_ns: int,
+        span_name: str,
+        trace_id: str | None,
+        parent_id: str | None,
+    ) -> None:
+        self.request_payload = request_payload
+        self.start_ns = start_ns
+        self.span_name = span_name
+        self.trace_id = trace_id
+        self.parent_id = parent_id
+        self.chunks: list[Any] = []
+        self.emitted = False
+
+    def capture(self, chunk: Any) -> None:
+        if len(self.chunks) < _MAX_STREAM_CHUNKS:
+            self.chunks.append(chunk)
+        else:
+            self.chunks[-1] = chunk
+
+    def emit(self, error: BaseException | None = None) -> None:
+        if self.emitted:
+            return
+        self.emitted = True
+        _emit(
+            request_payload=self.request_payload,
+            start_ns=self.start_ns,
+            span_name=self.span_name,
+            trace_id=self.trace_id,
+            parent_id=self.parent_id,
+            response_or_chunks=self.chunks,
+            error=error,
         )
 
 
-async def _wrap_async_iterator(
-    *,
-    async_iterator: AsyncIterator[Any],
-    instance: Any,
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-    start_ns: int,
-    span_name: str,
-) -> AsyncIterator[Any]:
-    chunks: list[Any] = []
-    try:
-        async for chunk in async_iterator:
-            chunks.append(chunk)
-            yield chunk
-    except Exception as exc:
-        _emit_span_safely(
-            instance=instance,
-            args=args,
-            kwargs=kwargs,
-            start_ns=start_ns,
-            span_name=span_name,
-            response_or_chunks=chunks,
-            error_message=str(exc),
-            status_code=500,
-        )
-        raise
-    else:
-        _emit_span_safely(
-            instance=instance,
-            args=args,
-            kwargs=kwargs,
-            start_ns=start_ns,
-            span_name=span_name,
-            response_or_chunks=chunks,
-        )
+class _SyncStreamProxy:
+    def __init__(self, source: Any, state: _StreamState) -> None:
+        self._source = source
+        self._iterator = iter(source)
+        self._state = state
+
+    def __iter__(self) -> _SyncStreamProxy:
+        return self
+
+    def __next__(self) -> Any:
+        try:
+            chunk = next(self._iterator)
+        except StopIteration:
+            self._state.emit()
+            raise
+        except BaseException as exc:
+            self._state.emit(exc)
+            raise
+        self._state.capture(chunk)
+        return chunk
+
+    def __enter__(self) -> Self:
+        enter = getattr(self._source, "__enter__", None)
+        if callable(enter):
+            enter()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Any:
+        exit_method = getattr(self._source, "__exit__", None)
+        try:
+            result = exit_method(exc_type, exc, tb) if callable(exit_method) else None
+        except BaseException as close_error:
+            self._state.emit(close_error)
+            raise
+        self._state.emit(exc)
+        return result
+
+    def close(self) -> None:
+        close = getattr(self._source, "close", None)
+        try:
+            if callable(close):
+                close()
+        except BaseException as exc:
+            self._state.emit(exc)
+            raise
+        self._state.emit()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._source, name)
+
+
+class _AsyncStreamProxy:
+    def __init__(self, source: Any, state: _StreamState) -> None:
+        self._source = source
+        self._iterator = source.__aiter__()
+        self._state = state
+
+    def __aiter__(self) -> _AsyncStreamProxy:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            chunk = await self._iterator.__anext__()
+        except StopAsyncIteration:
+            self._state.emit()
+            raise
+        except BaseException as exc:
+            self._state.emit(exc)
+            raise
+        self._state.capture(chunk)
+        return chunk
+
+    async def __aenter__(self) -> Self:
+        enter = getattr(self._source, "__aenter__", None)
+        if callable(enter):
+            await enter()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Any:
+        exit_method = getattr(self._source, "__aexit__", None)
+        try:
+            result = (
+                await exit_method(exc_type, exc, tb) if callable(exit_method) else None
+            )
+        except BaseException as close_error:
+            self._state.emit(close_error)
+            raise
+        self._state.emit(exc)
+        return result
+
+    async def aclose(self) -> None:
+        close = getattr(self._source, "aclose", None)
+        if not callable(close):
+            close = getattr(self._source, "close", None)
+        try:
+            if callable(close):
+                result = close()
+                if inspect.isawaitable(result):
+                    await result
+        except BaseException as exc:
+            self._state.emit(exc)
+            raise
+        self._state.emit()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._source, name)
 
 
 def _is_sync_stream(value: Any) -> bool:
-    if isinstance(value, (str, bytes, bytearray)):
-        return False
-    return hasattr(value, "__iter__") and not hasattr(value, "candidates")
+    return (
+        not isinstance(value, (str, bytes, bytearray))
+        and hasattr(value, "__iter__")
+        and not hasattr(value, "candidates")
+    )
 
 
-def _is_async_stream(value: Any) -> bool:
-    return hasattr(value, "__aiter__")
-
-
-def _wrap_sync_method(original: Any, span_name: str) -> Any:
+def _wrap_sync_method(
+    original: Callable[..., Any], span_name: str
+) -> Callable[..., Any]:
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = _current_trace_parent_ids()
+        request_payload = request_payload_from_call(
+            instance=self, args=args, kwargs=kwargs
+        )
         try:
             response = original(self, *args, **kwargs)
-        except Exception as exc:
-            _emit_span_safely(
-                instance=self,
-                args=args,
-                kwargs=kwargs,
+        except BaseException as exc:
+            _emit(
+                request_payload=request_payload,
                 start_ns=start_ns,
                 span_name=span_name,
-                error_message=str(exc),
-                status_code=500,
+                trace_id=trace_id,
+                parent_id=parent_id,
+                error=exc,
             )
             raise
-
         if _is_sync_stream(response):
-            return _wrap_sync_iterator(
-                iterator=response,
-                instance=self,
-                args=args,
-                kwargs=kwargs,
-                start_ns=start_ns,
-                span_name=span_name,
+            return _SyncStreamProxy(
+                response,
+                _StreamState(
+                    request_payload=request_payload,
+                    start_ns=start_ns,
+                    span_name=span_name,
+                    trace_id=trace_id,
+                    parent_id=parent_id,
+                ),
             )
-
-        _emit_span_safely(
-            instance=self,
-            args=args,
-            kwargs=kwargs,
+        _emit(
+            request_payload=request_payload,
             start_ns=start_ns,
             span_name=span_name,
+            trace_id=trace_id,
+            parent_id=parent_id,
             response_or_chunks=response,
         )
         return response
@@ -198,39 +315,44 @@ def _wrap_sync_method(original: Any, span_name: str) -> Any:
     return wrapper
 
 
-def _wrap_async_method(original: Any, span_name: str) -> Any:
+def _wrap_async_method(
+    original: Callable[..., Any], span_name: str
+) -> Callable[..., Any]:
     async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = _current_trace_parent_ids()
+        request_payload = request_payload_from_call(
+            instance=self, args=args, kwargs=kwargs
+        )
         try:
             response = await original(self, *args, **kwargs)
-        except Exception as exc:
-            _emit_span_safely(
-                instance=self,
-                args=args,
-                kwargs=kwargs,
+        except BaseException as exc:
+            _emit(
+                request_payload=request_payload,
                 start_ns=start_ns,
                 span_name=span_name,
-                error_message=str(exc),
-                status_code=500,
+                trace_id=trace_id,
+                parent_id=parent_id,
+                error=exc,
             )
             raise
-
-        if _is_async_stream(response):
-            return _wrap_async_iterator(
-                async_iterator=response,
-                instance=self,
-                args=args,
-                kwargs=kwargs,
-                start_ns=start_ns,
-                span_name=span_name,
+        if hasattr(response, "__aiter__"):
+            return _AsyncStreamProxy(
+                response,
+                _StreamState(
+                    request_payload=request_payload,
+                    start_ns=start_ns,
+                    span_name=span_name,
+                    trace_id=trace_id,
+                    parent_id=parent_id,
+                ),
             )
-
-        _emit_span_safely(
-            instance=self,
-            args=args,
-            kwargs=kwargs,
+        _emit(
+            request_payload=request_payload,
             start_ns=start_ns,
             span_name=span_name,
+            trace_id=trace_id,
+            parent_id=parent_id,
             response_or_chunks=response,
         )
         return response
@@ -249,144 +371,92 @@ class VertexAIInstrumentor:
     @staticmethod
     def _is_respan_tracing_enabled() -> bool:
         tracer = getattr(RespanTracer, "_instance", None)
-        if tracer is None:
-            return True
-        return bool(getattr(tracer, "is_enabled", True))
+        return tracer is None or bool(getattr(tracer, "is_enabled", True))
 
     def activate(self) -> None:
-        """Monkey-patch Vertex AI generation methods."""
-        global _original_generate_content
-        global _original_generate_content_async
-        global _original_send_message
-        global _original_send_message_async
-
-        if self._is_instrumented:
-            return
-
-        if not self._is_respan_tracing_enabled():
-            logger.info(
-                "Vertex AI instrumentation skipped because Respan tracing is disabled"
-            )
-            return
-
-        try:
-            GenerativeModel, ChatSession = _load_vertexai_classes()
-        except ImportError as exc:
-            # SDK genuinely absent - expected when the app doesn't use Vertex AI
-            # (the google-cloud-aiplatform SDK is an optional extra).
-            logger.debug(
-                "Vertex AI instrumentation inactive - missing dependency: %s",
-                exc,
-            )
-            return
-        except AttributeError as exc:
-            # SDK installed but incompatible (a class moved/renamed) - surface it
-            # so a broken install isn't silently left untraced.
-            logger.warning(
-                "google-cloud-aiplatform is installed but incompatible - Vertex AI instrumentation inactive: %s",
-                exc,
-            )
-            return
-        except Exception as exc:
-            logger.warning("Failed to activate Vertex AI instrumentation: %s", exc)
-            return
-
-        try:
-            if _original_generate_content is None:
-                _original_generate_content = getattr(
-                    GenerativeModel,
-                    GENERATE_CONTENT_METHOD_NAME,
+        global _ACTIVATION_COUNT
+        with _LOCK:
+            if self._is_instrumented:
+                return
+            if not self._is_respan_tracing_enabled():
+                return
+            if _ACTIVATION_COUNT:
+                _ACTIVATION_COUNT += 1
+                self._is_instrumented = True
+                return
+            installed: list[_Patch] = []
+            try:
+                generative_model, chat_session = _load_vertexai_classes()
+                targets = (
+                    (
+                        generative_model,
+                        GENERATE_CONTENT_METHOD_NAME,
+                        VERTEXAI_GENERATE_CONTENT_SPAN_NAME,
+                        False,
+                    ),
+                    (
+                        generative_model,
+                        GENERATE_CONTENT_ASYNC_METHOD_NAME,
+                        VERTEXAI_GENERATE_CONTENT_SPAN_NAME,
+                        True,
+                    ),
+                    (
+                        chat_session,
+                        SEND_MESSAGE_METHOD_NAME,
+                        VERTEXAI_CHAT_SPAN_NAME,
+                        False,
+                    ),
+                    (
+                        chat_session,
+                        SEND_MESSAGE_ASYNC_METHOD_NAME,
+                        VERTEXAI_CHAT_SPAN_NAME,
+                        True,
+                    ),
                 )
-            setattr(
-                GenerativeModel,
-                GENERATE_CONTENT_METHOD_NAME,
-                _wrap_sync_method(
-                    _original_generate_content,
-                    VERTEXAI_GENERATE_CONTENT_SPAN_NAME,
-                ),
-            )
-
-            if _original_generate_content_async is None:
-                _original_generate_content_async = getattr(
-                    GenerativeModel,
-                    GENERATE_CONTENT_ASYNC_METHOD_NAME,
-                )
-            setattr(
-                GenerativeModel,
-                GENERATE_CONTENT_ASYNC_METHOD_NAME,
-                _wrap_async_method(
-                    _original_generate_content_async,
-                    VERTEXAI_GENERATE_CONTENT_SPAN_NAME,
-                ),
-            )
-
-            if _original_send_message is None:
-                _original_send_message = getattr(ChatSession, SEND_MESSAGE_METHOD_NAME)
-            setattr(
-                ChatSession,
-                SEND_MESSAGE_METHOD_NAME,
-                _wrap_sync_method(_original_send_message, VERTEXAI_CHAT_SPAN_NAME),
-            )
-
-            if _original_send_message_async is None:
-                _original_send_message_async = getattr(
-                    ChatSession,
-                    SEND_MESSAGE_ASYNC_METHOD_NAME,
-                )
-            setattr(
-                ChatSession,
-                SEND_MESSAGE_ASYNC_METHOD_NAME,
-                _wrap_async_method(
-                    _original_send_message_async,
-                    VERTEXAI_CHAT_SPAN_NAME,
-                ),
-            )
-        except Exception as exc:
-            logger.warning("Failed to activate Vertex AI instrumentation: %s", exc)
-            self.deactivate()
-            return
-
-        self._is_instrumented = True
-        logger.info("Vertex AI instrumentation activated")
+                for cls, method_name, span_name, is_async in targets:
+                    original = getattr(cls, method_name)
+                    wrapper = (
+                        _wrap_async_method(original, span_name)
+                        if is_async
+                        else _wrap_sync_method(original, span_name)
+                    )
+                    setattr(cls, method_name, wrapper)
+                    installed.append(_Patch(cls, method_name, original, wrapper))
+            except (ImportError, AttributeError) as exc:
+                for patch in reversed(installed):
+                    if getattr(patch.cls, patch.method_name, None) is patch.wrapper:
+                        setattr(patch.cls, patch.method_name, patch.original)
+                logger.warning("Vertex AI instrumentation inactive: %s", exc)
+                return
+            except BaseException:
+                for patch in reversed(installed):
+                    if getattr(patch.cls, patch.method_name, None) is patch.wrapper:
+                        setattr(patch.cls, patch.method_name, patch.original)
+                raise
+            _PATCHES[:] = installed
+            _ACTIVATION_COUNT = 1
+            self._is_instrumented = True
 
     def deactivate(self) -> None:
-        """Restore original Vertex AI SDK methods."""
-        global _original_generate_content
-        global _original_generate_content_async
-        global _original_send_message
-        global _original_send_message_async
+        global _ACTIVATION_COUNT
+        with _LOCK:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            _ACTIVATION_COUNT = max(0, _ACTIVATION_COUNT - 1)
+            if _ACTIVATION_COUNT:
+                return
+            for patch in reversed(_PATCHES):
+                if getattr(patch.cls, patch.method_name, None) is patch.wrapper:
+                    setattr(patch.cls, patch.method_name, patch.original)
+            _PATCHES.clear()
 
-        if not self._is_instrumented:
-            return
 
-        try:
-            GenerativeModel, ChatSession = _load_vertexai_classes()
-            if _original_generate_content is not None:
-                setattr(
-                    GenerativeModel,
-                    GENERATE_CONTENT_METHOD_NAME,
-                    _original_generate_content,
-                )
-                _original_generate_content = None
-            if _original_generate_content_async is not None:
-                setattr(
-                    GenerativeModel,
-                    GENERATE_CONTENT_ASYNC_METHOD_NAME,
-                    _original_generate_content_async,
-                )
-                _original_generate_content_async = None
-            if _original_send_message is not None:
-                setattr(ChatSession, SEND_MESSAGE_METHOD_NAME, _original_send_message)
-                _original_send_message = None
-            if _original_send_message_async is not None:
-                setattr(
-                    ChatSession,
-                    SEND_MESSAGE_ASYNC_METHOD_NAME,
-                    _original_send_message_async,
-                )
-                _original_send_message_async = None
-        except Exception:
-            logger.debug("Failed to restore Vertex AI methods", exc_info=True)
-
-        self._is_instrumented = False
-        logger.info("Vertex AI instrumentation deactivated")
+def _reset_runtime_for_tests() -> None:
+    global _ACTIVATION_COUNT
+    with _LOCK:
+        for patch in reversed(_PATCHES):
+            if getattr(patch.cls, patch.method_name, None) is patch.wrapper:
+                setattr(patch.cls, patch.method_name, patch.original)
+        _PATCHES.clear()
+        _ACTIVATION_COUNT = 0

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_otel_emitter.py
@@ -12,12 +12,20 @@ from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 from respan_instrumentation_vertexai._constants import (
     ASSISTANT_ROLE,
     CANDIDATES_TOKEN_COUNT_KEY,
     PROMPT_TOKEN_COUNT_KEY,
     ROLE_KEY,
+    STREAM_KEY,
     SYSTEM_INSTRUCTION_KEY,
     TOOLS_KEY,
     TOTAL_TOKEN_COUNT_KEY,
@@ -34,13 +42,6 @@ from respan_instrumentation_vertexai._translator import (
     safe_json,
     to_json_attr,
 )
-from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
-from respan_sdk.utils.data_processing.id_processing import (
-    format_span_id,
-    format_trace_id,
-)
-from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ def _current_trace_parent_ids() -> tuple[str | None, str | None]:
     try:
         current_span = trace.get_current_span()
         span_context = current_span.get_span_context()
-    except Exception:
+    except BaseException:  # noqa: BLE001
         return None, None
 
     trace_id = getattr(span_context, "trace_id", 0) or 0
@@ -62,6 +63,7 @@ def _current_trace_parent_ids() -> tuple[str | None, str | None]:
 def _base_attrs(span_name: str) -> dict[str, Any]:
     attrs = {
         SpanAttributes.LLM_SYSTEM: VERTEXAI_SYSTEM_NAME,
+        GenAIAttributes.GEN_AI_PROVIDER_NAME: "google_vertex_ai",
         SpanAttributes.LLM_REQUEST_TYPE: LLMRequestTypeValues.CHAT.value,
         SpanAttributes.TRACELOOP_ENTITY_NAME: span_name,
         SpanAttributes.TRACELOOP_ENTITY_PATH: span_name,
@@ -88,7 +90,7 @@ def _set_input_attrs(attrs: dict[str, Any], request_payload: dict[str, Any]) -> 
         role = message.get(ROLE_KEY)
         content = message.get("content")
         if role is not None:
-            attrs[f"{SpanAttributes.LLM_PROMPTS}.{index}.role"] = str(role)
+            attrs[f"{SpanAttributes.LLM_PROMPTS}.{index}.role"] = to_json_attr(role)
         if content is not None:
             attrs[f"{SpanAttributes.LLM_PROMPTS}.{index}.content"] = to_json_attr(
                 content
@@ -141,6 +143,8 @@ def build_generate_content_attrs(
     span_name: str = VERTEXAI_GENERATE_CONTENT_SPAN_NAME,
 ) -> dict[str, Any]:
     attrs = _base_attrs(span_name=span_name)
+    if request_payload.get(STREAM_KEY) is True:
+        attrs[SpanAttributes.LLM_IS_STREAMING] = True
     _set_request_attrs(attrs=attrs, request_payload=request_payload)
     if response_or_chunks is not None:
         _set_output_attrs(attrs=attrs, response_or_chunks=response_or_chunks)
@@ -155,6 +159,8 @@ def emit_generate_content_span(
     span_name: str = VERTEXAI_GENERATE_CONTENT_SPAN_NAME,
     error_message: str | None = None,
     status_code: int = 200,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
     """Build a ReadableSpan for a Vertex AI generation and inject it."""
     try:
@@ -165,9 +171,22 @@ def emit_generate_content_span(
         )
         if error_message:
             attrs["error.message"] = error_message
-            attrs.setdefault("status_code", status_code if status_code >= 400 else 500)
+            attrs["http.response.status_code"] = (
+                status_code if status_code >= 400 else 500
+            )
+            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(
+                {
+                    "error": {
+                        "message": error_message,
+                        "status_code": status_code if status_code >= 400 else 500,
+                    }
+                }
+            )
 
-        trace_id, parent_id = _current_trace_parent_ids()
+        if trace_id is None or parent_id is None:
+            current_trace_id, current_parent_id = _current_trace_parent_ids()
+            trace_id = trace_id or current_trace_id
+            parent_id = parent_id or current_parent_id
         span = build_readable_span(
             name=span_name,
             trace_id=trace_id,

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_serialization.py
@@ -1,0 +1,239 @@
+"""Bounded, privacy-safe serialization for Vertex AI telemetry."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+MAX_JSON_BYTES = 16_000
+MAX_TEXT_BYTES = 4_000
+MAX_ITEMS = 50
+MAX_DEPTH = 8
+
+_SENSITIVE_KEY = re.compile(
+    r"(^|[._-])(api[_-]?key|authorization|cookie|password|secret|token)([._-]|$)",
+    re.IGNORECASE,
+)
+_ASSIGNMENT_SECRET = re.compile(
+    r"(?i)([a-z0-9_.-]*(?:api[_-]?key|authorization|cookie|password|secret|token))"
+    r"\s*[:=]\s*([^\s,;]+)"
+)
+_QUOTED_SECRET = re.compile(
+    r"""(?i)(["'][^"']*(?:api[_-]?key|authorization|cookie|password|secret|token)["']\s*:\s*)(["'])(.*?)\2"""
+)
+_BEARER_SECRET = re.compile(r"(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")
+
+
+def safe_type_name(value: Any) -> str:
+    return type(value).__name__[:120]
+
+
+def redact_text(value: str) -> str:
+    value = _BEARER_SECRET.sub(lambda match: f"{match.group(1)} [REDACTED]", value)
+    value = _QUOTED_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]{match.group(2)}",
+        value,
+    )
+    value = _ASSIGNMENT_SECRET.sub(
+        lambda match: f"{match.group(1)}=[REDACTED]",
+        value,
+    )
+    return value
+
+
+def safe_text(value: Any, *, max_bytes: int = MAX_TEXT_BYTES) -> str:
+    if isinstance(value, str):
+        text = redact_text(value)
+    elif value is None:
+        text = ""
+    elif isinstance(value, bool):
+        text = "true" if value else "false"
+    elif isinstance(value, int) or isinstance(value, float) and math.isfinite(value):
+        text = str(value)
+    else:
+        text = f"<{safe_type_name(value)}>"
+    if len(text.encode("utf-8")) <= max_bytes:
+        return text
+    low, high, best = 0, len(text), ""
+    suffix = "…[truncated]"
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = f"{text[:middle]}{suffix}"
+        if len(candidate.encode("utf-8")) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or "[truncated]"
+
+
+def safe_exception_message(exc: BaseException) -> str:
+    try:
+        raw_args = exc.args
+    except BaseException:  # noqa: BLE001
+        raw_args = ()
+    parts: list[str] = []
+    if isinstance(raw_args, tuple):
+        for value in raw_args[:4]:
+            if isinstance(value, (str, bool, int, float)) or value is None:
+                rendered = safe_text(value, max_bytes=1_000)
+                if rendered:
+                    parts.append(rendered)
+    detail = "; ".join(parts)
+    name = safe_type_name(exc)
+    return safe_text(f"{name}: {detail}" if detail else name)
+
+
+def provider_status_code(exc: BaseException) -> int:
+    candidates: list[Any] = []
+    for name in ("status_code", "status"):
+        try:
+            candidates.append(getattr(exc, name, None))
+        except BaseException:  # noqa: BLE001, S112
+            continue
+    try:
+        response = getattr(exc, "response", None)
+    except BaseException:  # noqa: BLE001
+        response = None
+    if response is not None:
+        for name in ("status_code", "status"):
+            try:
+                candidates.append(getattr(response, name, None))
+            except BaseException:  # noqa: BLE001, S112
+                continue
+    for value in candidates:
+        if (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 400 <= value <= 599
+        ):
+            return value
+    return 500
+
+
+def _safe_key(value: Any) -> str:
+    if isinstance(value, str):
+        return safe_text(value, max_bytes=256)
+    if isinstance(value, (int, bool)) or value is None:
+        return json.dumps(value)
+    return f"<{safe_type_name(value)}>"
+
+
+def to_jsonable(value: Any, *, depth: int = 0) -> Any:
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else safe_text(value)
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        try:
+            length = len(value)
+        except BaseException:  # noqa: BLE001
+            length = None
+        return {"type": "bytes", "length": length}
+    if depth >= MAX_DEPTH:
+        return {"type": safe_type_name(value), "truncated": True}
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        truncated = False
+        try:
+            for key, item in islice(iter(value.items()), MAX_ITEMS + 1):
+                if len(result) >= MAX_ITEMS:
+                    truncated = True
+                    break
+                rendered_key = _safe_key(key)
+                result[rendered_key] = (
+                    "[REDACTED]"
+                    if _SENSITIVE_KEY.search(rendered_key)
+                    else to_jsonable(item, depth=depth + 1)
+                )
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if truncated:
+            result["_respan_truncated_items"] = True
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items: list[Any] = []
+        truncated = False
+        try:
+            for item in islice(iter(value), MAX_ITEMS + 1):
+                if len(items) >= MAX_ITEMS:
+                    truncated = True
+                    break
+                items.append(to_jsonable(item, depth=depth + 1))
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if truncated:
+            items.append({"_respan_truncated_items": True})
+        return items
+    for method_name in ("model_dump", "to_dict"):
+        try:
+            method = getattr(value, method_name, None)
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if callable(method):
+            try:
+                dumped = (
+                    method(mode="json") if method_name == "model_dump" else method()
+                )
+            except TypeError:
+                try:
+                    dumped = method()
+                except BaseException:  # noqa: BLE001, S112
+                    continue
+            except BaseException:  # noqa: BLE001, S112
+                continue
+            return to_jsonable(dumped, depth=depth + 1)
+    return {"type": safe_type_name(value)}
+
+
+def json_dumps(value: Any, *, max_bytes: int = MAX_JSON_BYTES) -> str:
+    serialized = json.dumps(
+        to_jsonable(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    if len(serialized.encode("utf-8")) <= max_bytes:
+        return serialized
+    low, high, best = 0, len(serialized), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = json.dumps(
+            {"preview": serialized[:middle], "truncated": True},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        if len(candidate.encode("utf-8")) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or '{"truncated":true}'
+
+
+def sanitize_url(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = safe_text(value)
+    try:
+        parsed = urlsplit(text if "://" in text else f"//{text}")
+        host = parsed.hostname or ""
+        if not host:
+            return "[REDACTED-ENDPOINT]"
+        netloc = host
+        if ":" in host and not host.startswith("["):
+            netloc = f"[{host}]"
+        if parsed.port is not None:
+            netloc = f"{netloc}:{parsed.port}"
+        return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+    except (TypeError, ValueError):
+        return "[REDACTED-ENDPOINT]"

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/src/respan_instrumentation_vertexai/_translator.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import json
-from typing import Any, Iterable
+from collections.abc import Iterable
+from itertools import islice
+from typing import Any
 
 from respan_instrumentation_vertexai._constants import (
     ARGS_KEY,
@@ -38,55 +39,35 @@ from respan_instrumentation_vertexai._constants import (
     USAGE_METADATA_KEY,
     USER_ROLE,
 )
-from respan_sdk.utils.serialization import serialize_value
+from respan_instrumentation_vertexai._serialization import (
+    json_dumps,
+    safe_text,
+    to_jsonable,
+)
 
 
 def safe_json(value: Any) -> str:
-    """JSON-encode values after applying the SDK's serializer."""
-    try:
-        return json.dumps(serialize_value(value=value), default=str)
-    except Exception:
-        return str(value)
+    """JSON-encode values using the bounded capture policy."""
+    return json_dumps(value)
 
 
 def to_json_attr(value: Any) -> str:
     if isinstance(value, str):
-        return value
+        return safe_text(value)
     return safe_json(value=value)
 
 
 def _field(value: Any, name: str, default: Any = None) -> Any:
     if isinstance(value, dict):
         return value.get(name, default)
-    return getattr(value, name, default)
+    try:
+        return getattr(value, name, default)
+    except BaseException:  # noqa: BLE001
+        return default
 
 
 def _dump_value(value: Any) -> Any:
-    if value is None:
-        return None
-    if isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, dict):
-        return {
-            str(key): _dump_value(nested_value)
-            for key, nested_value in value.items()
-            if nested_value is not None
-        }
-    if isinstance(value, (list, tuple, set)):
-        return [_dump_value(item) for item in value if item is not None]
-    to_dict = getattr(value, "to_dict", None)
-    if callable(to_dict):
-        try:
-            return to_dict()
-        except Exception:
-            pass
-    model_dump = getattr(value, "model_dump", None)
-    if callable(model_dump):
-        try:
-            return model_dump(exclude_none=True, by_alias=False)
-        except TypeError:
-            return model_dump()
-    return serialize_value(value=value)
+    return to_jsonable(value)
 
 
 def _role(value: Any, default: str = USER_ROLE) -> str:
@@ -95,7 +76,7 @@ def _role(value: Any, default: str = USER_ROLE) -> str:
         return ASSISTANT_ROLE
     if role == FUNCTION_KEY:
         return TOOL_ROLE
-    return str(role)
+    return safe_text(role, max_bytes=128)
 
 
 def _is_content_like(value: Any) -> bool:
@@ -257,7 +238,7 @@ def normalize_input_messages(
         messages.append({ROLE_KEY: USER_ROLE, CONTENT_KEY: _normalize_parts(contents)})
         return messages
 
-    messages.append({ROLE_KEY: USER_ROLE, CONTENT_KEY: serialize_value(value=contents)})
+    messages.append({ROLE_KEY: USER_ROLE, CONTENT_KEY: _dump_value(contents)})
     return messages
 
 
@@ -383,8 +364,21 @@ def extract_tools(tools: Any) -> list[dict[str, Any]]:
         return []
 
     normalized_tools: list[dict[str, Any]] = []
-    for tool in tools:
+    for tool in islice(iter(tools), 50):
         declarations = _field(tool, FUNCTION_DECLARATIONS_KEY) or []
+        tool_type = type(tool)
+        if (
+            not declarations
+            and tool_type.__name__ == "Tool"
+            and tool_type.__module__.startswith("vertexai.generative_models")
+        ):
+            # Vertex's public Tool wrapper keeps declarations in a private proto,
+            # but exposes a stable public conversion at this adapter boundary.
+            try:
+                converted = tool.to_dict()
+            except BaseException:  # noqa: BLE001
+                converted = None
+            declarations = _field(converted, FUNCTION_DECLARATIONS_KEY) or []
         if isinstance(tool, dict) and FUNCTION_DECLARATIONS_KEY not in tool:
             normalized = _function_declaration_tool(tool)
             if normalized is not None:
@@ -403,10 +397,16 @@ def _first_arg(args: tuple[Any, ...]) -> Any:
 
 def _model_name(instance: Any) -> str | None:
     for attr_name in ("_model_name", "model_name", "_model_id", "model_id"):
-        value = getattr(instance, attr_name, None)
+        try:
+            value = getattr(instance, attr_name, None)
+        except BaseException:  # noqa: BLE001
+            value = None
         if value:
-            return str(value)
-    nested_model = getattr(instance, "model", None)
+            return safe_text(value, max_bytes=512)
+    try:
+        nested_model = getattr(instance, "model", None)
+    except BaseException:  # noqa: BLE001
+        nested_model = None
     if nested_model is not None and nested_model is not instance:
         return _model_name(nested_model)
     return None
@@ -414,10 +414,16 @@ def _model_name(instance: Any) -> str | None:
 
 def _system_instruction(instance: Any) -> Any:
     for attr_name in (SYSTEM_INSTRUCTION_KEY, f"_{SYSTEM_INSTRUCTION_KEY}"):
-        value = getattr(instance, attr_name, None)
+        try:
+            value = getattr(instance, attr_name, None)
+        except BaseException:  # noqa: BLE001
+            value = None
         if value is not None:
             return value
-    nested_model = getattr(instance, "model", None)
+    try:
+        nested_model = getattr(instance, "model", None)
+    except BaseException:  # noqa: BLE001
+        nested_model = None
     if nested_model is not None and nested_model is not instance:
         return _system_instruction(nested_model)
     return None
@@ -427,10 +433,16 @@ def _tools(instance: Any, kwargs: dict[str, Any]) -> Any:
     if kwargs.get(TOOLS_KEY) is not None:
         return kwargs.get(TOOLS_KEY)
     for attr_name in (TOOLS_KEY, f"_{TOOLS_KEY}"):
-        value = getattr(instance, attr_name, None)
+        try:
+            value = getattr(instance, attr_name, None)
+        except BaseException:  # noqa: BLE001
+            value = None
         if value is not None:
             return value
-    nested_model = getattr(instance, "model", None)
+    try:
+        nested_model = getattr(instance, "model", None)
+    except BaseException:  # noqa: BLE001
+        nested_model = None
     if nested_model is not None and nested_model is not instance:
         return _tools(nested_model, kwargs)
     return None

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_instrumentation.py
@@ -12,9 +12,7 @@ from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 from opentelemetry.semconv_ai import SpanAttributes
-
-from respan_instrumentation_vertexai import VertexAIInstrumentor
-from respan_instrumentation_vertexai import _instrumentation
+from respan_instrumentation_vertexai import VertexAIInstrumentor, _instrumentation
 from respan_instrumentation_vertexai._constants import (
     CHAT_SESSION_CLASS_NAME,
     GENERATE_CONTENT_ASYNC_METHOD_NAME,
@@ -60,11 +58,10 @@ def make_usage(prompt_tokens: int = 3, completion_tokens: int = 4) -> Obj:
 
 
 @pytest.fixture(autouse=True)
-def reset_instrumentation_globals() -> None:
-    _instrumentation._original_generate_content = None
-    _instrumentation._original_generate_content_async = None
-    _instrumentation._original_send_message = None
-    _instrumentation._original_send_message_async = None
+def reset_instrumentation_globals() -> Any:
+    _instrumentation._reset_runtime_for_tests()
+    yield
+    _instrumentation._reset_runtime_for_tests()
 
 
 @pytest.fixture()
@@ -129,7 +126,7 @@ def fake_vertexai(monkeypatch: pytest.MonkeyPatch) -> tuple[type[Any], type[Any]
     generative_models_module = ModuleType(VERTEXAI_GENERATIVE_MODELS_MODULE)
     setattr(generative_models_module, GENERATIVE_MODEL_CLASS_NAME, GenerativeModel)
     setattr(generative_models_module, CHAT_SESSION_CLASS_NAME, ChatSession)
-    setattr(vertexai_module, "generative_models", generative_models_module)
+    vertexai_module.generative_models = generative_models_module
 
     monkeypatch.setitem(sys.modules, "vertexai", vertexai_module)
     monkeypatch.setitem(
@@ -342,7 +339,7 @@ def test_function_calls_use_canonical_completion_field_only() -> None:
             "type": "function",
             "function": {
                 "name": "get_weather",
-                "arguments": '{"city": "Tokyo"}',
+                "arguments": '{"city":"Tokyo"}',
             },
         }
     ]
@@ -372,7 +369,7 @@ def test_error_path_emits_failed_span(
     assert len(captured_spans) == 1
     span = captured_spans[0]
     assert span.status.status_code.name == "ERROR"
-    assert span._attributes["error.message"] == "boom"
+    assert span._attributes["error.message"] == "RuntimeError: boom"
     assert span._attributes[SpanAttributes.LLM_REQUEST_MODEL] == "gemini-2.0-flash"
 
     instrumentor.deactivate()

--- a/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_otel2_contract.py
+++ b/python-sdks/instrumentations/respan-instrumentation-vertexai/tests/test_otel2_contract.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_instrumentation_vertexai import VertexAIInstrumentor, _instrumentation
+from respan_instrumentation_vertexai._constants import (
+    GENERATE_CONTENT_METHOD_NAME,
+    GENERATIVE_MODEL_CLASS_NAME,
+    VERTEXAI_GENERATIVE_MODELS_MODULE,
+)
+from respan_instrumentation_vertexai._serialization import json_dumps
+
+
+def _obj(**values: Any) -> SimpleNamespace:
+    return SimpleNamespace(**values)
+
+
+@pytest.fixture(autouse=True)
+def _clean_runtime() -> Any:
+    _instrumentation._reset_runtime_for_tests()
+    yield
+    _instrumentation._reset_runtime_for_tests()
+
+
+def _current_model_class() -> type[Any]:
+    module = pytest.importorskip(VERTEXAI_GENERATIVE_MODELS_MODULE)
+    return getattr(module, GENERATIVE_MODEL_CLASS_NAME)
+
+
+def _response(text: str, *, usage: Any = None) -> Any:
+    content = _obj(parts=[_obj(text=text)], role="model")
+    return _obj(
+        text=text,
+        candidates=[_obj(content=content)],
+        usage_metadata=usage,
+    )
+
+
+def test_real_current_vertex_stream_exports_canonical_readable_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_class = _current_model_class()
+    emitted: list[Any] = []
+    monkeypatch.setattr(
+        "respan_instrumentation_vertexai._otel_emitter.inject_span",
+        lambda span: emitted.append(span),
+    )
+
+    def fake_generate(self: Any, contents: Any, **kwargs: Any) -> Any:
+        del self, contents, kwargs
+        return iter(
+            [
+                _response("Vertex "),
+                _response(
+                    "streamed.",
+                    usage=_obj(
+                        prompt_token_count=8,
+                        candidates_token_count=3,
+                        thoughts_token_count=1,
+                        total_token_count=12,
+                    ),
+                ),
+            ]
+        )
+
+    monkeypatch.setattr(model_class, GENERATE_CONTENT_METHOD_NAME, fake_generate)
+    instrumentor = VertexAIInstrumentor()
+    instrumentor.activate()
+    instance = _obj(_model_name="gemini-2.5-flash", _tools=None)
+    provider = TracerProvider()
+    with provider.get_tracer(__name__).start_as_current_span("parent") as parent:
+        stream = getattr(model_class, GENERATE_CONTENT_METHOD_NAME)(
+            instance,
+            "Say streamed.",
+            stream=True,
+        )
+        assert [chunk for chunk in stream]
+        parent_context = parent.get_span_context()
+    instrumentor.deactivate()
+
+    assert len(emitted) == 1
+    span = emitted[0]
+    attrs = span.attributes
+    assert span.parent.span_id == parent_context.span_id
+    assert attrs[SpanAttributes.LLM_IS_STREAMING] is True
+    assert attrs[gen_ai_attributes.GEN_AI_PROVIDER_NAME] == "google_vertex_ai"
+    assert attrs[gen_ai_attributes.GEN_AI_USAGE_INPUT_TOKENS] == 8
+    assert attrs[gen_ai_attributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 4
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "Vertex streamed."
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
+
+
+def test_real_current_vertex_tool_exports_canonical_function_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = pytest.importorskip(VERTEXAI_GENERATIVE_MODELS_MODULE)
+    model_class = getattr(module, GENERATIVE_MODEL_CLASS_NAME)
+    function_declaration = module.FunctionDeclaration(
+        name="get_weather",
+        description="Return deterministic weather for a city.",
+        parameters={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    )
+    tool = module.Tool(function_declarations=[function_declaration])
+    emitted: list[Any] = []
+    monkeypatch.setattr(
+        "respan_instrumentation_vertexai._otel_emitter.inject_span",
+        lambda span: emitted.append(span),
+    )
+
+    def fake_generate(self: Any, contents: Any, **kwargs: Any) -> Any:
+        del self, contents, kwargs
+        return _response("Tool definition captured.")
+
+    monkeypatch.setattr(model_class, GENERATE_CONTENT_METHOD_NAME, fake_generate)
+    instrumentor = VertexAIInstrumentor()
+    instrumentor.activate()
+    getattr(model_class, GENERATE_CONTENT_METHOD_NAME)(
+        _obj(_model_name="gemini-2.5-flash", _tools=[tool]),
+        "Use get_weather.",
+    )
+    instrumentor.deactivate()
+
+    assert len(emitted) == 1
+    definitions = json.loads(
+        emitted[0].attributes[SpanAttributes.LLM_REQUEST_FUNCTIONS]
+    )
+    assert definitions == [
+        {
+            "function": {
+                "description": "Return deterministic weather for a city.",
+                "name": "get_weather",
+                "parameters": {
+                    "properties": {"city": {"type": "STRING"}},
+                    "property_ordering": ["city"],
+                    "required": ["city"],
+                    "type": "OBJECT",
+                },
+            },
+            "type": "function",
+        }
+    ]
+
+
+def test_real_current_vertex_lifecycle_is_shared_and_foreign_safe() -> None:
+    model_class = _current_model_class()
+    original = getattr(model_class, GENERATE_CONTENT_METHOD_NAME)
+    first = VertexAIInstrumentor()
+    second = VertexAIInstrumentor()
+    first.activate()
+    installed = getattr(model_class, GENERATE_CONTENT_METHOD_NAME)
+    second.activate()
+    first.deactivate()
+    assert getattr(model_class, GENERATE_CONTENT_METHOD_NAME) is installed
+    second.deactivate()
+    assert getattr(model_class, GENERATE_CONTENT_METHOD_NAME) is original
+
+    first.activate()
+    installed = getattr(model_class, GENERATE_CONTENT_METHOD_NAME)
+
+    def foreign(self: Any, *args: Any, **kwargs: Any) -> Any:
+        return installed(self, *args, **kwargs)
+
+    setattr(model_class, GENERATE_CONTENT_METHOD_NAME, foreign)
+    first.deactivate()
+    assert getattr(model_class, GENERATE_CONTENT_METHOD_NAME) is foreign
+    setattr(model_class, GENERATE_CONTENT_METHOD_NAME, original)
+
+
+def test_vertex_error_status_privacy_and_hostile_exception_are_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_class = _current_model_class()
+    emitted: list[Any] = []
+    monkeypatch.setattr(
+        "respan_instrumentation_vertexai._otel_emitter.inject_span",
+        lambda span: emitted.append(span),
+    )
+
+    class ProviderError(Exception):
+        status_code = 503
+
+        def __str__(self) -> str:
+            raise AssertionError("instrumentation called hostile __str__")
+
+    error = ProviderError("password=plain-secret provider unavailable")
+
+    def fail(self: Any, contents: Any, **kwargs: Any) -> Any:
+        del self, contents, kwargs
+        raise error
+
+    monkeypatch.setattr(model_class, GENERATE_CONTENT_METHOD_NAME, fail)
+    instrumentor = VertexAIInstrumentor()
+    instrumentor.activate()
+    with pytest.raises(ProviderError) as caught:
+        getattr(model_class, GENERATE_CONTENT_METHOD_NAME)(
+            _obj(_model_name="gemini-2.5-flash"),
+            "hello",
+        )
+    instrumentor.deactivate()
+    assert caught.value is error
+    assert len(emitted) == 1
+    span = emitted[0]
+    assert span.status.status_code.name == "ERROR"
+    assert span.attributes["http.response.status_code"] == 503
+    assert "plain-secret" not in json.dumps(dict(span.attributes), sort_keys=True)
+
+
+def test_vertex_json_capture_is_valid_bounded_and_redacted() -> None:
+    class Hostile:
+        def __str__(self) -> str:
+            raise AssertionError
+
+        __repr__ = __str__
+
+    value = json_dumps(
+        {
+            "api_key": "plain-secret",
+            "nested": {"auth_token": "token-value", "object": Hostile()},
+            "unicode": "😀" * 20_000,
+        }
+    )
+    assert len(value.encode("utf-8")) <= 16_000
+    assert "plain-secret" not in value
+    assert "token-value" not in value
+    assert json.loads(value)

--- a/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/src/respan_instrumentation_watson_orchestrate_adk/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/src/respan_instrumentation_watson_orchestrate_adk/_instrumentation.py
@@ -7,7 +7,17 @@ import importlib
 import inspect
 import logging
 import time
-from typing import Any, Callable
+from collections.abc import Callable
+from dataclasses import dataclass
+from threading import RLock
+from typing import Any
+
+from opentelemetry import trace
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.core.tracer import RespanTracer
 
 from respan_instrumentation_watson_orchestrate_adk import _otel_emitter
 from respan_instrumentation_watson_orchestrate_adk._constants import (
@@ -25,43 +35,72 @@ from respan_instrumentation_watson_orchestrate_adk._constants import (
     RUN_CLIENT_MODULE,
     RUN_METHODS,
     TOOL_CALL_METHOD,
+    WATSON_ORCHESTRATE_ADK_INSTRUMENTATION_NAME,
     WATSONX_AI_CLIENT_CLASS,
     WATSONX_AI_CLIENT_MODULE,
-    WATSON_ORCHESTRATE_ADK_INSTRUMENTATION_NAME,
 )
-from respan_tracing.core.tracer import RespanTracer
+from respan_instrumentation_watson_orchestrate_adk._serialization import (
+    provider_status_code,
+    safe_exception_message,
+    safe_text,
+)
 
 logger = logging.getLogger(__name__)
 
-_OriginalKey = tuple[type[Any], str]
-_original_methods: dict[_OriginalKey, Any] = {}
+_LOCK = RLock()
+_ACTIVATION_COUNT = 0
+
+
+@dataclass(frozen=True)
+class _Patch:
+    cls: type[Any]
+    method_name: str
+    original: Any
+    wrapper: Any
+
+
+_PATCHES: list[_Patch] = []
 
 
 def _load_class(module_name: str, class_name: str) -> type[Any]:
     module = importlib.import_module(module_name)
-    class_value = getattr(module, class_name, None)
-    if class_value is None:
+    value = getattr(module, class_name, None)
+    if value is None:
         raise AttributeError(f"{module_name}.{class_name}")
-    return class_value
+    return value
+
+
+def _current_trace_parent_ids() -> tuple[str | None, str | None]:
+    try:
+        context = trace.get_current_span().get_span_context()
+        if not context.is_valid:
+            return None, None
+        return format_trace_id(context.trace_id), format_span_id(context.span_id)
+    except BaseException:  # noqa: BLE001
+        return None, None
+
+
+def _safe_attr(instance: Any, name: str) -> Any:
+    try:
+        return getattr(instance, name, None)
+    except BaseException:  # noqa: BLE001
+        return None
 
 
 def _tool_name(instance: Any) -> str:
     for key in ("name", "display_name"):
-        value = getattr(instance, key, None)
+        value = _safe_attr(instance, key)
         if value:
-            return str(value)
-
-    spec = getattr(instance, "__tool_spec__", None)
-    value = getattr(spec, "name", None)
+            return safe_text(value, max_bytes=256)
+    spec = _safe_attr(instance, "__tool_spec__")
+    value = _safe_attr(spec, "name")
     if value:
-        return str(value)
-
-    fn = getattr(instance, "fn", None)
-    value = getattr(fn, "__name__", None)
+        return safe_text(value, max_bytes=256)
+    fn = _safe_attr(instance, "fn")
+    value = _safe_attr(fn, "__name__")
     if value:
-        return str(value)
-
-    return instance.__class__.__name__
+        return safe_text(value, max_bytes=256)
+    return safe_text(type(instance).__name__, max_bytes=256)
 
 
 def _call_kwargs(
@@ -76,48 +115,54 @@ def _call_kwargs(
     except (TypeError, ValueError):
         result = dict(kwargs)
         if args:
-            result["_args"] = list(args)
+            result["_args"] = list(args[:50])
         return result
-
-    result = {
-        key: value
-        for key, value in bound.arguments.items()
-        if key != "self"
-    }
-    if "kwargs" in result and isinstance(result["kwargs"], dict):
-        nested = dict(result.pop("kwargs"))
+    result = {key: value for key, value in bound.arguments.items() if key != "self"}
+    nested_kwargs = result.pop("kwargs", None)
+    if isinstance(nested_kwargs, dict):
+        nested = dict(nested_kwargs)
         nested.update(result)
         result = nested
-    if "args" in result and isinstance(result["args"], tuple):
-        positional = result.pop("args")
-        if positional:
-            result["_args"] = list(positional)
+    positional = result.pop("args", None)
+    if isinstance(positional, tuple) and positional:
+        result["_args"] = list(positional[:50])
     return result
+
+
+def _emit_error_kwargs(exc: BaseException) -> dict[str, Any]:
+    return {
+        "error_message": safe_exception_message(exc),
+        "status_code": provider_status_code(exc),
+    }
 
 
 def _wrap_tool_call(original: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(original)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = _current_trace_parent_ids()
         tool_name = _tool_name(self)
         try:
             response = original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _otel_emitter.emit_tool_span(
                 tool_name=tool_name,
                 args=args,
                 kwargs=kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
+                trace_id=trace_id,
+                parent_id=parent_id,
+                **_emit_error_kwargs(exc),
             )
             raise
-
         _otel_emitter.emit_tool_span(
             tool_name=tool_name,
             args=args,
             kwargs=kwargs,
             start_ns=start_ns,
             response=response,
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
         return response
 
@@ -125,35 +170,34 @@ def _wrap_tool_call(original: Callable[..., Any]) -> Callable[..., Any]:
 
 
 def _wrap_agent_run(
-    *,
-    method_name: str,
-    original: Callable[..., Any],
+    method_name: str, original: Callable[..., Any]
 ) -> Callable[..., Any]:
     @functools.wraps(original)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = _current_trace_parent_ids()
         call_kwargs = _call_kwargs(
-            original=original,
-            instance=self,
-            args=args,
-            kwargs=kwargs,
+            original=original, instance=self, args=args, kwargs=kwargs
         )
         try:
             response = original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _otel_emitter.emit_agent_run_span(
                 method_name=method_name,
                 call_kwargs=call_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
+                trace_id=trace_id,
+                parent_id=parent_id,
+                **_emit_error_kwargs(exc),
             )
             raise
-
         _otel_emitter.emit_agent_run_span(
             method_name=method_name,
             call_kwargs=call_kwargs,
             start_ns=start_ns,
             response=response,
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
         return response
 
@@ -161,35 +205,34 @@ def _wrap_agent_run(
 
 
 def _wrap_async_agent_run(
-    *,
-    method_name: str,
-    original: Callable[..., Any],
+    method_name: str, original: Callable[..., Any]
 ) -> Callable[..., Any]:
     @functools.wraps(original)
     async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = _current_trace_parent_ids()
         call_kwargs = _call_kwargs(
-            original=original,
-            instance=self,
-            args=args,
-            kwargs=kwargs,
+            original=original, instance=self, args=args, kwargs=kwargs
         )
         try:
             response = await original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _otel_emitter.emit_agent_run_span(
                 method_name=method_name,
                 call_kwargs=call_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
+                trace_id=trace_id,
+                parent_id=parent_id,
+                **_emit_error_kwargs(exc),
             )
             raise
-
         _otel_emitter.emit_agent_run_span(
             method_name=method_name,
             call_kwargs=call_kwargs,
             start_ns=start_ns,
             response=response,
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
         return response
 
@@ -197,75 +240,71 @@ def _wrap_async_agent_run(
 
 
 def _wrap_chat_method(
-    *,
-    method_name: str,
-    original: Callable[..., Any],
+    method_name: str, original: Callable[..., Any]
 ) -> Callable[..., Any]:
     @functools.wraps(original)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = _current_trace_parent_ids()
         call_kwargs = _call_kwargs(
-            original=original,
-            instance=self,
-            args=args,
-            kwargs=kwargs,
+            original=original, instance=self, args=args, kwargs=kwargs
         )
         try:
             response = original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _otel_emitter.emit_chat_span(
                 method_name=method_name,
                 call_kwargs=call_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
                 instance=self,
+                trace_id=trace_id,
+                parent_id=parent_id,
+                **_emit_error_kwargs(exc),
             )
             raise
-
         _otel_emitter.emit_chat_span(
             method_name=method_name,
             call_kwargs=call_kwargs,
             start_ns=start_ns,
             response=response,
             instance=self,
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
         return response
 
     return wrapper
 
 
-def _patch_method(
+def _install(
+    installed: list[_Patch],
     cls: type[Any],
     method_name: str,
-    wrapper_factory: Callable[[Callable[..., Any]], Callable[..., Any]],
-) -> bool:
+    factory: Callable[[Callable[..., Any]], Callable[..., Any]],
+) -> None:
     original = getattr(cls, method_name, None)
     if original is None:
-        return False
-
-    key = (cls, method_name)
-    if key in _original_methods:
-        return False
-
-    _original_methods[key] = original
-    setattr(cls, method_name, wrapper_factory(original))
-    return True
+        return
+    wrapper = factory(original)
+    setattr(cls, method_name, wrapper)
+    installed.append(_Patch(cls, method_name, original, wrapper))
 
 
-def _restore_methods() -> None:
-    for (cls, method_name), original in list(_original_methods.items()):
-        setattr(cls, method_name, original)
-    _original_methods.clear()
+def _optional_class(module_name: str, class_name: str) -> type[Any] | None:
+    try:
+        return _load_class(module_name, class_name)
+    except (ImportError, AttributeError):
+        return None
+
+
+def _restore_owned(patches: list[_Patch]) -> None:
+    for patch in reversed(patches):
+        if getattr(patch.cls, patch.method_name, None) is patch.wrapper:
+            setattr(patch.cls, patch.method_name, patch.original)
 
 
 class WatsonOrchestrateADKInstrumentor:
-    """Respan instrumentor for IBM watsonx Orchestrate ADK.
-
-    The IBM package exposes a mix of local Python tool objects and generated
-    REST clients. This instrumentor patches only stable public methods and
-    emits canonical Respan/OpenTelemetry spans without requiring the SDK at
-    import time.
-    """
+    """Respan instrumentor for IBM watsonx Orchestrate ADK."""
 
     name = WATSON_ORCHESTRATE_ADK_INSTRUMENTATION_NAME
 
@@ -275,157 +314,102 @@ class WatsonOrchestrateADKInstrumentor:
     @staticmethod
     def _is_respan_tracing_enabled() -> bool:
         tracer = getattr(RespanTracer, "_instance", None)
-        if tracer is None:
-            return True
-        return bool(getattr(tracer, "is_enabled", True))
-
-    def _patch_optional_class(
-        self,
-        *,
-        module_name: str,
-        class_name: str,
-        patcher: Callable[[type[Any]], int],
-    ) -> int:
-        try:
-            cls = _load_class(module_name, class_name)
-        except (ImportError, AttributeError) as exc:
-            logger.debug(
-                "Watson Orchestrate ADK instrumentation skipped %s.%s: %s",
-                module_name,
-                class_name,
-                exc,
-            )
-            return 0
-        return patcher(cls)
+        return tracer is None or bool(getattr(tracer, "is_enabled", True))
 
     def activate(self) -> None:
-        """Activate native Watson Orchestrate ADK instrumentation."""
-        if self._is_instrumented:
-            return
-
-        if not self._is_respan_tracing_enabled():
-            logger.info(
-                "Watson Orchestrate ADK instrumentation skipped because Respan tracing is disabled"
-            )
-            return
-
-        patched_count = 0
-        try:
-            patched_count += self._patch_optional_class(
-                module_name=PYTHON_TOOL_MODULE,
-                class_name=PYTHON_TOOL_CLASS,
-                patcher=lambda cls: int(
-                    _patch_method(cls, TOOL_CALL_METHOD, _wrap_tool_call)
-                ),
-            )
-            patched_count += self._patch_optional_class(
-                module_name=RUN_CLIENT_MODULE,
-                class_name=RUN_CLIENT_CLASS,
-                patcher=self._patch_run_client,
-            )
-            patched_count += self._patch_optional_class(
-                module_name=AGENT_BUILDER_CLIENT_MODULE,
-                class_name=AGENT_BUILDER_CLIENT_CLASS,
-                patcher=self._patch_chat_client,
-            )
-            patched_count += self._patch_optional_class(
-                module_name=CPE_CLIENT_MODULE,
-                class_name=CPE_CLIENT_CLASS,
-                patcher=self._patch_cpe_client,
-            )
-            patched_count += self._patch_optional_class(
-                module_name=WATSONX_AI_CLIENT_MODULE,
-                class_name=WATSONX_AI_CLIENT_CLASS,
-                patcher=self._patch_llm_client,
-            )
-        except Exception:
-            _restore_methods()
-            self._is_instrumented = False
-            logger.exception("Failed to activate Watson Orchestrate ADK instrumentation")
-            return
-
-        self._is_instrumented = patched_count > 0
-        if not self._is_instrumented:
-            logger.warning(
-                "Watson Orchestrate ADK instrumentation found no supported SDK classes to patch"
-            )
-            return
-        logger.info("Watson Orchestrate ADK instrumentation activated")
-
-    def _patch_run_client(self, cls: type[Any]) -> int:
-        patched = 0
-        for method_name in RUN_METHODS:
-            patched += int(
-                _patch_method(
-                    cls,
-                    method_name,
-                    lambda original, method_name=method_name: _wrap_agent_run(
-                        method_name=method_name,
-                        original=original,
+        global _ACTIVATION_COUNT
+        with _LOCK:
+            if self._is_instrumented:
+                return
+            if not self._is_respan_tracing_enabled():
+                return
+            if _ACTIVATION_COUNT:
+                _ACTIVATION_COUNT += 1
+                self._is_instrumented = True
+                return
+            installed: list[_Patch] = []
+            try:
+                tool = _optional_class(PYTHON_TOOL_MODULE, PYTHON_TOOL_CLASS)
+                if tool is not None:
+                    _install(installed, tool, TOOL_CALL_METHOD, _wrap_tool_call)
+                run_client = _optional_class(RUN_CLIENT_MODULE, RUN_CLIENT_CLASS)
+                if run_client is not None:
+                    for method_name in RUN_METHODS:
+                        _install(
+                            installed,
+                            run_client,
+                            method_name,
+                            lambda original, name=method_name: _wrap_agent_run(
+                                name, original
+                            ),
+                        )
+                    for method_name in ASYNC_RUN_METHODS:
+                        _install(
+                            installed,
+                            run_client,
+                            method_name,
+                            lambda original, name=method_name: _wrap_async_agent_run(
+                                name, original
+                            ),
+                        )
+                for module_name, class_name, methods in (
+                    (
+                        AGENT_BUILDER_CLIENT_MODULE,
+                        AGENT_BUILDER_CLIENT_CLASS,
+                        CHAT_METHODS,
                     ),
-                )
-            )
-        for method_name in ASYNC_RUN_METHODS:
-            patched += int(
-                _patch_method(
-                    cls,
-                    method_name,
-                    lambda original, method_name=method_name: _wrap_async_agent_run(
-                        method_name=method_name,
-                        original=original,
+                    (
+                        CPE_CLIENT_MODULE,
+                        CPE_CLIENT_CLASS,
+                        (*CHAT_METHODS, *CHAT_REFINEMENT_METHODS),
                     ),
-                )
-            )
-        return patched
-
-    def _patch_chat_client(self, cls: type[Any]) -> int:
-        patched = 0
-        for method_name in CHAT_METHODS:
-            patched += int(
-                _patch_method(
-                    cls,
-                    method_name,
-                    lambda original, method_name=method_name: _wrap_chat_method(
-                        method_name=method_name,
-                        original=original,
+                    (
+                        WATSONX_AI_CLIENT_MODULE,
+                        WATSONX_AI_CLIENT_CLASS,
+                        LLM_CHAT_METHODS,
                     ),
+                ):
+                    cls = _optional_class(module_name, class_name)
+                    if cls is None:
+                        continue
+                    for method_name in methods:
+                        _install(
+                            installed,
+                            cls,
+                            method_name,
+                            lambda original, name=method_name: _wrap_chat_method(
+                                name, original
+                            ),
+                        )
+            except BaseException:
+                _restore_owned(installed)
+                raise
+            if not installed:
+                logger.warning(
+                    "Watson Orchestrate ADK instrumentation found no supported SDK classes"
                 )
-            )
-        return patched
-
-    def _patch_cpe_client(self, cls: type[Any]) -> int:
-        patched = 0
-        for method_name in (*CHAT_METHODS, *CHAT_REFINEMENT_METHODS):
-            patched += int(
-                _patch_method(
-                    cls,
-                    method_name,
-                    lambda original, method_name=method_name: _wrap_chat_method(
-                        method_name=method_name,
-                        original=original,
-                    ),
-                )
-            )
-        return patched
-
-    def _patch_llm_client(self, cls: type[Any]) -> int:
-        patched = 0
-        for method_name in LLM_CHAT_METHODS:
-            patched += int(
-                _patch_method(
-                    cls,
-                    method_name,
-                    lambda original, method_name=method_name: _wrap_chat_method(
-                        method_name=method_name,
-                        original=original,
-                    ),
-                )
-            )
-        return patched
+                return
+            _PATCHES[:] = installed
+            _ACTIVATION_COUNT = 1
+            self._is_instrumented = True
 
     def deactivate(self) -> None:
-        """Deactivate the instrumentation and restore original SDK methods."""
-        if self._is_instrumented:
-            _restore_methods()
-        self._is_instrumented = False
-        logger.info("Watson Orchestrate ADK instrumentation deactivated")
+        global _ACTIVATION_COUNT
+        with _LOCK:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            _ACTIVATION_COUNT = max(0, _ACTIVATION_COUNT - 1)
+            if _ACTIVATION_COUNT:
+                return
+            _restore_owned(_PATCHES)
+            _PATCHES.clear()
+
+
+def _restore_methods() -> None:
+    """Compatibility test helper; restore only wrappers owned by this runtime."""
+    global _ACTIVATION_COUNT
+    with _LOCK:
+        _restore_owned(_PATCHES)
+        _PATCHES.clear()
+        _ACTIVATION_COUNT = 0

--- a/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/src/respan_instrumentation_watson_orchestrate_adk/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/src/respan_instrumentation_watson_orchestrate_adk/_otel_emitter.py
@@ -2,20 +2,39 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from collections.abc import Mapping, Sequence
+from itertools import islice
 from typing import Any
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_PROVIDER_NAME,
     GEN_AI_USAGE_INPUT_TOKENS,
     GEN_AI_USAGE_OUTPUT_TOKENS,
 )
 from opentelemetry.semconv_ai import LLMRequestTypeValues
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_AGENT,
+    LOG_TYPE_CHAT,
+    LOG_TYPE_TOOL,
+    LogMethodChoices,
+)
+from respan_sdk.constants.span_attributes import (
+    RESPAN_LOG_ID,
+    RESPAN_LOG_METHOD,
+    RESPAN_LOG_TYPE,
+    RESPAN_THREADS_ID,
+)
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.utils.span_factory import build_readable_span, inject_span
+
 from respan_instrumentation_watson_orchestrate_adk._constants import (
     AGENT_ID_KEY,
     ARGUMENTS_KEY,
@@ -41,7 +60,6 @@ from respan_instrumentation_watson_orchestrate_adk._constants import (
     PROMPT_TOKENS_KEY,
     ROLE_KEY,
     RUN_ID_KEY,
-    STATUS_KEY,
     TEXT_KEY,
     THREAD_ID_KEY,
     TOKEN_USAGE_KEY,
@@ -56,21 +74,11 @@ from respan_instrumentation_watson_orchestrate_adk._constants import (
     WATSON_ORCHESTRATE_RUN_SPAN_NAME,
     WATSON_ORCHESTRATE_TOOL_SPAN_NAME,
 )
-from respan_sdk.constants.llm_logging import (
-    LOG_TYPE_AGENT,
-    LOG_TYPE_CHAT,
-    LOG_TYPE_TOOL,
-    LogMethodChoices,
+from respan_instrumentation_watson_orchestrate_adk._serialization import (
+    json_dumps,
+    safe_text,
+    to_jsonable,
 )
-from respan_sdk.constants.span_attributes import (
-    RESPAN_LOG_ID,
-    RESPAN_LOG_METHOD,
-    RESPAN_LOG_TYPE,
-    RESPAN_THREADS_ID,
-)
-from respan_sdk.utils.data_processing.id_processing import format_span_id, format_trace_id
-from respan_sdk.utils.serialization import serialize_value
-from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 logger = logging.getLogger(__name__)
 
@@ -88,31 +96,23 @@ def _field(value: Any, key: str, default: Any = None) -> Any:
         return value.get(key, default)
     try:
         return getattr(value, key)
-    except Exception:
+    except BaseException:  # noqa: BLE001
         return default
 
 
 def _dump_value(value: Any) -> Any:
-    if value is None or isinstance(value, str | int | float | bool):
-        return value
-    try:
-        return serialize_value(value=value)
-    except Exception:
-        return str(value)
+    return to_jsonable(value)
 
 
 def safe_json(value: Any) -> str:
-    try:
-        return json.dumps(_dump_value(value), default=str, separators=(",", ":"))
-    except Exception:
-        return json.dumps(str(value), separators=(",", ":"))
+    return json_dumps(value)
 
 
 def _to_string(value: Any) -> str:
     if value is None:
         return ""
     if isinstance(value, str):
-        return value
+        return safe_text(value)
     return safe_json(value)
 
 
@@ -120,7 +120,10 @@ def _as_sequence(value: Any) -> list[Any]:
     if value is None:
         return []
     if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
-        return list(value)
+        try:
+            return list(islice(iter(value), 50))
+        except BaseException:  # noqa: BLE001
+            return [{"type": type(value).__name__[:120], "unavailable": True}]
     return [value]
 
 
@@ -136,7 +139,7 @@ def _normalize_messages(value: Any) -> list[dict[str, Any]]:
     if isinstance(value, Mapping):
         return [
             {
-                ROLE_KEY: str(value.get(ROLE_KEY) or USER_ROLE),
+                ROLE_KEY: safe_text(value.get(ROLE_KEY) or USER_ROLE, max_bytes=128),
                 CONTENT_KEY: _dump_value(value.get(CONTENT_KEY, value)),
             }
         ]
@@ -146,7 +149,7 @@ def _normalize_messages(value: Any) -> list[dict[str, Any]]:
         if isinstance(item, Mapping):
             messages.append(
                 {
-                    ROLE_KEY: str(item.get(ROLE_KEY) or USER_ROLE),
+                    ROLE_KEY: safe_text(item.get(ROLE_KEY) or USER_ROLE, max_bytes=128),
                     CONTENT_KEY: _dump_value(item.get(CONTENT_KEY, item)),
                 }
             )
@@ -180,7 +183,7 @@ def _set_prompt_attrs(attrs: dict[str, Any], messages: list[dict[str, Any]]) -> 
         role = message.get(ROLE_KEY)
         content = message.get(CONTENT_KEY)
         if role is not None:
-            attrs[f"{_PROMPT_PREFIX}{index}.role"] = str(role)
+            attrs[f"{_PROMPT_PREFIX}{index}.role"] = safe_text(role, max_bytes=128)
         if content is not None:
             attrs[f"{_PROMPT_PREFIX}{index}.content"] = _to_string(content)
 
@@ -190,7 +193,9 @@ def _set_completion_attrs(attrs: dict[str, Any], text: str) -> None:
     attrs[f"{_COMPLETION_PREFIX}0.content"] = text
 
 
-def _model_from_call(call_kwargs: Mapping[str, Any], instance: Any = None) -> str | None:
+def _model_from_call(
+    call_kwargs: Mapping[str, Any], instance: Any = None
+) -> str | None:
     for key in (
         MODEL_KEY,
         MODEL_ID_KEY,
@@ -201,17 +206,19 @@ def _model_from_call(call_kwargs: Mapping[str, Any], instance: Any = None) -> st
     ):
         value = call_kwargs.get(key)
         if value:
-            return str(value)
+            return safe_text(value, max_bytes=512)
     for key in (MODEL_KEY, MODEL_ID_KEY, "_model", "_model_id"):
         value = _field(instance, key)
         if value:
-            return str(value)
+            return safe_text(value, max_bytes=512)
     return None
 
 
 def _first_choice(response: Any) -> Any:
     choices = _field(response, CHOICES_KEY, []) or []
-    if isinstance(choices, Sequence) and not isinstance(choices, str | bytes | bytearray):
+    if isinstance(choices, Sequence) and not isinstance(
+        choices, str | bytes | bytearray
+    ):
         return choices[0] if choices else None
     return None
 
@@ -259,7 +266,9 @@ def _response_text(response: Any) -> str:
             if value is not None:
                 return _to_string(value)
 
-    if isinstance(response, Sequence) and not isinstance(response, str | bytes | bytearray):
+    if isinstance(response, Sequence) and not isinstance(
+        response, str | bytes | bytearray
+    ):
         for item in reversed(response):
             text = _response_text(item)
             if text:
@@ -304,7 +313,11 @@ def _set_usage_attrs(attrs: dict[str, Any], response: Any) -> None:
         completion_tokens = _coerce_int(_field(source, OUTPUT_TOKENS_KEY))
 
     total_tokens = _coerce_int(_field(source, TOTAL_TOKENS_KEY))
-    if total_tokens is None and prompt_tokens is not None and completion_tokens is not None:
+    if (
+        total_tokens is None
+        and prompt_tokens is not None
+        and completion_tokens is not None
+    ):
         total_tokens = prompt_tokens + completion_tokens
 
     if prompt_tokens is not None:
@@ -327,14 +340,18 @@ def _tool_definitions(value: Any) -> list[dict[str, Any]]:
                 tools.append(dict(item))
                 continue
             if item.get(FUNCTION_KEY):
-                tools.append({TYPE_KEY: FUNCTION_TOOL_TYPE, FUNCTION_KEY: item[FUNCTION_KEY]})
+                tools.append(
+                    {TYPE_KEY: FUNCTION_TOOL_TYPE, FUNCTION_KEY: item[FUNCTION_KEY]}
+                )
                 continue
             name = item.get(NAME_KEY)
             if name:
                 function = {NAME_KEY: name}
                 for key in ("description", "parameters", "input_schema", "schema"):
                     if item.get(key) is not None:
-                        function["parameters" if key in {"input_schema", "schema"} else key] = item[key]
+                        function[
+                            "parameters" if key in {"input_schema", "schema"} else key
+                        ] = item[key]
                 tools.append({TYPE_KEY: FUNCTION_TOOL_TYPE, FUNCTION_KEY: function})
                 continue
 
@@ -376,7 +393,7 @@ def _current_trace_parent_ids() -> tuple[str | None, str | None]:
     try:
         current_span = trace.get_current_span()
         span_context = current_span.get_span_context()
-    except Exception:
+    except BaseException:  # noqa: BLE001
         return None, None
     trace_id = getattr(span_context, "trace_id", 0) or 0
     span_id = getattr(span_context, "span_id", 0) or 0
@@ -402,7 +419,9 @@ def build_tool_attrs(
     )
 
     if error_message is not None:
-        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = error_message
+        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(
+            {"error": {"message": error_message}}
+        )
     elif response is not None:
         content = _field(response, CONTENT_KEY, response)
         context_updates = _field(response, "context_updates")
@@ -420,7 +439,7 @@ def build_agent_run_attrs(
     response: Any = None,
     error_message: str | None = None,
 ) -> dict[str, Any]:
-    agent_name = str(call_kwargs.get(AGENT_ID_KEY) or method_name)
+    agent_name = safe_text(call_kwargs.get(AGENT_ID_KEY) or method_name, max_bytes=256)
     attrs = _base_attrs(span_name=agent_name, log_type=LOG_TYPE_AGENT)
     attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = safe_json(
         {"method": method_name, "request": dict(call_kwargs)}
@@ -428,13 +447,15 @@ def build_agent_run_attrs(
 
     thread_id = call_kwargs.get(THREAD_ID_KEY) or _field(response, THREAD_ID_KEY)
     if thread_id:
-        attrs[RESPAN_THREADS_ID] = str(thread_id)
+        attrs[RESPAN_THREADS_ID] = safe_text(thread_id, max_bytes=512)
     run_id = _field(response, RUN_ID_KEY)
     if run_id:
-        attrs[RESPAN_LOG_ID] = str(run_id)
+        attrs[RESPAN_LOG_ID] = safe_text(run_id, max_bytes=512)
 
     if error_message is not None:
-        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = error_message
+        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(
+            {"error": {"message": error_message}}
+        )
     elif response is not None:
         attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(response)
     return _clean_attrs(attrs)
@@ -448,8 +469,11 @@ def build_chat_attrs(
     error_message: str | None = None,
     instance: Any = None,
 ) -> dict[str, Any]:
-    attrs = _base_attrs(span_name=WATSON_ORCHESTRATE_CHAT_SPAN_NAME, log_type=LOG_TYPE_CHAT)
+    attrs = _base_attrs(
+        span_name=WATSON_ORCHESTRATE_CHAT_SPAN_NAME, log_type=LOG_TYPE_CHAT
+    )
     attrs[TLSpanAttributes.LLM_SYSTEM] = WATSON_ORCHESTRATE_ADK_SYSTEM_NAME
+    attrs[GEN_AI_PROVIDER_NAME] = WATSON_ORCHESTRATE_ADK_SYSTEM_NAME
     attrs[TLSpanAttributes.LLM_REQUEST_TYPE] = _request_type_value("CHAT", "chat")
 
     model = _model_from_call(call_kwargs=call_kwargs, instance=instance)
@@ -469,8 +493,9 @@ def build_chat_attrs(
     )
 
     if error_message is not None:
-        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = error_message
-        _set_completion_attrs(attrs=attrs, text=error_message)
+        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(
+            {"error": {"message": error_message}}
+        )
     elif response is not None:
         response_text = _response_text(response)
         attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = (
@@ -489,14 +514,21 @@ def emit_span(
     start_ns: int,
     error_message: str | None = None,
     status_code: int = 200,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
     try:
         clean_attrs = _clean_attrs(attrs)
         if error_message is not None:
             clean_attrs["error.message"] = error_message
-            clean_attrs["status_code"] = status_code if status_code >= 400 else 500
+            clean_attrs["http.response.status_code"] = (
+                status_code if status_code >= 400 else 500
+            )
 
-        trace_id, parent_id = _current_trace_parent_ids()
+        if trace_id is None or parent_id is None:
+            current_trace_id, current_parent_id = _current_trace_parent_ids()
+            trace_id = trace_id or current_trace_id
+            parent_id = parent_id or current_parent_id
         span = build_readable_span(
             name=span_name,
             trace_id=trace_id,
@@ -520,6 +552,9 @@ def emit_tool_span(
     start_ns: int,
     response: Any = None,
     error_message: str | None = None,
+    status_code: int = 500,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
     emit_span(
         span_name=WATSON_ORCHESTRATE_TOOL_SPAN_NAME,
@@ -532,7 +567,9 @@ def emit_tool_span(
         ),
         start_ns=start_ns,
         error_message=error_message,
-        status_code=500 if error_message else 200,
+        status_code=status_code if error_message else 200,
+        trace_id=trace_id,
+        parent_id=parent_id,
     )
 
 
@@ -543,6 +580,9 @@ def emit_agent_run_span(
     start_ns: int,
     response: Any = None,
     error_message: str | None = None,
+    status_code: int = 500,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
     emit_span(
         span_name=WATSON_ORCHESTRATE_RUN_SPAN_NAME,
@@ -554,7 +594,9 @@ def emit_agent_run_span(
         ),
         start_ns=start_ns,
         error_message=error_message,
-        status_code=500 if error_message else 200,
+        status_code=status_code if error_message else 200,
+        trace_id=trace_id,
+        parent_id=parent_id,
     )
 
 
@@ -566,6 +608,9 @@ def emit_chat_span(
     response: Any = None,
     error_message: str | None = None,
     instance: Any = None,
+    status_code: int = 500,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
     emit_span(
         span_name=WATSON_ORCHESTRATE_CHAT_SPAN_NAME,
@@ -578,5 +623,7 @@ def emit_chat_span(
         ),
         start_ns=start_ns,
         error_message=error_message,
-        status_code=500 if error_message else 200,
+        status_code=status_code if error_message else 200,
+        trace_id=trace_id,
+        parent_id=parent_id,
     )

--- a/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/src/respan_instrumentation_watson_orchestrate_adk/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/src/respan_instrumentation_watson_orchestrate_adk/_serialization.py
@@ -1,0 +1,239 @@
+"""Bounded, privacy-safe serialization for Watson Orchestrate ADK telemetry."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+MAX_JSON_BYTES = 16_000
+MAX_TEXT_BYTES = 4_000
+MAX_ITEMS = 50
+MAX_DEPTH = 8
+
+_SENSITIVE_KEY = re.compile(
+    r"(^|[._-])(api[_-]?key|authorization|cookie|password|secret|token)([._-]|$)",
+    re.IGNORECASE,
+)
+_ASSIGNMENT_SECRET = re.compile(
+    r"(?i)([a-z0-9_.-]*(?:api[_-]?key|authorization|cookie|password|secret|token))"
+    r"\s*[:=]\s*([^\s,;]+)"
+)
+_QUOTED_SECRET = re.compile(
+    r"""(?i)(["'][^"']*(?:api[_-]?key|authorization|cookie|password|secret|token)["']\s*:\s*)(["'])(.*?)\2"""
+)
+_BEARER_SECRET = re.compile(r"(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")
+
+
+def safe_type_name(value: Any) -> str:
+    return type(value).__name__[:120]
+
+
+def redact_text(value: str) -> str:
+    value = _BEARER_SECRET.sub(lambda match: f"{match.group(1)} [REDACTED]", value)
+    value = _QUOTED_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]{match.group(2)}",
+        value,
+    )
+    value = _ASSIGNMENT_SECRET.sub(
+        lambda match: f"{match.group(1)}=[REDACTED]",
+        value,
+    )
+    return value
+
+
+def safe_text(value: Any, *, max_bytes: int = MAX_TEXT_BYTES) -> str:
+    if isinstance(value, str):
+        text = redact_text(value)
+    elif value is None:
+        text = ""
+    elif isinstance(value, bool):
+        text = "true" if value else "false"
+    elif isinstance(value, int) or isinstance(value, float) and math.isfinite(value):
+        text = str(value)
+    else:
+        text = f"<{safe_type_name(value)}>"
+    if len(text.encode("utf-8")) <= max_bytes:
+        return text
+    low, high, best = 0, len(text), ""
+    suffix = "…[truncated]"
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = f"{text[:middle]}{suffix}"
+        if len(candidate.encode("utf-8")) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or "[truncated]"
+
+
+def safe_exception_message(exc: BaseException) -> str:
+    try:
+        raw_args = exc.args
+    except BaseException:  # noqa: BLE001
+        raw_args = ()
+    parts: list[str] = []
+    if isinstance(raw_args, tuple):
+        for value in raw_args[:4]:
+            if isinstance(value, (str, bool, int, float)) or value is None:
+                rendered = safe_text(value, max_bytes=1_000)
+                if rendered:
+                    parts.append(rendered)
+    detail = "; ".join(parts)
+    name = safe_type_name(exc)
+    return safe_text(f"{name}: {detail}" if detail else name)
+
+
+def provider_status_code(exc: BaseException) -> int:
+    candidates: list[Any] = []
+    for name in ("status_code", "status"):
+        try:
+            candidates.append(getattr(exc, name, None))
+        except BaseException:  # noqa: BLE001, S112
+            continue
+    try:
+        response = getattr(exc, "response", None)
+    except BaseException:  # noqa: BLE001
+        response = None
+    if response is not None:
+        for name in ("status_code", "status"):
+            try:
+                candidates.append(getattr(response, name, None))
+            except BaseException:  # noqa: BLE001, S112
+                continue
+    for value in candidates:
+        if (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 400 <= value <= 599
+        ):
+            return value
+    return 500
+
+
+def _safe_key(value: Any) -> str:
+    if isinstance(value, str):
+        return safe_text(value, max_bytes=256)
+    if isinstance(value, (int, bool)) or value is None:
+        return json.dumps(value)
+    return f"<{safe_type_name(value)}>"
+
+
+def to_jsonable(value: Any, *, depth: int = 0) -> Any:
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else safe_text(value)
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        try:
+            length = len(value)
+        except BaseException:  # noqa: BLE001
+            length = None
+        return {"type": "bytes", "length": length}
+    if depth >= MAX_DEPTH:
+        return {"type": safe_type_name(value), "truncated": True}
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        truncated = False
+        try:
+            for key, item in islice(iter(value.items()), MAX_ITEMS + 1):
+                if len(result) >= MAX_ITEMS:
+                    truncated = True
+                    break
+                rendered_key = _safe_key(key)
+                result[rendered_key] = (
+                    "[REDACTED]"
+                    if _SENSITIVE_KEY.search(rendered_key)
+                    else to_jsonable(item, depth=depth + 1)
+                )
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if truncated:
+            result["_respan_truncated_items"] = True
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items: list[Any] = []
+        truncated = False
+        try:
+            for item in islice(iter(value), MAX_ITEMS + 1):
+                if len(items) >= MAX_ITEMS:
+                    truncated = True
+                    break
+                items.append(to_jsonable(item, depth=depth + 1))
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if truncated:
+            items.append({"_respan_truncated_items": True})
+        return items
+    for method_name in ("model_dump", "to_dict"):
+        try:
+            method = getattr(value, method_name, None)
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if callable(method):
+            try:
+                dumped = (
+                    method(mode="json") if method_name == "model_dump" else method()
+                )
+            except TypeError:
+                try:
+                    dumped = method()
+                except BaseException:  # noqa: BLE001, S112
+                    continue
+            except BaseException:  # noqa: BLE001, S112
+                continue
+            return to_jsonable(dumped, depth=depth + 1)
+    return {"type": safe_type_name(value)}
+
+
+def json_dumps(value: Any, *, max_bytes: int = MAX_JSON_BYTES) -> str:
+    serialized = json.dumps(
+        to_jsonable(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    if len(serialized.encode("utf-8")) <= max_bytes:
+        return serialized
+    low, high, best = 0, len(serialized), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = json.dumps(
+            {"preview": serialized[:middle], "truncated": True},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        if len(candidate.encode("utf-8")) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or '{"truncated":true}'
+
+
+def sanitize_url(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = safe_text(value)
+    try:
+        parsed = urlsplit(text if "://" in text else f"//{text}")
+        host = parsed.hostname or ""
+        if not host:
+            return "[REDACTED-ENDPOINT]"
+        netloc = host
+        if ":" in host and not host.startswith("["):
+            netloc = f"[{host}]"
+        if parsed.port is not None:
+            netloc = f"{netloc}:{parsed.port}"
+        return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+    except (TypeError, ValueError):
+        return "[REDACTED-ENDPOINT]"

--- a/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/tests/test_instrumentation.py
@@ -4,11 +4,10 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
-
 from respan_instrumentation_watson_orchestrate_adk import (
     WatsonOrchestrateADKInstrumentor,
+    _instrumentation,
 )
-from respan_instrumentation_watson_orchestrate_adk import _instrumentation
 from respan_instrumentation_watson_orchestrate_adk._constants import (
     AGENT_BUILDER_CLIENT_MODULE,
     CPE_CLIENT_MODULE,
@@ -98,8 +97,7 @@ def test_build_chat_attrs_maps_canonical_fields_without_aliases():
     assert attrs[f"{TLSpanAttributes.LLM_PROMPTS}.0.content"] == "Summarize the ticket."
     assert attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.role"] == "assistant"
     assert (
-        attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"]
-        == "Ticket summarized."
+        attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"] == "Ticket summarized."
     )
     assert attrs[TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 12
     assert attrs[TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 4
@@ -176,7 +174,9 @@ def test_activate_patches_tool_and_run_clients(monkeypatch):
             return SimpleNamespace(content={"ok": True, "kwargs": kwargs})
 
     class RunClient:
-        def create_run(self, message, agent_id=None, thread_id=None, capture_logs=False):
+        def create_run(
+            self, message, agent_id=None, thread_id=None, capture_logs=False
+        ):
             return {
                 "run_id": "run-1",
                 "thread_id": thread_id or "thread-1",
@@ -197,11 +197,14 @@ def test_activate_patches_tool_and_run_clients(monkeypatch):
     assert RunClient.create_run is not original_create_run
 
     assert PythonTool()(ticket_id="INC-7").content["ok"] is True
-    assert RunClient().create_run(
-        "hello",
-        agent_id="agent-123",
-        thread_id="thread-1",
-    )["run_id"] == "run-1"
+    assert (
+        RunClient().create_run(
+            "hello",
+            agent_id="agent-123",
+            thread_id="thread-1",
+        )["run_id"]
+        == "run-1"
+    )
 
     assert emitted[0][0] == "tool"
     assert emitted[0][1]["tool_name"] == "lookup_ticket"
@@ -244,15 +247,11 @@ def test_chat_client_failure_emits_error_span(monkeypatch):
     with pytest.raises(RuntimeError, match="provider unavailable"):
         WatsonxAIClient().generate_response("hello")
 
-    assert emitted == [
-        {
-            "method_name": "generate_response",
-            "call_kwargs": {"input": "hello"},
-            "start_ns": emitted[0]["start_ns"],
-            "error_message": "provider unavailable",
-            "instance": emitted[0]["instance"],
-        }
-    ]
+    assert len(emitted) == 1
+    assert emitted[0]["method_name"] == "generate_response"
+    assert emitted[0]["call_kwargs"] == {"input": "hello"}
+    assert emitted[0]["error_message"] == "RuntimeError: provider unavailable"
+    assert emitted[0]["status_code"] == 500
 
 
 def test_activate_is_idempotent(monkeypatch):

--- a/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/tests/test_otel2_contract.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watson-orchestrate-adk/tests/test_otel2_contract.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_instrumentation_watson_orchestrate_adk import (
+    WatsonOrchestrateADKInstrumentor,
+    _instrumentation,
+)
+from respan_instrumentation_watson_orchestrate_adk._constants import (
+    RUN_CLIENT_CLASS,
+    RUN_CLIENT_MODULE,
+)
+from respan_instrumentation_watson_orchestrate_adk._serialization import json_dumps
+
+
+@pytest.fixture(autouse=True)
+def _clean_runtime() -> Any:
+    _instrumentation._restore_methods()
+    yield
+    _instrumentation._restore_methods()
+
+
+def _current_run_client() -> type[Any]:
+    module = pytest.importorskip(RUN_CLIENT_MODULE)
+    return getattr(module, RUN_CLIENT_CLASS)
+
+
+def test_real_current_watson_run_client_exports_connected_readable_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_client = _current_run_client()
+    emitted: list[Any] = []
+    monkeypatch.setattr(
+        "respan_instrumentation_watson_orchestrate_adk._otel_emitter.inject_span",
+        lambda span: emitted.append(span),
+    )
+
+    def fake_create_run(
+        self: Any,
+        message: str,
+        agent_id: str | None = None,
+        thread_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        del self, kwargs
+        return {
+            "run_id": "run-current-1",
+            "thread_id": thread_id,
+            "agent_id": agent_id,
+            "status": "queued",
+            "message": message,
+        }
+
+    monkeypatch.setattr(run_client, "create_run", fake_create_run)
+    instrumentor = WatsonOrchestrateADKInstrumentor()
+    instrumentor.activate()
+    provider = TracerProvider()
+    with provider.get_tracer(__name__).start_as_current_span("parent") as parent:
+        response = run_client.create_run(
+            SimpleNamespace(),
+            "Trace current Watson client.",
+            agent_id="agent-current",
+            thread_id="thread-current",
+        )
+        parent_context = parent.get_span_context()
+    instrumentor.deactivate()
+
+    assert response["run_id"] == "run-current-1"
+    assert len(emitted) == 1
+    span = emitted[0]
+    attrs = span.attributes
+    assert span.parent.span_id == parent_context.span_id
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] == "agent-current"
+    assert (
+        json.loads(attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT])["request"]["message"]
+        == "Trace current Watson client."
+    )
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
+
+
+def test_real_current_watson_lifecycle_is_shared_and_foreign_safe() -> None:
+    run_client = _current_run_client()
+    original = run_client.create_run
+    first = WatsonOrchestrateADKInstrumentor()
+    second = WatsonOrchestrateADKInstrumentor()
+    first.activate()
+    installed = run_client.create_run
+    second.activate()
+    first.deactivate()
+    assert run_client.create_run is installed
+    second.deactivate()
+    assert run_client.create_run is original
+
+    first.activate()
+    installed = run_client.create_run
+
+    def foreign(self: Any, *args: Any, **kwargs: Any) -> Any:
+        return installed(self, *args, **kwargs)
+
+    run_client.create_run = foreign
+    first.deactivate()
+    assert run_client.create_run is foreign
+    run_client.create_run = original
+
+
+def test_watson_provider_error_keeps_status_and_redacts_without_str(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_client = _current_run_client()
+    emitted: list[Any] = []
+    monkeypatch.setattr(
+        "respan_instrumentation_watson_orchestrate_adk._otel_emitter.inject_span",
+        lambda span: emitted.append(span),
+    )
+
+    class ProviderError(Exception):
+        status_code = 401
+
+        def __str__(self) -> str:
+            raise AssertionError("instrumentation called hostile __str__")
+
+    error = ProviderError("authorization=Basic abcdef")
+
+    def fail(self: Any, message: str, **kwargs: Any) -> Any:
+        del self, message, kwargs
+        raise error
+
+    monkeypatch.setattr(run_client, "create_run", fail)
+    instrumentor = WatsonOrchestrateADKInstrumentor()
+    instrumentor.activate()
+    with pytest.raises(ProviderError) as caught:
+        run_client.create_run(SimpleNamespace(), "hello")
+    instrumentor.deactivate()
+    assert caught.value is error
+    assert len(emitted) == 1
+    span = emitted[0]
+    assert span.status.status_code.name == "ERROR"
+    assert span.attributes["http.response.status_code"] == 401
+    assert "abcdef" not in json.dumps(dict(span.attributes), sort_keys=True)
+
+
+def test_watson_json_capture_is_utf8_bounded_redacted_and_hostile_safe() -> None:
+    class Hostile:
+        def __str__(self) -> str:
+            raise AssertionError
+
+        __repr__ = __str__
+
+    value = json_dumps(
+        {
+            "password": "plain-secret",
+            "nested": {"client_secret": "secret-value", "object": Hostile()},
+            "unicode": "😀" * 20_000,
+        }
+    )
+    assert len(value.encode("utf-8")) <= 16_000
+    assert "plain-secret" not in value
+    assert "secret-value" not in value
+    assert json.loads(value)


### PR DESCRIPTION
## Summary

- Repair the Python Together, Vertex AI, and Watson Orchestrate ADK instrumentation packages for the OpenTelemetry 2.x span contract.
- Add cooperative lifecycle ownership, exact-once stream handling, call-time parenting, canonical tools and usage, precise provider errors, and bounded privacy-safe serialization.
- Add real current-SDK exported-span regressions and a patch release intent for all three packages.

## Validation

- [x] Focused package tests: Together 11/11, Vertex AI 15/15, Watson Orchestrate ADK 11/11 (37/37).
- [x] Root-config Ruff check and format check pass for all changed package source and tests.
- [x] Release inventory and release-intent validation pass.
- [x] All three package wheels build and import successfully; SHA-256: Together `1eb15d18...`, Vertex AI `d28ce0db...`, Watson Orchestrate ADK `14a803f8...`.
- [x] Exact editable `direct_url.json` entries point to the three local Group 27 package directories.
- [x] All 22 companion example processes completed under `otel2-fix-py-group-27-20260818T102109Z`; 19 deterministic traces exported and three credential-gated live scripts skipped explicitly.
- [x] Respan MCP audit opened all 19 trace trees and all 43 full details: 43 unique log IDs, 43 unique span IDs, one root per trace, exact counts, no orphans/duplicates, exact marker on every record, bounded payloads, correct streams/tools/usage/errors, and no forbidden aliases.

## External follow-ups

- Current ingestion leaves convenience `tools`/`tool_calls` arrays empty despite canonical definitions/calls, derives some provider IDs from model namespaces, and projects native OTel 429/503/500 errors as success/200 with estimated tokens.
- Direct Together, authenticated Vertex AI, and live Watson service runs remain credential-gated.
- Release publication must synchronize the package manifests with the aggregate `>=0.1.1` floors.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/75