### PR TITLE
fix(deps): pin hono to 4.13.3 and nanoid to 3.3.18

### DIFF
--- a/javascript-sdks/legacy/respan-exporter-n8n/package.json
+++ b/javascript-sdks/legacy/respan-exporter-n8n/package.json
@@ -61,6 +61,7 @@
 		"n8n-workflow": "*"
 	},
 	"resolutions": {
+		"nanoid": "3.3.18",
 		"uuid": "11.1.1"
 	}
 }

--- a/javascript-sdks/legacy/respan-exporter-n8n/yarn.lock
+++ b/javascript-sdks/legacy/respan-exporter-n8n/yarn.lock
@@ -4999,12 +4999,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
+"nanoid@npm:3.3.18":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 

--- a/javascript-sdks/package.json
+++ b/javascript-sdks/package.json
@@ -59,6 +59,7 @@
     "fast-xml-parser": "5.10.1",
     "form-data": "4.0.6",
     "glob": "13.0.6",
+    "hono": "4.13.3",
     "ip-address": "10.5.0",
     "js-yaml": "5.2.3",
     "jsondiffpatch": "0.7.6",

--- a/javascript-sdks/yarn.lock
+++ b/javascript-sdks/yarn.lock
@@ -4234,7 +4234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/otlp-transformer@npm:0.205.0":
+"@opentelemetry/otlp-transformer@npm:0.205.0, @opentelemetry/otlp-transformer@npm:^0.205.0":
   version: 0.205.0
   resolution: "@opentelemetry/otlp-transformer@npm:0.205.0"
   dependencies:
@@ -9863,17 +9863,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.11.4":
-  version: 4.12.9
-  resolution: "hono@npm:4.12.9"
-  checksum: 10c0/393256552642f681e52935163508d9605e5552e186d9b99ff2caf219d4248341b83e3eb975c40a97149c86890d19d73421efc889aa465a28eb5920ccc42cff34
-  languageName: node
-  linkType: hard
-
-"hono@npm:^4.8.3":
-  version: 4.12.30
-  resolution: "hono@npm:4.12.30"
-  checksum: 10c0/3262ba275e44dc9515032e15aa6a88e8915bc65f5a4b9a1bc538f3ac2bdd19aa2235e6e2fdd6af3b0e5551c162856c3dccd4f353e721c43fe81e5f3268573dde
+"hono@npm:4.13.3":
+  version: 4.13.3
+  resolution: "hono@npm:4.13.3"
+  checksum: 10c0/51ab0e8f2f769e806c7e2d6d0e1577643fa35e442250ffe4cc69cffa4a276aad5d2db4edc15ab2210ae0ef478638e44937d8b3e2eded313a05793bc219239c4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears **all 29** Oneleet dependency-scanning findings on this repo — and 4 more the scanner did not surface.

> Opened from a fork: `d-cryptic` has no push access on `respanai/respan` (branch-ref creation 404s, `permissions.push = false`). Happy to move this to a topic branch on the main repo if someone grants access.

## Changes

| Path | Package | From | To |
|---|---|---|---|
| `javascript-sdks/` | `hono` | 4.12.9 **and** 4.12.30 | 4.13.3 |
| `javascript-sdks/legacy/respan-exporter-n8n/` | `nanoid` | 3.3.8 | 3.3.18 |

## The scanner under-reported hono

The lockfile held **two** hono ranges — `^4.11.4` resolving to 4.12.9, and `^4.8.3` resolving to 4.12.30. Only 4.12.9 was flagged, but 4.12.30 carries 4 advisories of its own. A single resolution collapses both to 4.13.3.

Verified against OSV:

```
hono@4.12.9    -> 27 advisories
hono@4.12.30   ->  4 advisories
hono@4.13.3    ->  0 advisories   CLEAN
nanoid@3.3.8   ->  2 advisories
nanoid@3.3.18  ->  0 advisories   CLEAN
```

**33 advisories closed**, against the 29 the scanner reported.

The hono set is mostly cookie handling and routing: `setCookie()` missing cookie-name validation, `sameSite`/`priority` not sanitised (Set-Cookie injection), and `app.mount()` stripping the mount prefix using an undecoded path, causing incorrect routing. The most severe is CVE-2026-54290 (HIGH 7.1) — CORS middleware reflecting any Origin with credentials when `origin` defaults to the wildcard.

hono is transitive here (no workspace package declares it directly), so this is a `resolutions` pin rather than a dependency bump.

## nanoid stays on the 3.x line

`nanoid` lives in the legacy n8n exporter's **own separate** `yarn.lock`, not the main workspace tree — which is why the root `resolutions` entry (nanoid 6.0.1) never applied to it.

Pinned to **3.3.18**, not npm `latest`. OSV shows the fix was backported to the 3.x line, so the 3.x -> 6.x major jump is unnecessary:

```
CVE-2026-67213  [{introduced: 0},     {fixed: 3.3.18}]
                [{introduced: 4.0.0}, {fixed: 5.1.6}]
```

## Lockfiles

Both regenerated with yarn 4.9.2 via `corepack`, `--mode=update-lockfile`. The diff is 11 insertions / 16 deletions across 4 files — two `resolutions` entries and the resulting lock changes, nothing else. Collapsing the two hono ranges into one is why the main lock shrinks.

Ref: DEV-11091