### PR TITLE
fix(instrumentation-py): repair Watsonx, Weaviate, and Writer OTel 2.x spans

### DIFF
--- a/.release-intents/20260818-watsonx-weaviate-writer-otel2.json
+++ b/.release-intents/20260818-watsonx-weaviate-writer-otel2.json
@@ -1,0 +1,8 @@
+{
+  "summary": "Repair Watsonx, Weaviate, and Writer OTel 2.x stream, lifecycle, privacy, and semantic span behavior",
+  "packages": {
+    "respan-instrumentation-watsonx": "patch",
+    "respan-instrumentation-weaviate": "patch",
+    "respan-instrumentation-writer": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-watsonx/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-watsonx/README.md
@@ -40,5 +40,10 @@ The instrumentor traces:
 
 Chat and text-generation spans use canonical GenAI fields such as
 `gen_ai.prompt.*`, `gen_ai.completion.*`, `llm.request.functions`, and token
-usage attributes. Embedding spans record the input and usage metadata but do not
-export embedding vectors.
+usage attributes. Stream calls are finalized on normal completion, early close,
+or failure and carry the canonical streaming flag. Embedding spans retain the
+complete numeric vector payload, as required by the Respan span contract.
+
+Create the model/client inside application code and close it according to the
+IBM SDK lifecycle. Always call `respan.shutdown()` in an outer `finally` block
+so buffered spans are exported even when the provider call fails.

--- a/python-sdks/instrumentations/respan-instrumentation-watsonx/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-watsonx/pyproject.toml
@@ -13,8 +13,8 @@ packages = [
 python = ">=3.11,<3.15"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.1"
-ibm-watsonx-ai = ">=1.0.0"
-opentelemetry-semantic-conventions-ai = ">=0.4.1"
+ibm-watsonx-ai = ">=1.6.3,<2"
+opentelemetry-semantic-conventions-ai = ">=0.5.1,<0.6.0"
 
 [tool.poetry.plugins."respan.instrumentations"]
 watsonx = "respan_instrumentation_watsonx:WatsonxInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_constants.py
@@ -2,6 +2,7 @@
 
 WATSONX_INSTRUMENTATION_NAME = "watsonx"
 WATSONX_SYSTEM_NAME = "watsonx"
+WATSONX_PROVIDER_NAME = "ibm"
 
 MODEL_INFERENCE_MODULE = "ibm_watsonx_ai.foundation_models.inference"
 EMBEDDINGS_MODULE = "ibm_watsonx_ai.foundation_models.embeddings"

--- a/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_instrumentation.py
@@ -5,24 +5,27 @@ from __future__ import annotations
 import importlib
 import logging
 import time
-from collections.abc import AsyncIterator, Iterator
-from typing import Any, Callable
+from collections.abc import AsyncIterator, Callable, Iterator
+from threading import Condition, RLock
+from typing import Any
+
+from respan_tracing.core.tracer import RespanTracer
 
 from respan_instrumentation_watsonx._constants import (
     ACHAT_METHOD_NAME,
     ACHAT_STREAM_METHOD_NAME,
-    AEMBEDDINGS_GENERATE_METHOD_NAME,
     AEMBED_DOCUMENTS_METHOD_NAME,
     AEMBED_QUERY_METHOD_NAME,
+    AEMBEDDINGS_GENERATE_METHOD_NAME,
     AGENERATE_METHOD_NAME,
     AGENERATE_STREAM_METHOD_NAME,
     CHAT_METHOD_NAME,
     CHAT_STREAM_METHOD_NAME,
+    EMBED_DOCUMENTS_METHOD_NAME,
+    EMBED_QUERY_METHOD_NAME,
     EMBEDDINGS_CLASS_NAME,
     EMBEDDINGS_GENERATE_METHOD_NAME,
     EMBEDDINGS_MODULE,
-    EMBED_DOCUMENTS_METHOD_NAME,
-    EMBED_QUERY_METHOD_NAME,
     GENERATE_METHOD_NAME,
     GENERATE_TEXT_METHOD_NAME,
     GENERATE_TEXT_STREAM_METHOD_NAME,
@@ -31,15 +34,25 @@ from respan_instrumentation_watsonx._constants import (
     WATSONX_INSTRUMENTATION_NAME,
 )
 from respan_instrumentation_watsonx._otel_emitter import (
+    current_trace_parent_ids,
     emit_chat_span,
     emit_embedding_span,
     emit_text_span,
 )
-from respan_tracing.core.tracer import RespanTracer
+from respan_instrumentation_watsonx._serialization import (
+    provider_status_code,
+    safe_exception_message,
+)
 
 logger = logging.getLogger(__name__)
 
 _original_methods: dict[tuple[type[Any], str], Any] = {}
+_installed_methods: dict[tuple[type[Any], str], Any] = {}
+_activation_lock = RLock()
+_activation_condition = Condition(_activation_lock)
+_activation_count = 0
+_activation_installing = False
+_MAX_STREAM_CHUNKS = 256
 
 _TEXT_PROMPT_METHODS = {
     GENERATE_METHOD_NAME,
@@ -115,6 +128,14 @@ def _is_iterator(value: Any) -> bool:
     return hasattr(value, "__iter__")
 
 
+def _append_stream_chunk(chunks: list[Any], chunk: Any) -> None:
+    """Keep bounded raw stream state while retaining the terminal chunk."""
+    if len(chunks) < _MAX_STREAM_CHUNKS:
+        chunks.append(chunk)
+    else:
+        chunks[-1] = chunk
+
+
 def _wrap_sync_iterator(
     *,
     iterator: Iterator[Any],
@@ -123,21 +144,40 @@ def _wrap_sync_iterator(
     request_kwargs: dict[str, Any],
     start_ns: int,
     response_kwarg_name: str,
+    trace_id: str | None,
+    parent_id: str | None,
 ) -> Iterator[Any]:
     chunks: list[Any] = []
+    emitted = False
     try:
         for chunk in iterator:
-            chunks.append(chunk)
+            _append_stream_chunk(chunks, chunk)
             yield chunk
-    except Exception as exc:
+    except GeneratorExit:
         emit(
             instance=instance,
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             **{response_kwarg_name: chunks},
-            error_message=str(exc),
-            status_code=500,
+            is_streaming=True,
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
+        emitted = True
+        raise
+    except BaseException as exc:
+        emit(
+            instance=instance,
+            request_kwargs=request_kwargs,
+            start_ns=start_ns,
+            **{response_kwarg_name: chunks},
+            error_message=safe_exception_message(exc),
+            status_code=provider_status_code(exc),
+            is_streaming=True,
+            trace_id=trace_id,
+            parent_id=parent_id,
+        )
+        emitted = True
         raise
     else:
         emit(
@@ -145,7 +185,28 @@ def _wrap_sync_iterator(
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             **{response_kwarg_name: chunks},
+            is_streaming=True,
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
+        emitted = True
+    finally:
+        if not emitted:
+            emit(
+                instance=instance,
+                request_kwargs=request_kwargs,
+                start_ns=start_ns,
+                **{response_kwarg_name: chunks},
+                is_streaming=True,
+                trace_id=trace_id,
+                parent_id=parent_id,
+            )
+        close = getattr(iterator, "close", None)
+        if callable(close):
+            try:
+                close()
+            except BaseException:
+                logger.debug("Failed to close Watsonx stream", exc_info=True)
 
 
 async def _wrap_async_iterator(
@@ -156,21 +217,40 @@ async def _wrap_async_iterator(
     request_kwargs: dict[str, Any],
     start_ns: int,
     response_kwarg_name: str,
+    trace_id: str | None,
+    parent_id: str | None,
 ) -> AsyncIterator[Any]:
     chunks: list[Any] = []
+    emitted = False
     try:
         async for chunk in async_iterator:
-            chunks.append(chunk)
+            _append_stream_chunk(chunks, chunk)
             yield chunk
-    except Exception as exc:
+    except (GeneratorExit, StopAsyncIteration):
         emit(
             instance=instance,
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             **{response_kwarg_name: chunks},
-            error_message=str(exc),
-            status_code=500,
+            is_streaming=True,
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
+        emitted = True
+        raise
+    except BaseException as exc:
+        emit(
+            instance=instance,
+            request_kwargs=request_kwargs,
+            start_ns=start_ns,
+            **{response_kwarg_name: chunks},
+            error_message=safe_exception_message(exc),
+            status_code=provider_status_code(exc),
+            is_streaming=True,
+            trace_id=trace_id,
+            parent_id=parent_id,
+        )
+        emitted = True
         raise
     else:
         emit(
@@ -178,7 +258,28 @@ async def _wrap_async_iterator(
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             **{response_kwarg_name: chunks},
+            is_streaming=True,
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
+        emitted = True
+    finally:
+        if not emitted:
+            emit(
+                instance=instance,
+                request_kwargs=request_kwargs,
+                start_ns=start_ns,
+                **{response_kwarg_name: chunks},
+                is_streaming=True,
+                trace_id=trace_id,
+                parent_id=parent_id,
+            )
+        close = getattr(async_iterator, "aclose", None)
+        if callable(close):
+            try:
+                await close()
+            except BaseException:
+                logger.debug("Failed to close Watsonx async stream", exc_info=True)
 
 
 def _wrap_sync_method(
@@ -192,6 +293,7 @@ def _wrap_sync_method(
 ) -> Any:
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = current_trace_parent_ids()
         request_kwargs = _request_kwargs_from_call(
             method_name=method_name,
             args=args,
@@ -200,13 +302,15 @@ def _wrap_sync_method(
         )
         try:
             response = original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             emit(
                 instance=self,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=safe_exception_message(exc),
+                status_code=provider_status_code(exc),
+                trace_id=trace_id,
+                parent_id=parent_id,
             )
             raise
 
@@ -218,6 +322,8 @@ def _wrap_sync_method(
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
                 response_kwarg_name=response_kwarg_name,
+                trace_id=trace_id,
+                parent_id=parent_id,
             )
 
         emit(
@@ -225,6 +331,8 @@ def _wrap_sync_method(
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             **{response_kwarg_name: response},
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
         return response
 
@@ -242,6 +350,7 @@ def _wrap_async_method(
 ) -> Any:
     async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         start_ns = time.time_ns()
+        trace_id, parent_id = current_trace_parent_ids()
         request_kwargs = _request_kwargs_from_call(
             method_name=method_name,
             args=args,
@@ -254,13 +363,15 @@ def _wrap_async_method(
                 response = pending_response
             else:
                 response = await pending_response
-        except Exception as exc:
+        except BaseException as exc:
             emit(
                 instance=self,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=safe_exception_message(exc),
+                status_code=provider_status_code(exc),
+                trace_id=trace_id,
+                parent_id=parent_id,
             )
             raise
 
@@ -272,6 +383,8 @@ def _wrap_async_method(
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
                 response_kwarg_name=response_kwarg_name,
+                trace_id=trace_id,
+                parent_id=parent_id,
             )
 
         emit(
@@ -279,6 +392,8 @@ def _wrap_async_method(
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             **{response_kwarg_name: response},
+            trace_id=trace_id,
+            parent_id=parent_id,
         )
         return response
 
@@ -292,7 +407,18 @@ def _patch_method(target_class: type[Any], method_name: str, replacement: Any) -
     key = (target_class, method_name)
     if key not in _original_methods:
         _original_methods[key] = original
-    setattr(target_class, method_name, replacement(original=_original_methods[key]))
+    wrapped = replacement(original=_original_methods[key])
+    setattr(target_class, method_name, wrapped)
+    _installed_methods[key] = wrapped
+
+
+def _complete_installation(*, success: bool) -> None:
+    global _activation_count, _activation_installing
+    with _activation_condition:
+        if success:
+            _activation_count = 1
+        _activation_installing = False
+        _activation_condition.notify_all()
 
 
 class WatsonxInstrumentor:
@@ -312,11 +438,23 @@ class WatsonxInstrumentor:
 
     def activate(self) -> None:
         """Monkey-patch Watsonx model and embedding methods."""
-        if self._is_instrumented:
-            return
-        if not self._is_respan_tracing_enabled():
-            logger.info("Watsonx instrumentation skipped because Respan tracing is disabled")
-            return
+        global _activation_count, _activation_installing
+        with _activation_condition:
+            if self._is_instrumented:
+                return
+            if not self._is_respan_tracing_enabled():
+                logger.info(
+                    "Watsonx instrumentation skipped because Respan tracing is disabled"
+                )
+                return
+            while _activation_installing:
+                _activation_condition.wait()
+            if _activation_count:
+                _activation_count += 1
+                self._is_instrumented = True
+                return
+            _activation_installing = True
+            self._is_instrumented = True
 
         try:
             ModelInference, Embeddings = _load_watsonx_classes()
@@ -325,9 +463,13 @@ class WatsonxInstrumentor:
                 "Failed to activate Watsonx instrumentation - missing dependency: %s",
                 exc,
             )
+            self.deactivate()
+            _complete_installation(success=False)
             return
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.warning("Failed to activate Watsonx instrumentation: %s", exc)
+            self.deactivate()
+            _complete_installation(success=False)
             return
 
         try:
@@ -439,12 +581,14 @@ class WatsonxInstrumentor:
                 _patch_method(
                     Embeddings,
                     method_name,
-                    lambda original, method_name=method_name, positional_arg_name=positional_arg_name: _wrap_sync_method(
-                        original=original,
-                        method_name=method_name,
-                        emit=emit_embedding_span,
-                        response_kwarg_name="response",
-                        positional_arg_name=positional_arg_name,
+                    lambda original, method_name=method_name, positional_arg_name=positional_arg_name: (
+                        _wrap_sync_method(
+                            original=original,
+                            method_name=method_name,
+                            emit=emit_embedding_span,
+                            response_kwarg_name="response",
+                            positional_arg_name=positional_arg_name,
+                        )
                     ),
                 )
             for method_name in (
@@ -460,39 +604,51 @@ class WatsonxInstrumentor:
                 _patch_method(
                     Embeddings,
                     method_name,
-                    lambda original, method_name=method_name, positional_arg_name=positional_arg_name: _wrap_async_method(
-                        original=original,
-                        method_name=method_name,
-                        emit=emit_embedding_span,
-                        response_kwarg_name="response",
-                        positional_arg_name=positional_arg_name,
+                    lambda original, method_name=method_name, positional_arg_name=positional_arg_name: (
+                        _wrap_async_method(
+                            original=original,
+                            method_name=method_name,
+                            emit=emit_embedding_span,
+                            response_kwarg_name="response",
+                            positional_arg_name=positional_arg_name,
+                        )
                     ),
                 )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.warning("Failed to activate Watsonx instrumentation: %s", exc)
             self.deactivate()
+            _complete_installation(success=False)
             return
 
-        self._is_instrumented = True
+        _complete_installation(success=True)
         logger.info("Watsonx instrumentation activated")
 
     def deactivate(self) -> None:
         """Restore original Watsonx SDK methods."""
-        if not self._is_instrumented and not _original_methods:
-            return
-
-        for (target_class, method_name), original in list(_original_methods.items()):
-            try:
-                setattr(target_class, method_name, original)
-            except Exception:
-                logger.debug(
-                    "Failed to restore Watsonx method %s.%s",
-                    target_class,
-                    method_name,
-                    exc_info=True,
-                )
-            finally:
-                _original_methods.pop((target_class, method_name), None)
-
-        self._is_instrumented = False
+        global _activation_count
+        with _activation_lock:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            _activation_count = max(_activation_count - 1, 0)
+            if _activation_count:
+                return
+            for (target_class, method_name), original in list(
+                _original_methods.items()
+            ):
+                try:
+                    current = getattr(target_class, method_name, None)
+                    installed = _installed_methods.get((target_class, method_name))
+                    if current is installed:
+                        setattr(target_class, method_name, original)
+                except Exception:
+                    logger.debug(
+                        "Failed to restore Watsonx method %s.%s",
+                        target_class,
+                        method_name,
+                        exc_info=True,
+                    )
+                finally:
+                    _original_methods.pop((target_class, method_name), None)
+                    _installed_methods.pop((target_class, method_name), None)
         logger.info("Watsonx instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_otel_emitter.py
@@ -11,6 +11,17 @@ from opentelemetry import trace
 from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
 from opentelemetry.semconv_ai import LLMRequestTypeValues
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_TEXT,
+)
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 from respan_instrumentation_watsonx._constants import (
     ASSISTANT_ROLE,
@@ -22,11 +33,14 @@ from respan_instrumentation_watsonx._constants import (
     TOTAL_TOKENS_KEY,
     WATSONX_CHAT_SPAN_NAME,
     WATSONX_EMBEDDING_SPAN_NAME,
+    WATSONX_PROVIDER_NAME,
     WATSONX_SYSTEM_NAME,
     WATSONX_TEXT_SPAN_NAME,
 )
+from respan_instrumentation_watsonx._serialization import embedding_json_dumps
 from respan_instrumentation_watsonx._translator import (
     embedding_dimension,
+    embedding_output,
     embedding_vector_count,
     extract_chat_tool_calls,
     extract_usage,
@@ -41,14 +55,6 @@ from respan_instrumentation_watsonx._translator import (
     safe_json,
     to_attr_value,
 )
-from respan_sdk.constants.llm_logging import (
-    LOG_TYPE_CHAT,
-    LOG_TYPE_EMBEDDING,
-    LOG_TYPE_TEXT,
-)
-from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
-from respan_sdk.utils.data_processing.id_processing import format_span_id, format_trace_id
-from respan_tracing.utils.span_factory import build_readable_span, inject_span
 
 logger = logging.getLogger(__name__)
 
@@ -61,11 +67,11 @@ def _request_type_value(name: str, fallback: str) -> str:
     return getattr(value, "value", fallback)
 
 
-def _current_trace_parent_ids() -> tuple[str | None, str | None]:
+def current_trace_parent_ids() -> tuple[str | None, str | None]:
     try:
         current_span = trace.get_current_span()
         span_context = current_span.get_span_context()
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None, None
     trace_id = getattr(span_context, "trace_id", 0) or 0
     span_id = getattr(span_context, "span_id", 0) or 0
@@ -74,12 +80,19 @@ def _current_trace_parent_ids() -> tuple[str | None, str | None]:
     return format_trace_id(trace_id=trace_id), format_span_id(span_id=span_id)
 
 
-def _base_attrs(*, span_name: str, log_type: str, request_type: str) -> dict[str, Any]:
+def _base_attrs(
+    *,
+    span_name: str,
+    log_type: str,
+    request_type: str,
+    parent_id: str | None = None,
+) -> dict[str, Any]:
     attrs = {
         TLSpanAttributes.LLM_SYSTEM: WATSONX_SYSTEM_NAME,
+        gen_ai_attributes.GEN_AI_PROVIDER_NAME: WATSONX_PROVIDER_NAME,
         TLSpanAttributes.LLM_REQUEST_TYPE: request_type,
         TLSpanAttributes.TRACELOOP_ENTITY_NAME: span_name,
-        TLSpanAttributes.TRACELOOP_ENTITY_PATH: span_name,
+        TLSpanAttributes.TRACELOOP_ENTITY_PATH: span_name if parent_id else "",
         RESPAN_LOG_TYPE: log_type,
     }
     workflow_name = context_api.get_value(TLSpanAttributes.TRACELOOP_ENTITY_NAME)
@@ -88,10 +101,12 @@ def _base_attrs(*, span_name: str, log_type: str, request_type: str) -> dict[str
     return attrs
 
 
-def _set_model(attrs: dict[str, Any], instance: Any, request_kwargs: dict[str, Any]) -> None:
+def _set_model(
+    attrs: dict[str, Any], instance: Any, request_kwargs: dict[str, Any]
+) -> None:
     model = request_kwargs.get(MODEL_ID_KEY) or model_id_from_instance(instance)
     if model:
-        attrs[TLSpanAttributes.LLM_REQUEST_MODEL] = str(model)
+        attrs[TLSpanAttributes.LLM_REQUEST_MODEL] = to_attr_value(model)
 
 
 def _set_prompt_attrs(attrs: dict[str, Any], messages: list[dict[str, Any]]) -> None:
@@ -129,12 +144,17 @@ def build_text_attrs(
     instance: Any,
     request_kwargs: dict[str, Any],
     response_or_chunks: Any = None,
+    is_streaming: bool = False,
+    parent_id: str | None = None,
 ) -> dict[str, Any]:
     attrs = _base_attrs(
         span_name=WATSONX_TEXT_SPAN_NAME,
         log_type=LOG_TYPE_TEXT,
-        request_type=_request_type_value("COMPLETION", "completion"),
+        request_type=_request_type_value("CHAT", "chat"),
+        parent_id=parent_id,
     )
+    if is_streaming:
+        attrs[TLSpanAttributes.LLM_IS_STREAMING] = True
     _set_model(attrs=attrs, instance=instance, request_kwargs=request_kwargs)
     messages = normalize_text_prompts(request_kwargs.get("prompt"))
     attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = format_input_messages(messages)
@@ -152,12 +172,17 @@ def build_chat_attrs(
     instance: Any,
     request_kwargs: dict[str, Any],
     response_or_chunks: Any = None,
+    is_streaming: bool = False,
+    parent_id: str | None = None,
 ) -> dict[str, Any]:
     attrs = _base_attrs(
         span_name=WATSONX_CHAT_SPAN_NAME,
         log_type=LOG_TYPE_CHAT,
         request_type=_request_type_value("CHAT", "chat"),
+        parent_id=parent_id,
     )
+    if is_streaming:
+        attrs[TLSpanAttributes.LLM_IS_STREAMING] = True
     _set_model(attrs=attrs, instance=instance, request_kwargs=request_kwargs)
     messages = normalize_chat_messages(request_kwargs.get("messages"))
     attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = format_input_messages(messages)
@@ -185,11 +210,13 @@ def build_embedding_attrs(
     instance: Any,
     request_kwargs: dict[str, Any],
     response: Any = None,
+    parent_id: str | None = None,
 ) -> dict[str, Any]:
     attrs = _base_attrs(
         span_name=WATSONX_EMBEDDING_SPAN_NAME,
         log_type=LOG_TYPE_EMBEDDING,
         request_type=_request_type_value("EMBEDDING", "embedding"),
+        parent_id=parent_id,
     )
     _set_model(attrs=attrs, instance=instance, request_kwargs=request_kwargs)
     inputs = normalize_embedding_inputs(
@@ -201,13 +228,11 @@ def build_embedding_attrs(
     attrs[f"{_GEN_AI_PROMPT_PREFIX}0.content"] = safe_json(inputs)
 
     if response is not None:
-        summary = {
-            "vector_count": embedding_vector_count(response),
-            "dimension": embedding_dimension(response),
-        }
-        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(
-            {key: value for key, value in summary.items() if value is not None}
+        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = embedding_json_dumps(
+            embedding_output(response)
         )
+        attrs["watsonx.embedding.vector_count"] = embedding_vector_count(response) or 0
+        attrs["watsonx.embedding.dimension"] = embedding_dimension(response) or 0
         _set_usage_attrs(attrs=attrs, response_or_chunks=response)
     return attrs
 
@@ -219,12 +244,15 @@ def emit_span(
     start_ns: int,
     error_message: str | None = None,
     status_code: int = 200,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
     try:
         if error_message:
             attrs["error.message"] = error_message
             attrs.setdefault("status_code", status_code if status_code >= 400 else 500)
-        trace_id, parent_id = _current_trace_parent_ids()
+        if trace_id is None and parent_id is None:
+            trace_id, parent_id = current_trace_parent_ids()
         span = build_readable_span(
             name=span_name,
             trace_id=trace_id,
@@ -236,7 +264,7 @@ def emit_span(
             status_code=status_code,
         )
         inject_span(span=span)
-    except Exception:
+    except BaseException:
         logger.debug("Failed to emit Watsonx span", exc_info=True)
 
 
@@ -248,18 +276,29 @@ def emit_text_span(
     response_or_chunks: Any = None,
     error_message: str | None = None,
     status_code: int = 200,
+    is_streaming: bool = False,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
-    emit_span(
-        span_name=WATSONX_TEXT_SPAN_NAME,
-        attrs=build_text_attrs(
+    try:
+        attrs = build_text_attrs(
             instance=instance,
             request_kwargs=request_kwargs,
             response_or_chunks=response_or_chunks,
-        ),
-        start_ns=start_ns,
-        error_message=error_message,
-        status_code=status_code,
-    )
+            is_streaming=is_streaming,
+            parent_id=parent_id,
+        )
+        emit_span(
+            span_name=WATSONX_TEXT_SPAN_NAME,
+            attrs=attrs,
+            start_ns=start_ns,
+            error_message=error_message,
+            status_code=status_code,
+            trace_id=trace_id,
+            parent_id=parent_id,
+        )
+    except BaseException:
+        logger.debug("Failed to build Watsonx text span", exc_info=True)
 
 
 def emit_chat_span(
@@ -270,18 +309,29 @@ def emit_chat_span(
     response_or_chunks: Any = None,
     error_message: str | None = None,
     status_code: int = 200,
+    is_streaming: bool = False,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
-    emit_span(
-        span_name=WATSONX_CHAT_SPAN_NAME,
-        attrs=build_chat_attrs(
+    try:
+        attrs = build_chat_attrs(
             instance=instance,
             request_kwargs=request_kwargs,
             response_or_chunks=response_or_chunks,
-        ),
-        start_ns=start_ns,
-        error_message=error_message,
-        status_code=status_code,
-    )
+            is_streaming=is_streaming,
+            parent_id=parent_id,
+        )
+        emit_span(
+            span_name=WATSONX_CHAT_SPAN_NAME,
+            attrs=attrs,
+            start_ns=start_ns,
+            error_message=error_message,
+            status_code=status_code,
+            trace_id=trace_id,
+            parent_id=parent_id,
+        )
+    except BaseException:
+        logger.debug("Failed to build Watsonx chat span", exc_info=True)
 
 
 def emit_embedding_span(
@@ -292,15 +342,24 @@ def emit_embedding_span(
     response: Any = None,
     error_message: str | None = None,
     status_code: int = 200,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
 ) -> None:
-    emit_span(
-        span_name=WATSONX_EMBEDDING_SPAN_NAME,
-        attrs=build_embedding_attrs(
+    try:
+        attrs = build_embedding_attrs(
             instance=instance,
             request_kwargs=request_kwargs,
             response=response,
-        ),
-        start_ns=start_ns,
-        error_message=error_message,
-        status_code=status_code,
-    )
+            parent_id=parent_id,
+        )
+        emit_span(
+            span_name=WATSONX_EMBEDDING_SPAN_NAME,
+            attrs=attrs,
+            start_ns=start_ns,
+            error_message=error_message,
+            status_code=status_code,
+            trace_id=trace_id,
+            parent_id=parent_id,
+        )
+    except BaseException:
+        logger.debug("Failed to build Watsonx embedding span", exc_info=True)

--- a/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_serialization.py
@@ -1,0 +1,276 @@
+"""Bounded, privacy-safe serialization for Watsonx telemetry."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from numbers import Real
+from typing import Any
+
+MAX_JSON_BYTES = 16_000
+MAX_TEXT_BYTES = 4_000
+MAX_ITEMS = 50
+MAX_DEPTH = 8
+
+_SENSITIVE_KEY = re.compile(
+    r"(^|[._-])(api[_-]?key|authorization|cookie|password|secret|token)([._-]|$)",
+    re.IGNORECASE,
+)
+_ASSIGNMENT_SECRET = re.compile(
+    r"(?i)([a-z0-9_.-]*(?:api[_-]?key|authorization|cookie|password|secret|token))"
+    r"\s*[:=]\s*([^\s,;]+)"
+)
+_QUOTED_SECRET = re.compile(
+    r"""(?i)(["'][^"']*(?:api[_-]?key|authorization|cookie|password|secret|token)["']\s*:\s*)(["'])(.*?)\2"""
+)
+_AUTH_SECRET = re.compile(r"(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")
+
+
+def safe_type_name(value: Any) -> str:
+    return type(value).__name__[:120]
+
+
+def redact_text(value: str) -> str:
+    value = _AUTH_SECRET.sub(lambda match: f"{match.group(1)} [REDACTED]", value)
+    value = _QUOTED_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]{match.group(2)}",
+        value,
+    )
+    return _ASSIGNMENT_SECRET.sub(
+        lambda match: f"{match.group(1)}=[REDACTED]",
+        value,
+    )
+
+
+def safe_text(value: Any, *, max_bytes: int = MAX_TEXT_BYTES) -> str:
+    if isinstance(value, str):
+        text = redact_text(value)
+    elif value is None:
+        text = ""
+    elif isinstance(value, bool):
+        text = "true" if value else "false"
+    elif isinstance(value, int) or isinstance(value, float) and math.isfinite(value):
+        text = str(value)
+    else:
+        text = f"<{safe_type_name(value)}>"
+    if len(text.encode()) <= max_bytes:
+        return text
+    low, high, best = 0, len(text), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = f"{text[:middle]}…[truncated]"
+        if len(candidate.encode()) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or "[truncated]"
+
+
+def safe_exception_message(exc: BaseException) -> str:
+    try:
+        args = exc.args
+    except BaseException:  # noqa: BLE001
+        args = ()
+    details = [
+        safe_text(item, max_bytes=1_000)
+        for item in args[:4]
+        if item is None or isinstance(item, (str, bool, int, float))
+    ]
+    name = safe_type_name(exc)
+    return safe_text(f"{name}: {'; '.join(filter(None, details))}" if details else name)
+
+
+def provider_status_code(exc: BaseException) -> int:
+    candidates: list[Any] = []
+    for name in ("status_code", "status"):
+        try:
+            candidates.append(getattr(exc, name, None))
+        except BaseException:  # noqa: BLE001, S112
+            continue
+    try:
+        response = getattr(exc, "response", None)
+    except BaseException:  # noqa: BLE001
+        response = None
+    if response is not None:
+        for name in ("status_code", "status"):
+            try:
+                candidates.append(getattr(response, name, None))
+            except BaseException:  # noqa: BLE001, S112
+                continue
+    for value in candidates:
+        if (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 400 <= value <= 599
+        ):
+            return value
+    return 500
+
+
+def _safe_key(value: Any) -> str:
+    if isinstance(value, str):
+        return safe_text(value, max_bytes=256)
+    if value is None or isinstance(value, (bool, int)):
+        return json.dumps(value)
+    return f"<{safe_type_name(value)}>"
+
+
+def to_jsonable(value: Any, *, depth: int = 0) -> Any:
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else safe_text(value)
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        try:
+            length = len(value)
+        except BaseException:  # noqa: BLE001
+            length = None
+        return {"type": "bytes", "length": length}
+    if depth >= MAX_DEPTH:
+        return {"type": safe_type_name(value), "truncated": True}
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        try:
+            for key, item in islice(iter(value.items()), MAX_ITEMS + 1):
+                if len(result) >= MAX_ITEMS:
+                    result["_respan_truncated_items"] = True
+                    break
+                rendered_key = _safe_key(key)
+                result[rendered_key] = (
+                    "[REDACTED]"
+                    if _SENSITIVE_KEY.search(rendered_key)
+                    else to_jsonable(item, depth=depth + 1)
+                )
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items: list[Any] = []
+        try:
+            for item in islice(iter(value), MAX_ITEMS + 1):
+                if len(items) >= MAX_ITEMS:
+                    items.append({"_respan_truncated_items": True})
+                    break
+                items.append(to_jsonable(item, depth=depth + 1))
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        return items
+    for method_name in ("model_dump", "to_dict"):
+        try:
+            method = getattr(value, method_name, None)
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if not callable(method):
+            continue
+        try:
+            dumped = method(mode="json") if method_name == "model_dump" else method()
+        except TypeError:
+            try:
+                dumped = method()
+            except BaseException:  # noqa: BLE001, S112
+                continue
+        except BaseException:  # noqa: BLE001, S112
+            continue
+        return to_jsonable(dumped, depth=depth + 1)
+    return {"type": safe_type_name(value)}
+
+
+def json_dumps(value: Any, *, max_bytes: int = MAX_JSON_BYTES) -> str:
+    serialized = json.dumps(
+        to_jsonable(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    if len(serialized.encode()) <= max_bytes:
+        return serialized
+    low, high, best = 0, len(serialized), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = json.dumps(
+            {"preview": serialized[:middle], "truncated": True},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        if len(candidate.encode()) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or '{"truncated":true}'
+
+
+def _is_numeric_vector(value: Any) -> bool:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return False
+    try:
+        return all(
+            isinstance(item, Real)
+            and not isinstance(item, bool)
+            and (not isinstance(item, float) or math.isfinite(item))
+            for item in value
+        )
+    except BaseException:  # noqa: BLE001
+        return False
+
+
+def _embedding_jsonable(value: Any, *, depth: int = 0, vector: bool = False) -> Any:
+    """Preserve complete numeric vectors while bounding all non-vector payloads."""
+    if vector and _is_numeric_vector(value):
+        return list(value)
+    if isinstance(value, Mapping) and depth < MAX_DEPTH:
+        result: dict[str, Any] = {}
+        try:
+            for key, item in islice(iter(value.items()), MAX_ITEMS + 1):
+                if len(result) >= MAX_ITEMS:
+                    result["_respan_truncated_items"] = True
+                    break
+                rendered_key = _safe_key(key)
+                item_is_vector = any(
+                    marker in rendered_key.lower() for marker in ("embedding", "vector")
+                )
+                result[rendered_key] = (
+                    "[REDACTED]"
+                    if _SENSITIVE_KEY.search(rendered_key)
+                    else _embedding_jsonable(
+                        item,
+                        depth=depth + 1,
+                        vector=item_is_vector,
+                    )
+                )
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        if _is_numeric_vector(value):
+            return list(value)
+        items: list[Any] = []
+        try:
+            for item in islice(iter(value), MAX_ITEMS + 1):
+                if len(items) >= MAX_ITEMS:
+                    items.append({"_respan_truncated_items": True})
+                    break
+                items.append(_embedding_jsonable(item, depth=depth + 1, vector=vector))
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        return items
+    return to_jsonable(value, depth=depth)
+
+
+def embedding_json_dumps(value: Any) -> str:
+    """Serialize the provider payload without truncating numeric embeddings."""
+    return json.dumps(
+        _embedding_jsonable(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )

--- a/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watsonx/src/respan_instrumentation_watsonx/_translator.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import inspect
-import json
 from collections.abc import Iterable, Mapping
 from typing import Any
 
 from respan_instrumentation_watsonx._constants import (
-    ASSISTANT_ROLE,
     CHOICES_KEY,
     COMPLETION_TOKENS_KEY,
     CONTENT_KEY,
@@ -32,7 +30,11 @@ from respan_instrumentation_watsonx._constants import (
     USAGE_KEY,
     USER_ROLE,
 )
-from respan_sdk.utils.serialization import serialize_value
+from respan_instrumentation_watsonx._serialization import (
+    json_dumps,
+    safe_text,
+    to_jsonable,
+)
 
 
 def _field(value: Any, name: str, default: Any = None) -> Any:
@@ -40,46 +42,21 @@ def _field(value: Any, name: str, default: Any = None) -> Any:
         return value.get(name, default)
     try:
         return getattr(value, name)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return default
 
 
 def _dump_value(value: Any) -> Any:
-    if value is None or isinstance(value, str | int | float | bool):
-        return value
-    if isinstance(value, Mapping):
-        return {
-            str(key): _dump_value(nested_value)
-            for key, nested_value in value.items()
-            if nested_value is not None
-        }
-    if isinstance(value, list | tuple | set):
-        return [_dump_value(item) for item in value if item is not None]
-    model_dump = getattr(value, "model_dump", None)
-    if callable(model_dump):
-        try:
-            return model_dump(exclude_none=True, by_alias=False)
-        except TypeError:
-            return model_dump()
-    to_dict = getattr(value, "to_dict", None)
-    if callable(to_dict):
-        try:
-            return to_dict()
-        except Exception:
-            pass
-    return serialize_value(value=value)
+    return to_jsonable(value)
 
 
 def safe_json(value: Any) -> str:
-    try:
-        return json.dumps(_dump_value(value), default=str)
-    except Exception:
-        return str(value)
+    return json_dumps(value)
 
 
 def to_attr_value(value: Any) -> str:
     if isinstance(value, str):
-        return value
+        return safe_text(value)
     return safe_json(value)
 
 
@@ -87,7 +64,7 @@ def _coerce_text(value: Any) -> str:
     if value is None:
         return ""
     if isinstance(value, str):
-        return value
+        return safe_text(value)
     return safe_json(value)
 
 
@@ -95,7 +72,9 @@ def normalize_text_prompts(prompt: Any) -> list[dict[str, Any]]:
     if prompt is None:
         return []
     if isinstance(prompt, list | tuple):
-        return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(item)} for item in prompt]
+        return [
+            {ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(item)} for item in prompt
+        ]
     return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(prompt)}]
 
 
@@ -112,7 +91,9 @@ def normalize_chat_messages(messages: Any) -> list[dict[str, Any]]:
             if isinstance(message, Mapping):
                 normalized.append(_normalize_message(message))
             else:
-                normalized.append({ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(message)})
+                normalized.append(
+                    {ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(message)}
+                )
         return normalized
     return [{ROLE_KEY: USER_ROLE, CONTENT_KEY: _coerce_text(messages)}]
 
@@ -180,7 +161,9 @@ def _text_from_generation_response(response: Any) -> str:
 
 def format_text_output(response_or_chunks: Any) -> str:
     if isinstance(response_or_chunks, list):
-        return "".join(_text_from_generation_response(chunk) for chunk in response_or_chunks)
+        return "".join(
+            _text_from_generation_response(chunk) for chunk in response_or_chunks
+        )
     return _text_from_generation_response(response_or_chunks)
 
 
@@ -196,20 +179,25 @@ def _chat_content_from_response(response: Any) -> str:
 
 def format_chat_output(response_or_chunks: Any) -> str:
     if isinstance(response_or_chunks, list):
-        return "".join(_chat_content_from_response(chunk) for chunk in response_or_chunks)
+        return "".join(
+            _chat_content_from_response(chunk) for chunk in response_or_chunks
+        )
     return _chat_content_from_response(response_or_chunks)
 
 
 def _usage_sources(response_or_chunks: Any) -> Iterable[Any]:
-    responses = response_or_chunks if isinstance(response_or_chunks, list) else [response_or_chunks]
+    responses = (
+        response_or_chunks
+        if isinstance(response_or_chunks, list)
+        else [response_or_chunks]
+    )
     for response in reversed(responses):
         if response is None:
             continue
         usage = _field(response, USAGE_KEY)
         if usage is not None:
             yield usage
-        for result in _iter_results(response):
-            yield result
+        yield from _iter_results(response)
         yield response
 
 
@@ -239,7 +227,11 @@ def extract_usage(response_or_chunks: Any) -> dict[str, int]:
             completion_tokens = _coerce_int(_field(source, GENERATED_TOKEN_COUNT_KEY))
 
         total_tokens = _coerce_int(_field(source, TOTAL_TOKENS_KEY))
-        if total_tokens is None and prompt_tokens is not None and completion_tokens is not None:
+        if (
+            total_tokens is None
+            and prompt_tokens is not None
+            and completion_tokens is not None
+        ):
             total_tokens = prompt_tokens + completion_tokens
 
         result: dict[str, int] = {}
@@ -269,7 +261,9 @@ def _annotation_to_json_schema(annotation: Any) -> dict[str, Any]:
 
 
 def _callable_tool_definition(tool: Any) -> dict[str, Any]:
-    function: dict[str, Any] = {NAME_KEY: getattr(tool, "__name__", tool.__class__.__name__)}
+    function: dict[str, Any] = {
+        NAME_KEY: getattr(tool, "__name__", tool.__class__.__name__)
+    }
     doc = inspect.getdoc(tool)
     if doc:
         function["description"] = doc
@@ -313,16 +307,22 @@ def normalize_tools(tools: Any) -> list[dict[str, Any]]:
             continue
         function = dumped.get(FUNCTION_KEY)
         if isinstance(function, Mapping):
-            normalized.append({TYPE_KEY: FUNCTION_TOOL_TYPE, FUNCTION_KEY: dict(function)})
+            normalized.append(
+                {TYPE_KEY: FUNCTION_TOOL_TYPE, FUNCTION_KEY: dict(function)}
+            )
             continue
         name = dumped.get(NAME_KEY)
         if name:
             function_payload = {NAME_KEY: name}
             for key in ("description", "parameters", "schema", "input_schema"):
                 if dumped.get(key) is not None:
-                    target_key = "parameters" if key in {"schema", "input_schema"} else key
+                    target_key = (
+                        "parameters" if key in {"schema", "input_schema"} else key
+                    )
                     function_payload[target_key] = dumped[key]
-            normalized.append({TYPE_KEY: FUNCTION_TOOL_TYPE, FUNCTION_KEY: function_payload})
+            normalized.append(
+                {TYPE_KEY: FUNCTION_TOOL_TYPE, FUNCTION_KEY: function_payload}
+            )
     return normalized
 
 
@@ -342,7 +342,9 @@ def _normalize_single_tool_call(tool_call: Any) -> dict[str, Any] | None:
         return None
     normalized_function = dict(function)
     if "arguments" in normalized_function:
-        normalized_function["arguments"] = to_attr_value(normalized_function["arguments"])
+        normalized_function["arguments"] = to_attr_value(
+            normalized_function["arguments"]
+        )
     result = {
         TYPE_KEY: dumped.get(TYPE_KEY) or FUNCTION_TOOL_TYPE,
         FUNCTION_KEY: normalized_function,
@@ -366,11 +368,18 @@ def normalize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
 
 
 def extract_chat_tool_calls(response_or_chunks: Any) -> list[dict[str, Any]]:
-    responses = response_or_chunks if isinstance(response_or_chunks, list) else [response_or_chunks]
+    responses = (
+        response_or_chunks
+        if isinstance(response_or_chunks, list)
+        else [response_or_chunks]
+    )
     tool_calls: list[dict[str, Any]] = []
     seen: set[str] = set()
     for response in responses:
-        for source in (_extract_choice_message(response), _extract_choice_delta(response)):
+        for source in (
+            _extract_choice_message(response),
+            _extract_choice_delta(response),
+        ):
             for tool_call in normalize_tool_calls(_field(source, TOOL_CALLS_KEY)):
                 signature = safe_json(tool_call)
                 if signature in seen:
@@ -429,9 +438,14 @@ def embedding_dimension(response: Any) -> int | None:
     return None
 
 
+def embedding_output(response: Any) -> Any:
+    """Return the provider's full vector payload in JSON-safe form."""
+    return response
+
+
 def model_id_from_instance(instance: Any) -> str | None:
     for key in (MODEL_ID_KEY, "_model_id", "deployment_id", "_deployment_id"):
         value = _field(instance, key)
         if value:
-            return str(value)
+            return safe_text(value)
     return None

--- a/python-sdks/instrumentations/respan-instrumentation-watsonx/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-watsonx/tests/test_instrumentation.py
@@ -8,23 +8,23 @@ from typing import Any
 
 import pytest
 from opentelemetry import context as context_api
+from opentelemetry import trace
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
-
-from respan_instrumentation_watsonx import WatsonxInstrumentor
-from respan_instrumentation_watsonx import _instrumentation
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from respan_instrumentation_watsonx import WatsonxInstrumentor, _instrumentation
 from respan_instrumentation_watsonx._constants import (
-    AEMBEDDINGS_GENERATE_METHOD_NAME,
     AEMBED_DOCUMENTS_METHOD_NAME,
     AEMBED_QUERY_METHOD_NAME,
+    AEMBEDDINGS_GENERATE_METHOD_NAME,
     AGENERATE_METHOD_NAME,
     AGENERATE_STREAM_METHOD_NAME,
     CHAT_METHOD_NAME,
     CHAT_STREAM_METHOD_NAME,
+    EMBED_DOCUMENTS_METHOD_NAME,
+    EMBED_QUERY_METHOD_NAME,
     EMBEDDINGS_CLASS_NAME,
     EMBEDDINGS_GENERATE_METHOD_NAME,
     EMBEDDINGS_MODULE,
-    EMBED_DOCUMENTS_METHOD_NAME,
-    EMBED_QUERY_METHOD_NAME,
     GENERATE_METHOD_NAME,
     GENERATE_TEXT_METHOD_NAME,
     GENERATE_TEXT_STREAM_METHOD_NAME,
@@ -36,7 +36,11 @@ from respan_instrumentation_watsonx._otel_emitter import (
     build_embedding_attrs,
     build_text_attrs,
 )
-from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_EMBEDDING, LOG_TYPE_TEXT
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_TEXT,
+)
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
 
 FORBIDDEN_ALIASES = {
@@ -64,6 +68,9 @@ class Obj:
 @pytest.fixture(autouse=True)
 def reset_instrumentation_globals() -> None:
     _instrumentation._original_methods.clear()
+    _instrumentation._installed_methods.clear()
+    _instrumentation._activation_count = 0
+    _instrumentation._activation_installing = False
 
 
 @pytest.fixture()
@@ -100,7 +107,9 @@ def fake_watsonx(monkeypatch: pytest.MonkeyPatch) -> tuple[type[Any], type[Any]]
             yield "stream "
             yield "text"
 
-        async def agenerate(self, prompt: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        async def agenerate(
+            self, prompt: str | None = None, **kwargs: Any
+        ) -> dict[str, Any]:
             return {
                 "results": [
                     {
@@ -138,16 +147,24 @@ def fake_watsonx(monkeypatch: pytest.MonkeyPatch) -> tuple[type[Any], type[Any]]
                         }
                     }
                 ],
-                "usage": {"prompt_tokens": 9, "completion_tokens": 7, "total_tokens": 16},
+                "usage": {
+                    "prompt_tokens": 9,
+                    "completion_tokens": 7,
+                    "total_tokens": 16,
+                },
             }
 
         def chat_stream(self, messages: list[dict[str, Any]], **kwargs: Any):
             yield {"choices": [{"delta": {"content": "hello "}}]}
             yield {"choices": [{"delta": {"content": "world"}}]}
 
-        async def achat(self, messages: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
+        async def achat(
+            self, messages: list[dict[str, Any]], **kwargs: Any
+        ) -> dict[str, Any]:
             return {
-                "choices": [{"message": {"role": "assistant", "content": "async chat"}}],
+                "choices": [
+                    {"message": {"role": "assistant", "content": "async chat"}}
+                ],
                 "usage": {"prompt_tokens": 1, "completion_tokens": 2},
             }
 
@@ -179,7 +196,9 @@ def fake_watsonx(monkeypatch: pytest.MonkeyPatch) -> tuple[type[Any], type[Any]]
         async def agenerate(self, inputs: list[str], **kwargs: Any) -> dict[str, Any]:
             return {"results": [{"embedding": [0.1, 0.2], "input": inputs[0]}]}
 
-        async def aembed_documents(self, texts: list[str], **kwargs: Any) -> list[list[float]]:
+        async def aembed_documents(
+            self, texts: list[str], **kwargs: Any
+        ) -> list[list[float]]:
             return [[0.1, 0.2], [0.3, 0.4]]
 
         async def aembed_query(self, text: str, **kwargs: Any) -> list[float]:
@@ -191,9 +210,9 @@ def fake_watsonx(monkeypatch: pytest.MonkeyPatch) -> tuple[type[Any], type[Any]]
     embeddings_module = ModuleType(EMBEDDINGS_MODULE)
     setattr(inference_module, MODEL_INFERENCE_CLASS_NAME, ModelInference)
     setattr(embeddings_module, EMBEDDINGS_CLASS_NAME, Embeddings)
-    setattr(foundation_models_module, "inference", inference_module)
-    setattr(foundation_models_module, "embeddings", embeddings_module)
-    setattr(ibm_module, "foundation_models", foundation_models_module)
+    foundation_models_module.inference = inference_module
+    foundation_models_module.embeddings = embeddings_module
+    ibm_module.foundation_models = foundation_models_module
 
     monkeypatch.setitem(sys.modules, "ibm_watsonx_ai", ibm_module)
     monkeypatch.setitem(
@@ -225,10 +244,13 @@ def test_activate_patches_text_generation_and_emits_text_span(
     assert len(captured_spans) == 1
     attrs = captured_spans[0].attributes
     assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_TEXT
-    assert attrs[TLSpanAttributes.LLM_REQUEST_TYPE] == "completion"
+    assert attrs[TLSpanAttributes.LLM_REQUEST_TYPE] == "chat"
+    assert attrs["gen_ai.provider.name"] == "ibm"
     assert attrs[TLSpanAttributes.LLM_REQUEST_MODEL] == "ibm/granite-3-8b-instruct"
     assert attrs[f"{TLSpanAttributes.LLM_PROMPTS}.0.content"] == "Say hello"
-    assert attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"] == "generated: Say hello"
+    assert (
+        attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"] == "generated: Say hello"
+    )
     assert attrs[TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 3
     assert attrs[TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 4
     assert FORBIDDEN_ALIASES.isdisjoint(attrs)
@@ -252,6 +274,7 @@ def test_stream_emits_one_text_span_after_iterator_is_consumed(
         captured_spans[0].attributes[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"]
         == "stream text"
     )
+    assert captured_spans[0].attributes[TLSpanAttributes.LLM_IS_STREAMING] is True
 
     instrumentor.deactivate()
 
@@ -276,14 +299,15 @@ def test_chat_span_maps_tools_tool_calls_and_avoids_aliases(
     attrs = captured_spans[0].attributes
     assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_CHAT
     assert attrs[TLSpanAttributes.LLM_REQUEST_TYPE] == "chat"
-    assert json.loads(attrs[TLSpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"][
-        "name"
-    ] == "get_weather"
-    assert json.loads(
-        attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.tool_calls"]
-    )[0]["function"] == {
+    assert (
+        json.loads(attrs[TLSpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"]["name"]
+        == "get_weather"
+    )
+    assert json.loads(attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])[0][
+        "function"
+    ] == {
         "name": "get_weather",
-        "arguments": '{"city": "Tokyo"}',
+        "arguments": '{"city":"Tokyo"}',
     }
     assert attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"] == (
         "The weather is sunny."
@@ -327,13 +351,14 @@ def test_async_model_methods_emit_spans(
             ]
             == "async chat stream"
         )
+        assert captured_spans[1].attributes[TLSpanAttributes.LLM_IS_STREAMING] is True
 
         instrumentor.deactivate()
 
     asyncio.run(run())
 
 
-def test_embedding_methods_emit_embedding_span_without_vectors(
+def test_embedding_methods_emit_embedding_span_with_full_vectors(
     fake_watsonx: tuple[type[Any], type[Any]],
     captured_spans: list[Any],
 ) -> None:
@@ -348,12 +373,13 @@ def test_embedding_methods_emit_embedding_span_without_vectors(
     assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_EMBEDDING
     assert attrs[TLSpanAttributes.LLM_REQUEST_TYPE] == "embedding"
     assert attrs[TLSpanAttributes.LLM_REQUEST_MODEL] == "ibm/slate-125m-english-rtrvr"
-    assert attrs[f"{TLSpanAttributes.LLM_PROMPTS}.0.content"] == '["first", "second"]'
-    assert json.loads(attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == {
-        "vector_count": 2,
-        "dimension": 2,
-    }
-    assert "embedding" not in attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+    assert json.loads(attrs[f"{TLSpanAttributes.LLM_PROMPTS}.0.content"]) == [
+        "first",
+        "second",
+    ]
+    output = json.loads(attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    assert output["results"][0]["embedding"] == [0.1, 0.2]
+    assert output["results"][1]["embedding"] == [0.3, 0.4]
     assert FORBIDDEN_ALIASES.isdisjoint(attrs)
 
     instrumentor.deactivate()
@@ -373,10 +399,10 @@ def test_async_embedding_methods_emit_spans(
 
         assert len(captured_spans) == 2
         assert captured_spans[0].attributes[RESPAN_LOG_TYPE] == LOG_TYPE_EMBEDDING
-        assert json.loads(captured_spans[1].attributes["traceloop.entity.output"]) == {
-            "vector_count": 2,
-            "dimension": 2,
-        }
+        assert json.loads(captured_spans[1].attributes["traceloop.entity.output"]) == [
+            [0.1, 0.2],
+            [0.3, 0.4],
+        ]
 
         instrumentor.deactivate()
 
@@ -444,7 +470,7 @@ def test_error_path_emits_failed_span(
     assert len(captured_spans) == 1
     span = captured_spans[0]
     assert span.status.status_code.name == "ERROR"
-    assert span.attributes["error.message"] == "boom"
+    assert span.attributes["error.message"] == "RuntimeError: boom"
     assert (
         span.attributes[TLSpanAttributes.LLM_REQUEST_MODEL]
         == "ibm/granite-3-8b-instruct"
@@ -458,7 +484,9 @@ def test_deactivate_restores_original_methods(
 ) -> None:
     ModelInference, Embeddings = fake_watsonx
     original_methods = {
-        (ModelInference, GENERATE_METHOD_NAME): getattr(ModelInference, GENERATE_METHOD_NAME),
+        (ModelInference, GENERATE_METHOD_NAME): getattr(
+            ModelInference, GENERATE_METHOD_NAME
+        ),
         (ModelInference, GENERATE_TEXT_METHOD_NAME): getattr(
             ModelInference,
             GENERATE_TEXT_METHOD_NAME,
@@ -488,7 +516,9 @@ def test_deactivate_restores_original_methods(
             Embeddings,
             EMBED_DOCUMENTS_METHOD_NAME,
         ),
-        (Embeddings, EMBED_QUERY_METHOD_NAME): getattr(Embeddings, EMBED_QUERY_METHOD_NAME),
+        (Embeddings, EMBED_QUERY_METHOD_NAME): getattr(
+            Embeddings, EMBED_QUERY_METHOD_NAME
+        ),
         (Embeddings, AEMBEDDINGS_GENERATE_METHOD_NAME): getattr(
             Embeddings,
             AEMBEDDINGS_GENERATE_METHOD_NAME,
@@ -497,18 +527,90 @@ def test_deactivate_restores_original_methods(
             Embeddings,
             AEMBED_DOCUMENTS_METHOD_NAME,
         ),
-        (Embeddings, AEMBED_QUERY_METHOD_NAME): getattr(Embeddings, AEMBED_QUERY_METHOD_NAME),
+        (Embeddings, AEMBED_QUERY_METHOD_NAME): getattr(
+            Embeddings, AEMBED_QUERY_METHOD_NAME
+        ),
     }
 
     instrumentor = WatsonxInstrumentor()
     instrumentor.activate()
-    assert getattr(ModelInference, GENERATE_METHOD_NAME) is not original_methods[
-        (ModelInference, GENERATE_METHOD_NAME)
-    ]
-    assert getattr(Embeddings, EMBED_QUERY_METHOD_NAME) is not original_methods[
-        (Embeddings, EMBED_QUERY_METHOD_NAME)
-    ]
+    assert (
+        getattr(ModelInference, GENERATE_METHOD_NAME)
+        is not original_methods[(ModelInference, GENERATE_METHOD_NAME)]
+    )
+    assert (
+        getattr(Embeddings, EMBED_QUERY_METHOD_NAME)
+        is not original_methods[(Embeddings, EMBED_QUERY_METHOD_NAME)]
+    )
 
     instrumentor.deactivate()
     for (target_class, method_name), original in original_methods.items():
         assert getattr(target_class, method_name) is original
+
+
+def test_two_instances_keep_watsonx_patched_until_final_deactivate(
+    fake_watsonx: tuple[type[Any], type[Any]],
+    captured_spans: list[Any],
+) -> None:
+    ModelInference, _ = fake_watsonx
+    original = ModelInference.generate
+    first = WatsonxInstrumentor()
+    second = WatsonxInstrumentor()
+
+    first.activate()
+    second.activate()
+    first.deactivate()
+    ModelInference().generate("still active")
+    assert len(captured_spans) == 1
+    assert ModelInference.generate is not original
+
+    second.deactivate()
+    assert ModelInference.generate is original
+
+
+def test_large_embedding_preserves_every_numeric_dimension() -> None:
+    vector = [index / 10_000 for index in range(5_000)]
+    attrs = build_embedding_attrs(
+        instance=Obj(model_id="ibm/slate"),
+        request_kwargs={"text": "full vector"},
+        response={"results": [{"embedding": vector}]},
+    )
+
+    output = json.loads(attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    assert output["results"][0]["embedding"] == vector
+
+
+def test_stream_keeps_call_time_parent_when_consumed_outside_context(
+    fake_watsonx: tuple[type[Any], type[Any]],
+    captured_spans: list[Any],
+) -> None:
+    ModelInference, _ = fake_watsonx
+    instrumentor = WatsonxInstrumentor()
+    instrumentor.activate()
+    parent_span_id = 0x1234
+    parent = NonRecordingSpan(
+        SpanContext(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=parent_span_id,
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            trace_state=None,
+        )
+    )
+    token = context_api.attach(trace.set_span_in_context(parent))
+    try:
+        stream = ModelInference().generate_text_stream(prompt="parent")
+    finally:
+        context_api.detach(token)
+
+    list(stream)
+    assert captured_spans[0].parent.span_id == parent_span_id
+
+
+def test_watsonx_stream_retention_is_bounded_and_keeps_terminal_chunk() -> None:
+    chunks: list[Any] = []
+    for index in range(_instrumentation._MAX_STREAM_CHUNKS + 20):
+        _instrumentation._append_stream_chunk(chunks, {"index": index})
+
+    assert len(chunks) == _instrumentation._MAX_STREAM_CHUNKS
+    assert chunks[-1] == {"index": _instrumentation._MAX_STREAM_CHUNKS + 19}

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/README.md
@@ -8,7 +8,7 @@ operations.
 ## Install
 
 ```bash
-pip install respan-ai respan-instrumentation-weaviate "weaviate-client>=4.22.0,<5"
+pip install respan-ai respan-instrumentation-weaviate "weaviate-client>=4.23.0,<5"
 ```
 
 ## Quickstart
@@ -49,7 +49,7 @@ Pass `capture_content=False` to omit operation arguments and results while
 retaining names, status, and database attributes. Activation/deactivation and
 the `instrument()` / `uninstrument()` aliases are idempotent.
 
-The adapter targets `weaviate-client>=4.22.0,<5` and its v4 collection API.
+The adapter targets `weaviate-client>=4.23.0,<5` and its v4 collection API.
 Generative search calls are left to an LLM-specific integration because they require chat
 semantics rather than vector-store task semantics.
 

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/pyproject.toml
@@ -13,8 +13,8 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.1"
-weaviate-client = ">=4.22.0,<5"
-opentelemetry-semantic-conventions-ai = ">=0.4.1"
+weaviate-client = ">=4.23.0,<5"
+opentelemetry-semantic-conventions-ai = ">=0.5.1,<0.6.0"
 wrapt = ">=1.16.0"
 
 [tool.poetry.plugins."respan.instrumentations"]

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/src/respan_instrumentation_weaviate/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/src/respan_instrumentation_weaviate/_instrumentation.py
@@ -6,45 +6,142 @@ import importlib
 import inspect
 import json
 import logging
+import math
+import re
 from collections.abc import Mapping, Sequence
 from contextvars import ContextVar
 from dataclasses import asdict, is_dataclass
 from enum import Enum
+from importlib import metadata
+from itertools import islice
 from numbers import Real
-from typing import Any
+from threading import RLock
+from typing import Any, ClassVar
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.semconv.trace import SpanAttributes as OTelSpanAttributes
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import SpanKind, Status, StatusCode
-from respan_instrumentation_weaviate._constants import (
-    MAX_ATTRIBUTE_CHARS,
-    MAX_PREVIEW_ITEMS,
-    SENSITIVE_KEY_PARTS,
-    WEAVIATE_INSTRUMENTATION_NAME,
-    WEAVIATE_PATCH_SPECS,
-    PatchSpec,
-)
 from respan_sdk.constants import ERROR_MESSAGE_ATTR
 from respan_sdk.constants.llm_logging import LOG_TYPE_TASK
 from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
 from respan_tracing.core.tracer import RespanTracer
 from wrapt import wrap_function_wrapper
 
+from respan_instrumentation_weaviate._constants import (
+    MAX_ATTRIBUTE_CHARS,
+    MAX_PREVIEW_ITEMS,
+    WEAVIATE_INSTRUMENTATION_NAME,
+    WEAVIATE_PATCH_SPECS,
+    PatchSpec,
+)
+
 logger = logging.getLogger(__name__)
+_SCOPE_NAME = "respan-instrumentation-weaviate"
+try:
+    _SCOPE_VERSION = metadata.version(_SCOPE_NAME)
+except metadata.PackageNotFoundError:
+    _SCOPE_VERSION = "0.1.0"
 
 
 _VECTOR_KEY_PARTS = ("embedding", "vector")
+_SENSITIVE_KEY = re.compile(
+    r"(^|[._-])(api[_-]?key|authorization|cookie|password|secret|token)([._-]|$)",
+    re.IGNORECASE,
+)
+_ASSIGNMENT_SECRET = re.compile(
+    r"(?i)([a-z0-9_.-]*(?:api[_-]?key|authorization|cookie|password|secret|token))"
+    r"\s*[:=]\s*([^\s,;]+)"
+)
+
+
+def _safe_text(value: Any, *, max_bytes: int = 4_000) -> str:
+    if isinstance(value, str):
+        text = _ASSIGNMENT_SECRET.sub(
+            lambda match: f"{match.group(1)}=[REDACTED]",
+            value,
+        )
+    elif value is None or isinstance(value, (bool, int)):
+        text = json.dumps(value)
+    elif isinstance(value, float) and math.isfinite(value):
+        text = str(value)
+    else:
+        text = f"<{type(value).__name__[:120]}>"
+    if len(text.encode()) <= max_bytes:
+        return text
+    low, high, best = 0, len(text), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = f"{text[:middle]}…[truncated]"
+        if len(candidate.encode()) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or "[truncated]"
+
+
+def _safe_exception_message(exc: BaseException) -> str:
+    try:
+        args = exc.args
+    except BaseException:  # noqa: BLE001
+        args = ()
+    details = [
+        _safe_text(item, max_bytes=1_000)
+        for item in args[:4]
+        if item is None or isinstance(item, (str, bool, int, float))
+    ]
+    name = type(exc).__name__[:120]
+    return _safe_text(
+        f"{name}: {'; '.join(filter(None, details))}" if details else name
+    )
+
+
+def _provider_status_code(exc: BaseException) -> int:
+    candidates: list[Any] = []
+    for owner in (exc,):
+        for name in ("status_code", "status"):
+            try:
+                candidates.append(getattr(owner, name, None))
+            except BaseException:
+                logger.debug("Ignored unsafe Weaviate exception status", exc_info=True)
+                continue
+    try:
+        response = getattr(exc, "response", None)
+    except BaseException:
+        logger.debug("Ignored unsafe Weaviate exception response", exc_info=True)
+        response = None
+    if response is not None:
+        for name in ("status_code", "status"):
+            try:
+                candidates.append(getattr(response, name, None))
+            except BaseException:
+                logger.debug("Ignored unsafe Weaviate response status", exc_info=True)
+                continue
+    for value in candidates:
+        if (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 400 <= value <= 599
+        ):
+            return value
+    return 500
 
 
 def _is_numeric_vector(value: Any) -> bool:
-    return (
-        isinstance(value, Sequence)
-        and not isinstance(value, (str, bytes, bytearray))
-        and bool(value)
-        and all(isinstance(item, Real) and not isinstance(item, bool) for item in value)
-    )
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return False
+    try:
+        return all(
+            isinstance(item, Real)
+            and not isinstance(item, bool)
+            and (not isinstance(item, float) or math.isfinite(item))
+            for item in value
+        )
+    except BaseException:
+        logger.debug("Ignored unsafe Weaviate vector iterator", exc_info=True)
+        return False
 
 
 def _is_vector_key(value: str) -> bool:
@@ -60,10 +157,14 @@ def _jsonable(
     preserved_vector: list[bool] | None = None,
 ) -> Any:
     preserved_vector = preserved_vector if preserved_vector is not None else [False]
-    if depth > 7 and not (vector_context or _is_numeric_vector(value)):
-        return repr(value)
-    if value is None or isinstance(value, (str, int, float, bool)):
+    if value is None or isinstance(value, (int, bool)):
         return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else _safe_text(value)
+    if isinstance(value, str):
+        return _safe_text(value, max_bytes=16_000)
+    if depth > 7 and not (vector_context or _is_numeric_vector(value)):
+        return {"type": type(value).__name__[:120], "truncated": True}
     if isinstance(value, bytes):
         return {"type": "bytes", "length": len(value)}
     if isinstance(value, Enum):
@@ -85,15 +186,15 @@ def _jsonable(
         omitted = 0
         regular_items = 0
         for key, item in value.items():
-            key_text = str(key)
+            key_text = _safe_text(key, max_bytes=256)
             item_is_vector = vector_context or _is_vector_key(key_text)
             if not item_is_vector and regular_items >= MAX_PREVIEW_ITEMS:
                 omitted += 1
                 continue
             regular_items += int(not item_is_vector)
             result[key_text] = (
-                "<redacted>"
-                if any(part in key_text.lower() for part in SENSITIVE_KEY_PARTS)
+                "[REDACTED]"
+                if _SENSITIVE_KEY.search(key_text)
                 else _jsonable(
                     item,
                     depth=depth + 1,
@@ -108,7 +209,7 @@ def _jsonable(
         preserve_all = vector_context or _is_numeric_vector(value)
         if preserve_all:
             preserved_vector[0] = True
-        source = value if preserve_all else value[:MAX_PREVIEW_ITEMS]
+        source = value if preserve_all else islice(iter(value), MAX_PREVIEW_ITEMS + 1)
         items = [
             _jsonable(
                 item,
@@ -120,8 +221,11 @@ def _jsonable(
         ]
         if preserve_all:
             return items
-        if len(value) > MAX_PREVIEW_ITEMS:
-            return {"count": len(value), "items": items, "truncated": True}
+        if len(items) > MAX_PREVIEW_ITEMS:
+            return {
+                "items": items[:MAX_PREVIEW_ITEMS],
+                "truncated": True,
+            }
         return items
     for method_name in ("model_dump", "to_dict", "dict", "to_json", "tolist"):
         method = getattr(value, method_name, None)
@@ -135,6 +239,7 @@ def _jsonable(
                 preserved_vector=preserved_vector,
             )
         except Exception:
+            logger.debug("Ignored unsafe Weaviate model conversion", exc_info=True)
             continue
     public_values = getattr(value, "__dict__", None)
     if isinstance(public_values, dict):
@@ -148,22 +253,41 @@ def _jsonable(
             vector_context=vector_context,
             preserved_vector=preserved_vector,
         )
-    return repr(value)
+    return {"type": type(value).__name__[:120]}
 
 
-def _json_dumps(value: Any) -> str:
+def _json_dumps_impl(value: Any) -> str:
     preserved_vector = [False]
     text = json.dumps(
         _jsonable(value, preserved_vector=preserved_vector),
-        default=str,
+        ensure_ascii=False,
         sort_keys=True,
+        allow_nan=False,
     )
-    if preserved_vector[0] or len(text) <= MAX_ATTRIBUTE_CHARS:
+    if preserved_vector[0] or len(text.encode()) <= MAX_ATTRIBUTE_CHARS:
         return text
-    return json.dumps(
-        {"preview": text[:MAX_ATTRIBUTE_CHARS], "truncated": True},
-        sort_keys=True,
-    )
+    low, high, best = 0, len(text), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = json.dumps(
+            {"preview": text[:middle], "truncated": True},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        if len(candidate.encode()) <= MAX_ATTRIBUTE_CHARS:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or '{"truncated":true}'
+
+
+def _json_dumps(value: Any) -> str:
+    try:
+        return _json_dumps_impl(value)
+    except BaseException:
+        logger.debug("Failed to serialize Weaviate telemetry", exc_info=True)
+        return json.dumps({"type": type(value).__name__[:120], "unavailable": True})
 
 
 def _instance_identity(instance: Any) -> dict[str, str]:
@@ -174,9 +298,13 @@ def _instance_identity(instance: Any) -> dict[str, str]:
         ("tenant", "tenant"),
         ("_tenant", "tenant"),
     ):
-        value = getattr(instance, source, None)
+        try:
+            value = getattr(instance, source, None)
+        except BaseException:
+            logger.debug("Ignored unsafe Weaviate identity field", exc_info=True)
+            continue
         if value is not None and target not in identity:
-            identity[target] = str(value)
+            identity[target] = _safe_text(value, max_bytes=1_000)
     return identity
 
 
@@ -193,7 +321,7 @@ def _call_input(
         arguments = {
             key: value for key, value in bound.arguments.items() if key != "self"
         }
-    except Exception:
+    except (TypeError, ValueError):
         arguments = {"args": list(args), "kwargs": kwargs}
     return {
         "operation": f"{label}.{operation}",
@@ -208,7 +336,10 @@ class WeaviateInstrumentor:
     name = WEAVIATE_INSTRUMENTATION_NAME
     _patches_applied = False
     _activation_count = 0
-    _patched_targets: list[tuple[type, str]] = []
+    _patched_targets: ClassVar[list[tuple[type, str]]] = []
+    _installed_targets: ClassVar[dict[tuple[type, str], Any]] = {}
+    _lock = RLock()
+    _capture_content_config: bool | None = None
     _active_call: ContextVar[bool] = ContextVar(
         "respan_weaviate_active_call",
         default=False,
@@ -232,12 +363,16 @@ class WeaviateInstrumentor:
         wrapped: Any,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
+        has_parent: bool,
     ) -> None:
         operation_name = f"{label}.{operation}"
         entity_name = f"weaviate.{operation_name}"
         span.set_attribute(RESPAN_LOG_TYPE, LOG_TYPE_TASK)
         span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_NAME, entity_name)
-        span.set_attribute(SpanAttributes.TRACELOOP_ENTITY_PATH, entity_name)
+        span.set_attribute(
+            SpanAttributes.TRACELOOP_ENTITY_PATH,
+            entity_name if has_parent else "",
+        )
         span.set_attribute(OTelSpanAttributes.DB_SYSTEM, "weaviate")
         span.set_attribute(OTelSpanAttributes.DB_OPERATION, operation_name)
         if self._capture_content:
@@ -255,15 +390,18 @@ class WeaviateInstrumentor:
                 ),
             )
 
-    def _set_error(self, span: Any, exc: Exception) -> None:
-        span.record_exception(exc)
-        span.set_status(Status(StatusCode.ERROR, str(exc)))
-        span.set_attribute("status_code", 500)
-        span.set_attribute(ERROR_MESSAGE_ATTR, str(exc))
+    def _set_error(self, span: Any, exc: BaseException) -> None:
+        message = _safe_exception_message(exc)
+        status_code = _provider_status_code(exc)
+        span.record_exception(RuntimeError(message))
+        span.set_status(Status(StatusCode.ERROR, message))
+        span.set_attribute("status_code", status_code)
+        span.set_attribute(OTelSpanAttributes.HTTP_STATUS_CODE, status_code)
+        span.set_attribute(ERROR_MESSAGE_ATTR, message)
         if self._capture_content:
             span.set_attribute(
                 SpanAttributes.TRACELOOP_ENTITY_OUTPUT,
-                _json_dumps({"error": type(exc).__name__, "message": str(exc)}),
+                _json_dumps({"error": type(exc).__name__, "message": message}),
             )
 
     def _trace_sync(
@@ -280,17 +418,26 @@ class WeaviateInstrumentor:
             return wrapped(*args, **kwargs)
         token = active_call.set(True)
         try:
-            tracer = trace.get_tracer(__name__)
+            parent_context = trace.get_current_span().get_span_context()
+            has_parent = bool(getattr(parent_context, "is_valid", False))
+            tracer = trace.get_tracer(_SCOPE_NAME, _SCOPE_VERSION)
             with tracer.start_as_current_span(
                 f"weaviate.{label}.{operation}",
                 kind=SpanKind.CLIENT,
             ) as span:
                 self._set_start_attributes(
-                    span, label, operation, instance, wrapped, args, kwargs
+                    span,
+                    label,
+                    operation,
+                    instance,
+                    wrapped,
+                    args,
+                    kwargs,
+                    has_parent,
                 )
                 try:
                     result = wrapped(*args, **kwargs)
-                except Exception as exc:
+                except BaseException as exc:
                     self._set_error(span, exc)
                     raise
                 span.set_status(Status(StatusCode.OK))
@@ -317,17 +464,26 @@ class WeaviateInstrumentor:
             return await wrapped(*args, **kwargs)
         token = active_call.set(True)
         try:
-            tracer = trace.get_tracer(__name__)
+            parent_context = trace.get_current_span().get_span_context()
+            has_parent = bool(getattr(parent_context, "is_valid", False))
+            tracer = trace.get_tracer(_SCOPE_NAME, _SCOPE_VERSION)
             with tracer.start_as_current_span(
                 f"weaviate.{label}.{operation}",
                 kind=SpanKind.CLIENT,
             ) as span:
                 self._set_start_attributes(
-                    span, label, operation, instance, wrapped, args, kwargs
+                    span,
+                    label,
+                    operation,
+                    instance,
+                    wrapped,
+                    args,
+                    kwargs,
+                    has_parent,
                 )
                 try:
                     result = await wrapped(*args, **kwargs)
-                except Exception as exc:
+                except BaseException as exc:
                     self._set_error(span, exc)
                     raise
                 span.set_status(Status(StatusCode.OK))
@@ -389,50 +545,81 @@ class WeaviateInstrumentor:
                 traced,
             )
             patched.append((target_class, operation))
+            type(self)._installed_targets[(target_class, operation)] = (
+                inspect.getattr_static(target_class, operation)
+            )
         return patched
 
     def activate(self) -> None:
         """Patch supported Weaviate v4 managers."""
         cls = type(self)
-        if self._is_instrumented or not self._tracing_enabled():
-            return
-        if cls._patches_applied:
-            cls._activation_count += 1
-            self._is_instrumented = True
-            return
+        with cls._lock:
+            if self._is_instrumented or not self._tracing_enabled():
+                return
+            if cls._patches_applied:
+                if cls._capture_content_config != self._capture_content:
+                    raise ValueError(
+                        "Weaviate instrumentation is already active with different capture_content"
+                    )
+                cls._activation_count += 1
+                self._is_instrumented = True
+                return
 
-        patched_targets: list[tuple[type, str]] = []
-        for spec in WEAVIATE_PATCH_SPECS:
-            patched_targets.extend(self._patch_spec(spec))
+            patched_targets: list[tuple[type, str]] = []
+            try:
+                for spec in WEAVIATE_PATCH_SPECS:
+                    patched_targets.extend(self._patch_spec(spec))
+            except BaseException:
+                for target_class, operation in reversed(patched_targets):
+                    if inspect.getattr_static(
+                        target_class,
+                        operation,
+                        None,
+                    ) is cls._installed_targets.get((target_class, operation)):
+                        unwrap(target_class, operation)
+                    cls._installed_targets.pop((target_class, operation), None)
+                raise
 
-        self._is_instrumented = bool(patched_targets)
-        cls._patches_applied = self._is_instrumented
-        cls._activation_count = int(self._is_instrumented)
-        cls._patched_targets = patched_targets
-        if not self._is_instrumented:
-            logger.warning("Weaviate instrumentation found no supported v4 methods")
+            self._is_instrumented = bool(patched_targets)
+            cls._patches_applied = self._is_instrumented
+            cls._activation_count = int(self._is_instrumented)
+            cls._patched_targets = patched_targets
+            cls._capture_content_config = (
+                self._capture_content if self._is_instrumented else None
+            )
+            if not self._is_instrumented:
+                logger.warning("Weaviate instrumentation found no supported v4 methods")
 
     def deactivate(self) -> None:
         """Remove Weaviate patches after the final active instance stops."""
-        if not self._is_instrumented:
-            return
-        self._is_instrumented = False
         cls = type(self)
-        cls._activation_count = max(cls._activation_count - 1, 0)
-        if cls._activation_count:
-            return
-        for target_class, operation in reversed(cls._patched_targets):
-            try:
-                unwrap(target_class, operation)
-            except Exception:
-                logger.debug(
-                    "Failed to unwrap Weaviate %s.%s",
-                    target_class.__name__,
-                    operation,
-                    exc_info=True,
-                )
-        cls._patched_targets = []
-        cls._patches_applied = False
+        with cls._lock:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            cls._activation_count = max(cls._activation_count - 1, 0)
+            if cls._activation_count:
+                return
+            for target_class, operation in reversed(cls._patched_targets):
+                try:
+                    if inspect.getattr_static(
+                        target_class,
+                        operation,
+                        None,
+                    ) is cls._installed_targets.get((target_class, operation)):
+                        unwrap(target_class, operation)
+                except Exception:
+                    logger.debug(
+                        "Failed to unwrap Weaviate %s.%s",
+                        target_class.__name__,
+                        operation,
+                        exc_info=True,
+                    )
+                finally:
+                    cls._installed_targets.pop((target_class, operation), None)
+            cls._patched_targets = []
+            cls._patches_applied = False
+            cls._capture_content_config = None
 
     def instrument(self) -> None:
         """OpenTelemetry-style alias for :meth:`activate`."""

--- a/python-sdks/instrumentations/respan-instrumentation-weaviate/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-weaviate/tests/test_instrumentation.py
@@ -4,11 +4,12 @@ from contextlib import contextmanager
 from types import ModuleType
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import StatusCode
-
-from respan_instrumentation_weaviate import WeaviateInstrumentor
-from respan_instrumentation_weaviate import _instrumentation
+from respan_instrumentation_weaviate import WeaviateInstrumentor, _instrumentation
 from respan_instrumentation_weaviate._constants import (
     MAX_ATTRIBUTE_CHARS,
     MAX_PREVIEW_ITEMS,
@@ -67,7 +68,6 @@ def _install_fake_weaviate(monkeypatch):
         def delete(self, name):
             if name == "missing":
                 raise RuntimeError("collection missing")
-            return None
 
     class _DataCollection:
         name = "Docs"
@@ -141,19 +141,23 @@ def reset_instrumentor():
     WeaviateInstrumentor._patches_applied = False
     WeaviateInstrumentor._activation_count = 0
     WeaviateInstrumentor._patched_targets = []
+    WeaviateInstrumentor._installed_targets = {}
+    WeaviateInstrumentor._capture_content_config = None
     yield
     for target, method in reversed(WeaviateInstrumentor._patched_targets):
         _instrumentation.unwrap(target, method)
     WeaviateInstrumentor._patches_applied = False
     WeaviateInstrumentor._activation_count = 0
     WeaviateInstrumentor._patched_targets = []
+    WeaviateInstrumentor._installed_targets = {}
+    WeaviateInstrumentor._capture_content_config = None
 
 
 def _assert_contract(span):
     attrs = span.attributes
     assert attrs[RESPAN_LOG_TYPE] == "task"
     assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME]
-    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH]
+    assert isinstance(attrs[SpanAttributes.TRACELOOP_ENTITY_PATH], str)
     for banned_alias in (
         "tools",
         "tool_calls",
@@ -178,7 +182,9 @@ def test_package_exports_weaviate_instrumentor():
 def test_collection_data_and_query_operations_emit_spans(monkeypatch):
     Collections, Data, _, Query = _install_fake_weaviate(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(
+        _instrumentation.trace, "get_tracer", lambda *_args, **_kwargs: tracer
+    )
     instrumentor = WeaviateInstrumentor()
     instrumentor.activate()
 
@@ -212,7 +218,9 @@ def test_collection_data_and_query_operations_emit_spans(monkeypatch):
 async def test_async_data_operation_is_awaited(monkeypatch):
     _, _, AsyncData, _ = _install_fake_weaviate(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(
+        _instrumentation.trace, "get_tracer", lambda *_args, **_kwargs: tracer
+    )
     instrumentor = WeaviateInstrumentor()
     instrumentor.instrument()
 
@@ -230,7 +238,9 @@ async def test_async_data_operation_is_awaited(monkeypatch):
 def test_error_status_and_content_control(monkeypatch):
     Collections, _, _, _ = _install_fake_weaviate(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(
+        _instrumentation.trace, "get_tracer", lambda *_args, **_kwargs: tracer
+    )
     instrumentor = WeaviateInstrumentor(capture_content=False)
     instrumentor.activate()
 
@@ -241,7 +251,7 @@ def test_error_status_and_content_control(monkeypatch):
     assert span.status.status_code is StatusCode.ERROR
     assert span.exceptions
     assert span.attributes["status_code"] == 500
-    assert span.attributes["error.message"] == "collection missing"
+    assert span.attributes["error.message"] == "RuntimeError: collection missing"
     assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in span.attributes
     assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in span.attributes
     _assert_contract(span)
@@ -251,7 +261,9 @@ def test_error_status_and_content_control(monkeypatch):
 def test_full_vectors_survive_canonical_input_and_output(monkeypatch):
     _, _, _, Query = _install_fake_weaviate(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(
+        _instrumentation.trace, "get_tracer", lambda *_args, **_kwargs: tracer
+    )
     instrumentor = WeaviateInstrumentor()
     instrumentor.activate()
     vector = [0.125] * (MAX_ATTRIBUTE_CHARS + 17)
@@ -280,7 +292,9 @@ def test_full_vectors_survive_canonical_input_and_output(monkeypatch):
 def test_lifecycle_is_idempotent_and_reference_counted(monkeypatch):
     Collections, _, _, _ = _install_fake_weaviate(monkeypatch)
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(
+        _instrumentation.trace, "get_tracer", lambda *_args, **_kwargs: tracer
+    )
     first = WeaviateInstrumentor()
     second = WeaviateInstrumentor()
     first.activate()
@@ -301,7 +315,9 @@ def test_real_dynamic_batch_runtime_target_is_patched_and_unwrapped(monkeypatch)
     from weaviate.collections.batch.collection import _BatchCollection
 
     tracer = _FakeTracer()
-    monkeypatch.setattr(_instrumentation.trace, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(
+        _instrumentation.trace, "get_tracer", lambda *_args, **_kwargs: tracer
+    )
     monkeypatch.setattr(
         _instrumentation,
         "WEAVIATE_PATCH_SPECS",
@@ -362,3 +378,64 @@ def test_real_dynamic_batch_runtime_target_is_patched_and_unwrapped(monkeypatch)
     assert _BatchCollection.flush is original_flush
     batch.flush()
     assert len(tracer.spans) == 4
+
+
+def test_provider_status_and_nested_credentials_are_preserved_safely(monkeypatch):
+    Collections, Data, _, _ = _install_fake_weaviate(monkeypatch)
+    tracer = _FakeTracer()
+    monkeypatch.setattr(
+        _instrumentation.trace, "get_tracer", lambda *_args, **_kwargs: tracer
+    )
+
+    class ProviderError(RuntimeError):
+        status_code = 429
+
+    def fail_delete(self, name):
+        raise ProviderError("rate limited api_key=plain-secret")
+
+    monkeypatch.setattr(Collections, "delete", fail_delete)
+    instrumentor = WeaviateInstrumentor()
+    instrumentor.activate()
+
+    Data().insert(
+        {
+            "text": "safe",
+            "api_key": "plain-secret",
+            "nested": {"client_secret": "nested-secret"},
+        }
+    )
+    with pytest.raises(ProviderError):
+        Collections().delete("Docs")
+
+    serialized = json.dumps([span.attributes for span in tracer.spans])
+    assert "plain-secret" not in serialized
+    assert "nested-secret" not in serialized
+    assert tracer.spans[-1].attributes["status_code"] == 429
+
+
+def test_real_otel_export_has_scope_parent_and_nested_entity_path(monkeypatch):
+    Collections, _, _, _ = _install_fake_weaviate(monkeypatch)
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(
+        _instrumentation.trace,
+        "get_tracer",
+        lambda *args, **kwargs: provider.get_tracer(*args, **kwargs),
+    )
+    instrumentor = WeaviateInstrumentor()
+    instrumentor.activate()
+
+    with provider.get_tracer("test-root").start_as_current_span("root") as root:
+        Collections().exists("Docs")
+        root_span_id = root.get_span_context().span_id
+
+    spans = exporter.get_finished_spans()
+    client = next(span for span in spans if span.name == "weaviate.collections.exists")
+    assert client.parent.span_id == root_span_id
+    assert client.instrumentation_scope.name == "respan-instrumentation-weaviate"
+    assert client.instrumentation_scope.version == "0.1.0"
+    assert (
+        client.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH]
+        == "weaviate.collections.exists"
+    )

--- a/python-sdks/instrumentations/respan-instrumentation-writer/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-writer/README.md
@@ -35,7 +35,8 @@ completion = client.chat.chat(
 )
 
 print(completion.choices[0].message.content)
-respan.flush()
+client.close()
+respan.shutdown()
 ```
 
 ## Notes
@@ -46,3 +47,7 @@ respan.flush()
   calls are traced.
 - Writer-specific SDK field names stay local to this package; emitted spans use
   canonical GenAI/LLM and Respan-owned attribute constants.
+- Streamed chat, completion, graph, and application calls carry
+  `llm.is_streaming=true` and finalize on completion, early close, or error.
+- Close `Writer`/`AsyncWriter` before calling `respan.shutdown()` in an outer
+  `finally` block.

--- a/python-sdks/instrumentations/respan-instrumentation-writer/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-writer/pyproject.toml
@@ -13,8 +13,8 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.1"
-writerai = ">=4.0.1"
-opentelemetry-semantic-conventions-ai = ">=0.4.1"
+writerai = ">=4.0.1,<5"
+opentelemetry-semantic-conventions-ai = ">=0.5.1,<0.6.0"
 
 [tool.poetry.plugins."respan.instrumentations"]
 writer = "respan_instrumentation_writer:WriterInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_instrumentation.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 import importlib
 import logging
 import time
-from typing import Any, Callable
+from collections.abc import Callable
+from itertools import islice
+from threading import Condition, RLock
+from types import TracebackType
+from typing import Any, Self
+
+from opentelemetry import context as context_api
+from respan_tracing.core.tracer import RespanTracer
 
 from respan_instrumentation_writer._constants import (
     ANALYZE_METHOD_NAME,
+    APPLICATION_ID_KEY,
     ASYNC_APPLICATIONS_CLASS_NAME,
     ASYNC_CHAT_CLASS_NAME,
     ASYNC_COMPLETIONS_CLASS_NAME,
@@ -20,7 +28,6 @@ from respan_instrumentation_writer._constants import (
     CREATE_METHOD_NAME,
     FILE_ID_KEY,
     GENERATE_CONTENT_METHOD_NAME,
-    APPLICATION_ID_KEY,
     PARSE_PDF_METHOD_NAME,
     QUESTION_METHOD_NAME,
     STREAM_KEY,
@@ -33,10 +40,10 @@ from respan_instrumentation_writer._constants import (
     SYNC_VISION_CLASS_NAME,
     TRANSLATE_METHOD_NAME,
     WEB_SEARCH_METHOD_NAME,
-    WRITER_APPLICATIONS_MODULE,
     WRITER_APPLICATION_GENERATE_SPAN_NAME,
-    WRITER_CHAT_SPAN_NAME,
+    WRITER_APPLICATIONS_MODULE,
     WRITER_CHAT_MODULE,
+    WRITER_CHAT_SPAN_NAME,
     WRITER_COMPLETION_SPAN_NAME,
     WRITER_COMPLETIONS_MODULE,
     WRITER_GRAPH_QUESTION_SPAN_NAME,
@@ -51,6 +58,10 @@ from respan_instrumentation_writer._constants import (
     WRITER_WEB_SEARCH_TOOL_NAME,
 )
 from respan_instrumentation_writer._otel_emitter import emit_writer_span
+from respan_instrumentation_writer._serialization import (
+    provider_status_code,
+    safe_exception_message,
+)
 from respan_instrumentation_writer._translator import (
     build_application_generate_attrs,
     build_chat_attrs,
@@ -61,7 +72,6 @@ from respan_instrumentation_writer._translator import (
     build_vision_attrs,
     request_kwargs_with_positionals,
 )
-from respan_tracing.core.tracer import RespanTracer
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +91,12 @@ _original_sync_tool_web_search = None
 _original_async_tool_web_search = None
 _original_sync_tool_parse_pdf = None
 _original_async_tool_parse_pdf = None
+_activation_lock = RLock()
+_activation_condition = Condition(_activation_lock)
+_activation_count = 0
+_activation_installing = False
+_installed_methods: dict[tuple[type[Any], str], Any] = {}
+_MAX_STREAM_CHUNKS = 256
 
 _ITERABLE_REQUEST_FIELDS = {
     "graph_ids",
@@ -89,6 +105,46 @@ _ITERABLE_REQUEST_FIELDS = {
     "tools",
     "variables",
 }
+
+_RESTORE_TARGETS = (
+    ("sync_chat", CHAT_METHOD_NAME, "_original_sync_chat"),
+    ("async_chat", CHAT_METHOD_NAME, "_original_async_chat"),
+    ("sync_completions", CREATE_METHOD_NAME, "_original_sync_completion_create"),
+    ("async_completions", CREATE_METHOD_NAME, "_original_async_completion_create"),
+    ("sync_graphs", QUESTION_METHOD_NAME, "_original_sync_graph_question"),
+    ("async_graphs", QUESTION_METHOD_NAME, "_original_async_graph_question"),
+    (
+        "sync_applications",
+        GENERATE_CONTENT_METHOD_NAME,
+        "_original_sync_application_generate",
+    ),
+    (
+        "async_applications",
+        GENERATE_CONTENT_METHOD_NAME,
+        "_original_async_application_generate",
+    ),
+    ("sync_vision", ANALYZE_METHOD_NAME, "_original_sync_vision_analyze"),
+    ("async_vision", ANALYZE_METHOD_NAME, "_original_async_vision_analyze"),
+    ("sync_translation", TRANSLATE_METHOD_NAME, "_original_sync_translation_translate"),
+    (
+        "async_translation",
+        TRANSLATE_METHOD_NAME,
+        "_original_async_translation_translate",
+    ),
+    ("sync_tools", WEB_SEARCH_METHOD_NAME, "_original_sync_tool_web_search"),
+    ("async_tools", WEB_SEARCH_METHOD_NAME, "_original_async_tool_web_search"),
+    ("sync_tools", PARSE_PDF_METHOD_NAME, "_original_sync_tool_parse_pdf"),
+    ("async_tools", PARSE_PDF_METHOD_NAME, "_original_async_tool_parse_pdf"),
+)
+
+
+def _complete_installation(*, success: bool) -> None:
+    global _activation_count, _activation_installing
+    with _activation_condition:
+        if success:
+            _activation_count = 1
+        _activation_installing = False
+        _activation_condition.notify_all()
 
 
 def _get_module_attr(module_path: str, attr_name: str) -> Any:
@@ -146,8 +202,8 @@ def _materialize_iterable(value: Any) -> Any:
     if isinstance(value, (str, bytes, dict, list, tuple)):
         return value
     try:
-        return list(value)
-    except TypeError:
+        return list(islice(iter(value), 50))
+    except (TypeError, RuntimeError):
         return value
 
 
@@ -157,6 +213,13 @@ def _snapshot_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
         if field_name in snapshot:
             snapshot[field_name] = _materialize_iterable(snapshot[field_name])
     return snapshot
+
+
+def _append_stream_chunk(chunks: list[Any], chunk: Any) -> None:
+    if len(chunks) < _MAX_STREAM_CHUNKS:
+        chunks.append(chunk)
+    else:
+        chunks[-1] = chunk
 
 
 def _is_stream_request(request_kwargs: dict[str, Any]) -> bool:
@@ -172,8 +235,12 @@ def _emit_safely(
     response_or_chunks: Any = None,
     error_message: str | None = None,
     status_code: int = 200,
+    otel_context: Any = None,
 ) -> None:
+    token = None
     try:
+        if otel_context is not None:
+            token = context_api.attach(otel_context)
         attrs = attrs_builder(
             request_kwargs=request_kwargs,
             response_or_chunks=response_or_chunks,
@@ -185,8 +252,11 @@ def _emit_safely(
             error_message=error_message,
             status_code=status_code,
         )
-    except Exception:
+    except BaseException:
         logger.debug("Failed to build Writer span attrs", exc_info=True)
+    finally:
+        if token is not None:
+            context_api.detach(token)
 
 
 def _emit_unary_safely(
@@ -198,8 +268,12 @@ def _emit_unary_safely(
     response: Any = None,
     error_message: str | None = None,
     status_code: int = 200,
+    otel_context: Any = None,
 ) -> None:
+    token = None
     try:
+        if otel_context is not None:
+            token = context_api.attach(otel_context)
         attrs = attrs_builder(request_kwargs=request_kwargs, response=response)
         emit_writer_span(
             name=span_name,
@@ -208,8 +282,11 @@ def _emit_unary_safely(
             error_message=error_message,
             status_code=status_code,
         )
-    except Exception:
+    except BaseException:
         logger.debug("Failed to build Writer span attrs", exc_info=True)
+    finally:
+        if token is not None:
+            context_api.detach(token)
 
 
 class _SyncStreamCapture:
@@ -221,6 +298,7 @@ class _SyncStreamCapture:
         attrs_builder: Callable[..., dict[str, Any]],
         request_kwargs: dict[str, Any],
         start_ns: int,
+        otel_context: Any,
     ) -> None:
         self._stream = stream
         self._iterator = iter(stream)
@@ -228,11 +306,12 @@ class _SyncStreamCapture:
         self._attrs_builder = attrs_builder
         self._request_kwargs = request_kwargs
         self._start_ns = start_ns
+        self._otel_context = otel_context
         self._chunks: list[Any] = []
         self._emitted = False
         self.response = getattr(stream, "response", None)
 
-    def __iter__(self) -> "_SyncStreamCapture":
+    def __iter__(self) -> _SyncStreamCapture:
         return self
 
     def __next__(self) -> Any:
@@ -241,13 +320,13 @@ class _SyncStreamCapture:
         except StopIteration:
             self._emit_success()
             raise
-        except Exception as exc:
+        except BaseException as exc:
             self._emit_error(exc)
             raise
-        self._chunks.append(chunk)
+        _append_stream_chunk(self._chunks, chunk)
         return chunk
 
-    def __enter__(self) -> "_SyncStreamCapture":
+    def __enter__(self) -> Self:
         enter = getattr(self._stream, "__enter__", None)
         if callable(enter):
             entered = enter()
@@ -257,7 +336,12 @@ class _SyncStreamCapture:
                 self.response = getattr(entered, "response", self.response)
         return self
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> Any:
         exit_method = getattr(self._stream, "__exit__", None)
         result = None
         if callable(exit_method):
@@ -285,6 +369,7 @@ class _SyncStreamCapture:
             request_kwargs=self._request_kwargs,
             start_ns=self._start_ns,
             response_or_chunks=self._chunks,
+            otel_context=self._otel_context,
         )
 
     def _emit_error(self, exc: BaseException) -> None:
@@ -297,8 +382,9 @@ class _SyncStreamCapture:
             request_kwargs=self._request_kwargs,
             start_ns=self._start_ns,
             response_or_chunks=self._chunks,
-            error_message=str(exc),
-            status_code=500,
+            error_message=safe_exception_message(exc),
+            status_code=provider_status_code(exc),
+            otel_context=self._otel_context,
         )
 
     def __getattr__(self, name: str) -> Any:
@@ -314,6 +400,7 @@ class _AsyncStreamCapture:
         attrs_builder: Callable[..., dict[str, Any]],
         request_kwargs: dict[str, Any],
         start_ns: int,
+        otel_context: Any,
     ) -> None:
         self._stream = stream
         self._iterator = None
@@ -321,11 +408,12 @@ class _AsyncStreamCapture:
         self._attrs_builder = attrs_builder
         self._request_kwargs = request_kwargs
         self._start_ns = start_ns
+        self._otel_context = otel_context
         self._chunks: list[Any] = []
         self._emitted = False
         self.response = getattr(stream, "response", None)
 
-    def __aiter__(self) -> "_AsyncStreamCapture":
+    def __aiter__(self) -> _AsyncStreamCapture:
         self._iterator = self._stream.__aiter__()
         return self
 
@@ -337,13 +425,13 @@ class _AsyncStreamCapture:
         except StopAsyncIteration:
             self._emit_success()
             raise
-        except Exception as exc:
+        except BaseException as exc:
             self._emit_error(exc)
             raise
-        self._chunks.append(chunk)
+        _append_stream_chunk(self._chunks, chunk)
         return chunk
 
-    async def __aenter__(self) -> "_AsyncStreamCapture":
+    async def __aenter__(self) -> Self:
         enter = getattr(self._stream, "__aenter__", None)
         if callable(enter):
             entered = await enter()
@@ -353,7 +441,12 @@ class _AsyncStreamCapture:
                 self.response = getattr(entered, "response", self.response)
         return self
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> Any:
         exit_method = getattr(self._stream, "__aexit__", None)
         result = None
         if callable(exit_method):
@@ -365,13 +458,18 @@ class _AsyncStreamCapture:
         return result
 
     async def close(self) -> None:
-        close = getattr(self._stream, "close", None)
+        close = getattr(self._stream, "aclose", None) or getattr(
+            self._stream, "close", None
+        )
         if callable(close):
             result = close()
             if hasattr(result, "__await__"):
                 await result
         if not self._emitted:
             self._emit_success()
+
+    async def aclose(self) -> None:
+        await self.close()
 
     def _emit_success(self) -> None:
         if self._emitted:
@@ -383,6 +481,7 @@ class _AsyncStreamCapture:
             request_kwargs=self._request_kwargs,
             start_ns=self._start_ns,
             response_or_chunks=self._chunks,
+            otel_context=self._otel_context,
         )
 
     def _emit_error(self, exc: BaseException) -> None:
@@ -395,8 +494,9 @@ class _AsyncStreamCapture:
             request_kwargs=self._request_kwargs,
             start_ns=self._start_ns,
             response_or_chunks=self._chunks,
-            error_message=str(exc),
-            status_code=500,
+            error_message=safe_exception_message(exc),
+            status_code=provider_status_code(exc),
+            otel_context=self._otel_context,
         )
 
     def __getattr__(self, name: str) -> Any:
@@ -418,16 +518,18 @@ def _wrap_sync_streamable(
             positional_names=positional_names,
         )
         start_ns = time.time_ns()
+        otel_context = context_api.get_current()
         try:
             response = original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _emit_safely(
                 span_name=span_name,
                 attrs_builder=attrs_builder,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=safe_exception_message(exc),
+                status_code=provider_status_code(exc),
+                otel_context=otel_context,
             )
             raise
 
@@ -438,6 +540,7 @@ def _wrap_sync_streamable(
                 attrs_builder=attrs_builder,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
+                otel_context=otel_context,
             )
 
         _emit_safely(
@@ -446,6 +549,7 @@ def _wrap_sync_streamable(
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             response_or_chunks=response,
+            otel_context=otel_context,
         )
         return response
 
@@ -467,16 +571,18 @@ def _wrap_async_streamable(
             positional_names=positional_names,
         )
         start_ns = time.time_ns()
+        otel_context = context_api.get_current()
         try:
             response = await original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _emit_safely(
                 span_name=span_name,
                 attrs_builder=attrs_builder,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=safe_exception_message(exc),
+                status_code=provider_status_code(exc),
+                otel_context=otel_context,
             )
             raise
 
@@ -487,6 +593,7 @@ def _wrap_async_streamable(
                 attrs_builder=attrs_builder,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
+                otel_context=otel_context,
             )
 
         _emit_safely(
@@ -495,6 +602,7 @@ def _wrap_async_streamable(
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             response_or_chunks=response,
+            otel_context=otel_context,
         )
         return response
 
@@ -516,16 +624,18 @@ def _wrap_sync_unary(
             positional_names=positional_names,
         )
         start_ns = time.time_ns()
+        otel_context = context_api.get_current()
         try:
             response = original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _emit_unary_safely(
                 span_name=span_name,
                 attrs_builder=attrs_builder,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=safe_exception_message(exc),
+                status_code=provider_status_code(exc),
+                otel_context=otel_context,
             )
             raise
 
@@ -535,6 +645,7 @@ def _wrap_sync_unary(
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             response=response,
+            otel_context=otel_context,
         )
         return response
 
@@ -556,16 +667,18 @@ def _wrap_async_unary(
             positional_names=positional_names,
         )
         start_ns = time.time_ns()
+        otel_context = context_api.get_current()
         try:
             response = await original(self, *args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             _emit_unary_safely(
                 span_name=span_name,
                 attrs_builder=attrs_builder,
                 request_kwargs=request_kwargs,
                 start_ns=start_ns,
-                error_message=str(exc),
-                status_code=500,
+                error_message=safe_exception_message(exc),
+                status_code=provider_status_code(exc),
+                otel_context=otel_context,
             )
             raise
 
@@ -575,6 +688,7 @@ def _wrap_async_unary(
             request_kwargs=request_kwargs,
             start_ns=start_ns,
             response=response,
+            otel_context=otel_context,
         )
         return response
 
@@ -582,7 +696,9 @@ def _wrap_async_unary(
 
 
 def _make_tool_attrs_builder(tool_name: str) -> Callable[..., dict[str, Any]]:
-    def builder(*, request_kwargs: dict[str, Any], response: Any = None) -> dict[str, Any]:
+    def builder(
+        *, request_kwargs: dict[str, Any], response: Any = None
+    ) -> dict[str, Any]:
         return build_tool_attrs(
             tool_name=tool_name,
             request_kwargs=request_kwargs,
@@ -614,17 +730,31 @@ class WriterInstrumentor:
         global _original_sync_graph_question, _original_async_graph_question
         global _original_sync_application_generate, _original_async_application_generate
         global _original_sync_vision_analyze, _original_async_vision_analyze
-        global _original_sync_translation_translate, _original_async_translation_translate
+        global \
+            _original_sync_translation_translate, \
+            _original_async_translation_translate
         global _original_sync_tool_web_search, _original_async_tool_web_search
         global _original_sync_tool_parse_pdf, _original_async_tool_parse_pdf
+        global _activation_count, _activation_installing
 
-        if self._is_instrumented:
-            return
+        with _activation_condition:
+            if self._is_instrumented:
+                return
+            while _activation_installing:
+                _activation_condition.wait()
+            if _activation_count:
+                _activation_count += 1
+                self._is_instrumented = True
+                return
+            _activation_installing = True
+            self._is_instrumented = True
 
         if not self._is_respan_tracing_enabled():
             logger.info(
                 "Writer instrumentation skipped because Respan tracing is disabled"
             )
+            self.deactivate()
+            _complete_installation(success=False)
             return
 
         try:
@@ -634,6 +764,13 @@ class WriterInstrumentor:
                 "Failed to activate Writer instrumentation - missing dependency: %s",
                 exc,
             )
+            self.deactivate()
+            _complete_installation(success=False)
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to activate Writer instrumentation: %s", exc)
+            self.deactivate()
+            _complete_installation(success=False)
             return
 
         try:
@@ -707,7 +844,9 @@ class WriterInstrumentor:
             )
 
             if _original_sync_graph_question is None:
-                _original_sync_graph_question = getattr(sync_graphs, QUESTION_METHOD_NAME)
+                _original_sync_graph_question = getattr(
+                    sync_graphs, QUESTION_METHOD_NAME
+                )
             setattr(
                 sync_graphs,
                 QUESTION_METHOD_NAME,
@@ -766,7 +905,9 @@ class WriterInstrumentor:
             )
 
             if _original_sync_vision_analyze is None:
-                _original_sync_vision_analyze = getattr(sync_vision, ANALYZE_METHOD_NAME)
+                _original_sync_vision_analyze = getattr(
+                    sync_vision, ANALYZE_METHOD_NAME
+                )
             setattr(
                 sync_vision,
                 ANALYZE_METHOD_NAME,
@@ -823,7 +964,9 @@ class WriterInstrumentor:
             )
 
             if _original_sync_tool_web_search is None:
-                _original_sync_tool_web_search = getattr(sync_tools, WEB_SEARCH_METHOD_NAME)
+                _original_sync_tool_web_search = getattr(
+                    sync_tools, WEB_SEARCH_METHOD_NAME
+                )
             setattr(
                 sync_tools,
                 WEB_SEARCH_METHOD_NAME,
@@ -850,7 +993,9 @@ class WriterInstrumentor:
             )
 
             if _original_sync_tool_parse_pdf is None:
-                _original_sync_tool_parse_pdf = getattr(sync_tools, PARSE_PDF_METHOD_NAME)
+                _original_sync_tool_parse_pdf = getattr(
+                    sync_tools, PARSE_PDF_METHOD_NAME
+                )
             setattr(
                 sync_tools,
                 PARSE_PDF_METHOD_NAME,
@@ -877,79 +1022,70 @@ class WriterInstrumentor:
                     positional_names=(FILE_ID_KEY,),
                 ),
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.warning("Failed to activate Writer instrumentation: %s", exc)
+            for class_key, method_name, _ in _RESTORE_TARGETS:
+                resource_class = classes.get(class_key)
+                if resource_class is not None:
+                    _installed_methods[(resource_class, method_name)] = getattr(
+                        resource_class,
+                        method_name,
+                        None,
+                    )
             self.deactivate()
+            _complete_installation(success=False)
             return
 
-        self._is_instrumented = True
+        for class_key, method_name, _ in _RESTORE_TARGETS:
+            resource_class = classes.get(class_key)
+            if resource_class is not None:
+                _installed_methods[(resource_class, method_name)] = getattr(
+                    resource_class,
+                    method_name,
+                )
+        _complete_installation(success=True)
         logger.info("Writer instrumentation activated")
 
     def deactivate(self) -> None:
         """Deactivate the instrumentation."""
-        global _original_sync_chat, _original_async_chat
-        global _original_sync_completion_create, _original_async_completion_create
-        global _original_sync_graph_question, _original_async_graph_question
-        global _original_sync_application_generate, _original_async_application_generate
-        global _original_sync_vision_analyze, _original_async_vision_analyze
-        global _original_sync_translation_translate, _original_async_translation_translate
-        global _original_sync_tool_web_search, _original_async_tool_web_search
-        global _original_sync_tool_parse_pdf, _original_async_tool_parse_pdf
+        global _activation_count, _activation_installing
+
+        with _activation_condition:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            _activation_count = max(_activation_count - 1, 0)
+            if _activation_count:
+                return
+            _activation_installing = True
 
         try:
             classes = _load_resource_classes()
-        except Exception:
+        except BaseException:
+            logger.debug(
+                "Failed to load Writer resources during teardown", exc_info=True
+            )
             classes = {}
 
-        restore_targets = (
-            ("sync_chat", CHAT_METHOD_NAME, "_original_sync_chat"),
-            ("async_chat", CHAT_METHOD_NAME, "_original_async_chat"),
-            (
-                "sync_completions",
-                CREATE_METHOD_NAME,
-                "_original_sync_completion_create",
-            ),
-            (
-                "async_completions",
-                CREATE_METHOD_NAME,
-                "_original_async_completion_create",
-            ),
-            ("sync_graphs", QUESTION_METHOD_NAME, "_original_sync_graph_question"),
-            ("async_graphs", QUESTION_METHOD_NAME, "_original_async_graph_question"),
-            (
-                "sync_applications",
-                GENERATE_CONTENT_METHOD_NAME,
-                "_original_sync_application_generate",
-            ),
-            (
-                "async_applications",
-                GENERATE_CONTENT_METHOD_NAME,
-                "_original_async_application_generate",
-            ),
-            ("sync_vision", ANALYZE_METHOD_NAME, "_original_sync_vision_analyze"),
-            ("async_vision", ANALYZE_METHOD_NAME, "_original_async_vision_analyze"),
-            (
-                "sync_translation",
-                TRANSLATE_METHOD_NAME,
-                "_original_sync_translation_translate",
-            ),
-            (
-                "async_translation",
-                TRANSLATE_METHOD_NAME,
-                "_original_async_translation_translate",
-            ),
-            ("sync_tools", WEB_SEARCH_METHOD_NAME, "_original_sync_tool_web_search"),
-            ("async_tools", WEB_SEARCH_METHOD_NAME, "_original_async_tool_web_search"),
-            ("sync_tools", PARSE_PDF_METHOD_NAME, "_original_sync_tool_parse_pdf"),
-            ("async_tools", PARSE_PDF_METHOD_NAME, "_original_async_tool_parse_pdf"),
-        )
-
-        for class_key, method_name, original_name in restore_targets:
+        for class_key, method_name, original_name in _RESTORE_TARGETS:
             original = globals().get(original_name)
             resource_class = classes.get(class_key)
-            if original is not None and resource_class is not None:
-                setattr(resource_class, method_name, original)
-            globals()[original_name] = None
+            try:
+                if original is not None and resource_class is not None:
+                    current = getattr(resource_class, method_name, None)
+                    if current is _installed_methods.get((resource_class, method_name)):
+                        setattr(resource_class, method_name, original)
+            except BaseException:
+                logger.debug(
+                    "Failed to restore Writer resource %s.%s",
+                    class_key,
+                    method_name,
+                    exc_info=True,
+                )
+            finally:
+                if resource_class is not None:
+                    _installed_methods.pop((resource_class, method_name), None)
+                globals()[original_name] = None
 
-        self._is_instrumented = False
+        _complete_installation(success=False)
         logger.info("Writer instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_otel_emitter.py
@@ -7,7 +7,6 @@ import time
 from typing import Any
 
 from opentelemetry import trace
-
 from respan_sdk.utils.data_processing.id_processing import (
     format_span_id,
     format_trace_id,
@@ -21,7 +20,7 @@ def _current_trace_parent_ids() -> tuple[str | None, str | None]:
     try:
         current_span = trace.get_current_span()
         span_context = current_span.get_span_context()
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None, None
 
     trace_id = getattr(span_context, "trace_id", 0) or 0
@@ -46,6 +45,7 @@ def emit_writer_span(
         if error_message:
             span_attrs["error.message"] = error_message
             status_code = status_code if status_code >= 400 else 500
+            span_attrs.setdefault("status_code", status_code)
 
         trace_id, parent_id = _current_trace_parent_ids()
         span = build_readable_span(
@@ -59,5 +59,5 @@ def emit_writer_span(
             status_code=status_code,
         )
         inject_span(span=span)
-    except Exception:
+    except BaseException:
         logger.debug("Failed to emit Writer span", exc_info=True)

--- a/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_serialization.py
@@ -1,0 +1,204 @@
+"""Bounded, privacy-safe serialization for Writer telemetry."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from typing import Any
+
+MAX_JSON_BYTES = 16_000
+MAX_TEXT_BYTES = 4_000
+MAX_ITEMS = 50
+MAX_DEPTH = 8
+
+_SENSITIVE_KEY = re.compile(
+    r"(^|[._-])(api[_-]?key|authorization|cookie|password|secret|token)([._-]|$)",
+    re.IGNORECASE,
+)
+_ASSIGNMENT_SECRET = re.compile(
+    r"(?i)([a-z0-9_.-]*(?:api[_-]?key|authorization|cookie|password|secret|token))"
+    r"\s*[:=]\s*([^\s,;]+)"
+)
+_QUOTED_SECRET = re.compile(
+    r"""(?i)(["'][^"']*(?:api[_-]?key|authorization|cookie|password|secret|token)["']\s*:\s*)(["'])(.*?)\2"""
+)
+_AUTH_SECRET = re.compile(r"(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+")
+
+
+def safe_type_name(value: Any) -> str:
+    return type(value).__name__[:120]
+
+
+def redact_text(value: str) -> str:
+    value = _AUTH_SECRET.sub(lambda match: f"{match.group(1)} [REDACTED]", value)
+    value = _QUOTED_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]{match.group(2)}",
+        value,
+    )
+    return _ASSIGNMENT_SECRET.sub(lambda match: f"{match.group(1)}=[REDACTED]", value)
+
+
+def safe_text(value: Any, *, max_bytes: int = MAX_TEXT_BYTES) -> str:
+    if isinstance(value, str):
+        text = redact_text(value)
+    elif value is None:
+        text = ""
+    elif isinstance(value, bool):
+        text = "true" if value else "false"
+    elif isinstance(value, int) or isinstance(value, float) and math.isfinite(value):
+        text = str(value)
+    else:
+        text = f"<{safe_type_name(value)}>"
+    if len(text.encode()) <= max_bytes:
+        return text
+    low, high, best = 0, len(text), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = f"{text[:middle]}…[truncated]"
+        if len(candidate.encode()) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or "[truncated]"
+
+
+def safe_exception_message(exc: BaseException) -> str:
+    try:
+        args = exc.args
+    except BaseException:  # noqa: BLE001
+        args = ()
+    details = [
+        safe_text(item, max_bytes=1_000)
+        for item in args[:4]
+        if item is None or isinstance(item, (str, bool, int, float))
+    ]
+    name = safe_type_name(exc)
+    return safe_text(f"{name}: {'; '.join(filter(None, details))}" if details else name)
+
+
+def provider_status_code(exc: BaseException) -> int:
+    candidates: list[Any] = []
+    for name in ("status_code", "status"):
+        try:
+            candidates.append(getattr(exc, name, None))
+        except BaseException:  # noqa: BLE001, S112
+            continue
+    try:
+        response = getattr(exc, "response", None)
+    except BaseException:  # noqa: BLE001
+        response = None
+    if response is not None:
+        for name in ("status_code", "status"):
+            try:
+                candidates.append(getattr(response, name, None))
+            except BaseException:  # noqa: BLE001, S112
+                continue
+    for value in candidates:
+        if (
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 400 <= value <= 599
+        ):
+            return value
+    return 500
+
+
+def _safe_key(value: Any) -> str:
+    if isinstance(value, str):
+        return safe_text(value, max_bytes=256)
+    if value is None or isinstance(value, (bool, int)):
+        return json.dumps(value)
+    return f"<{safe_type_name(value)}>"
+
+
+def to_jsonable(value: Any, *, depth: int = 0) -> Any:
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else safe_text(value)
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        try:
+            length = len(value)
+        except BaseException:  # noqa: BLE001
+            length = None
+        return {"type": "bytes", "length": length}
+    if depth >= MAX_DEPTH:
+        return {"type": safe_type_name(value), "truncated": True}
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        try:
+            for key, item in islice(iter(value.items()), MAX_ITEMS + 1):
+                if len(result) >= MAX_ITEMS:
+                    result["_respan_truncated_items"] = True
+                    break
+                rendered_key = _safe_key(key)
+                result[rendered_key] = (
+                    "[REDACTED]"
+                    if _SENSITIVE_KEY.search(rendered_key)
+                    else to_jsonable(item, depth=depth + 1)
+                )
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items: list[Any] = []
+        try:
+            for item in islice(iter(value), MAX_ITEMS + 1):
+                if len(items) >= MAX_ITEMS:
+                    items.append({"_respan_truncated_items": True})
+                    break
+                items.append(to_jsonable(item, depth=depth + 1))
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        return items
+    for method_name in ("model_dump", "to_dict"):
+        try:
+            method = getattr(value, method_name, None)
+        except BaseException:  # noqa: BLE001
+            return {"type": safe_type_name(value), "unavailable": True}
+        if not callable(method):
+            continue
+        try:
+            dumped = method(mode="json") if method_name == "model_dump" else method()
+        except TypeError:
+            try:
+                dumped = method()
+            except BaseException:  # noqa: BLE001, S112
+                continue
+        except BaseException:  # noqa: BLE001, S112
+            continue
+        return to_jsonable(dumped, depth=depth + 1)
+    return {"type": safe_type_name(value)}
+
+
+def json_dumps(value: Any, *, max_bytes: int = MAX_JSON_BYTES) -> str:
+    serialized = json.dumps(
+        to_jsonable(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    if len(serialized.encode()) <= max_bytes:
+        return serialized
+    low, high, best = 0, len(serialized), ""
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = json.dumps(
+            {"preview": serialized[:middle], "truncated": True},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        if len(candidate.encode()) <= max_bytes:
+            best = candidate
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best or '{"truncated":true}'

--- a/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-writer/src/respan_instrumentation_writer/_translator.py
@@ -2,16 +2,23 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
+from itertools import islice
 from typing import Any
 
 from opentelemetry import context as context_api
+from opentelemetry import trace
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 from opentelemetry.semconv_ai import LLMRequestTypeValues
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
+from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_TEXT, LOG_TYPE_TOOL
+from respan_sdk.constants.span_attributes import (
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    RESPAN_INTERNAL_SPAN_NAME_KIND,
+    RESPAN_LOG_TYPE,
+)
 
 from respan_instrumentation_writer._constants import (
     ANSWER_KEY,
@@ -35,6 +42,7 @@ from respan_instrumentation_writer._constants import (
     PROMPT_KEY,
     QUESTION_KEY,
     ROLE_KEY,
+    STREAM_KEY,
     SUGGESTION_KEY,
     TEXT_KEY,
     TOOL_CALLS_KEY,
@@ -53,11 +61,9 @@ from respan_instrumentation_writer._constants import (
     WRITER_TRANSLATION_SPAN_NAME,
     WRITER_VISION_SPAN_NAME,
 )
-from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT, LOG_TYPE_TEXT, LOG_TYPE_TOOL
-from respan_sdk.constants.span_attributes import (
-    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
-    RESPAN_INTERNAL_SPAN_NAME_KIND,
-    RESPAN_LOG_TYPE,
+from respan_instrumentation_writer._serialization import (
+    json_dumps,
+    safe_text,
 )
 
 _WRITER_SENTINEL_CLASS_NAMES = {"Omit", "NotGiven"}
@@ -117,7 +123,7 @@ def _drop_empty(value: Any) -> Any:
 
 
 def safe_json(value: Any) -> str:
-    return json.dumps(_to_plain(value), default=str)
+    return json_dumps(value)
 
 
 def _json_content_attr(value: Any) -> str:
@@ -125,7 +131,7 @@ def _json_content_attr(value: Any) -> str:
     if plain_value is None:
         return ""
     if isinstance(plain_value, str):
-        return plain_value
+        return safe_text(plain_value)
     return safe_json(plain_value)
 
 
@@ -141,22 +147,24 @@ def _as_list(value: Any) -> list[Any]:
     if value is None or _is_omitted(value):
         return []
     if isinstance(value, list):
-        return value
+        return value[:50]
     if isinstance(value, tuple):
-        return list(value)
+        return list(value[:50])
     if isinstance(value, (str, bytes, Mapping)):
         return [value]
     try:
-        return list(value)
-    except TypeError:
+        return list(islice(iter(value), 50))
+    except (TypeError, RuntimeError):
         return [value]
 
 
 def _get_value(value: Any, key: str, default: Any = None) -> Any:
     if isinstance(value, Mapping):
         return value.get(key, default)
-    return getattr(value, key, default)
-
+    try:
+        return getattr(value, key, default)
+    except BaseException:  # noqa: BLE001
+        return default
 
 
 def _normalize_messages(messages: Any) -> list[dict[str, Any]]:
@@ -223,11 +231,14 @@ def _base_llm_attrs(
     log_type: str,
     request_type: str,
 ) -> dict[str, Any]:
+    current = trace.get_current_span().get_span_context()
+    has_parent = bool(getattr(current, "span_id", 0))
     attrs = {
         TLSpanAttributes.LLM_SYSTEM: WRITER_SYSTEM_NAME,
+        GenAIAttributes.GEN_AI_PROVIDER_NAME: WRITER_SYSTEM_NAME,
         TLSpanAttributes.LLM_REQUEST_TYPE: request_type,
         TLSpanAttributes.TRACELOOP_ENTITY_NAME: span_name,
-        TLSpanAttributes.TRACELOOP_ENTITY_PATH: span_name,
+        TLSpanAttributes.TRACELOOP_ENTITY_PATH: span_name if has_parent else "",
         RESPAN_LOG_TYPE: log_type,
     }
     workflow_name = context_api.get_value(TLSpanAttributes.TRACELOOP_ENTITY_NAME)
@@ -262,7 +273,7 @@ def _set_single_prompt_attrs(
     role: str = USER_ROLE,
 ) -> None:
     prompt_content = _json_content_attr(content)
-    attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = prompt_content
+    attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = safe_json(content)
     attrs[f"{TLSpanAttributes.LLM_PROMPTS}.0.role"] = role
     attrs[f"{TLSpanAttributes.LLM_PROMPTS}.0.content"] = prompt_content
 
@@ -312,17 +323,15 @@ def _set_completion_attrs(
             _json_content_attr(content)
         )
         if tool_calls:
-            attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.{index}.tool_calls"] = (
-                safe_json(tool_calls)
+            attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.{index}.tool_calls"] = safe_json(
+                tool_calls
             )
         output_values.append(content)
 
     if not output_values:
         return
     if len(output_values) == 1:
-        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _json_content_attr(
-            output_values[0]
-        )
+        attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(output_values[0])
     else:
         attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safe_json(output_values)
 
@@ -373,9 +382,9 @@ def _merge_streaming_tool_call(
             merged_function[NAME_KEY] = function[NAME_KEY]
         arguments = function.get(ARGUMENTS_KEY)
         if arguments:
-            merged_function[ARGUMENTS_KEY] = (
-                str(merged_function.get(ARGUMENTS_KEY, "")) + str(arguments)
-            )
+            merged_function[ARGUMENTS_KEY] = str(
+                merged_function.get(ARGUMENTS_KEY, "")
+            ) + str(arguments)
 
 
 def _chat_completions_from_chunks(chunks: list[Any]) -> list[dict[str, Any]]:
@@ -409,7 +418,9 @@ def _chat_completions_from_chunks(chunks: list[Any]) -> list[dict[str, Any]]:
                 )
 
     completions: list[dict[str, Any]] = []
-    for index in sorted(set(content_by_index) | set(role_by_index) | set(tool_calls_by_choice)):
+    for index in sorted(
+        set(content_by_index) | set(role_by_index) | set(tool_calls_by_choice)
+    ):
         tool_calls = [
             _drop_empty(tool_call)
             for _, tool_call in sorted(tool_calls_by_choice.get(index, {}).items())
@@ -419,7 +430,9 @@ def _chat_completions_from_chunks(chunks: list[Any]) -> list[dict[str, Any]]:
                 {
                     ROLE_KEY: role_by_index.get(index, ASSISTANT_ROLE),
                     CONTENT_KEY: "".join(content_by_index.get(index, [])),
-                    TOOL_CALLS_KEY: [tool_call for tool_call in tool_calls if tool_call],
+                    TOOL_CALLS_KEY: [
+                        tool_call for tool_call in tool_calls if tool_call
+                    ],
                 }
             )
         )
@@ -452,6 +465,8 @@ def build_chat_attrs(
         log_type=LOG_TYPE_CHAT,
         request_type=LLMRequestTypeValues.CHAT.value,
     )
+    if request_kwargs.get(STREAM_KEY) is True:
+        attrs[TLSpanAttributes.LLM_IS_STREAMING] = True
 
     model = _get_value(response_or_chunks, MODEL_KEY) or request_kwargs.get(MODEL_KEY)
     chunks = response_or_chunks if isinstance(response_or_chunks, list) else None
@@ -492,8 +507,10 @@ def build_completion_attrs(
     attrs = _base_llm_attrs(
         span_name=WRITER_COMPLETION_SPAN_NAME,
         log_type=LOG_TYPE_TEXT,
-        request_type=LLMRequestTypeValues.COMPLETION.value,
+        request_type=LLMRequestTypeValues.CHAT.value,
     )
+    if request_kwargs.get(STREAM_KEY) is True:
+        attrs[TLSpanAttributes.LLM_IS_STREAMING] = True
     model = _get_value(response_or_chunks, MODEL_KEY) or request_kwargs.get(MODEL_KEY)
     if model:
         attrs[TLSpanAttributes.LLM_REQUEST_MODEL] = str(model)
@@ -531,8 +548,10 @@ def _simple_text_operation_attrs(
     attrs = _base_llm_attrs(
         span_name=span_name,
         log_type=LOG_TYPE_TEXT,
-        request_type=LLMRequestTypeValues.COMPLETION.value,
+        request_type=LLMRequestTypeValues.CHAT.value,
     )
+    if request_kwargs.get(STREAM_KEY) is True:
+        attrs[TLSpanAttributes.LLM_IS_STREAMING] = True
     if model:
         attrs[TLSpanAttributes.LLM_REQUEST_MODEL] = model
 
@@ -661,7 +680,9 @@ def build_tool_attrs(
             attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _json_content_attr(
                 output[CONTENT_KEY]
             )
-        elif isinstance(output, Mapping) and ANSWER_KEY in output and output[ANSWER_KEY]:
+        elif (
+            isinstance(output, Mapping) and ANSWER_KEY in output and output[ANSWER_KEY]
+        ):
             attrs[TLSpanAttributes.TRACELOOP_ENTITY_OUTPUT] = _json_content_attr(
                 output[ANSWER_KEY]
             )

--- a/python-sdks/instrumentations/respan-instrumentation-writer/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-writer/tests/test_instrumentation.py
@@ -3,17 +3,23 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+import time
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
 import pytest
+from opentelemetry import context as context_api
+from opentelemetry import trace
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
 from opentelemetry.semconv_ai import SpanAttributes as TLSpanAttributes
-
-from respan_instrumentation_writer import WriterInstrumentor
-from respan_instrumentation_writer import _instrumentation
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from respan_instrumentation_writer import (
+    WriterInstrumentor,
+    _instrumentation,
+    _otel_emitter,
+)
 from respan_instrumentation_writer._constants import (
     WRITER_PARSE_PDF_TOOL_NAME,
     WRITER_WEB_SEARCH_TOOL_NAME,
@@ -35,7 +41,6 @@ from respan_sdk.constants.span_attributes import (
 from respan_tracing.core.tracer import RespanTracer
 from respan_tracing.exporters.respan import _export_span_name
 
-
 OFF_CONTRACT_ALIASES = {
     "model",
     "prompt_tokens",
@@ -55,11 +60,17 @@ OFF_CONTRACT_ALIASES = {
 @pytest.fixture(autouse=True)
 def reset_state() -> None:
     RespanTracer.reset_instance()
+    _instrumentation._activation_count = 0
+    _instrumentation._activation_installing = False
+    _instrumentation._installed_methods.clear()
     yield
     RespanTracer.reset_instance()
     for name in list(vars(_instrumentation)):
         if name.startswith("_original_"):
             setattr(_instrumentation, name, None)
+    _instrumentation._activation_count = 0
+    _instrumentation._activation_installing = False
+    _instrumentation._installed_methods.clear()
     for module_name in list(sys.modules):
         if module_name == "writerai" or module_name.startswith("writerai."):
             sys.modules.pop(module_name, None)
@@ -120,9 +131,7 @@ def _chat_stream_chunks() -> list[SimpleNamespace]:
         ),
         SimpleNamespace(
             model="palmyra-x5",
-            choices=[
-                SimpleNamespace(index=0, delta=SimpleNamespace(content="stream"))
-            ],
+            choices=[SimpleNamespace(index=0, delta=SimpleNamespace(content="stream"))],
             usage=SimpleNamespace(prompt_tokens=2, completion_tokens=3, total_tokens=5),
         ),
     ]
@@ -142,7 +151,9 @@ def _install_fake_writer_modules(monkeypatch: pytest.MonkeyPatch) -> Any:
     class CompletionsResource:
         def create(self, **kwargs: Any) -> Any:
             if kwargs.get("stream") is True:
-                return iter([SimpleNamespace(value="alpha "), SimpleNamespace(value="beta")])
+                return iter(
+                    [SimpleNamespace(value="alpha "), SimpleNamespace(value="beta")]
+                )
             return SimpleNamespace(
                 model=kwargs.get("model"),
                 choices=[SimpleNamespace(text="Generated completion")],
@@ -157,14 +168,25 @@ def _install_fake_writer_modules(monkeypatch: pytest.MonkeyPatch) -> Any:
 
     class GraphsResource:
         def question(self, **kwargs: Any) -> Any:
-            return SimpleNamespace(answer="Graph answer", question=kwargs.get("question"))
+            return SimpleNamespace(
+                answer="Graph answer", question=kwargs.get("question")
+            )
 
     class AsyncGraphsResource:
         async def question(self, **kwargs: Any) -> Any:
-            return SimpleNamespace(answer="Graph answer", question=kwargs.get("question"))
+            return SimpleNamespace(
+                answer="Graph answer", question=kwargs.get("question")
+            )
 
     class ApplicationsResource:
         def generate_content(self, application_id: str, **kwargs: Any) -> Any:
+            if kwargs.get("stream") is True:
+                return iter(
+                    [
+                        SimpleNamespace(suggestion="Application "),
+                        SimpleNamespace(suggestion="stream"),
+                    ]
+                )
             return SimpleNamespace(title="Summary", suggestion="Application answer")
 
     class AsyncApplicationsResource:
@@ -189,14 +211,18 @@ def _install_fake_writer_modules(monkeypatch: pytest.MonkeyPatch) -> Any:
 
     class ToolsResource:
         def web_search(self, **kwargs: Any) -> Any:
-            return SimpleNamespace(query=kwargs.get("query"), answer="Search answer", sources=[])
+            return SimpleNamespace(
+                query=kwargs.get("query"), answer="Search answer", sources=[]
+            )
 
         def parse_pdf(self, file_id: str, **kwargs: Any) -> Any:
             return SimpleNamespace(content="PDF text")
 
     class AsyncToolsResource:
         async def web_search(self, **kwargs: Any) -> Any:
-            return SimpleNamespace(query=kwargs.get("query"), answer="Search answer", sources=[])
+            return SimpleNamespace(
+                query=kwargs.get("query"), answer="Search answer", sources=[]
+            )
 
         async def parse_pdf(self, file_id: str, **kwargs: Any) -> Any:
             return SimpleNamespace(content="PDF text")
@@ -250,6 +276,7 @@ def _install_fake_writer_modules(monkeypatch: pytest.MonkeyPatch) -> Any:
         ChatResource=ChatResource,
         AsyncChatResource=AsyncChatResource,
         CompletionsResource=CompletionsResource,
+        ApplicationsResource=ApplicationsResource,
         ToolsResource=ToolsResource,
     )
 
@@ -290,6 +317,7 @@ def test_sync_chat_emits_canonical_attrs_without_aliases(
     assert captured_spans[0]["name"] == "writer.chat"
     assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_CHAT
     assert attrs[TLSpanAttributes.LLM_SYSTEM] == "writer"
+    assert attrs[GenAIAttributes.GEN_AI_PROVIDER_NAME] == "writer"
     assert attrs[TLSpanAttributes.LLM_REQUEST_TYPE] == "chat"
     assert attrs[TLSpanAttributes.LLM_REQUEST_MODEL] == "palmyra-x5"
     assert attrs[f"{TLSpanAttributes.LLM_PROMPTS}.0.role"] == "user"
@@ -299,8 +327,14 @@ def test_sync_chat_emits_canonical_attrs_without_aliases(
         attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"]
         == "Use the forecast tool."
     )
-    assert json.loads(attrs[TLSpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"]["name"] == "get_weather"
-    assert json.loads(attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])[0]["id"] == "call_1"
+    assert (
+        json.loads(attrs[TLSpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"]["name"]
+        == "get_weather"
+    )
+    assert (
+        json.loads(attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])[0]["id"]
+        == "call_1"
+    )
     assert attrs[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 12
     assert attrs[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 8
     assert attrs[TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 12
@@ -326,6 +360,7 @@ def test_streaming_chat_emits_after_consumption(
     attrs = captured_spans[0]["attrs"]
     assert attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"] == "Hello stream"
     assert attrs[TLSpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 5
+    assert attrs[TLSpanAttributes.LLM_IS_STREAMING] is True
     assert not OFF_CONTRACT_ALIASES.intersection(attrs)
 
 
@@ -356,7 +391,7 @@ def test_completion_mapper_uses_text_log_type_without_aliases() -> None:
     )
 
     assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_TEXT
-    assert attrs[TLSpanAttributes.LLM_REQUEST_TYPE] == "completion"
+    assert attrs[TLSpanAttributes.LLM_REQUEST_TYPE] == "chat"
     assert attrs[TLSpanAttributes.LLM_REQUEST_MODEL] == "palmyra-x5"
     assert attrs[f"{TLSpanAttributes.LLM_PROMPTS}.0.content"] == "Write a headline."
     assert attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"] == "Tracing works"
@@ -369,11 +404,18 @@ def test_other_writer_text_operations_map_to_canonical_attrs() -> None:
         response_or_chunks=SimpleNamespace(answer="The docs changed."),
     )
     app_attrs = build_application_generate_attrs(
-        request_kwargs={"application_id": "app_1", "inputs": [{"id": "topic", "value": "AI"}]},
+        request_kwargs={
+            "application_id": "app_1",
+            "inputs": [{"id": "topic", "value": "AI"}],
+        },
         response_or_chunks=SimpleNamespace(suggestion="Application output"),
     )
     vision_attrs = build_vision_attrs(
-        request_kwargs={"model": "palmyra-vision", "prompt": "Describe {{image}}", "variables": []},
+        request_kwargs={
+            "model": "palmyra-vision",
+            "prompt": "Describe {{image}}",
+            "variables": [],
+        },
         response=SimpleNamespace(data="Vision output"),
     )
     translation_attrs = build_translation_attrs(
@@ -391,12 +433,18 @@ def test_other_writer_text_operations_map_to_canonical_attrs() -> None:
 
     for attrs in (graph_attrs, app_attrs, vision_attrs, translation_attrs):
         assert attrs[RESPAN_LOG_TYPE] == LOG_TYPE_TEXT
-        assert attrs[TLSpanAttributes.LLM_REQUEST_TYPE] == "completion"
+        assert attrs[TLSpanAttributes.LLM_REQUEST_TYPE] == "chat"
         assert not OFF_CONTRACT_ALIASES.intersection(attrs)
 
-    assert graph_attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"] == "The docs changed."
+    assert (
+        graph_attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"]
+        == "The docs changed."
+    )
     assert graph_attrs[TLSpanAttributes.LLM_REQUEST_MODEL] == "writer-graph"
-    assert app_attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"] == "Application output"
+    assert (
+        app_attrs[f"{TLSpanAttributes.LLM_COMPLETIONS}.0.content"]
+        == "Application output"
+    )
     assert app_attrs[TLSpanAttributes.LLM_REQUEST_MODEL] == "writer-application"
     assert vision_attrs[TLSpanAttributes.LLM_REQUEST_MODEL] == "palmyra-vision"
     assert translation_attrs[TLSpanAttributes.LLM_REQUEST_MODEL] == "palmyra-translate"
@@ -408,7 +456,9 @@ def test_direct_writer_tools_emit_tool_spans_without_llm_tool_attrs(
     web_attrs = build_tool_attrs(
         tool_name=WRITER_WEB_SEARCH_TOOL_NAME,
         request_kwargs={"query": "Respan tracing", "include_answer": True},
-        response=SimpleNamespace(query="Respan tracing", answer="Search output", sources=[]),
+        response=SimpleNamespace(
+            query="Respan tracing", answer="Search output", sources=[]
+        ),
     )
     pdf_attrs = build_tool_attrs(
         tool_name=WRITER_PARSE_PDF_TOOL_NAME,
@@ -435,3 +485,117 @@ def test_direct_writer_tools_emit_tool_spans_without_llm_tool_attrs(
         monkeypatch.setenv("RESPAN_SPAN_NAME_STYLE", "legacy")
         assert _export_span_name(span) == legacy_name
         monkeypatch.delenv("RESPAN_SPAN_NAME_STYLE")
+
+
+def test_completion_and_application_streams_emit_canonical_stream_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_spans: list[dict[str, Any]],
+) -> None:
+    fake = _install_fake_writer_modules(monkeypatch)
+    instrumentor = WriterInstrumentor()
+    instrumentor.activate()
+
+    completion = fake.CompletionsResource().create(
+        model="palmyra-x5",
+        prompt="stream",
+        stream=True,
+    )
+    application = fake.ApplicationsResource().generate_content(
+        "app_1",
+        inputs=[{"id": "topic", "value": "tracing"}],
+        stream=True,
+    )
+    list(completion)
+    list(application)
+
+    assert len(captured_spans) == 2
+    assert all(
+        span["attrs"][TLSpanAttributes.LLM_IS_STREAMING] is True
+        for span in captured_spans
+    )
+    instrumentor.deactivate()
+
+
+def test_two_writer_instances_keep_patches_until_final_deactivate(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_spans: list[dict[str, Any]],
+) -> None:
+    fake = _install_fake_writer_modules(monkeypatch)
+    original = fake.ChatResource.chat
+    first = WriterInstrumentor()
+    second = WriterInstrumentor()
+    first.activate()
+    second.activate()
+
+    first.deactivate()
+    fake.ChatResource().chat(**_chat_request_kwargs())
+    assert len(captured_spans) == 1
+    assert fake.ChatResource.chat is not original
+
+    second.deactivate()
+    assert fake.ChatResource.chat is original
+
+
+def test_writer_stream_keeps_call_time_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _install_fake_writer_modules(monkeypatch)
+    parent_ids: list[int] = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_writer_span",
+        lambda **_kwargs: parent_ids.append(
+            trace.get_current_span().get_span_context().span_id
+        ),
+    )
+    WriterInstrumentor().activate()
+    parent_span_id = 0x4321
+    parent = NonRecordingSpan(
+        SpanContext(
+            trace_id=0xABCDEF1234567890ABCDEF1234567890,
+            span_id=parent_span_id,
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            trace_state=None,
+        )
+    )
+    token = context_api.attach(trace.set_span_in_context(parent))
+    try:
+        stream = fake.ChatResource().chat(**_chat_request_kwargs(), stream=True)
+    finally:
+        context_api.detach(token)
+
+    list(stream)
+    assert parent_ids == [parent_span_id]
+
+
+def test_writer_stream_retention_is_bounded() -> None:
+    chunks: list[Any] = []
+    for index in range(_instrumentation._MAX_STREAM_CHUNKS + 20):
+        _instrumentation._append_stream_chunk(chunks, index)
+
+    assert len(chunks) == _instrumentation._MAX_STREAM_CHUNKS
+    assert chunks[-1] == _instrumentation._MAX_STREAM_CHUNKS + 19
+
+
+def test_writer_error_span_retains_provider_status_for_ingestion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[Any] = []
+    monkeypatch.setattr(
+        _otel_emitter,
+        "inject_span",
+        lambda *, span: captured.append(span),
+    )
+
+    _otel_emitter.emit_writer_span(
+        name="writer.chat",
+        attrs={},
+        start_ns=time.time_ns(),
+        error_message="RateLimitError: provider limit",
+        status_code=429,
+    )
+
+    assert len(captured) == 1
+    assert captured[0].attributes["status_code"] == 429
+    assert captured[0].status.is_ok is False


### PR DESCRIPTION
## Summary

- Repair the Python Watsonx, Weaviate, and Writer instrumentation packages for OpenTelemetry 2.x-compatible runtimes.
- Preserve canonical streaming, provider, tool, usage, error-status, entity/path, embedding/vector, privacy, and lifecycle semantics across current vendor SDKs.
- Add one patch release intent covering exactly these three packages without manually changing package versions.

## Validation

- [x] Watsonx focused package tests: 14/14 passed.
- [x] Weaviate focused package tests: 9/9 passed.
- [x] Writer focused package tests: 11/11 passed, including a real ReadableSpan regression for provider status 429.
- [x] Root-config Ruff check and format check passed for all three package directories.
- [x] Release inventory, release-intent validation, and changed-package intent coverage passed.
- [x] Editable `direct_url.json` entries resolve all three instrumentations and Respan core packages to the intended local worktree.
- [x] All three wheels built and passed isolated import checks; the declared-dependency wheel environment passes `pip check`.
- [x] Companion examples passed 11/11 contract tests and all 20 runner processes completed under exact marker `otel2-fix-py-group-28-20260818T113842Z`.
- [x] Respan MCP audit inspected all 19 trees and all 59 full records: one root per trace, exact parentage, unique IDs, seven streams, four connected tools, precise Writer/Watsonx/Weaviate child failures, bounded content, and exact marker/run ID throughout.

## External follow-ups

- Real Watsonx, Writer, and Weaviate service behavior remains credential-gated in this environment.
- Ingestion still leaves top-level `tools`/`tool_calls` empty despite canonical definitions/current-turn calls, leaves Writer `provider_id` blank despite `gen_ai.provider.name=writer`, and stores escaped workflow roots as success/200.
- The Weaviate local-error fault classifier is backend-owned.

## Companion examples

- https://github.com/respanai/respan-example-projects/pull/76