### PR TITLE
fix(cli): correct the auto mode provider list

### DIFF
--- a/.release-intents/20260822-auto-provider-list.json
+++ b/.release-intents/20260822-auto-provider-list.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Fix the auto mode provider list in the tracing skill and rebuild the generated skill files",
+  "packages": {
+    "@respan/cli": "patch"
+  }
+}

--- a/claude-plugin/skills/respan/references/tracing.md
+++ b/claude-plugin/skills/respan/references/tracing.md
@@ -30,7 +30,7 @@ The API key is stored in `.env` as `RESPAN_API_KEY`.
 
 **Before analyzing anything, ask the user which setup they want.** This is the first question — the two branches diverge immediately.
 
-1. **Auto** — the fastest path. Install the core SDK and add `Respan()` (one line). Every LLM call from a supported direct SDK — OpenAI, Anthropic, Azure OpenAI, Bedrock, Vertex, Cohere, Together, Gemini, LiteLLM — is automatically captured as a flat span. **No decorators and no framework instrumentor, even if a framework is detected.** Best for a quick start or a live demo: traces flowing in under two minutes.
+1. **Auto** — the fastest path. Install the core SDK and add `Respan()` (one line). Every LLM call from a direct SDK whose Respan instrumentation adapter the facade bundles for that language is automatically captured as a flat span. **Python:** OpenAI, Azure OpenAI, Anthropic, Vertex AI, Google GenAI, Bedrock, Together AI, Ollama. **TypeScript:** OpenAI, Azure OpenAI, Anthropic, Vertex AI, Bedrock, Cohere, Together AI, OpenRouter, Writer. Any other provider needs the Full path. **No decorators and no framework instrumentor, even if a framework is detected.** Best for a quick start or a live demo: traces flowing in under two minutes.
 2. **Full** — structured setup. Adds framework-specific instrumentation and/or workflow structure on top:
    - **Explicit instrumentor** — for agent frameworks (LangChain, CrewAI, OpenAI Agents, Claude Agent SDK, LlamaIndex, Haystack, …) so the framework's agent / tool / chain structure is captured.
    - **Decorators** — wrap the user's own functions with `@workflow` / `@task` for nested spans.
@@ -107,19 +107,23 @@ If a Priority 1 framework is found, use its instrumentation. Do NOT also add Pri
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 
-These are **auto-instrumented** — just `Respan()` / `new Respan()`, no extra packages needed:
+The integrations listed for each language are **auto-instrumented** with `Respan()` / `new Respan()`. The application still provides the provider SDK; the matching first-party instrumentation adapter is bundled by the Respan facade. A dash means that language currently requires an explicit instrumentation package and instrumentor.
 
-| Library | Python package | JS/TS package | Docs |
-|---------|---------------|---------------|------|
+| Library | Python SDK (auto) | JS/TS SDK (auto) | Docs |
+|---------|-------------------|------------------|------|
 | OpenAI SDK | `openai` | `openai` | [docs](https://respan.ai/docs/integrations/openai-sdk.md) |
 | Anthropic SDK | `anthropic` | `@anthropic-ai/sdk` | [docs](https://respan.ai/docs/integrations/anthropic.md) |
-| Azure OpenAI | `openai` (azure config) | `openai` | [docs](https://respan.ai/docs/integrations/providers/azure.md) |
-| Google Vertex AI | `google-cloud-aiplatform` | — | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
-| AWS Bedrock | `boto3` | — | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
-| Cohere | `cohere` | — | [docs](https://respan.ai/docs/integrations/providers/cohere.md) |
-| Together AI | `together` | — | [docs](https://respan.ai/docs/integrations/together-ai.md) |
+| Azure OpenAI | `openai` (Azure config) | `openai` (Azure client) | [docs](https://respan.ai/docs/integrations/providers/azure.md) |
+| Google Vertex AI | `google-cloud-aiplatform` | `@google-cloud/vertexai` | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
+| Google GenAI | `google-genai` | — | [docs](https://respan.ai/docs/integrations/google-genai.md) |
+| AWS Bedrock | `boto3` | `@aws-sdk/client-bedrock-runtime` | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
+| Cohere | — | `cohere-ai` | [docs](https://respan.ai/docs/integrations/providers/cohere.md) |
+| Together AI | `together` | `together-ai` | [docs](https://respan.ai/docs/integrations/together-ai.md) |
+| OpenRouter | — | `@openrouter/sdk` | [docs](https://respan.ai/docs/integrations/providers/openrouter.md) |
+| Writer | — | `writer-sdk` | [docs](https://respan.ai/docs/integrations/writer.md) |
+| Ollama | `ollama` | — | [docs](https://respan.ai/docs/integrations/ollama.md) |
 
-**Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). For Google GenAI (`@google/genai`), see [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md).
+**Note:** LLM wrappers such as Python LiteLLM stay explicit-only to avoid overlapping provider spans. See the [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md) for its explicit setup.
 
 **1c. Read the actual code and understand the workflow:**
 

--- a/cursor-plugin/skills/respan/references/tracing.md
+++ b/cursor-plugin/skills/respan/references/tracing.md
@@ -30,7 +30,7 @@ The API key is stored in `.env` as `RESPAN_API_KEY`.
 
 **Before analyzing anything, ask the user which setup they want.** This is the first question — the two branches diverge immediately.
 
-1. **Auto** — the fastest path. Install the core SDK and add `Respan()` (one line). Every LLM call from a supported direct SDK — OpenAI, Anthropic, Azure OpenAI, Bedrock, Vertex, Cohere, Together, Gemini, LiteLLM — is automatically captured as a flat span. **No decorators and no framework instrumentor, even if a framework is detected.** Best for a quick start or a live demo: traces flowing in under two minutes.
+1. **Auto** — the fastest path. Install the core SDK and add `Respan()` (one line). Every LLM call from a direct SDK whose Respan instrumentation adapter the facade bundles for that language is automatically captured as a flat span. **Python:** OpenAI, Azure OpenAI, Anthropic, Vertex AI, Google GenAI, Bedrock, Together AI, Ollama. **TypeScript:** OpenAI, Azure OpenAI, Anthropic, Vertex AI, Bedrock, Cohere, Together AI, OpenRouter, Writer. Any other provider needs the Full path. **No decorators and no framework instrumentor, even if a framework is detected.** Best for a quick start or a live demo: traces flowing in under two minutes.
 2. **Full** — structured setup. Adds framework-specific instrumentation and/or workflow structure on top:
    - **Explicit instrumentor** — for agent frameworks (LangChain, CrewAI, OpenAI Agents, Claude Agent SDK, LlamaIndex, Haystack, …) so the framework's agent / tool / chain structure is captured.
    - **Decorators** — wrap the user's own functions with `@workflow` / `@task` for nested spans.
@@ -107,19 +107,23 @@ If a Priority 1 framework is found, use its instrumentation. Do NOT also add Pri
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 
-These are **auto-instrumented** — just `Respan()` / `new Respan()`, no extra packages needed:
+The integrations listed for each language are **auto-instrumented** with `Respan()` / `new Respan()`. The application still provides the provider SDK; the matching first-party instrumentation adapter is bundled by the Respan facade. A dash means that language currently requires an explicit instrumentation package and instrumentor.
 
-| Library | Python package | JS/TS package | Docs |
-|---------|---------------|---------------|------|
+| Library | Python SDK (auto) | JS/TS SDK (auto) | Docs |
+|---------|-------------------|------------------|------|
 | OpenAI SDK | `openai` | `openai` | [docs](https://respan.ai/docs/integrations/openai-sdk.md) |
 | Anthropic SDK | `anthropic` | `@anthropic-ai/sdk` | [docs](https://respan.ai/docs/integrations/anthropic.md) |
-| Azure OpenAI | `openai` (azure config) | `openai` | [docs](https://respan.ai/docs/integrations/providers/azure.md) |
-| Google Vertex AI | `google-cloud-aiplatform` | — | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
-| AWS Bedrock | `boto3` | — | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
-| Cohere | `cohere` | — | [docs](https://respan.ai/docs/integrations/providers/cohere.md) |
-| Together AI | `together` | — | [docs](https://respan.ai/docs/integrations/together-ai.md) |
+| Azure OpenAI | `openai` (Azure config) | `openai` (Azure client) | [docs](https://respan.ai/docs/integrations/providers/azure.md) |
+| Google Vertex AI | `google-cloud-aiplatform` | `@google-cloud/vertexai` | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
+| Google GenAI | `google-genai` | — | [docs](https://respan.ai/docs/integrations/google-genai.md) |
+| AWS Bedrock | `boto3` | `@aws-sdk/client-bedrock-runtime` | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
+| Cohere | — | `cohere-ai` | [docs](https://respan.ai/docs/integrations/providers/cohere.md) |
+| Together AI | `together` | `together-ai` | [docs](https://respan.ai/docs/integrations/together-ai.md) |
+| OpenRouter | — | `@openrouter/sdk` | [docs](https://respan.ai/docs/integrations/providers/openrouter.md) |
+| Writer | — | `writer-sdk` | [docs](https://respan.ai/docs/integrations/writer.md) |
+| Ollama | `ollama` | — | [docs](https://respan.ai/docs/integrations/ollama.md) |
 
-**Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). For Google GenAI (`@google/genai`), see [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md).
+**Note:** LLM wrappers such as Python LiteLLM stay explicit-only to avoid overlapping provider spans. See the [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md) for its explicit setup.
 
 **1c. Read the actual code and understand the workflow:**
 

--- a/javascript-sdks/respan-cli/src/lib/skill-refs.generated.ts
+++ b/javascript-sdks/respan-cli/src/lib/skill-refs.generated.ts
@@ -79,7 +79,7 @@ The API key is stored in \`.env\` as \`RESPAN_API_KEY\`.
 
 **Before analyzing anything, ask the user which setup they want.** This is the first question — the two branches diverge immediately.
 
-1. **Auto** — the fastest path. Install the core SDK and add \`Respan()\` (one line). Every LLM call from a supported direct SDK — OpenAI, Anthropic, Azure OpenAI, Bedrock, Vertex, Cohere, Together, Gemini, LiteLLM — is automatically captured as a flat span. **No decorators and no framework instrumentor, even if a framework is detected.** Best for a quick start or a live demo: traces flowing in under two minutes.
+1. **Auto** — the fastest path. Install the core SDK and add \`Respan()\` (one line). Every LLM call from a direct SDK whose Respan instrumentation adapter the facade bundles for that language is automatically captured as a flat span. **Python:** OpenAI, Azure OpenAI, Anthropic, Vertex AI, Google GenAI, Bedrock, Together AI, Ollama. **TypeScript:** OpenAI, Azure OpenAI, Anthropic, Vertex AI, Bedrock, Cohere, Together AI, OpenRouter, Writer. Any other provider needs the Full path. **No decorators and no framework instrumentor, even if a framework is detected.** Best for a quick start or a live demo: traces flowing in under two minutes.
 2. **Full** — structured setup. Adds framework-specific instrumentation and/or workflow structure on top:
    - **Explicit instrumentor** — for agent frameworks (LangChain, CrewAI, OpenAI Agents, Claude Agent SDK, LlamaIndex, Haystack, …) so the framework's agent / tool / chain structure is captured.
    - **Decorators** — wrap the user's own functions with \`@workflow\` / \`@task\` for nested spans.
@@ -156,19 +156,23 @@ If a Priority 1 framework is found, use its instrumentation. Do NOT also add Pri
 
 **Priority 2 — Direct LLM SDKs** (only if no P1 framework covers this provider):
 
-These are **auto-instrumented** — just \`Respan()\` / \`new Respan()\`, no extra packages needed:
+The integrations listed for each language are **auto-instrumented** with \`Respan()\` / \`new Respan()\`. The application still provides the provider SDK; the matching first-party instrumentation adapter is bundled by the Respan facade. A dash means that language currently requires an explicit instrumentation package and instrumentor.
 
-| Library | Python package | JS/TS package | Docs |
-|---------|---------------|---------------|------|
+| Library | Python SDK (auto) | JS/TS SDK (auto) | Docs |
+|---------|-------------------|------------------|------|
 | OpenAI SDK | \`openai\` | \`openai\` | [docs](https://respan.ai/docs/integrations/openai-sdk.md) |
 | Anthropic SDK | \`anthropic\` | \`@anthropic-ai/sdk\` | [docs](https://respan.ai/docs/integrations/anthropic.md) |
-| Azure OpenAI | \`openai\` (azure config) | \`openai\` | [docs](https://respan.ai/docs/integrations/providers/azure.md) |
-| Google Vertex AI | \`google-cloud-aiplatform\` | — | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
-| AWS Bedrock | \`boto3\` | — | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
-| Cohere | \`cohere\` | — | [docs](https://respan.ai/docs/integrations/providers/cohere.md) |
-| Together AI | \`together\` | — | [docs](https://respan.ai/docs/integrations/together-ai.md) |
+| Azure OpenAI | \`openai\` (Azure config) | \`openai\` (Azure client) | [docs](https://respan.ai/docs/integrations/providers/azure.md) |
+| Google Vertex AI | \`google-cloud-aiplatform\` | \`@google-cloud/vertexai\` | [docs](https://respan.ai/docs/integrations/vertex-ai.md) |
+| Google GenAI | \`google-genai\` | — | [docs](https://respan.ai/docs/integrations/google-genai.md) |
+| AWS Bedrock | \`boto3\` | \`@aws-sdk/client-bedrock-runtime\` | [docs](https://respan.ai/docs/integrations/aws-bedrock.md) |
+| Cohere | — | \`cohere-ai\` | [docs](https://respan.ai/docs/integrations/providers/cohere.md) |
+| Together AI | \`together\` | \`together-ai\` | [docs](https://respan.ai/docs/integrations/together-ai.md) |
+| OpenRouter | — | \`@openrouter/sdk\` | [docs](https://respan.ai/docs/integrations/providers/openrouter.md) |
+| Writer | — | \`writer-sdk\` | [docs](https://respan.ai/docs/integrations/writer.md) |
+| Ollama | \`ollama\` | — | [docs](https://respan.ai/docs/integrations/ollama.md) |
 
-**Note:** LiteLLM in JS uses the OpenAI-compatible API, so the OpenAI auto-instrument covers it. For Python LiteLLM, see [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md). For Google GenAI (\`@google/genai\`), see [Google GenAI guide](https://respan.ai/docs/integrations/google-genai.md).
+**Note:** LLM wrappers such as Python LiteLLM stay explicit-only to avoid overlapping provider spans. See the [LiteLLM guide](https://respan.ai/docs/integrations/litellm.md) for its explicit setup.
 
 **1c. Read the actual code and understand the workflow:**
 

--- a/skills/references/tracing.md
+++ b/skills/references/tracing.md
@@ -30,7 +30,7 @@ The API key is stored in `.env` as `RESPAN_API_KEY`.
 
 **Before analyzing anything, ask the user which setup they want.** This is the first question — the two branches diverge immediately.
 
-1. **Auto** — the fastest path. Install the core SDK and add `Respan()` (one line). Every LLM call from a supported direct SDK — OpenAI, Anthropic, Azure OpenAI, Bedrock, Vertex, Cohere, Together, Gemini, LiteLLM — is automatically captured as a flat span. **No decorators and no framework instrumentor, even if a framework is detected.** Best for a quick start or a live demo: traces flowing in under two minutes.
+1. **Auto** — the fastest path. Install the core SDK and add `Respan()` (one line). Every LLM call from a direct SDK whose Respan instrumentation adapter the facade bundles for that language is automatically captured as a flat span. **Python:** OpenAI, Azure OpenAI, Anthropic, Vertex AI, Google GenAI, Bedrock, Together AI, Ollama. **TypeScript:** OpenAI, Azure OpenAI, Anthropic, Vertex AI, Bedrock, Cohere, Together AI, OpenRouter, Writer. Any other provider needs the Full path. **No decorators and no framework instrumentor, even if a framework is detected.** Best for a quick start or a live demo: traces flowing in under two minutes.
 2. **Full** — structured setup. Adds framework-specific instrumentation and/or workflow structure on top:
    - **Explicit instrumentor** — for agent frameworks (LangChain, CrewAI, OpenAI Agents, Claude Agent SDK, LlamaIndex, Haystack, …) so the framework's agent / tool / chain structure is captured.
    - **Decorators** — wrap the user's own functions with `@workflow` / `@task` for nested spans.


### PR DESCRIPTION
## Summary

Line 33 of `skills/references/tracing.md` gives one flat list of the providers a bare `Respan()` picks up. The default set isn't the same in both languages though — Python bundles 7 adapters, TypeScript bundles 9, and they don't line up — so a single list can't be right for both. It wasn't:

- **LiteLLM** is listed as automatic. It's opt-in in Python (`_FRAMEWORK_REASON`, so it doesn't double-count spans the OpenAI adapter already traces), and there's no LiteLLM entry in the JS registry at all.
- **Cohere** is listed with no qualifier. That's true for TypeScript, not for Python.
- **Ollama** and **Google GenAI** are missing on the Python side, **OpenRouter** and **Writer** on the TypeScript side.

Quick check for Python:

```bash
python3 -c "
import sys, importlib.util as u
spec = u.spec_from_file_location('reg','python-sdks/respan/src/respan/_auto_instrumentation_registry.py')
m = u.module_from_spec(spec); sys.modules['reg']=m; spec.loader.exec_module(m)
print(sorted(s.entry_point for s in m.AUTO_INSTRUMENTATION_REGISTRY if s.enabled_by_default))"
```

prints `['anthropic', 'aws-bedrock', 'google-genai', 'ollama', 'openai', 'together', 'vertexai']`, the same set the `respan-ai auto-instrument smoke check` step in ci.yml asserts. The JS side comes out of `javascript-sdks/respan/src/_auto_instrumentation_registry.ts` and matches the table in `javascript-sdks/respan/README.md`.

The per-language table at line 108 already has all of this right. Line 33 just never got updated along with it in #323.

This one matters a bit more than a normal doc line, because `respan setup` writes the file straight into `~/.agents/skills/` and `~/.claude/skills/` (setup-base-command.ts:738). Right now it tells a Python user on Cohere or LiteLLM that one line is enough. They get no spans and no error.

**What changed**

1. Line 33 now lists the providers per language instead of as one set. I kept it inline rather than pointing at the table, since line 38 tells the reader to skip whichever branch they didn't pick and the table sits under Full path.
2. It now says the *instrumentation adapter* is bundled, not the provider SDK. The old wording contradicted line 110, and an agent that reads it as "the SDK is bundled" will skip `pip install openai`.
3. Reran `scripts/build-plugins.mjs` and `generate:skill-refs`. #323 changed the source but didn't rerun them, so the CLI bundle and both plugin copies have been shipping the pre-#323 table since Aug 7 — including `| Cohere | cohere | — |`, which is backwards in both columns now. That's most of the diff here and it's all generator output.

## Release Intent

`.release-intents/20260822-auto-provider-list.json` with `{"@respan/cli": "patch"}`, since `skill-refs.generated.ts` lives in that package. Same shape as #346.

## Validation

- [x] I updated or added a `.release-intents/*.json` file if this PR changes a release-managed package
- [x] I ran the relevant local checks for the packages I touched

What I ran:

- `release_inventory.py --validate` and `release_intents.py validate` — both pass
- `release_intents.py missing --changed-from main --changed-to HEAD` — empty
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 11 tests, OK
- reran both generators after committing — no diff
- `tsc --noEmit` on the regenerated file — clean, and it round-trips byte-identical to the markdown
- JS matrix resolves to `@respan/cli` only, Python matrix is 0

## Notes

Refs #257 and #323. Not closing #257, since #285 already did the bundling half of it.

Two follow-ups I'm happy to pick up, left out to keep this small:

- a CI step that reruns the generators and fails on a diff, so the copies can't silently drift again
- moving the Priority 2 table above the Full path gate, so the Auto branch can point at it and the list lives in exactly one place
