### PR TITLE
feat(instrumentation-py): add Helicone Manual Logger instrumentation

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -623,6 +623,12 @@
       "name": "respan-instrumentation-restate",
       "path": "python-sdks/instrumentations/respan-instrumentation-restate",
       "registry": "pypi"
+    },
+    {
+      "ecosystem": "python",
+      "name": "respan-instrumentation-helicone",
+      "path": "python-sdks/instrumentations/respan-instrumentation-helicone",
+      "registry": "pypi"
     }
   ]
 }

--- a/.release-intents/20260829-helicone-python-instrumentation.json
+++ b/.release-intents/20260829-helicone-python-instrumentation.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add Python instrumentation for Helicone Manual Logger workflows; version 0.1.0 was published manually before this PR",
+  "packages": {
+    "respan-instrumentation-helicone": "none"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/.gitignore
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+dist/
+*.egg-info/

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/README.md
@@ -1,0 +1,94 @@
+# Respan Helicone instrumentation
+
+Trace calls made through Helicone's Python manual logger with Respan. This
+package instruments the published `helicone-helpers` `HeliconeManualLogger`
+surface without replacing or bypassing Helicone's own logging behavior.
+
+The instrumentation covers:
+
+- `HeliconeManualLogger.log_request()` and direct `send_log()` calls
+- `HeliconeLogBuilder`, including streamed chunks and error logs
+- OpenAI-, Anthropic-, and custom-model request/response payloads
+- Helicone `_type=tool`, `_type=vector_db`, and `_type=data` custom logs
+- sync manual logging and the builder's async `send_log()` lifecycle
+
+## Install
+
+```bash
+pip install respan-ai respan-instrumentation-helicone "helicone-helpers~=1.2.1"
+```
+
+## Usage
+
+```python
+import os
+
+from helicone_helpers import HeliconeManualLogger
+from respan import Respan, workflow
+from respan_instrumentation_helicone import HeliconeInstrumentor
+
+respan = Respan(
+    api_key=os.environ["RESPAN_API_KEY"],
+    instrumentations=[HeliconeInstrumentor()],
+)
+helicone = HeliconeManualLogger(api_key=os.environ["HELICONE_API_KEY"])
+
+
+@workflow(name="helicone_manual_log")
+def run(prompt: str) -> str:
+    request = {
+        "model": "custom-chat-model",
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+    def operation(recorder):
+        response = {
+            "model": "custom-chat-model",
+            "choices": [{"message": {"role": "assistant", "content": "Hello!"}}],
+            "usage": {
+                "prompt_tokens": 4,
+                "completion_tokens": 2,
+                "total_tokens": 6,
+            },
+        }
+        recorder.append_results(response)
+        return "Hello!"
+
+    return helicone.log_request(request, operation, provider="openai")
+
+
+try:
+    print(run("Say hello."))
+finally:
+    respan.flush()
+    respan.shutdown()
+```
+
+`HeliconeInstrumentor(capture_content=False)` keeps span identity, model,
+provider, timing, usage, and errors while omitting request and response content.
+Authentication and Helicone transport headers are never copied into spans.
+Safe constructor/request correlation headers are normalized into canonical
+customer/session fields and one JSON `respan.metadata` attribute.
+
+## Activation and overlap policy
+
+Helicone manual logging is explicit instrumentation. Activate
+`HeliconeInstrumentor()` only in applications that use `HeliconeManualLogger`;
+it is not a direct-provider auto-instrumentor. The package patches Helicone's
+logger and builder methods only—it does not patch OpenAI, Anthropic, or another
+provider SDK.
+
+Do not combine this package with instrumentation for the provider operation
+that the same manual log describes unless you intentionally want both records.
+For example, wrapping an OpenAI call in `HeliconeManualLogger.log_request()`
+while also activating `OpenAIInstrumentor()` produces one provider span and one
+Helicone manual-log span for the same logical model call.
+
+The instrumentor is reference-counted and restores the exact SDK methods it
+patched when the final owner deactivates. It also exposes `instrument()` and
+`uninstrument()` aliases for compatibility with OpenTelemetry-style lifecycle
+code.
+
+See the Helicone example set in `respan-example-projects/python/tracing/helicone`
+for deterministic sync, async-builder, streaming, error, tool, vector database,
+and custom data coverage.

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/pyproject.toml
@@ -1,0 +1,30 @@
+[tool.poetry]
+name = "respan-instrumentation-helicone"
+version = "0.1.0"
+description = "Respan instrumentation plugin for Helicone's Python manual logger"
+authors = ["Respan <team@respan.ai>"]
+license = "Apache 2.0"
+readme = "README.md"
+packages = [
+    { include = "respan_instrumentation_helicone", from = "./src" },
+]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<3.14"
+helicone-helpers = ">=1.2.1,<1.3.0"
+respan-tracing = "^2.19.2"
+respan-sdk = ">=2.7.4,<3.0.0"
+opentelemetry-semantic-conventions = ">=0.65b0,<0.66"
+opentelemetry-semantic-conventions-ai = ">=0.5.1,<0.6.0"
+
+[tool.poetry.plugins."respan.instrumentations"]
+helicone = "respan_instrumentation_helicone:HeliconeInstrumentor"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests against the installed Helicone SDK surface",
+]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/__init__.py
@@ -1,0 +1,5 @@
+"""Respan instrumentation for Helicone's Python manual logger."""
+
+from respan_instrumentation_helicone._instrumentation import HeliconeInstrumentor
+
+__all__ = ["HeliconeInstrumentor"]

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/_constants.py
@@ -1,0 +1,22 @@
+"""Helicone SDK-specific constants owned by this translator."""
+
+HELICONE_INSTRUMENTATION_NAME = "helicone"
+HELICONE_HELPERS_MODULE = "helicone_helpers"
+HELICONE_MANUAL_LOGGER_CLASS = "HeliconeManualLogger"
+HELICONE_LOG_BUILDER_CLASS = "HeliconeLogBuilder"
+HELICONE_BUILDER_CONTEXT_ATTR = "_respan_helicone_emission_context"
+
+HELICONE_TYPE_KEY = "_type"
+HELICONE_TYPE_TOOL = "tool"
+HELICONE_TYPE_VECTOR_DB = "vector_db"
+HELICONE_TYPE_DATA = "data"
+HELICONE_TYPE_EMBEDDING = "embedding"
+
+HELICONE_TOOL_NAME_KEY = "toolName"
+HELICONE_OPERATION_KEY = "operation"
+HELICONE_DATA_NAME_KEY = "name"
+
+MAX_ATTRIBUTE_BYTES = 32_000
+MAX_TEXT_BYTES = 12_000
+MAX_COLLECTION_ITEMS = 128
+MAX_DEPTH = 8

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/_emitter.py
@@ -1,0 +1,1142 @@
+"""Translate Helicone manual logs into the canonical Respan span contract."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from itertools import islice
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.semconv._incubating.attributes.error_attributes import (
+    ERROR_MESSAGE,
+    ERROR_TYPE,
+)
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_REQUEST_STREAM,
+    GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
+from opentelemetry.semconv.attributes.http_attributes import (
+    HTTP_RESPONSE_STATUS_CODE,
+)
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_EMBEDDING,
+    LOG_TYPE_TASK,
+    LOG_TYPE_TEXT,
+    LOG_TYPE_TOOL,
+    LogMethodChoices,
+)
+from respan_sdk.constants.span_attributes import (
+    RESPAN_CUSTOMER_PARAMS_ID,
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    RESPAN_INTERNAL_SPAN_NAME_KIND,
+    RESPAN_LOG_METHOD,
+    RESPAN_LOG_TYPE,
+    RESPAN_METADATA,
+    RESPAN_SESSION_ID,
+)
+from respan_sdk.utils.data_processing.id_processing import (
+    format_span_id,
+    format_trace_id,
+)
+from respan_tracing.utils.span_factory import (
+    build_readable_span,
+    inject_span,
+    read_propagated_attributes,
+)
+
+from respan_instrumentation_helicone._constants import (
+    HELICONE_DATA_NAME_KEY,
+    HELICONE_OPERATION_KEY,
+    HELICONE_TOOL_NAME_KEY,
+    HELICONE_TYPE_DATA,
+    HELICONE_TYPE_EMBEDDING,
+    HELICONE_TYPE_KEY,
+    HELICONE_TYPE_TOOL,
+    HELICONE_TYPE_VECTOR_DB,
+    MAX_COLLECTION_ITEMS,
+    MAX_DEPTH,
+)
+from respan_instrumentation_helicone._serialization import (
+    exception_message,
+    is_sensitive_key,
+    json_dumps,
+    parse_json,
+    safe_text,
+    safe_type_name,
+    sanitize,
+)
+
+logger = logging.getLogger(__name__)
+
+_PROMPT_PREFIX = f"{SpanAttributes.LLM_PROMPTS}."
+_COMPLETION_PREFIX = f"{SpanAttributes.LLM_COMPLETIONS}."
+_COMPLETION_TOOL_CALLS = f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"
+_LABEL_RE = re.compile(r"[^a-z0-9_.-]+")
+
+
+@dataclass(frozen=True)
+class HeliconeEmissionContext:
+    """Trace and propagated attributes captured when a builder is created."""
+
+    trace_id: str | None
+    parent_id: str | None
+    propagated_attributes: Mapping[str, Any]
+
+
+def _label(value: Any, fallback: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return fallback
+    normalized = _LABEL_RE.sub("_", value.strip().lower()).strip("_.-")
+    return normalized[:128] or fallback
+
+
+def _display_text(value: Any, fallback: str) -> str:
+    if isinstance(value, str):
+        return safe_text(value)[:128] or fallback
+    if value is None:
+        return fallback
+    if isinstance(value, bool | int | float):
+        return safe_text(str(value))[:128]
+    return safe_type_name(value)[:128]
+
+
+def _canonical_role(value: Any, fallback: str) -> str:
+    if not isinstance(value, str):
+        return fallback
+    normalized = value.strip().lower()
+    aliases = {
+        "human": "user",
+        "ai": "assistant",
+        "bot": "assistant",
+        "model": "assistant",
+        "function": "tool",
+        "developer": "system",
+    }
+    normalized = aliases.get(normalized, normalized)
+    return (
+        normalized
+        if normalized in {"user", "assistant", "tool", "system"}
+        else fallback
+    )
+
+
+def _number(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value >= 0:
+        return value
+    if isinstance(value, float) and value.is_integer() and value >= 0:
+        return int(value)
+    return None
+
+
+def _seconds(value: Any, fallback: float) -> float:
+    if isinstance(value, bool):
+        return fallback
+    if (
+        isinstance(value, int | float)
+        and math.isfinite(float(value))
+        and float(value) > 0
+    ):
+        return float(value)
+    return fallback
+
+
+def _current_ids() -> tuple[str | None, str | None]:
+    context = trace.get_current_span().get_span_context()
+    trace_id = getattr(context, "trace_id", 0) or 0
+    span_id = getattr(context, "span_id", 0) or 0
+    if not trace_id or not span_id:
+        return None, None
+    return format_trace_id(trace_id=trace_id), format_span_id(span_id=span_id)
+
+
+def _snapshot_propagated_value(value: Any, *, depth: int = 0) -> Any:
+    if depth >= MAX_DEPTH:
+        return json_dumps(value)
+    if isinstance(value, Mapping):
+        return {
+            key: _snapshot_propagated_value(item, depth=depth + 1)
+            for key, item in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return tuple(
+            _snapshot_propagated_value(item, depth=depth + 1) for item in value
+        )
+    return value
+
+
+def capture_emission_context() -> HeliconeEmissionContext:
+    trace_id, parent_id = _current_ids()
+    return HeliconeEmissionContext(
+        trace_id=trace_id,
+        parent_id=parent_id,
+        propagated_attributes={
+            key: _snapshot_propagated_value(value)
+            for key, value in read_propagated_attributes().items()
+        },
+    )
+
+
+def _response_payload(response: Any) -> Any:
+    parsed = parse_json(response)
+    if not isinstance(parsed, str):
+        return parsed
+
+    chunks: list[Any] = []
+    for line in parsed.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("data:"):
+            line = line[5:].strip()
+        if line == "[DONE]":
+            continue
+        try:
+            chunks.append(json.loads(line))
+        except (TypeError, ValueError):
+            continue
+    return chunks if chunks else parsed
+
+
+def _unwrap_response(response: Any) -> Any:
+    if not isinstance(response, Mapping):
+        return response
+    nested = response.get("response")
+    if isinstance(nested, Mapping) and any(
+        key in nested for key in ("choices", "content", "data", "output")
+    ):
+        return nested
+    return response
+
+
+def _stream_summary(chunks: Sequence[Any]) -> dict[str, Any]:
+    text_parts: list[str] = []
+    usage: Mapping[str, Any] | None = None
+    model: str | None = None
+    tool_slots: dict[int, dict[str, Any]] = {}
+    for chunk in chunks:
+        if not isinstance(chunk, Mapping):
+            continue
+        if isinstance(chunk.get("model"), str):
+            model = chunk["model"]
+        if isinstance(chunk.get("usage"), Mapping):
+            usage = chunk["usage"]
+        choices = chunk.get("choices")
+        if not isinstance(choices, Sequence) or isinstance(choices, str) or not choices:
+            continue
+        choice = choices[0]
+        if not isinstance(choice, Mapping):
+            continue
+        delta = choice.get("delta")
+        if not isinstance(delta, Mapping):
+            continue
+        content = delta.get("content")
+        if isinstance(content, str):
+            text_parts.append(content)
+        calls = delta.get("tool_calls")
+        if not isinstance(calls, Sequence) or isinstance(calls, str):
+            continue
+        for raw_call in calls:
+            if not isinstance(raw_call, Mapping):
+                continue
+            index = raw_call.get("index", 0)
+            index = index if isinstance(index, int) and index >= 0 else 0
+            slot = tool_slots.setdefault(
+                index,
+                {
+                    "id": None,
+                    "type": "function",
+                    "function": {"name": "", "arguments": ""},
+                },
+            )
+            if isinstance(raw_call.get("id"), str):
+                slot["id"] = raw_call["id"]
+            function = raw_call.get("function")
+            if isinstance(function, Mapping):
+                if isinstance(function.get("name"), str):
+                    slot["function"]["name"] += function["name"]
+                if isinstance(function.get("arguments"), str):
+                    slot["function"]["arguments"] += function["arguments"]
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": "".join(text_parts) or None,
+    }
+    if tool_slots:
+        message["tool_calls"] = [tool_slots[index] for index in sorted(tool_slots)]
+    result: dict[str, Any] = {"choices": [{"message": message}]}
+    if model:
+        result["model"] = model
+    if usage:
+        result["usage"] = dict(usage)
+    return result
+
+
+def _anthropic_stream_summary(events: Sequence[Any]) -> dict[str, Any]:
+    model: str | None = None
+    usage: dict[str, Any] = {}
+    blocks: dict[int, dict[str, Any]] = {}
+    partial_json: dict[int, str] = {}
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        event_type = event.get("type")
+        if event_type == "message_start":
+            message = event.get("message")
+            if isinstance(message, Mapping):
+                if isinstance(message.get("model"), str):
+                    model = message["model"]
+                if isinstance(message.get("usage"), Mapping):
+                    usage.update(message["usage"])
+        if isinstance(event.get("usage"), Mapping):
+            usage.update(event["usage"])
+        index = event.get("index", 0)
+        index = index if isinstance(index, int) and index >= 0 else 0
+        if event_type == "content_block_start":
+            block = event.get("content_block")
+            if isinstance(block, Mapping):
+                blocks[index] = dict(block)
+        elif event_type == "content_block_delta":
+            delta = event.get("delta")
+            if not isinstance(delta, Mapping):
+                continue
+            block = blocks.setdefault(index, {"type": "text", "text": ""})
+            if delta.get("type") == "text_delta" and isinstance(delta.get("text"), str):
+                block["text"] = str(block.get("text") or "") + delta["text"]
+            elif delta.get("type") == "input_json_delta" and isinstance(
+                delta.get("partial_json"), str
+            ):
+                partial_json[index] = (
+                    partial_json.get(index, "") + delta["partial_json"]
+                )
+    for index, value in partial_json.items():
+        try:
+            blocks.setdefault(index, {"type": "tool_use"})["input"] = json.loads(value)
+        except (TypeError, ValueError):
+            blocks.setdefault(index, {"type": "tool_use"})["input"] = value
+    result: dict[str, Any] = {
+        "role": "assistant",
+        "content": [blocks[index] for index in sorted(blocks)],
+    }
+    if model:
+        result["model"] = model
+    if usage:
+        result["usage"] = usage
+    return result
+
+
+def _google_stream_summary(chunks: Sequence[Any]) -> dict[str, Any]:
+    model_version: str | None = None
+    usage_metadata: dict[str, Any] = {}
+    text_parts: list[str] = []
+    structured_parts: list[Any] = []
+    for chunk in chunks:
+        if not isinstance(chunk, Mapping):
+            continue
+        if isinstance(chunk.get("modelVersion"), str):
+            model_version = chunk["modelVersion"]
+        if isinstance(chunk.get("usageMetadata"), Mapping):
+            usage_metadata.update(chunk["usageMetadata"])
+        candidates = chunk.get("candidates")
+        if (
+            not isinstance(candidates, Sequence)
+            or isinstance(candidates, str)
+            or not candidates
+        ):
+            continue
+        candidate = candidates[0]
+        content = candidate.get("content") if isinstance(candidate, Mapping) else None
+        parts = content.get("parts") if isinstance(content, Mapping) else None
+        if not isinstance(parts, Sequence) or isinstance(parts, str):
+            continue
+        for part in parts:
+            if isinstance(part, Mapping) and isinstance(part.get("text"), str):
+                text_parts.append(part["text"])
+            else:
+                structured_parts.append(part)
+    combined_parts: list[Any] = []
+    if text_parts:
+        combined_parts.append({"text": "".join(text_parts)})
+    combined_parts.extend(structured_parts)
+    result: dict[str, Any] = {
+        "candidates": [{"content": {"role": "model", "parts": combined_parts}}]
+    }
+    if model_version:
+        result["modelVersion"] = model_version
+    if usage_metadata:
+        result["usageMetadata"] = usage_metadata
+    return result
+
+
+def _summarize_stream(chunks: Sequence[Any]) -> dict[str, Any]:
+    if any(
+        isinstance(item, Mapping)
+        and isinstance(item.get("type"), str)
+        and item["type"].startswith(("message_", "content_block_"))
+        for item in chunks
+    ):
+        return _anthropic_stream_summary(chunks)
+    if any(isinstance(item, Mapping) and "candidates" in item for item in chunks):
+        return _google_stream_summary(chunks)
+    return _stream_summary(chunks)
+
+
+def _normalized_response(response: Any) -> Any:
+    payload = _response_payload(response)
+    if isinstance(payload, Mapping):
+        raw_chunks = payload.get("chunks")
+        if isinstance(raw_chunks, Sequence) and not isinstance(
+            raw_chunks, str | bytes | bytearray
+        ):
+            chunks = [parse_json(item) for item in raw_chunks]
+            summary = _summarize_stream(chunks)
+            ttft = payload.get("time_to_first_token_ms")
+            if isinstance(ttft, int | float) and not isinstance(ttft, bool):
+                summary["time_to_first_token_ms"] = float(ttft)
+            return summary
+    if (
+        isinstance(payload, Sequence)
+        and not isinstance(payload, str | bytes | bytearray)
+        and payload
+        and all(isinstance(item, Mapping) for item in payload)
+    ):
+        return _summarize_stream(payload)
+    return _unwrap_response(payload)
+
+
+def _normalize_input_message(message: Mapping[str, Any]) -> Mapping[str, Any]:
+    normalized = dict(message)
+    content = message.get("content")
+    tool_calls: list[dict[str, Any]] = []
+    if isinstance(content, Sequence) and not isinstance(
+        content, str | bytes | bytearray
+    ):
+        normalized["content"] = json_dumps(content)
+        for block in content:
+            if not isinstance(block, Mapping):
+                continue
+            if block.get("type") == "tool_use" and isinstance(block.get("name"), str):
+                tool_call: dict[str, Any] = {
+                    "type": "function",
+                    "function": {
+                        "name": block["name"],
+                        "arguments": json_dumps(block.get("input", {})),
+                    },
+                }
+                if isinstance(block.get("id"), str):
+                    tool_call["id"] = block["id"]
+                tool_calls.append(tool_call)
+
+    parts = message.get("parts")
+    if isinstance(parts, Sequence) and not isinstance(parts, str | bytes | bytearray):
+        normalized["content"] = json_dumps(parts)
+        if normalized.get("role") == "model":
+            normalized["role"] = "assistant"
+        for part in parts:
+            if not isinstance(part, Mapping):
+                continue
+            function_call = part.get("functionCall")
+            if isinstance(function_call, Mapping) and isinstance(
+                function_call.get("name"), str
+            ):
+                tool_calls.append(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": function_call["name"],
+                            "arguments": json_dumps(function_call.get("args", {})),
+                        },
+                    }
+                )
+    if tool_calls:
+        normalized["tool_calls"] = tool_calls
+    return normalized
+
+
+def _messages(request: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    result: list[Mapping[str, Any]] = []
+    system = request.get("system")
+    if system is not None:
+        result.append(_normalize_input_message({"role": "system", "content": system}))
+    system_instruction = request.get("systemInstruction")
+    if system_instruction is not None:
+        if isinstance(system_instruction, Mapping) and "parts" in system_instruction:
+            result.append(
+                _normalize_input_message(
+                    {"role": "system", "parts": system_instruction["parts"]}
+                )
+            )
+        else:
+            result.append(
+                _normalize_input_message(
+                    {"role": "system", "content": system_instruction}
+                )
+            )
+
+    value = request.get("messages")
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        result.extend(
+            _normalize_input_message(item)
+            if isinstance(item, Mapping)
+            else {"role": "user", "content": item}
+            for item in islice(value, max(0, MAX_COLLECTION_ITEMS - len(result)))
+        )
+        return result
+    contents = request.get("contents")
+    if isinstance(contents, Sequence) and not isinstance(
+        contents, str | bytes | bytearray
+    ):
+        result.extend(
+            _normalize_input_message(item)
+            if isinstance(item, Mapping)
+            else {"role": "user", "content": item}
+            for item in islice(contents, max(0, MAX_COLLECTION_ITEMS - len(result)))
+        )
+        return result
+    prompt = request.get("prompt")
+    if prompt is not None:
+        prompts = prompt if isinstance(prompt, list | tuple) else [prompt]
+        result.extend(
+            {"role": "user", "content": item}
+            for item in islice(prompts, max(0, MAX_COLLECTION_ITEMS - len(result)))
+        )
+        return result
+    response_input = request.get("input")
+    if isinstance(response_input, str):
+        result.append({"role": "user", "content": response_input})
+        return result
+    if isinstance(response_input, Sequence) and not isinstance(
+        response_input, str | bytes | bytearray
+    ):
+        result.extend(
+            _normalize_input_message(item)
+            if isinstance(item, Mapping)
+            else {"role": "user", "content": item}
+            for item in islice(
+                response_input, max(0, MAX_COLLECTION_ITEMS - len(result))
+            )
+        )
+    return result
+
+
+def _output_message(response: Any) -> dict[str, Any]:
+    if isinstance(response, str):
+        return {"role": "assistant", "content": response}
+    if not isinstance(response, Mapping):
+        return {"role": "assistant", "content": sanitize(response)}
+
+    choices = response.get("choices")
+    if isinstance(choices, Sequence) and not isinstance(choices, str) and choices:
+        first = choices[0]
+        if isinstance(first, Mapping):
+            message = first.get("message")
+            if isinstance(message, Mapping):
+                return dict(message)
+            text = first.get("text")
+            if text is not None:
+                return {"role": "assistant", "content": text}
+
+    candidates = response.get("candidates")
+    if (
+        isinstance(candidates, Sequence)
+        and not isinstance(candidates, str)
+        and candidates
+    ):
+        first_candidate = candidates[0]
+        if isinstance(first_candidate, Mapping):
+            candidate_content = first_candidate.get("content")
+            if isinstance(candidate_content, Mapping):
+                normalized = dict(_normalize_input_message(candidate_content))
+                normalized["role"] = "assistant"
+                return normalized
+
+    content = response.get("content")
+    if isinstance(content, Sequence) and not isinstance(content, str | bytes):
+        tool_calls: list[dict[str, Any]] = []
+        for item in content:
+            if not isinstance(item, Mapping):
+                continue
+            if item.get("type") == "tool_use" and isinstance(item.get("name"), str):
+                tool_call: dict[str, Any] = {
+                    "type": "function",
+                    "function": {
+                        "name": item["name"],
+                        "arguments": json_dumps(item.get("input", {})),
+                    },
+                }
+                if isinstance(item.get("id"), str):
+                    tool_call["id"] = item["id"]
+                tool_calls.append(tool_call)
+        message: dict[str, Any] = {
+            "role": response.get("role", "assistant"),
+            "content": json_dumps(content),
+        }
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        return message
+    if isinstance(content, str):
+        return {"role": response.get("role", "assistant"), "content": content}
+
+    output_text = response.get("output_text")
+    if isinstance(output_text, str):
+        return {"role": "assistant", "content": output_text}
+    return {"role": "assistant", "content": sanitize(response)}
+
+
+def _usage(response: Any) -> Mapping[str, Any]:
+    if not isinstance(response, Mapping):
+        return {}
+    usage = response.get("usage")
+    if isinstance(usage, Mapping):
+        return usage
+    usage_metadata = response.get("usageMetadata")
+    return usage_metadata if isinstance(usage_metadata, Mapping) else {}
+
+
+def _request_model(request: Mapping[str, Any]) -> str | None:
+    value = request.get("model")
+    return safe_text(value)[:128] if isinstance(value, str) else None
+
+
+def _response_model(response: Any) -> str | None:
+    if not isinstance(response, Mapping):
+        return None
+    for key in ("model", "modelVersion"):
+        value = response.get(key)
+        if isinstance(value, str):
+            return safe_text(value)[:128]
+    return None
+
+
+def _embedding_values(request: Mapping[str, Any], response: Any) -> tuple[Any, Any]:
+    input_value = request.get("input")
+    vectors: list[Any] = []
+    if isinstance(response, Mapping):
+        data = response.get("data")
+        if isinstance(data, Sequence) and not isinstance(data, str | bytes | bytearray):
+            vectors = [
+                item["embedding"]
+                for item in data
+                if isinstance(item, Mapping) and "embedding" in item
+            ]
+        elif "embedding" in response:
+            vectors = [response["embedding"]]
+        elif "embeddings" in response and isinstance(response["embeddings"], Sequence):
+            vectors = list(response["embeddings"])
+    output_value: Any = vectors[0] if len(vectors) == 1 else vectors
+    return input_value, output_value
+
+
+def _error_from_response(
+    response: Any,
+) -> tuple[str | None, int | None, str | None]:
+    if not isinstance(response, Mapping):
+        return None, None, None
+    status_value = response.get("status_code")
+    status = (
+        status_value
+        if isinstance(status_value, int) and not isinstance(status_value, bool)
+        else None
+    )
+    error = response.get("error")
+    if isinstance(error, Mapping):
+        message = error.get("message")
+        raw_type = error.get("type", error.get("code"))
+        error_type = (
+            safe_text(raw_type)
+            if isinstance(raw_type, str) and raw_type.strip()
+            else "HeliconeError"
+        )
+        return (
+            safe_text(message)
+            if isinstance(message, str)
+            else "Helicone operation failed",
+            status,
+            error_type,
+        )
+    if isinstance(error, str):
+        raw_type = response.get("type", response.get("error_type"))
+        error_type = (
+            safe_text(raw_type)
+            if isinstance(raw_type, str) and raw_type.strip()
+            else "HeliconeError"
+        )
+        return safe_text(error), status, error_type
+    if (
+        isinstance(response.get("status"), str)
+        and response["status"].lower() == "error"
+    ):
+        message = response.get("message")
+        raw_type = response.get("type", response.get("error_type"))
+        error_type = (
+            safe_text(raw_type)
+            if isinstance(raw_type, str) and raw_type.strip()
+            else safe_text(response["status"])
+        )
+        return (
+            safe_text(message)
+            if isinstance(message, str)
+            else "Helicone operation failed",
+            status,
+            error_type,
+        )
+    return None, status, None
+
+
+def _base_attrs(
+    *, log_type: str, entity_name: str, parent_id: str | None
+) -> dict[str, Any]:
+    return {
+        RESPAN_LOG_METHOD: LogMethodChoices.TRACING_INTEGRATION.value,
+        RESPAN_LOG_TYPE: log_type,
+        SpanAttributes.TRACELOOP_ENTITY_NAME: entity_name,
+        SpanAttributes.TRACELOOP_ENTITY_PATH: entity_name if parent_id else "",
+    }
+
+
+def _metadata_dict(value: Any) -> dict[str, Any]:
+    parsed = parse_json(value)
+    return dict(parsed) if isinstance(parsed, Mapping) else {}
+
+
+def _merge_metadata(attrs: dict[str, Any], update: Mapping[str, Any]) -> None:
+    metadata = _metadata_dict(attrs.get(RESPAN_METADATA))
+    for key, value in update.items():
+        if (
+            key == "helicone"
+            and isinstance(value, Mapping)
+            and isinstance(metadata.get(key), Mapping)
+        ):
+            helicone = dict(metadata[key])
+            for nested_key, nested_value in value.items():
+                if (
+                    nested_key == "properties"
+                    and isinstance(nested_value, Mapping)
+                    and isinstance(helicone.get(nested_key), Mapping)
+                ):
+                    properties = dict(helicone[nested_key])
+                    properties.update(nested_value)
+                    helicone[nested_key] = properties
+                else:
+                    helicone[nested_key] = nested_value
+            metadata[key] = helicone
+        else:
+            metadata[key] = value
+    if metadata:
+        attrs[RESPAN_METADATA] = json_dumps(metadata)
+
+
+def _otel_propagated_value(value: Any) -> Any:
+    if isinstance(value, bool | str | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else json_dumps(value)
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        if not value:
+            return json_dumps(value)
+        scalar_types = {type(item) for item in value}
+        if (
+            len(scalar_types) == 1
+            and scalar_types.pop() in {bool, str, int, float}
+            and all(
+                not isinstance(item, float) or math.isfinite(item) for item in value
+            )
+        ):
+            return tuple(value)
+    return json_dumps(value)
+
+
+def _apply_propagated_attributes(
+    attrs: dict[str, Any], propagated: Mapping[str, Any]
+) -> None:
+    metadata: dict[str, Any] = {}
+    prefix = f"{RESPAN_METADATA}."
+    for key, value in propagated.items():
+        if key == RESPAN_METADATA:
+            metadata.update(_metadata_dict(value))
+        elif key.startswith(prefix):
+            metadata[key.removeprefix(prefix)] = value
+        else:
+            attrs.setdefault(key, _otel_propagated_value(value))
+    _merge_metadata(attrs, metadata)
+
+
+def _apply_safe_options(
+    attrs: dict[str, Any],
+    options: Mapping[str, Any],
+    *,
+    constructor_headers: Any,
+    response: Any,
+) -> None:
+    merged_headers: dict[str, str] = {}
+    if isinstance(constructor_headers, Mapping):
+        merged_headers.update(
+            (key, value)
+            for key, value in constructor_headers.items()
+            if isinstance(key, str) and isinstance(value, str)
+        )
+    additional_headers = options.get("additional_headers")
+    if isinstance(additional_headers, Mapping):
+        merged_headers.update(
+            (key, value)
+            for key, value in additional_headers.items()
+            if isinstance(key, str) and isinstance(value, str)
+        )
+
+    helicone_metadata: dict[str, Any] = {}
+    properties: dict[str, str] = {}
+    for raw_name, raw_value in merged_headers.items():
+        name = raw_name.strip().lower()
+        if name == "helicone-session-id":
+            attrs[RESPAN_SESSION_ID] = safe_text(raw_value)
+        elif name == "helicone-user-id":
+            attrs[RESPAN_CUSTOMER_PARAMS_ID] = safe_text(raw_value)
+        elif name in {"helicone-session-name", "helicone-session-path"}:
+            suffix = name.removeprefix("helicone-").replace("-", "_")
+            helicone_metadata[suffix] = safe_text(raw_value)
+        elif name.startswith("helicone-property-"):
+            property_name = _label(name.removeprefix("helicone-property-"), "property")
+            if not is_sensitive_key(property_name):
+                properties[property_name] = safe_text(raw_value)
+    if properties:
+        helicone_metadata["properties"] = properties
+
+    ttft = options.get("time_to_first_token_ms")
+    if ttft is None and isinstance(response, Mapping):
+        ttft = response.get("time_to_first_token_ms")
+    if (
+        isinstance(ttft, int | float)
+        and not isinstance(ttft, bool)
+        and math.isfinite(float(ttft))
+        and ttft >= 0
+    ):
+        ttft_ms = float(ttft)
+        attrs[GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK] = ttft_ms / 1000
+        helicone_metadata["time_to_first_token_ms"] = ttft_ms
+    if helicone_metadata:
+        _merge_metadata(attrs, {"helicone": helicone_metadata})
+
+
+def _set_usage(attrs: dict[str, Any], response: Any) -> None:
+    usage = _usage(response)
+    input_tokens = _number(usage.get("input_tokens"))
+    if input_tokens is None:
+        input_tokens = _number(usage.get("prompt_tokens"))
+    if input_tokens is None:
+        input_tokens = _number(
+            usage.get("promptTokenCount", usage.get("inputTokenCount"))
+        )
+    output_tokens = _number(usage.get("output_tokens"))
+    if output_tokens is None:
+        output_tokens = _number(usage.get("completion_tokens"))
+    if output_tokens is None:
+        output_tokens = _number(
+            usage.get("candidatesTokenCount", usage.get("outputTokenCount"))
+        )
+    total_tokens = _number(usage.get("total_tokens"))
+    if total_tokens is None:
+        total_tokens = _number(usage.get("totalTokenCount"))
+    cache_read_tokens = _number(usage.get("cache_read_input_tokens"))
+    if cache_read_tokens is None:
+        cache_read_tokens = _number(usage.get("cache_read_tokens"))
+    prompt_details = usage.get("prompt_tokens_details")
+    if cache_read_tokens is None and isinstance(prompt_details, Mapping):
+        cache_read_tokens = _number(prompt_details.get("cached_tokens"))
+    if cache_read_tokens is None:
+        cache_read_tokens = _number(usage.get("cachedContentTokenCount"))
+    if total_tokens is None and input_tokens is not None and output_tokens is not None:
+        total_tokens = input_tokens + output_tokens
+    if input_tokens is not None:
+        attrs[GEN_AI_USAGE_INPUT_TOKENS] = input_tokens
+        attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = input_tokens
+    if output_tokens is not None:
+        attrs[GEN_AI_USAGE_OUTPUT_TOKENS] = output_tokens
+        attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = output_tokens
+    if total_tokens is not None:
+        attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = total_tokens
+    if cache_read_tokens is not None:
+        attrs[SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] = cache_read_tokens
+        attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] = cache_read_tokens
+
+
+def _llm_attrs(
+    request: Mapping[str, Any],
+    response: Any,
+    *,
+    provider: str | None,
+    parent_id: str | None,
+    capture_content: bool,
+    is_streaming_override: bool | None,
+) -> tuple[str, dict[str, Any]]:
+    is_embedding = request.get(HELICONE_TYPE_KEY) == HELICONE_TYPE_EMBEDDING or (
+        "input" in request
+        and isinstance(response, Mapping)
+        and isinstance(response.get("data"), Sequence)
+        and any(
+            isinstance(item, Mapping) and "embedding" in item
+            for item in response.get("data", [])
+        )
+    )
+    raw_messages = request.get("messages")
+    is_chat = isinstance(raw_messages, Sequence) and not isinstance(
+        raw_messages, str | bytes | bytearray
+    )
+    raw_contents = request.get("contents")
+    if isinstance(raw_contents, Sequence) and not isinstance(
+        raw_contents, str | bytes | bytearray
+    ):
+        is_chat = True
+    if not is_embedding and "input" in request and "prompt" not in request:
+        is_chat = True
+    log_type = (
+        LOG_TYPE_EMBEDDING
+        if is_embedding
+        else (LOG_TYPE_CHAT if is_chat else LOG_TYPE_TEXT)
+    )
+    entity_name = {
+        LOG_TYPE_EMBEDDING: "helicone.manual.embedding",
+        LOG_TYPE_CHAT: "helicone.manual.chat",
+        LOG_TYPE_TEXT: "helicone.manual.text",
+    }[log_type]
+    attrs = _base_attrs(log_type=log_type, entity_name=entity_name, parent_id=parent_id)
+    provider_name = _label(provider or request.get("provider"), "custom")
+    attrs[SpanAttributes.LLM_SYSTEM] = provider_name
+    attrs[GEN_AI_PROVIDER_NAME] = provider_name
+    attrs[SpanAttributes.LLM_REQUEST_TYPE] = "embedding" if is_embedding else "chat"
+    is_streaming = (
+        bool(is_streaming_override)
+        if is_streaming_override is not None
+        else bool(request.get("stream"))
+    )
+    attrs[GEN_AI_REQUEST_STREAM] = is_streaming
+    attrs[SpanAttributes.GEN_AI_IS_STREAMING] = is_streaming
+    request_model = _request_model(request)
+    response_model = _response_model(response)
+    if request_model:
+        attrs[SpanAttributes.LLM_REQUEST_MODEL] = request_model
+    if response_model:
+        attrs[SpanAttributes.LLM_RESPONSE_MODEL] = response_model
+    _set_usage(attrs, response)
+
+    if not capture_content:
+        return "embedding" if is_embedding else "llm", attrs
+
+    if is_embedding:
+        embedding_input, embedding_output = _embedding_values(request, response)
+        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_dumps(
+            embedding_input, preserve_large_vectors=True
+        )
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_dumps(
+            embedding_output, preserve_large_vectors=True
+        )
+    else:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_dumps(request)
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_dumps(response)
+    for index, message in enumerate(_messages(request)):
+        role = message.get("role")
+        content = message.get("content")
+        attrs[f"{_PROMPT_PREFIX}{index}.role"] = _canonical_role(role, "user")
+        if content is not None:
+            attrs[f"{_PROMPT_PREFIX}{index}.content"] = (
+                safe_text(content) if isinstance(content, str) else json_dumps(content)
+            )
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            attrs[f"{_PROMPT_PREFIX}{index}.tool_calls"] = json_dumps(tool_calls)
+    tools = request.get("tools")
+    if isinstance(tools, Sequence) and not isinstance(tools, str | bytes):
+        attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS] = json_dumps(tools)
+    if not is_embedding:
+        output_message = _output_message(response)
+        attrs[f"{_COMPLETION_PREFIX}0.role"] = "assistant"
+        content = output_message.get("content")
+        if content is not None:
+            attrs[f"{_COMPLETION_PREFIX}0.content"] = (
+                safe_text(content) if isinstance(content, str) else json_dumps(content)
+            )
+        tool_calls = output_message.get("tool_calls")
+        if tool_calls:
+            attrs[_COMPLETION_TOOL_CALLS] = json_dumps(tool_calls)
+    return "embedding" if is_embedding else "llm", attrs
+
+
+def _custom_attrs(
+    request: Mapping[str, Any],
+    response: Any,
+    *,
+    parent_id: str | None,
+    capture_content: bool,
+) -> tuple[str, dict[str, Any]]:
+    event_type = request.get(HELICONE_TYPE_KEY)
+    if event_type == HELICONE_TYPE_TOOL:
+        name = _display_text(
+            request.get(HELICONE_TOOL_NAME_KEY) or request.get("name"), "tool"
+        )
+        attrs = _base_attrs(
+            log_type=LOG_TYPE_TOOL, entity_name=name, parent_id=parent_id
+        )
+        attrs[RESPAN_INTERNAL_SPAN_NAME_KIND] = "tool"
+        attrs[RESPAN_INTERNAL_SPAN_NAME_DETAIL] = name
+        if capture_content:
+            arguments = request.get("input", request.get("arguments", request))
+            attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_dumps(
+                {"name": name, "arguments": arguments}
+            )
+            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_dumps(response)
+        return "tool", attrs
+
+    if event_type == HELICONE_TYPE_VECTOR_DB:
+        operation = _label(request.get(HELICONE_OPERATION_KEY), "operation")
+        attrs = _base_attrs(
+            log_type=LOG_TYPE_TASK,
+            entity_name=f"vector_db.{operation}",
+            parent_id=parent_id,
+        )
+        if capture_content:
+            attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_dumps(
+                request, preserve_large_vectors=True
+            )
+            attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_dumps(
+                response, preserve_large_vectors=True
+            )
+        return "task", attrs
+
+    name = _display_text(request.get(HELICONE_DATA_NAME_KEY), "custom_data")
+    attrs = _base_attrs(log_type=LOG_TYPE_TASK, entity_name=name, parent_id=parent_id)
+    if capture_content:
+        attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT] = json_dumps(request)
+        attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = json_dumps(response)
+    return "task", attrs
+
+
+def emit_helicone_log(
+    *,
+    provider: str | None,
+    request: Any,
+    response: Any,
+    options: Any,
+    capture_content: bool,
+    error: BaseException | None = None,
+    status_code: int | None = None,
+    is_streaming: bool | None = None,
+    context_snapshot: HeliconeEmissionContext | None = None,
+    constructor_headers: Any = None,
+) -> bool:
+    """Emit one Helicone sink call while never changing SDK behavior."""
+
+    try:
+        request_map = request if isinstance(request, Mapping) else {"value": request}
+        inferred_streaming = is_streaming
+        if inferred_streaming is None:
+            inferred_streaming = (
+                bool(request_map.get("stream"))
+                or (
+                    isinstance(response, Mapping)
+                    and isinstance(response.get("chunks"), Sequence)
+                    and not isinstance(response.get("chunks"), str | bytes | bytearray)
+                )
+                or (
+                    isinstance(response, Sequence)
+                    and not isinstance(response, str | bytes | bytearray)
+                )
+            )
+        normalized_response = _normalized_response(response)
+        effective_context = context_snapshot or capture_emission_context()
+        trace_id = effective_context.trace_id
+        parent_id = effective_context.parent_id
+        event_type = request_map.get(HELICONE_TYPE_KEY)
+        if event_type in {
+            HELICONE_TYPE_TOOL,
+            HELICONE_TYPE_VECTOR_DB,
+            HELICONE_TYPE_DATA,
+        }:
+            semantic_kind, attrs = _custom_attrs(
+                request_map,
+                normalized_response,
+                parent_id=parent_id,
+                capture_content=capture_content,
+            )
+        elif provider is not None or any(
+            key in request_map for key in ("model", "messages", "prompt", "input")
+        ):
+            semantic_kind, attrs = _llm_attrs(
+                request_map,
+                normalized_response,
+                provider=provider,
+                parent_id=parent_id,
+                capture_content=capture_content,
+                is_streaming_override=inferred_streaming,
+            )
+        else:
+            semantic_kind, attrs = _custom_attrs(
+                request_map,
+                normalized_response,
+                parent_id=parent_id,
+                capture_content=capture_content,
+            )
+
+        options_map = options if isinstance(options, Mapping) else {}
+        _apply_safe_options(
+            attrs,
+            options_map,
+            constructor_headers=constructor_headers,
+            response=normalized_response,
+        )
+        _apply_propagated_attributes(attrs, effective_context.propagated_attributes)
+
+        response_error, response_status, response_error_type = _error_from_response(
+            normalized_response
+        )
+        message = exception_message(error) if error is not None else response_error
+        error_type = safe_type_name(error) if error is not None else response_error_type
+        if status_code is not None:
+            resolved_status = status_code
+        elif response_status is not None and response_status >= 400:
+            resolved_status = response_status
+        elif message:
+            resolved_status = 500
+        else:
+            resolved_status = response_status or 200
+        attrs[HTTP_RESPONSE_STATUS_CODE] = resolved_status
+        if message:
+            attrs[ERROR_MESSAGE] = message
+            attrs[ERROR_TYPE] = error_type or "HeliconeError"
+
+        now = time.time()
+        start = _seconds(options_map.get("start_time"), now)
+        end = _seconds(options_map.get("end_time"), now)
+        end = max(end, start)
+        model = attrs.get(SpanAttributes.LLM_REQUEST_MODEL) or attrs.get(
+            SpanAttributes.LLM_RESPONSE_MODEL
+        )
+        span_name = (
+            f"llm.{model}"
+            if semantic_kind == "llm" and isinstance(model, str)
+            else semantic_kind
+        )
+        span = build_readable_span(
+            name=span_name,
+            trace_id=trace_id,
+            parent_id=parent_id,
+            start_time_ns=int(start * 1_000_000_000),
+            end_time_ns=int(end * 1_000_000_000),
+            attributes=attrs,
+            status_code=resolved_status,
+            error_message=message,
+            merge_propagated=False,
+        )
+        return inject_span(span=span)
+    except BaseException:
+        logger.debug("Failed to emit Helicone manual logger span", exc_info=True)
+        return False

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/_instrumentation.py
@@ -1,0 +1,408 @@
+"""Lifecycle-safe patching for Helicone's Python manual logger."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+import threading
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any
+
+from respan_tracing.core.tracer import RespanTracer
+
+from respan_instrumentation_helicone._constants import (
+    HELICONE_BUILDER_CONTEXT_ATTR,
+    HELICONE_HELPERS_MODULE,
+    HELICONE_INSTRUMENTATION_NAME,
+    HELICONE_LOG_BUILDER_CLASS,
+    HELICONE_MANUAL_LOGGER_CLASS,
+)
+from respan_instrumentation_helicone._emitter import (
+    HeliconeEmissionContext,
+    capture_emission_context,
+    emit_helicone_log,
+)
+from respan_instrumentation_helicone._serialization import safe_text, safe_type_name
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.RLock()
+_REFCOUNT = 0
+_CONFIG: tuple[bool] | None = None
+_ORIGINAL_METHODS: dict[tuple[type[Any], str], Any] = {}
+_INSTALLED_METHODS: dict[tuple[type[Any], str], Any] = {}
+
+
+@dataclass
+class _PatchGeneration:
+    capture_content: bool
+    enabled: bool = True
+
+
+@dataclass
+class _LogRequestState:
+    start_time: float
+    terminal_sink_calls: int = 0
+    in_operation: bool = False
+
+
+@dataclass(frozen=True)
+class _BuilderState:
+    error: BaseException | None
+    status_code: int
+    is_streaming: bool
+    context_snapshot: HeliconeEmissionContext | None
+
+
+_GENERATION: _PatchGeneration | None = None
+_CURRENT_LOG_REQUEST: ContextVar[_LogRequestState | None] = ContextVar(
+    "respan_helicone_log_request", default=None
+)
+_CURRENT_BUILDER: ContextVar[_BuilderState | None] = ContextVar(
+    "respan_helicone_builder", default=None
+)
+
+
+def _tracing_enabled() -> bool:
+    tracer = getattr(RespanTracer, "_instance", None)
+    return tracer is None or bool(getattr(tracer, "is_enabled", True))
+
+
+def _load_classes() -> tuple[type[Any], type[Any]]:
+    module = importlib.import_module(HELICONE_HELPERS_MODULE)
+    return (
+        getattr(module, HELICONE_MANUAL_LOGGER_CLASS),
+        getattr(module, HELICONE_LOG_BUILDER_CLASS),
+    )
+
+
+def _builder_error(value: Any) -> BaseException | None:
+    if value is None:
+        return None
+    if isinstance(value, BaseException):
+        return value
+    if isinstance(value, str):
+        return RuntimeError(safe_text(value))
+    return RuntimeError(safe_type_name(value))
+
+
+def _builder_status(builder: Any, error: BaseException | None) -> int:
+    if bool(getattr(builder, "was_cancelled", False)):
+        return 499
+    status = getattr(builder, "status", None)
+    if (
+        isinstance(status, int)
+        and not isinstance(status, bool)
+        and 400 <= status <= 599
+    ):
+        return status
+    return 500 if error is not None else 200
+
+
+def _make_send_log_wrapper(original: Any, generation: _PatchGeneration) -> Any:
+    @wraps(original)
+    def wrapper(
+        instance: Any,
+        provider: str | None,
+        request: dict,
+        response: dict | str,
+        options: Any,
+    ) -> Any:
+        if not generation.enabled:
+            return original(instance, provider, request, response, options)
+        request_state = _CURRENT_LOG_REQUEST.get()
+        is_terminal_sink = request_state is not None and not request_state.in_operation
+        if is_terminal_sink:
+            if request_state.terminal_sink_calls:
+                return original(instance, provider, request, response, options)
+            request_state.terminal_sink_calls += 1
+        builder_state = _CURRENT_BUILDER.get()
+        constructor_headers = getattr(instance, "headers", None)
+        try:
+            result = original(instance, provider, request, response, options)
+        except BaseException as exc:
+            emit_helicone_log(
+                provider=provider,
+                request=request,
+                response=response,
+                options=options,
+                capture_content=generation.capture_content,
+                error=exc,
+                status_code=500,
+                constructor_headers=constructor_headers,
+            )
+            raise
+        emit_helicone_log(
+            provider=provider,
+            request=request,
+            response=response,
+            options=options,
+            capture_content=generation.capture_content,
+            error=builder_state.error if builder_state is not None else None,
+            status_code=(
+                builder_state.status_code if builder_state is not None else None
+            ),
+            is_streaming=(
+                builder_state.is_streaming if builder_state is not None else None
+            ),
+            context_snapshot=(
+                builder_state.context_snapshot if builder_state is not None else None
+            ),
+            constructor_headers=constructor_headers,
+        )
+        return result
+
+    wrapper.__respan_helicone_wrapper__ = True
+    return wrapper
+
+
+def _make_log_request_wrapper(original: Any, generation: _PatchGeneration) -> Any:
+    @wraps(original)
+    def wrapper(
+        instance: Any,
+        request: dict,
+        operation: Any,
+        additional_headers: dict | None = None,
+        provider: str | None = None,
+    ) -> Any:
+        resolved_headers = additional_headers or {}
+        if not generation.enabled:
+            return original(
+                instance,
+                request,
+                operation,
+                additional_headers=resolved_headers,
+                provider=provider,
+            )
+        state = _LogRequestState(start_time=time.time())
+
+        @wraps(operation)
+        def observed_operation(recorder: Any) -> Any:
+            state.in_operation = True
+            try:
+                return operation(recorder)
+            finally:
+                state.in_operation = False
+
+        token = _CURRENT_LOG_REQUEST.set(state)
+        try:
+            return original(
+                instance,
+                request,
+                observed_operation,
+                additional_headers=resolved_headers,
+                provider=provider,
+            )
+        except BaseException as exc:
+            if state.terminal_sink_calls == 0:
+                emit_helicone_log(
+                    provider=provider,
+                    request=request,
+                    response={
+                        "status": "error",
+                        "error": {"type": type(exc).__name__},
+                    },
+                    options={
+                        "start_time": state.start_time,
+                        "end_time": time.time(),
+                        "additional_headers": resolved_headers,
+                    },
+                    capture_content=generation.capture_content,
+                    error=exc,
+                    status_code=500,
+                    constructor_headers=getattr(instance, "headers", None),
+                )
+            raise
+        finally:
+            _CURRENT_LOG_REQUEST.reset(token)
+
+    wrapper.__respan_helicone_wrapper__ = True
+    return wrapper
+
+
+def _make_builder_send_log_wrapper(original: Any, generation: _PatchGeneration) -> Any:
+    @wraps(original)
+    async def wrapper(instance: Any, *args: Any, **kwargs: Any) -> Any:
+        if not generation.enabled:
+            result = original(instance, *args, **kwargs)
+            return await result if inspect.isawaitable(result) else result
+        error = _builder_error(getattr(instance, "error", None))
+        state = _BuilderState(
+            error=error,
+            status_code=_builder_status(instance, error),
+            is_streaming=(
+                bool(getattr(instance, "stream_chunks", None))
+                or bool(getattr(instance, "request", {}).get("stream"))
+            ),
+            context_snapshot=getattr(instance, HELICONE_BUILDER_CONTEXT_ATTR, None),
+        )
+        token = _CURRENT_BUILDER.set(state)
+        try:
+            result = original(instance, *args, **kwargs)
+            return await result if inspect.isawaitable(result) else result
+        finally:
+            _CURRENT_BUILDER.reset(token)
+
+    wrapper.__respan_helicone_wrapper__ = True
+    return wrapper
+
+
+def _make_log_builder_wrapper(original: Any, generation: _PatchGeneration) -> Any:
+    @wraps(original)
+    def wrapper(instance: Any, *args: Any, **kwargs: Any) -> Any:
+        if not generation.enabled:
+            return original(instance, *args, **kwargs)
+        snapshot = capture_emission_context()
+        builder = original(instance, *args, **kwargs)
+        try:
+            setattr(builder, HELICONE_BUILDER_CONTEXT_ATTR, snapshot)
+        except BaseException:
+            logger.debug("Failed to attach Helicone builder context", exc_info=True)
+        return builder
+
+    wrapper.__respan_helicone_wrapper__ = True
+    return wrapper
+
+
+def _patch(
+    target: type[Any],
+    method_name: str,
+    factory: Any,
+    generation: _PatchGeneration,
+) -> None:
+    key = (target, method_name)
+    if key in _ORIGINAL_METHODS:
+        return
+    original = getattr(target, method_name)
+    installed = factory(original, generation)
+    _ORIGINAL_METHODS[key] = original
+    try:
+        setattr(target, method_name, installed)
+    except BaseException:
+        _ORIGINAL_METHODS.pop(key, None)
+        raise
+    _INSTALLED_METHODS[key] = installed
+
+
+def _restore_all() -> None:
+    for key, original in list(_ORIGINAL_METHODS.items())[::-1]:
+        target, method_name = key
+        installed = _INSTALLED_METHODS.get(key)
+        try:
+            current = getattr(target, method_name)
+        except BaseException:
+            logger.debug("Failed to inspect Helicone patch", exc_info=True)
+            continue
+        if current is installed:
+            try:
+                setattr(target, method_name, original)
+            except BaseException:
+                logger.debug("Failed to restore Helicone patch", exc_info=True)
+                continue
+        _ORIGINAL_METHODS.pop(key, None)
+        _INSTALLED_METHODS.pop(key, None)
+
+
+def _install_all(generation: _PatchGeneration) -> None:
+    logger_class, builder_class = _load_classes()
+    installed_before = set(_ORIGINAL_METHODS)
+    try:
+        _patch(logger_class, "send_log", _make_send_log_wrapper, generation)
+        _patch(logger_class, "log_request", _make_log_request_wrapper, generation)
+        _patch(logger_class, "log_builder", _make_log_builder_wrapper, generation)
+        _patch(builder_class, "send_log", _make_builder_send_log_wrapper, generation)
+    except BaseException:
+        for key in set(_ORIGINAL_METHODS) - installed_before:
+            target, method_name = key
+            original = _ORIGINAL_METHODS.get(key)
+            installed = _INSTALLED_METHODS.get(key)
+            if original is not None and getattr(target, method_name, None) is installed:
+                try:
+                    setattr(target, method_name, original)
+                except BaseException:
+                    logger.debug("Failed to roll back Helicone patch", exc_info=True)
+            _ORIGINAL_METHODS.pop(key, None)
+            _INSTALLED_METHODS.pop(key, None)
+        raise
+
+
+class HeliconeInstrumentor:
+    """Instrument one shared `helicone-helpers` manual logger runtime."""
+
+    name = HELICONE_INSTRUMENTATION_NAME
+
+    def __init__(self, *, capture_content: bool = True) -> None:
+        self._capture_content = bool(capture_content)
+        self._is_instrumented = False
+
+    def activate(self) -> None:
+        global _CONFIG, _GENERATION, _REFCOUNT
+
+        if self._is_instrumented:
+            return
+        if not _tracing_enabled():
+            logger.info(
+                "Helicone instrumentation skipped because Respan tracing is disabled"
+            )
+            return
+        with _LOCK:
+            if self._is_instrumented:
+                return
+            requested_config = (self._capture_content,)
+            if _REFCOUNT:
+                if _CONFIG != requested_config:
+                    logger.error(
+                        "Helicone instrumentation is already active with a different "
+                        "capture_content setting"
+                    )
+                    return
+                _REFCOUNT += 1
+                self._is_instrumented = True
+                return
+            generation = _PatchGeneration(capture_content=self._capture_content)
+            try:
+                _install_all(generation)
+            except ImportError as exc:
+                logger.warning(
+                    "Failed to activate Helicone instrumentation - missing dependency: %s",
+                    exc,
+                )
+                return
+            except BaseException:
+                generation.enabled = False
+                logger.exception("Failed to activate Helicone instrumentation")
+                return
+            _CONFIG = requested_config
+            _GENERATION = generation
+            _REFCOUNT = 1
+            self._is_instrumented = True
+            logger.info("Helicone instrumentation activated")
+
+    def deactivate(self) -> None:
+        global _CONFIG, _GENERATION, _REFCOUNT
+
+        if not self._is_instrumented:
+            return
+        with _LOCK:
+            if not self._is_instrumented:
+                return
+            self._is_instrumented = False
+            _REFCOUNT = max(0, _REFCOUNT - 1)
+            if _REFCOUNT:
+                return
+            if _GENERATION is not None:
+                _GENERATION.enabled = False
+            _restore_all()
+            _CONFIG = None
+            _GENERATION = None
+            logger.info("Helicone instrumentation deactivated")
+
+    def instrument(self) -> None:
+        self.activate()
+
+    def uninstrument(self) -> None:
+        self.deactivate()

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/_serialization.py
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/src/respan_instrumentation_helicone/_serialization.py
@@ -1,0 +1,377 @@
+"""Bounded, secret-safe serialization for Helicone payloads."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from itertools import islice
+from numbers import Integral, Real
+from typing import Any
+
+from respan_instrumentation_helicone._constants import (
+    MAX_ATTRIBUTE_BYTES,
+    MAX_COLLECTION_ITEMS,
+    MAX_DEPTH,
+    MAX_TEXT_BYTES,
+)
+
+_SENSITIVE_KEYS = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "authorization",
+        "cookie",
+        "credentials",
+        "credential",
+        "helicone_auth",
+        "password",
+        "passwd",
+        "private_key",
+        "secret",
+        "set_cookie",
+        "token",
+    }
+)
+_SENSITIVE_SUFFIXES = (
+    "access_key_id",
+    "api_key",
+    "auth_token",
+    "authorization",
+    "bearer_token",
+    "client_secret",
+    "cookie",
+    "credential",
+    "credentials",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "session_token",
+    "secret_access_key",
+    "secret_key",
+    "token",
+    "access_token",
+    "id_token",
+)
+_KEY_VALUE = re.compile(
+    r"(?i)(?P<prefix>[\"']?(?P<key>[A-Za-z][A-Za-z0-9_-]*)[\"']?\s*[:=]\s*)"
+    r'(?:"(?P<double>(?:\\.|[^"\\])*)"|'
+    r"'(?P<single>(?:\\.|[^'\\])*)'|"
+    r"(?P<bare>[^\s}\[{]+))"
+)
+_BEARER = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+")
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_AUTHORIZATION_VALUE = re.compile(
+    r'(?im)(?P<prefix>(?<!["\'])\bauthorization\s*[:=]\s*)[^\r\n}]*'
+)
+
+
+def truncate_utf8(value: str, limit: int = MAX_TEXT_BYTES) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit:
+        return value
+    suffix = "...[truncated]"
+    budget = max(0, limit - len(suffix.encode("utf-8")))
+    return encoded[:budget].decode("utf-8", errors="ignore") + suffix
+
+
+_SENSITIVE_PREFIXES = ("password_", "secret_")
+
+
+def _redact_json_value(value: Any, *, depth: int) -> Any:
+    if depth >= MAX_DEPTH:
+        return {"type": safe_type_name(value), "truncated": True}
+    if isinstance(value, Mapping):
+        result = {
+            key: (
+                "<redacted>"
+                if isinstance(key, str) and is_sensitive_key(key)
+                else _redact_json_value(item, depth=depth + 1)
+            )
+            for key, item in islice(value.items(), MAX_COLLECTION_ITEMS)
+        }
+        if len(value) > MAX_COLLECTION_ITEMS:
+            result["_truncated"] = True
+        return result
+    if isinstance(value, list):
+        result = [
+            _redact_json_value(item, depth=depth + 1)
+            for item in islice(value, MAX_COLLECTION_ITEMS)
+        ]
+        if len(value) > MAX_COLLECTION_ITEMS:
+            result.append({"truncated": True})
+        return result
+    if isinstance(value, str):
+        return safe_text(value, _depth=depth + 1)
+    return value
+
+
+def _redact_free_text(value: str, *, depth: int = 0) -> str:
+    redacted = _AUTHORIZATION_VALUE.sub(
+        lambda match: f"{match.group('prefix')}<redacted>", value
+    )
+    redacted = _BEARER.sub("Bearer <redacted>", redacted)
+    if depth >= MAX_DEPTH:
+        return "<redacted>" if _KEY_VALUE.search(redacted) else redacted
+
+    def replace_secret(match: re.Match[str]) -> str:
+        is_sensitive = is_sensitive_key(match.group("key"))
+        if match.group("double") is not None:
+            inner = (
+                "<redacted>"
+                if is_sensitive
+                else _redact_free_text(match.group("double"), depth=depth + 1)
+            )
+            replacement = f'"{inner}"'
+        elif match.group("single") is not None:
+            inner = (
+                "<redacted>"
+                if is_sensitive
+                else _redact_free_text(match.group("single"), depth=depth + 1)
+            )
+            replacement = f"'{inner}'"
+        else:
+            replacement = (
+                "<redacted>"
+                if is_sensitive
+                else _redact_free_text(match.group("bare"), depth=depth + 1)
+            )
+        return f"{match.group('prefix')}{replacement}"
+
+    return _KEY_VALUE.sub(replace_secret, redacted)
+
+
+def safe_text(value: str, *, _depth: int = 0) -> str:
+    if _depth >= MAX_DEPTH:
+        return truncate_utf8(_redact_free_text(value, depth=_depth))
+    try:
+        parsed = json.loads(value)
+    except (RecursionError, TypeError, ValueError):
+        parsed = None
+    if isinstance(parsed, Mapping | list):
+        redacted = json.dumps(
+            _redact_json_value(parsed, depth=_depth),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    elif isinstance(parsed, str):
+        redacted = json.dumps(
+            _redact_free_text(parsed, depth=_depth + 1),
+            ensure_ascii=False,
+        )
+    else:
+        redacted = _redact_free_text(value, depth=_depth)
+    return truncate_utf8(redacted)
+
+
+def safe_type_name(value: Any) -> str:
+    value_type = value if isinstance(value, type) else type(value)
+    module = getattr(value_type, "__module__", "")
+    name = getattr(value_type, "__qualname__", None) or getattr(
+        value_type, "__name__", "object"
+    )
+    resolved = f"{module}.{name}" if module and module != "builtins" else name
+    return re.sub(r"[^A-Za-z0-9_.-]+", ".", resolved).strip(".")[:256] or "object"
+
+
+def is_sensitive_key(value: str) -> bool:
+    normalized = _CAMEL_BOUNDARY.sub("_", value.strip()).lower().replace("-", "_")
+    return (
+        normalized in _SENSITIVE_KEYS
+        or normalized.startswith(_SENSITIVE_PREFIXES)
+        or any(
+            normalized == suffix or normalized.endswith(f"_{suffix}")
+            for suffix in _SENSITIVE_SUFFIXES
+        )
+    )
+
+
+def _is_numeric_vector(value: Sequence[Any]) -> bool:
+    if not value:
+        return False
+    return all(isinstance(item, Real) and not isinstance(item, bool) for item in value)
+
+
+def _numeric_vector(value: Sequence[Any]) -> list[float | None]:
+    return [float(item) if math.isfinite(float(item)) else None for item in value]
+
+
+def _budgeted_text(value: str, budget: list[int]) -> str:
+    safe_value = safe_text(value)
+    available = max(0, min(MAX_TEXT_BYTES, budget[0]))
+    if available == 0:
+        return ""
+    result = truncate_utf8(safe_value, available)
+    budget[0] = max(0, budget[0] - len(result.encode("utf-8")))
+    return result
+
+
+def _sanitize_preserving_vectors(
+    value: Any,
+    *,
+    budget: list[int],
+    depth: int = 0,
+    allow_numeric_vector: bool = False,
+) -> Any:
+    """Preserve numeric vectors while bounding all surrounding context."""
+
+    if depth >= MAX_DEPTH:
+        return {"type": safe_type_name(value), "truncated": True}
+    if value is None or isinstance(value, bool):
+        budget[0] = max(0, budget[0] - 5)
+        return value
+    if isinstance(value, str):
+        return _budgeted_text(value, budget)
+    if isinstance(value, Integral):
+        budget[0] = max(0, budget[0] - 24)
+        return int(value)
+    if isinstance(value, Real):
+        budget[0] = max(0, budget[0] - 32)
+        return float(value) if math.isfinite(float(value)) else None
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        consumed = 0
+        for key, item in islice(value.items(), MAX_COLLECTION_ITEMS):
+            if budget[0] <= 0:
+                break
+            raw_key_text = key if isinstance(key, str) else safe_type_name(key)
+            is_sensitive = is_sensitive_key(raw_key_text)
+            key_text = safe_text(raw_key_text) if isinstance(key, str) else raw_key_text
+            key_text = _budgeted_text(key_text, budget)
+            if not key_text:
+                break
+            result[key_text] = (
+                "<redacted>"
+                if is_sensitive
+                else _sanitize_preserving_vectors(
+                    item,
+                    budget=budget,
+                    depth=depth + 1,
+                    allow_numeric_vector=key_text.lower()
+                    in {"vector", "vectors", "embedding", "embeddings"},
+                )
+            )
+            consumed += 1
+        if consumed < len(value):
+            result["_truncated"] = True
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, bytes | bytearray):
+        if allow_numeric_vector and _is_numeric_vector(value):
+            return _numeric_vector(value)
+        is_vector_batch = allow_numeric_vector and all(
+            isinstance(item, Sequence)
+            and not isinstance(item, str | bytes | bytearray)
+            and _is_numeric_vector(item)
+            for item in value
+        )
+        items: list[Any] = []
+        consumed = 0
+        limit = len(value) if is_vector_batch else MAX_COLLECTION_ITEMS
+        for item in islice(value, limit):
+            if budget[0] <= 0 and not is_vector_batch:
+                break
+            items.append(
+                _sanitize_preserving_vectors(
+                    item,
+                    budget=budget,
+                    depth=depth + 1,
+                    allow_numeric_vector=allow_numeric_vector,
+                )
+            )
+            consumed += 1
+        if consumed < len(value):
+            items.append({"truncated": True})
+        return items
+    return {"type": _budgeted_text(safe_type_name(value), budget)}
+
+
+def sanitize(
+    value: Any, *, depth: int = 0, preserve_large_sequences: bool = False
+) -> Any:
+    if depth >= MAX_DEPTH:
+        return {"type": safe_type_name(value), "truncated": True}
+    if value is None or isinstance(value, bool | str):
+        return safe_text(value) if isinstance(value, str) else value
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, Real):
+        return float(value) if math.isfinite(float(value)) else None
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        for key, item in islice(value.items(), MAX_COLLECTION_ITEMS):
+            raw_key_text = key if isinstance(key, str) else safe_type_name(key)
+            is_sensitive = is_sensitive_key(raw_key_text)
+            key_text = safe_text(raw_key_text) if isinstance(key, str) else raw_key_text
+            result[key_text] = (
+                "<redacted>"
+                if is_sensitive
+                else sanitize(
+                    item,
+                    depth=depth + 1,
+                    preserve_large_sequences=preserve_large_sequences,
+                )
+            )
+        if len(value) > MAX_COLLECTION_ITEMS:
+            result["_truncated"] = True
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, bytes | bytearray):
+        if preserve_large_sequences and _is_numeric_vector(value):
+            return _numeric_vector(value)
+        items = [
+            sanitize(
+                item,
+                depth=depth + 1,
+                preserve_large_sequences=preserve_large_sequences,
+            )
+            for item in islice(value, MAX_COLLECTION_ITEMS)
+        ]
+        if len(value) > MAX_COLLECTION_ITEMS:
+            items.append({"truncated": True})
+        return items
+    return {"type": safe_type_name(value)}
+
+
+def json_dumps(value: Any, *, preserve_large_vectors: bool = False) -> str:
+    sanitized = (
+        _sanitize_preserving_vectors(
+            value,
+            budget=[MAX_ATTRIBUTE_BYTES // 2],
+            allow_numeric_vector=not isinstance(value, Mapping),
+        )
+        if preserve_large_vectors
+        else sanitize(value)
+    )
+    encoded = json.dumps(
+        sanitized,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if preserve_large_vectors or len(encoded.encode("utf-8")) <= MAX_ATTRIBUTE_BYTES:
+        return encoded
+    preview = truncate_utf8(encoded, MAX_ATTRIBUTE_BYTES - 64)
+    return json.dumps(
+        {"preview": preview, "truncated": True},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def parse_json(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def exception_message(error: BaseException) -> str:
+    for argument in getattr(error, "args", ()):
+        if isinstance(argument, str) and argument:
+            return safe_text(argument)
+    return safe_type_name(error)

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/tests/test_emitter_contract.py
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/tests/test_emitter_contract.py
@@ -1,0 +1,1126 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from opentelemetry.semconv._incubating.attributes.error_attributes import (
+    ERROR_MESSAGE,
+    ERROR_TYPE,
+)
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
+from opentelemetry.semconv.attributes.http_attributes import (
+    HTTP_RESPONSE_STATUS_CODE,
+)
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_instrumentation_helicone import _emitter, _serialization
+from respan_sdk.constants.llm_logging import LogMethodChoices
+from respan_sdk.constants.otlp_constants import (
+    OTLP_ATTR_KEY,
+    OTLP_ATTRIBUTES_KEY,
+    OTLP_NAME_KEY,
+    OTLP_PARENT_SPAN_ID_KEY,
+)
+from respan_sdk.constants.span_attributes import (
+    RESPAN_CUSTOMER_PARAMS_ID,
+    RESPAN_INTERNAL_SPAN_NAME_DETAIL,
+    RESPAN_INTERNAL_SPAN_NAME_KIND,
+    RESPAN_LOG_METHOD,
+    RESPAN_LOG_TYPE,
+    RESPAN_METADATA,
+    RESPAN_PROPERTIES,
+    RESPAN_SESSION_ID,
+)
+from respan_tracing.exporters.respan import _span_to_otlp_json
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    spans = []
+    monkeypatch.setattr(
+        _emitter, "inject_span", lambda span: spans.append(span) or True
+    )
+    return spans
+
+
+def emit(captured, *, request, response, provider=None, error=None, capture=True):
+    assert _emitter.emit_helicone_log(
+        provider=provider,
+        request=request,
+        response=response,
+        options={"start_time": 10.0, "end_time": 11.0},
+        capture_content=capture,
+        error=error,
+    )
+    assert len(captured) == 1
+    return captured[0]
+
+
+def test_openai_chat_contract_tools_usage_and_no_aliases(captured):
+    span = emit(
+        captured,
+        provider="openai",
+        request={
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "weather"}],
+            "tools": [{"type": "function", "function": {"name": "weather"}}],
+            "api_key": "request-secret",
+        },
+        response={
+            "model": "gpt-test",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "weather",
+                                    "arguments": '{"city":"Tokyo"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        },
+    )
+    attrs = span.attributes
+
+    assert attrs[RESPAN_LOG_TYPE] == "chat"
+    assert attrs[RESPAN_LOG_METHOD] == LogMethodChoices.TRACING_INTEGRATION.value
+    assert attrs[SpanAttributes.LLM_SYSTEM] == "openai"
+    assert attrs[GEN_AI_PROVIDER_NAME] == "openai"
+    assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "gpt-test"
+    assert attrs[GEN_AI_USAGE_INPUT_TOKENS] == 10
+    assert attrs[GEN_AI_USAGE_OUTPUT_TOKENS] == 5
+    assert attrs[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 10
+    assert attrs[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 5
+    assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 15
+    assert attrs[HTTP_RESPONSE_STATUS_CODE] == 200
+    assert "status_code" not in attrs
+    assert (
+        json.loads(attrs[SpanAttributes.LLM_REQUEST_FUNCTIONS])[0]["function"]["name"]
+        == "weather"
+    )
+    calls = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])
+    assert calls[0]["id"] == "call-1"
+    assert "request-secret" not in attrs[SpanAttributes.TRACELOOP_ENTITY_INPUT]
+    for alias in (
+        "tools",
+        "tool_calls",
+        "model",
+        "prompt_tokens",
+        "completion_tokens",
+        "respan.span.tools",
+        "respan.span.tool_calls",
+    ):
+        assert alias not in attrs
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
+
+
+def test_request_and_response_models_remain_distinct(captured):
+    span = emit(
+        captured,
+        provider="router",
+        request={"model": "requested-model", "messages": []},
+        response={"model": "resolved-model", "choices": []},
+    )
+
+    assert span.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "requested-model"
+    assert span.attributes[SpanAttributes.LLM_RESPONSE_MODEL] == "resolved-model"
+
+
+def test_anthropic_shape_maps_content_and_modern_usage(captured):
+    span = emit(
+        captured,
+        provider="anthropic",
+        request={
+            "model": "claude-test",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        response={
+            "model": "claude-test",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hello back"}],
+            "usage": {"input_tokens": 7, "output_tokens": 3},
+        },
+    )
+    attrs = span.attributes
+
+    assert attrs[SpanAttributes.LLM_SYSTEM] == "anthropic"
+    assert attrs[GEN_AI_USAGE_INPUT_TOKENS] == 7
+    assert attrs[GEN_AI_USAGE_OUTPUT_TOKENS] == 3
+    content = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"])
+    assert content == [{"type": "text", "text": "hello back"}]
+
+
+def test_roles_are_normalized_to_the_canonical_contract(captured):
+    span = emit(
+        captured,
+        provider="custom",
+        request={
+            "model": "role-model",
+            "messages": [
+                {"role": "USER", "content": "one"},
+                {"role": "human", "content": "two"},
+                {"role": "ai", "content": "three"},
+                {"role": "bot", "content": "four"},
+                {"role": "function", "content": "five"},
+                {"role": "developer", "content": "six"},
+                {"role": "unknown-role", "content": "seven"},
+                {"content": "eight"},
+            ],
+        },
+        response={
+            "choices": [{"message": {"role": "BOT", "content": "normalized response"}}]
+        },
+    )
+    attrs = span.attributes
+
+    assert [
+        attrs[f"{SpanAttributes.LLM_PROMPTS}.{index}.role"] for index in range(8)
+    ] == [
+        "user",
+        "user",
+        "assistant",
+        "assistant",
+        "tool",
+        "system",
+        "user",
+        "user",
+    ]
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.role"] == "assistant"
+
+
+def test_primitive_custom_messages_receive_user_roles(captured):
+    span = emit(
+        captured,
+        provider="custom",
+        request={"model": "primitive-messages", "messages": ["hello", 42]},
+        response={"choices": []},
+    )
+    attrs = span.attributes
+
+    assert attrs[f"{SpanAttributes.LLM_PROMPTS}.0.role"] == "user"
+    assert attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"] == "hello"
+    assert attrs[f"{SpanAttributes.LLM_PROMPTS}.1.role"] == "user"
+    assert attrs[f"{SpanAttributes.LLM_PROMPTS}.1.content"] == "42"
+
+
+def test_anthropic_tool_use_maps_current_turn_tool_calls(captured):
+    span = emit(
+        captured,
+        provider="anthropic",
+        request={
+            "model": "claude-test",
+            "messages": [
+                {"role": "user", "content": "weather"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Previous lookup."},
+                        {
+                            "type": "tool_use",
+                            "id": "toolu-history",
+                            "name": "weather",
+                            "input": {"city": "Paris"},
+                        },
+                    ],
+                },
+                {"role": "user", "content": "Now check Tokyo."},
+            ],
+            "tools": [{"name": "weather", "input_schema": {"type": "object"}}],
+        },
+        response={
+            "model": "claude-test",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Checking."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu-1",
+                    "name": "weather",
+                    "input": {"city": "Tokyo"},
+                },
+            ],
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 4,
+                "cache_read_input_tokens": 8,
+            },
+        },
+    )
+    attrs = span.attributes
+
+    current_content = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"])
+    assert current_content == [
+        {"type": "text", "text": "Checking."},
+        {
+            "type": "tool_use",
+            "id": "toolu-1",
+            "name": "weather",
+            "input": {"city": "Tokyo"},
+        },
+    ]
+    historical_content = json.loads(attrs[f"{SpanAttributes.LLM_PROMPTS}.1.content"])
+    assert historical_content[1]["id"] == "toolu-history"
+    historical = json.loads(attrs[f"{SpanAttributes.LLM_PROMPTS}.1.tool_calls"])
+    assert historical[0]["id"] == "toolu-history"
+    assert historical[0]["function"]["arguments"] == '{"city":"Paris"}'
+    calls = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])
+    assert calls == [
+        {
+            "id": "toolu-1",
+            "type": "function",
+            "function": {
+                "name": "weather",
+                "arguments": '{"city":"Tokyo"}',
+            },
+        }
+    ]
+    assert calls[0]["id"] != historical[0]["id"]
+    assert attrs[SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 8
+    assert attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] == 8
+
+
+def test_anthropic_system_and_structured_blocks_are_lossless(captured):
+    system_blocks = [
+        {"type": "text", "text": "Use tools safely."},
+        {"type": "text", "text": "Keep structure."},
+    ]
+    user_blocks = [
+        {"type": "text", "text": "Inspect Tokyo."},
+        {"type": "image", "source": {"type": "base64", "data": "safe-image"}},
+    ]
+    span = emit(
+        captured,
+        provider="anthropic",
+        request={
+            "model": "claude-structured",
+            "system": system_blocks,
+            "messages": [{"role": "user", "content": user_blocks}],
+        },
+        response={
+            "model": "claude-structured-response",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Structured response."}],
+        },
+    )
+    attrs = span.attributes
+
+    assert attrs[f"{SpanAttributes.LLM_PROMPTS}.0.role"] == "system"
+    assert json.loads(attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"]) == system_blocks
+    assert json.loads(attrs[f"{SpanAttributes.LLM_PROMPTS}.1.content"]) == user_blocks
+    assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "claude-structured"
+    assert attrs[SpanAttributes.LLM_RESPONSE_MODEL] == "claude-structured-response"
+
+
+def test_stream_lines_are_aggregated_with_terminal_usage(captured):
+    chunks = [
+        {
+            "model": "stream-model",
+            "choices": [{"delta": {"role": "assistant", "content": "Helicone "}}],
+        },
+        {
+            "model": "stream-model",
+            "choices": [{"delta": {"content": "streams."}}],
+        },
+        {
+            "model": "stream-model",
+            "choices": [],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+        },
+    ]
+    span = emit(
+        captured,
+        request={
+            "model": "stream-model",
+            "messages": [{"role": "user", "content": "stream"}],
+            "stream": True,
+        },
+        response="\n".join(json.dumps(chunk) for chunk in chunks),
+    )
+    attrs = span.attributes
+
+    assert attrs[SpanAttributes.GEN_AI_IS_STREAMING] is True
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "Helicone streams."
+    assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 6
+
+
+def test_documented_log_request_chunks_shape_and_ttft(captured):
+    response = {
+        "chunks": [
+            {
+                "model": "chunk-model",
+                "choices": [{"delta": {"content": "Chunked "}}],
+            },
+            {
+                "model": "chunk-model",
+                "choices": [{"delta": {"content": "response."}}],
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 2,
+                    "total_tokens": 5,
+                },
+            },
+        ],
+        "time_to_first_token_ms": 18.25,
+    }
+    span = emit(
+        captured,
+        provider="openai",
+        request={"model": "chunk-model", "messages": []},
+        response=response,
+    )
+    attrs = span.attributes
+
+    assert attrs[SpanAttributes.GEN_AI_IS_STREAMING] is True
+    assert attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == ("Chunked response.")
+    assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 5
+    assert (
+        json.loads(attrs[RESPAN_METADATA])["helicone"]["time_to_first_token_ms"]
+        == 18.25
+    )
+    assert attrs[GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK] == 0.01825
+
+
+def test_anthropic_streaming_events_preserve_blocks_tools_and_usage(captured):
+    events = [
+        {
+            "type": "message_start",
+            "message": {
+                "model": "claude-stream-response",
+                "usage": {"input_tokens": 9, "cache_read_input_tokens": 4},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Streaming."},
+        },
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu-stream",
+                "name": "lookup",
+                "input": {},
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": '{"topic":"tracing"}',
+            },
+        },
+        {"type": "message_delta", "usage": {"output_tokens": 3}},
+    ]
+    span = emit(
+        captured,
+        provider="anthropic",
+        request={"model": "claude-stream-request", "messages": [], "stream": True},
+        response={"chunks": events, "time_to_first_token_ms": 7.5},
+    )
+    attrs = span.attributes
+
+    blocks = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"])
+    assert blocks[0] == {"type": "text", "text": "Streaming."}
+    assert blocks[1]["input"] == {"topic": "tracing"}
+    calls = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])
+    assert calls[0]["id"] == "toolu-stream"
+    assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "claude-stream-request"
+    assert attrs[SpanAttributes.LLM_RESPONSE_MODEL] == "claude-stream-response"
+    assert attrs[GEN_AI_USAGE_INPUT_TOKENS] == 9
+    assert attrs[GEN_AI_USAGE_OUTPUT_TOKENS] == 3
+    assert attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] == 4
+
+
+def test_google_custom_shape_contents_candidates_usage_and_models(captured):
+    span = emit(
+        captured,
+        provider="google",
+        request={
+            "model": "gemini-request",
+            "systemInstruction": {"parts": [{"text": "Be concise."}]},
+            "contents": [
+                {"role": "user", "parts": [{"text": "Use the weather tool."}]}
+            ],
+            "tools": [
+                {"functionDeclarations": [{"name": "weather", "parameters": {}}]}
+            ],
+        },
+        response={
+            "modelVersion": "gemini-response",
+            "candidates": [
+                {
+                    "content": {
+                        "role": "model",
+                        "parts": [
+                            {"text": "Checking."},
+                            {
+                                "functionCall": {
+                                    "name": "weather",
+                                    "args": {"city": "Tokyo"},
+                                }
+                            },
+                        ],
+                    }
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 6,
+                "candidatesTokenCount": 2,
+                "totalTokenCount": 8,
+                "cachedContentTokenCount": 3,
+            },
+        },
+    )
+    attrs = span.attributes
+
+    assert attrs[RESPAN_LOG_TYPE] == "chat"
+    assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "gemini-request"
+    assert attrs[SpanAttributes.LLM_RESPONSE_MODEL] == "gemini-response"
+    assert json.loads(attrs[f"{SpanAttributes.LLM_PROMPTS}.0.content"]) == [
+        {"text": "Be concise."}
+    ]
+    assert json.loads(attrs[f"{SpanAttributes.LLM_PROMPTS}.1.content"]) == [
+        {"text": "Use the weather tool."}
+    ]
+    output_parts = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"])
+    assert output_parts[1]["functionCall"]["name"] == "weather"
+    calls = json.loads(attrs[f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"])
+    assert calls[0]["function"]["arguments"] == '{"city":"Tokyo"}'
+    assert attrs[GEN_AI_USAGE_INPUT_TOKENS] == 6
+    assert attrs[GEN_AI_USAGE_OUTPUT_TOKENS] == 2
+    assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 8
+    assert attrs[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] == 3
+
+
+def test_embedding_contract_preserves_vector(captured):
+    vector = [float(index) / 100 for index in range(512)]
+    span = emit(
+        captured,
+        provider="openai",
+        request={"_type": "embedding", "model": "embed-test", "input": ["hello"]},
+        response={
+            "model": "embed-test",
+            "data": [{"index": 0, "embedding": vector}],
+            "usage": {"prompt_tokens": 2, "total_tokens": 2},
+        },
+    )
+
+    assert span.attributes[RESPAN_LOG_TYPE] == "embedding"
+    input_value = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
+    output = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    assert input_value == ["hello"]
+    assert output == vector
+    assert "llm.embeddings.0" not in span.attributes
+
+
+def test_embedding_vector_larger_than_legacy_cap_is_not_truncated(captured):
+    vector = [float(index) for index in range(20_000)]
+    span = emit(
+        captured,
+        request={"_type": "embedding", "model": "large-vector", "input": "value"},
+        response={"data": [{"embedding": vector}]},
+    )
+
+    output = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    assert len(output) == 20_000
+    assert output == vector
+    assert "llm.embeddings.0" not in span.attributes
+
+
+def test_embedding_vectors_preserve_non_finite_diagnostics_and_batches(captured):
+    vector = [float(index) for index in range(300)]
+    vector[150] = float("nan")
+    batch = [vector, [float(index) for index in range(300, 600)]]
+    span = emit(
+        captured,
+        request={
+            "_type": "embedding",
+            "model": "diagnostic-vector",
+            "input": ["a", "b"],
+        },
+        response={"data": [{"embedding": item} for item in batch]},
+    )
+
+    output = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    assert len(output) == 2
+    assert len(output[0]) == 300
+    assert output[0][150] is None
+    assert output[1] == batch[1]
+
+
+def test_embedding_vector_batch_larger_than_collection_cap_is_not_truncated(captured):
+    batch = [[float(index), float(index + 1)] for index in range(200)]
+    span = emit(
+        captured,
+        request={"_type": "embedding", "model": "batch-vector", "input": ["x"] * 200},
+        response={"data": [{"embedding": item} for item in batch]},
+    )
+
+    output = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT])
+    assert output == batch
+
+
+def test_indexed_prompt_attributes_are_bounded(captured):
+    span = emit(
+        captured,
+        provider="custom",
+        request={
+            "model": "large-history",
+            "messages": [
+                {"role": "user", "content": f"message-{index}"}
+                for index in range(10_000)
+            ],
+        },
+        response={"choices": []},
+    )
+
+    role_keys = [
+        key
+        for key in span.attributes
+        if key.startswith(f"{SpanAttributes.LLM_PROMPTS}.") and key.endswith(".role")
+    ]
+    assert len(role_keys) == _serialization.MAX_COLLECTION_ITEMS
+    assert (
+        f"{SpanAttributes.LLM_PROMPTS}.{_serialization.MAX_COLLECTION_ITEMS}.role"
+        not in span.attributes
+    )
+
+
+def test_prompt_request_is_text_not_chat(captured):
+    span = emit(
+        captured,
+        provider="custom-provider",
+        request={"model": "completion-model", "prompt": "Complete this sentence"},
+        response={"choices": [{"text": " with an observable result."}]},
+    )
+
+    assert span.attributes[RESPAN_LOG_TYPE] == "text"
+    assert span.attributes[SpanAttributes.LLM_REQUEST_TYPE] == "chat"
+    assert span.attributes[f"{SpanAttributes.LLM_PROMPTS}.0.content"] == (
+        "Complete this sentence"
+    )
+    assert span.attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == (
+        " with an observable result."
+    )
+
+
+def test_missing_provider_uses_custom_identity_not_helicone(captured):
+    span = emit(
+        captured,
+        request={"model": "private-model", "messages": []},
+        response={"choices": []},
+    )
+
+    assert span.attributes[SpanAttributes.LLM_SYSTEM] == "custom"
+    assert span.attributes[GEN_AI_PROVIDER_NAME] == "custom"
+
+
+def test_model_and_tool_identity_suffixes_are_concise(captured):
+    long_model = "model-" + ("m" * 1_000)
+    llm_span = emit(
+        captured,
+        request={"model": long_model, "messages": []},
+        response={"choices": []},
+    )
+    assert len(llm_span.attributes[SpanAttributes.LLM_REQUEST_MODEL]) == 128
+    assert len(llm_span.name) <= len("llm.") + 128
+
+    captured.clear()
+    tool_span = emit(
+        captured,
+        request={"_type": "tool", "toolName": "t" * 1_000, "input": {}},
+        response={"ok": True},
+    )
+    assert len(tool_span.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME]) == 128
+    assert len(tool_span.attributes[RESPAN_INTERNAL_SPAN_NAME_DETAIL]) == 128
+
+
+@pytest.mark.parametrize(
+    ("request_payload", "expected_log_type", "expected_name"),
+    [
+        (
+            {"_type": "tool", "toolName": "lookup", "input": {"city": "Tokyo"}},
+            "tool",
+            "lookup",
+        ),
+        (
+            {"_type": "vector_db", "operation": "search", "vector": [0.1, 0.2]},
+            "task",
+            "vector_db.search",
+        ),
+        (
+            {"_type": "data", "name": "database_query", "query": "select 1"},
+            "task",
+            "database_query",
+        ),
+    ],
+)
+def test_custom_types_map_without_fake_tool_call_aliases(
+    captured, request_payload, expected_log_type, expected_name
+):
+    span = emit(captured, request=request_payload, response={"status": "success"})
+    attrs = span.attributes
+
+    assert attrs[RESPAN_LOG_TYPE] == expected_log_type
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] == expected_name
+    assert "tool_calls" not in attrs
+    assert "respan.span.tool_calls" not in attrs
+    assert SpanAttributes.TRACELOOP_SPAN_KIND not in attrs
+
+
+def test_tool_hints_drive_semantic_name_and_strip_in_both_styles(captured, monkeypatch):
+    snapshot = _emitter.HeliconeEmissionContext(
+        trace_id="1" * 32,
+        parent_id="2" * 16,
+        propagated_attributes={},
+    )
+    assert _emitter.emit_helicone_log(
+        provider=None,
+        request={
+            "_type": "tool",
+            "toolName": "get_weather",
+            "input": {"city": "Tokyo"},
+        },
+        response={"temperature_f": 72},
+        options={"start_time": 10.0, "end_time": 11.0},
+        capture_content=True,
+        context_snapshot=snapshot,
+    )
+    span = captured[0]
+    assert span.attributes[RESPAN_INTERNAL_SPAN_NAME_KIND] == "tool"
+    assert span.attributes[RESPAN_INTERNAL_SPAN_NAME_DETAIL] == "get_weather"
+
+    for style, expected_name in (("semantic", "tool.get_weather"), ("legacy", "tool")):
+        monkeypatch.setenv("RESPAN_SPAN_NAME_STYLE", style)
+        exported = _span_to_otlp_json(span)
+        assert exported[OTLP_NAME_KEY] == expected_name
+        assert exported[OTLP_PARENT_SPAN_ID_KEY] == "2" * 16
+        exported_keys = {
+            attribute[OTLP_ATTR_KEY] for attribute in exported[OTLP_ATTRIBUTES_KEY]
+        }
+        assert RESPAN_INTERNAL_SPAN_NAME_KIND not in exported_keys
+        assert RESPAN_INTERNAL_SPAN_NAME_DETAIL not in exported_keys
+
+
+def test_capture_content_false_keeps_identity_usage_and_error(captured):
+    span = emit(
+        captured,
+        provider="openai",
+        request={
+            "model": "private",
+            "messages": [{"role": "user", "content": "secret"}],
+        },
+        response={
+            "model": "private",
+            "choices": [{"message": {"role": "assistant", "content": "private"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        },
+        error=RuntimeError("safe failure"),
+        capture=False,
+    )
+    attrs = span.attributes
+
+    assert attrs[RESPAN_LOG_TYPE] == "chat"
+    assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "private"
+    assert attrs[ERROR_MESSAGE] == "safe failure"
+    assert attrs[ERROR_TYPE] == "RuntimeError"
+    assert attrs[HTTP_RESPONSE_STATUS_CODE] == 500
+    assert "status_code" not in attrs
+    assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in attrs
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in attrs
+    assert span.status.is_ok is False
+
+
+def test_error_payload_cannot_be_downgraded_by_success_status(captured):
+    span = emit(
+        captured,
+        request={"model": "failed", "messages": []},
+        response={
+            "status_code": 200,
+            "error": {"message": "provider failed"},
+        },
+    )
+
+    assert span.status.is_ok is False
+    assert span.attributes[ERROR_MESSAGE] == "provider failed"
+    assert span.attributes[ERROR_TYPE] == "HeliconeError"
+    assert span.attributes[HTTP_RESPONSE_STATUS_CODE] == 500
+    assert "status_code" not in span.attributes
+
+
+def test_response_error_type_uses_provider_status_type(captured):
+    span = emit(
+        captured,
+        request={"model": "failed", "messages": []},
+        response={
+            "status": "error",
+            "type": "quota_exceeded",
+            "message": "provider quota exceeded",
+        },
+    )
+
+    assert span.attributes[ERROR_MESSAGE] == "provider quota exceeded"
+    assert span.attributes[ERROR_TYPE] == "quota_exceeded"
+    assert span.attributes[HTTP_RESPONSE_STATUS_CODE] == 500
+
+
+def test_non_finite_timings_fall_back_without_dropping_span(captured):
+    assert _emitter.emit_helicone_log(
+        provider="openai",
+        request={"model": "timing-model", "messages": []},
+        response={"choices": []},
+        options={"start_time": float("inf"), "end_time": float("inf")},
+        capture_content=True,
+    )
+    assert len(captured) == 1
+    assert captured[0].start_time < 10**30
+    assert captured[0].end_time < 10**30
+
+
+def test_safe_helicone_headers_and_ttft_use_single_canonical_metadata(captured):
+    assert _emitter.emit_helicone_log(
+        provider="openai",
+        request={"model": "model", "messages": []},
+        response={"choices": []},
+        options={
+            "start_time": 10.0,
+            "end_time": 11.0,
+            "time_to_first_token_ms": 42.5,
+            "additional_headers": {
+                "Helicone-Session-Id": "session-1",
+                "Helicone-User-Id": "user-1",
+                "Helicone-Session-Name": "support-chat",
+                "Helicone-Property-Environment": "test",
+                "Helicone-Property-Api-Key": "must-not-appear",
+                "Authorization": "Bearer transport-secret",
+            },
+        },
+        constructor_headers={
+            "Helicone-Session-Name": "constructor-session",
+            "Helicone-Property-Tier": "pro",
+            "Authorization": "Bearer constructor-secret",
+        },
+        capture_content=True,
+    )
+    attrs = captured[0].attributes
+
+    assert attrs[RESPAN_SESSION_ID] == "session-1"
+    assert attrs[RESPAN_CUSTOMER_PARAMS_ID] == "user-1"
+    metadata = json.loads(attrs[RESPAN_METADATA])
+    assert metadata == {
+        "helicone": {
+            "session_name": "support-chat",
+            "properties": {"environment": "test", "tier": "pro"},
+            "time_to_first_token_ms": 42.5,
+        }
+    }
+    assert not any(key.startswith(f"{RESPAN_METADATA}.") for key in attrs)
+    assert attrs[GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK] == 0.0425
+    combined = "\n".join(str(value) for value in attrs.values())
+    assert "must-not-appear" not in combined
+    assert "transport-secret" not in combined
+    assert "constructor-secret" not in combined
+
+
+def test_builder_context_snapshot_preserves_parent_and_propagated_attrs(captured):
+    snapshot = _emitter.HeliconeEmissionContext(
+        trace_id="1" * 32,
+        parent_id="2" * 16,
+        propagated_attributes={
+            "respan.metadata.snapshot": "creation-context",
+            RESPAN_PROPERTIES: {"nested": {"x": 1}},
+            "example.primitive_array": [1, 2, 3],
+        },
+    )
+    assert _emitter.emit_helicone_log(
+        provider="openai",
+        request={"model": "delayed", "messages": []},
+        response={"choices": []},
+        options={"start_time": 10.0, "end_time": 11.0},
+        capture_content=True,
+        is_streaming=True,
+        context_snapshot=snapshot,
+    )
+    span = captured[0]
+
+    assert f"{span.context.trace_id:032x}" == "1" * 32
+    assert span.parent is not None
+    assert f"{span.parent.span_id:016x}" == "2" * 16
+    assert json.loads(span.attributes[RESPAN_METADATA]) == {
+        "snapshot": "creation-context"
+    }
+    assert "respan.metadata.snapshot" not in span.attributes
+    assert json.loads(span.attributes[RESPAN_PROPERTIES]) == {"nested": {"x": 1}}
+    assert span.attributes["example.primitive_array"] == (1, 2, 3)
+    assert span.attributes[SpanAttributes.GEN_AI_IS_STREAMING] is True
+
+
+def test_capture_emission_context_freezes_mutable_propagation(captured, monkeypatch):
+    source = {
+        RESPAN_PROPERTIES: {"nested": {"x": 1}},
+        "example.primitive_array": [1, 2, 3],
+    }
+    monkeypatch.setattr(_emitter, "_current_ids", lambda: ("1" * 32, "2" * 16))
+    monkeypatch.setattr(_emitter, "read_propagated_attributes", lambda: source)
+    snapshot = _emitter.capture_emission_context()
+
+    source[RESPAN_PROPERTIES]["nested"]["x"] = 99
+    source["example.primitive_array"].append(4)
+    assert _emitter.emit_helicone_log(
+        provider="openai",
+        request={"model": "delayed", "messages": []},
+        response={"choices": []},
+        options={"start_time": 10.0, "end_time": 11.0},
+        capture_content=True,
+        context_snapshot=snapshot,
+    )
+    attrs = captured[0].attributes
+
+    assert json.loads(attrs[RESPAN_PROPERTIES]) == {"nested": {"x": 1}}
+    assert attrs["example.primitive_array"] == (1, 2, 3)
+
+
+def test_hostile_objects_and_secret_strings_never_escape(captured):
+    class Hostile:
+        def __repr__(self):
+            raise AssertionError("repr must not run")
+
+        def __str__(self):
+            raise AssertionError("str must not run")
+
+    span = emit(
+        captured,
+        request={
+            "model": "safe-model",
+            "messages": [{"role": "user", "content": "token=visible-secret"}],
+            "max_tokens": 100,
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "token_count": 15,
+            "tokenizer": "safe-tokenizer",
+            "promptTokens": 11,
+            "completionTokens": 6,
+            "tokenCount": 17,
+            "nested": {
+                "api_key": "nested-api-secret",
+                "refresh_token": "nested-refresh-secret",
+                "accessToken": "nested-access-secret",
+                "refreshToken": "nested-camel-refresh-secret",
+                "idToken": "nested-id-secret",
+                "authToken": "nested-auth-secret",
+                "bearerToken": "nested-bearer-secret",
+                "clientSecret": "nested-client-secret",
+                "privateKey": "nested-private-secret",
+                "sessionToken": "nested-session-secret",
+                "setCookie": "nested-cookie-secret",
+                "secret_key": "nested-secret-key",
+                "aws_secret_access_key": "nested-aws-secret",
+                "awsAccessKeyId": "nested-aws-access-id",
+                "apiToken": "nested-api-token",
+                "oauth_token": "nested-oauth-token",
+                "github_token": "nested-github-token",
+                "session_cookie": "nested-session-cookie",
+                "aws_credentials": "nested-aws-credentials",
+                "password_hash": "nested-password-hash",
+                "max_tokens": 22,
+            },
+            "payload": Hostile(),
+            "Authorization": "Bearer credential-secret",
+        },
+        response={"value": Hostile()},
+    )
+    combined = "\n".join(str(value) for value in span.attributes.values())
+
+    assert "visible-secret" not in combined
+    assert "credential-secret" not in combined
+    assert "nested-api-secret" not in combined
+    assert "nested-refresh-secret" not in combined
+    assert "nested-access-secret" not in combined
+    assert "nested-camel-refresh-secret" not in combined
+    assert "nested-id-secret" not in combined
+    assert "nested-auth-secret" not in combined
+    assert "nested-bearer-secret" not in combined
+    assert "nested-client-secret" not in combined
+    assert "nested-private-secret" not in combined
+    assert "nested-session-secret" not in combined
+    assert "nested-cookie-secret" not in combined
+    assert "nested-secret-key" not in combined
+    assert "nested-aws-secret" not in combined
+    assert "nested-aws-access-id" not in combined
+    assert "nested-api-token" not in combined
+    assert "nested-oauth-token" not in combined
+    assert "nested-github-token" not in combined
+    assert "nested-session-cookie" not in combined
+    assert "nested-aws-credentials" not in combined
+    assert "nested-password-hash" not in combined
+    assert "Hostile" in combined
+    input_payload = json.loads(span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT])
+    assert input_payload["max_tokens"] == 100
+    assert input_payload["prompt_tokens"] == 10
+    assert input_payload["completion_tokens"] == 5
+    assert input_payload["token_count"] == 15
+    assert input_payload["tokenizer"] == "safe-tokenizer"
+    assert input_payload["promptTokens"] == 11
+    assert input_payload["completionTokens"] == 6
+    assert input_payload["tokenCount"] == 17
+    assert input_payload["nested"]["max_tokens"] == 22
+    assert input_payload["nested"]["api_key"] == "<redacted>"
+    assert input_payload["nested"]["refresh_token"] == "<redacted>"
+    for key in (
+        "accessToken",
+        "refreshToken",
+        "idToken",
+        "authToken",
+        "bearerToken",
+        "clientSecret",
+        "privateKey",
+        "sessionToken",
+        "setCookie",
+        "secret_key",
+        "aws_secret_access_key",
+        "awsAccessKeyId",
+        "apiToken",
+        "oauth_token",
+        "github_token",
+        "session_cookie",
+        "aws_credentials",
+        "password_hash",
+    ):
+        assert input_payload["nested"][key] == "<redacted>"
+
+
+def test_error_json_secrets_are_redacted_without_hiding_token_counts(captured):
+    span = emit(
+        captured,
+        request={"model": "error-model", "messages": []},
+        response={},
+        error=RuntimeError(
+            'failure {"api_key":"error secret with spaces, and comma",'
+            '"accessToken":"camel secret; with separator",'
+            '"token_count":12,"promptTokens":13,"max_tokens":20} '
+            "secret_key=bare-secret,remaining\n"
+            "Authorization: Basic dXNlcjpwYXNz\n"
+            "authorization=ApiKey actual-secret"
+        ),
+    )
+
+    message = span.attributes[ERROR_MESSAGE]
+    assert span.attributes[ERROR_TYPE] == "RuntimeError"
+    assert "error secret" not in message
+    assert "and comma" not in message
+    assert "camel secret" not in message
+    assert "with separator" not in message
+    assert "bare-secret" not in message
+    assert "remaining" not in message
+    assert "dXNlcjpwYXNz" not in message
+    assert "actual-secret" not in message
+    assert '"token_count":12' in message
+    assert '"promptTokens":13' in message
+    assert '"max_tokens":20' in message
+
+
+def test_large_vector_mode_bounds_unrelated_collections():
+    vector = [float(index) for index in range(512)]
+    encoded = _serialization.json_dumps(
+        {
+            "vector": vector,
+            "unrelated_numeric": [float(index) for index in range(20_000)],
+            "unrelated": ["x" * 1_000 for _ in range(500)],
+        },
+        preserve_large_vectors=True,
+    )
+    payload = json.loads(encoded)
+
+    assert payload["vector"] == vector
+    assert len(payload["unrelated"]) < 500
+    assert payload["unrelated"][-1] == {"truncated": True}
+    assert len(payload["unrelated_numeric"]) < 20_000
+    assert payload["unrelated_numeric"][-1] == {"truncated": True}
+    assert len(encoded.encode("utf-8")) <= _serialization.MAX_ATTRIBUTE_BYTES
+
+
+def test_structured_bearer_redaction_is_valid_json_and_idempotent():
+    encoded = _serialization.json_dumps(
+        [
+            {"type": "text", "text": "Bearer secret-token"},
+            {"type": "text", "text": "keep this content"},
+        ]
+    )
+
+    assert json.loads(encoded) == [
+        {"text": "Bearer <redacted>", "type": "text"},
+        {"text": "keep this content", "type": "text"},
+    ]
+    assert _serialization.safe_text(encoded) == encoded
+
+
+def test_nested_json_and_authorization_strings_are_fully_redacted():
+    cases = (
+        '{"error":{"api_key":"nested-secret"}}',
+        '{"text":"Authorization: Basic nested-secret"}',
+        'failure={"context":{"aws_secret_access_key":"nested-aws"}}',
+        '{"proxyAuthorization":"Basic proxy-secret"}',
+        '{"x-authorization":"Basic x-secret"}',
+        '"Authorization: Basic scalar-secret"',
+    )
+
+    for value in cases:
+        redacted = _serialization.safe_text(value)
+        assert "nested-secret" not in redacted
+        assert "nested-aws" not in redacted
+        assert "proxy-secret" not in redacted
+        assert "x-secret" not in redacted
+        assert "scalar-secret" not in redacted
+
+
+def test_deep_json_redaction_is_bounded_and_never_raises():
+    nested: object = {"api_key": "deep-secret"}
+    for _ in range(_serialization.MAX_DEPTH * 3):
+        nested = {"nested": nested}
+    redacted = _serialization.safe_text(json.dumps(nested))
+    assert "deep-secret" not in redacted
+
+    deeply_encoded = ("[" * 2_000) + '{"api_key":"recursive-secret"}' + ("]" * 2_000)
+    redacted_encoded = _serialization.safe_text(deeply_encoded)
+    assert "recursive-secret" not in redacted_encoded
+
+    large_json = json.dumps([{"api_key": f"secret-{index}"} for index in range(1_000)])
+    bounded = json.loads(_serialization.safe_text(large_json))
+    assert len(bounded) == _serialization.MAX_COLLECTION_ITEMS + 1
+    assert bounded[-1] == {"truncated": True}
+    assert "secret-999" not in json.dumps(bounded)
+
+
+def test_sensitive_long_keys_are_classified_before_display_truncation():
+    long_key = f"{'x' * _serialization.MAX_TEXT_BYTES}_api_key"
+    for preserve_vectors in (False, True):
+        encoded = _serialization.json_dumps(
+            {long_key: "long-key-secret", "vector": [0.1, 0.2]},
+            preserve_large_vectors=preserve_vectors,
+        )
+        assert "long-key-secret" not in encoded

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/tests/test_instrumentation.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+import tomllib
+from respan_instrumentation_helicone import HeliconeInstrumentor, _instrumentation
+from respan_tracing.core.tracer import RespanTracer
+
+
+def test_manifest_pins_tested_helicone_helpers_minor_line():
+    manifest = tomllib.loads(
+        (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["tool"]["poetry"]["dependencies"]["helicone-helpers"] == (
+        ">=1.2.1,<1.3.0"
+    )
+    assert manifest["tool"]["poetry"]["dependencies"]["respan-sdk"] == (
+        ">=2.7.4,<3.0.0"
+    )
+    assert (
+        manifest["tool"]["poetry"]["dependencies"]["opentelemetry-semantic-conventions"]
+        == ">=0.65b0,<0.66"
+    )
+
+
+class FakeLogger:
+    send_calls: ClassVar[list[tuple]] = []
+
+    def __init__(self, headers=None):
+        self.headers = dict(headers or {})
+
+    def send_log(self, provider, request, response, options):
+        self.__class__.send_calls.append((provider, request, response, options))
+        return "sent"
+
+    def log_request(
+        self,
+        request,
+        operation,
+        additional_headers=None,
+        provider=None,
+    ):
+        additional_headers = additional_headers or {}
+        recorder = SimpleNamespace(
+            request=request,
+            results={},
+            append_results=lambda value: recorder.results.update(value),
+            get_results=lambda: recorder.results,
+        )
+        result = operation(recorder)
+        self.send_log(
+            provider,
+            request,
+            recorder.get_results(),
+            {
+                "start_time": 1.0,
+                "end_time": 2.0,
+                "additional_headers": additional_headers,
+            },
+        )
+        return result
+
+    def log_builder(self, request, additional_headers=None):
+        builder = FakeBuilder(self)
+        builder.request = dict(request)
+        return builder
+
+
+class FakeBuilder:
+    def __init__(self, logger):
+        self.logger = logger
+        self.request = {"model": "builder-model", "messages": []}
+        self.response_body = "builder response"
+        self.error = None
+        self.status = 200
+        self.was_cancelled = False
+        self.stream_chunks = []
+
+    async def send_log(self):
+        return self.logger.send_log(
+            None,
+            self.request,
+            self.response_body,
+            {"start_time": 1.0, "end_time": 2.0},
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    if _instrumentation._GENERATION is not None:
+        _instrumentation._GENERATION.enabled = False
+    _instrumentation._restore_all()
+    _instrumentation._REFCOUNT = 0
+    _instrumentation._CONFIG = None
+    _instrumentation._GENERATION = None
+    FakeLogger.send_calls.clear()
+    RespanTracer.reset_instance()
+    monkeypatch.setattr(
+        _instrumentation,
+        "_load_classes",
+        lambda: (FakeLogger, FakeBuilder),
+    )
+    yield
+    if _instrumentation._GENERATION is not None:
+        _instrumentation._GENERATION.enabled = False
+    _instrumentation._restore_all()
+    _instrumentation._REFCOUNT = 0
+    _instrumentation._CONFIG = None
+    _instrumentation._GENERATION = None
+    RespanTracer.reset_instance()
+
+
+def test_activate_patches_all_canonical_surfaces_and_deactivate_restores():
+    originals = (
+        FakeLogger.send_log,
+        FakeLogger.log_request,
+        FakeLogger.log_builder,
+        FakeBuilder.send_log,
+    )
+    instrumentor = HeliconeInstrumentor()
+
+    instrumentor.activate()
+
+    assert instrumentor._is_instrumented is True
+    assert FakeLogger.send_log.__respan_helicone_wrapper__ is True
+    assert FakeLogger.log_request.__respan_helicone_wrapper__ is True
+    assert FakeLogger.log_builder.__respan_helicone_wrapper__ is True
+    assert FakeBuilder.send_log.__respan_helicone_wrapper__ is True
+
+    instrumentor.deactivate()
+
+    assert instrumentor._is_instrumented is False
+    assert (
+        FakeLogger.send_log,
+        FakeLogger.log_request,
+        FakeLogger.log_builder,
+        FakeBuilder.send_log,
+    ) == originals
+
+
+def test_activate_is_idempotent_and_instances_share_one_generation():
+    first = HeliconeInstrumentor(capture_content=False)
+    second = HeliconeInstrumentor(capture_content=False)
+
+    first.activate()
+    first.activate()
+    installed = FakeLogger.send_log
+    second.activate()
+
+    assert FakeLogger.send_log is installed
+    assert _instrumentation._REFCOUNT == 2
+    first.deactivate()
+    assert FakeLogger.send_log is installed
+    second.deactivate()
+    assert _instrumentation._REFCOUNT == 0
+    assert not hasattr(FakeLogger.send_log, "__respan_helicone_wrapper__")
+
+
+def test_mismatched_capture_policy_is_rejected(caplog):
+    first = HeliconeInstrumentor(capture_content=True)
+    second = HeliconeInstrumentor(capture_content=False)
+    first.activate()
+
+    with caplog.at_level(logging.ERROR):
+        second.activate()
+
+    assert first._is_instrumented is True
+    assert second._is_instrumented is False
+    assert _instrumentation._REFCOUNT == 1
+    assert "different capture_content" in caplog.text
+
+
+def test_activation_skips_when_respan_tracing_is_disabled(caplog):
+    RespanTracer(is_enabled=False)
+    instrumentor = HeliconeInstrumentor()
+
+    with caplog.at_level(logging.INFO):
+        instrumentor.activate()
+
+    assert instrumentor._is_instrumented is False
+    assert not hasattr(FakeLogger.send_log, "__respan_helicone_wrapper__")
+    assert "tracing is disabled" in caplog.text
+
+
+def test_activation_handles_missing_sdk(monkeypatch, caplog):
+    monkeypatch.setattr(
+        _instrumentation,
+        "_load_classes",
+        lambda: (_ for _ in ()).throw(ImportError("helicone_helpers")),
+    )
+    instrumentor = HeliconeInstrumentor()
+
+    with caplog.at_level(logging.WARNING):
+        instrumentor.activate()
+
+    assert instrumentor._is_instrumented is False
+    assert "missing dependency" in caplog.text
+
+
+def test_send_log_preserves_return_and_emits_once(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor(capture_content=False)
+    instrumentor.activate()
+    logger = FakeLogger(
+        headers={"Helicone-Property-Constructor": "safe", "Authorization": "secret"}
+    )
+
+    result = logger.send_log(
+        "openai",
+        {"model": "gpt-test"},
+        {"choices": []},
+        {
+            "start_time": 1.0,
+            "end_time": 2.0,
+            "additional_headers": {"Authorization": "Bearer secret"},
+        },
+    )
+
+    assert result == "sent"
+    assert len(FakeLogger.send_calls) == 1
+    assert len(emitted) == 1
+    assert emitted[0]["provider"] == "openai"
+    assert emitted[0]["capture_content"] is False
+    assert emitted[0]["constructor_headers"] == logger.headers
+
+
+def test_log_request_success_flows_through_one_sink(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    logger = FakeLogger()
+
+    def operation(recorder):
+        recorder.append_results({"answer": "ok"})
+        return "application-result"
+
+    result = logger.log_request(
+        {"model": "local", "messages": [{"role": "user", "content": "hi"}]},
+        operation,
+        provider="openai",
+    )
+
+    assert result == "application-result"
+    assert len(FakeLogger.send_calls) == 1
+    assert len(emitted) == 1
+    assert emitted[0]["error"] is None
+
+
+def test_log_request_operation_error_gets_outer_fallback(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    logger = FakeLogger(headers={"Helicone-Session-Name": "constructor-session"})
+
+    def operation(_recorder):
+        raise ValueError("deterministic failure")
+
+    with pytest.raises(ValueError, match="deterministic failure"):
+        logger.log_request(
+            {"model": "broken"},
+            operation,
+            additional_headers={"Helicone-Property-Path": "outer-error"},
+            provider="anthropic",
+        )
+
+    assert FakeLogger.send_calls == []
+    assert len(emitted) == 1
+    assert isinstance(emitted[0]["error"], ValueError)
+    assert emitted[0]["status_code"] == 500
+    assert emitted[0]["provider"] == "anthropic"
+    assert emitted[0]["options"]["additional_headers"] == {
+        "Helicone-Property-Path": "outer-error"
+    }
+    assert emitted[0]["constructor_headers"] == logger.headers
+
+
+def test_log_request_cancellation_gets_outer_fallback(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    logger = FakeLogger()
+
+    def operation(_recorder):
+        raise asyncio.CancelledError("deterministic cancellation")
+
+    with pytest.raises(asyncio.CancelledError, match="deterministic cancellation"):
+        logger.log_request(
+            {"model": "cancelled"},
+            operation,
+            additional_headers={"Helicone-Property-Path": "cancelled"},
+        )
+
+    assert FakeLogger.send_calls == []
+    assert len(emitted) == 1
+    assert isinstance(emitted[0]["error"], asyncio.CancelledError)
+    assert emitted[0]["status_code"] == 500
+
+
+def test_nested_direct_send_then_outer_failure_emits_both(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    logger = FakeLogger()
+
+    def operation(_recorder):
+        logger.send_log(
+            "openai",
+            {"model": "nested-direct", "messages": []},
+            {"choices": []},
+            {"start_time": 1.0, "end_time": 1.5},
+        )
+        raise RuntimeError("outer callback failed")
+
+    with pytest.raises(RuntimeError, match="outer callback failed"):
+        logger.log_request(
+            {"model": "outer", "messages": []}, operation, provider="openai"
+        )
+
+    assert len(FakeLogger.send_calls) == 1
+    assert len(emitted) == 2
+    assert emitted[0]["request"]["model"] == "nested-direct"
+    assert emitted[0]["error"] is None
+    assert emitted[1]["request"]["model"] == "outer"
+    assert isinstance(emitted[1]["error"], RuntimeError)
+
+
+def test_nested_direct_success_keeps_one_helper_terminal_sink(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    logger = FakeLogger()
+
+    def operation(recorder):
+        logger.send_log(
+            "openai",
+            {"model": "nested"},
+            {"model": "nested-response"},
+            {"start_time": 1.0, "end_time": 1.2},
+        )
+        recorder.append_results({"model": "outer-response"})
+        return "ok"
+
+    assert logger.log_request({"model": "outer"}, operation, provider="openai") == "ok"
+
+    assert len(FakeLogger.send_calls) == 2
+    assert [item["request"]["model"] for item in emitted] == ["nested", "outer"]
+
+
+def test_builder_async_error_context_reaches_sink(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    builder = FakeBuilder(FakeLogger())
+    builder.error = RuntimeError("builder failed")
+    builder.status = 500
+
+    assert asyncio.run(builder.send_log()) == "sent"
+
+    assert len(emitted) == 1
+    assert isinstance(emitted[0]["error"], RuntimeError)
+    assert emitted[0]["status_code"] == 500
+
+
+def test_empty_builder_is_streaming_and_uses_creation_context(monkeypatch):
+    emitted = []
+    snapshot = object()
+    monkeypatch.setattr(
+        _instrumentation,
+        "capture_emission_context",
+        lambda: snapshot,
+    )
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    builder = FakeLogger().log_builder(
+        {"model": "empty-stream", "messages": [], "stream": True}
+    )
+    builder.response_body = ""
+
+    asyncio.run(builder.send_log())
+
+    assert emitted[0]["is_streaming"] is True
+    assert emitted[0]["context_snapshot"] is snapshot
+
+
+def test_cancelled_builder_maps_to_499(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    builder = FakeBuilder(FakeLogger())
+    builder.was_cancelled = True
+
+    asyncio.run(builder.send_log())
+
+    assert emitted[0]["status_code"] == 499
+
+
+def test_foreign_post_patch_is_not_clobbered_and_old_generation_disables(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        _instrumentation,
+        "emit_helicone_log",
+        lambda **kwargs: emitted.append(kwargs) or True,
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    installed = FakeLogger.send_log
+
+    def foreign(instance, *args, **kwargs):
+        return installed(instance, *args, **kwargs)
+
+    FakeLogger.send_log = foreign
+    instrumentor.deactivate()
+
+    assert FakeLogger.send_log is foreign
+    FakeLogger().send_log(None, {}, {}, {"start_time": 1, "end_time": 2})
+    assert emitted == []
+
+
+def test_explicit_helicone_instrumentation_does_not_patch_provider_sdks():
+    class ProviderSDK:
+        def create(self):
+            return "provider-result"
+
+    original = ProviderSDK.create
+    instrumentor = HeliconeInstrumentor()
+
+    instrumentor.activate()
+
+    assert ProviderSDK.create is original
+    assert ProviderSDK().create() == "provider-result"

--- a/python-sdks/instrumentations/respan-instrumentation-helicone/tests/test_real_helicone_helpers.py
+++ b/python-sdks/instrumentations/respan-instrumentation-helicone/tests/test_real_helicone_helpers.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from helicone_helpers import HeliconeManualLogger
+from opentelemetry.semconv._incubating.attributes.error_attributes import (
+    ERROR_MESSAGE,
+    ERROR_TYPE,
+)
+from opentelemetry.semconv.attributes.http_attributes import (
+    HTTP_RESPONSE_STATUS_CODE,
+)
+from opentelemetry.semconv_ai import SpanAttributes
+from respan_instrumentation_helicone import HeliconeInstrumentor, _emitter
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+
+
+class Response:
+    status_code = 200
+    text = "ok"
+
+
+@pytest.mark.integration
+def test_real_121_log_request_and_direct_sink(monkeypatch):
+    posts = []
+    spans = []
+    monkeypatch.setattr(
+        "helicone_helpers.manual_logger.requests.post",
+        lambda url, **kwargs: posts.append((url, kwargs)) or Response(),
+    )
+    monkeypatch.setattr(
+        _emitter, "inject_span", lambda span: spans.append(span) or True
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    logger = HeliconeManualLogger(api_key="local-helicone-key")
+    try:
+
+        def operation(recorder):
+            recorder.append_results(
+                {
+                    "model": "manual-model",
+                    "choices": [{"message": {"role": "assistant", "content": "done"}}],
+                    "usage": {
+                        "prompt_tokens": 3,
+                        "completion_tokens": 1,
+                        "total_tokens": 4,
+                    },
+                }
+            )
+            return "application-result"
+
+        assert (
+            logger.log_request(
+                {
+                    "model": "manual-model",
+                    "messages": [{"role": "user", "content": "run"}],
+                },
+                operation,
+                provider="openai",
+            )
+            == "application-result"
+        )
+        logger.send_log(
+            None,
+            {"_type": "data", "name": "direct"},
+            {"status": "success"},
+            {"start_time": 1.0, "end_time": 2.0},
+        )
+    finally:
+        instrumentor.deactivate()
+
+    assert len(posts) == 2
+    assert posts[0][0].endswith("/oai/v1/log")
+    assert posts[1][0].endswith("/custom/v1/log")
+    assert [span.attributes[RESPAN_LOG_TYPE] for span in spans] == ["chat", "task"]
+
+
+@pytest.mark.integration
+def test_real_121_builder_stream_and_error(monkeypatch):
+    posts = []
+    spans = []
+    monkeypatch.setattr(
+        "helicone_helpers.manual_logger.requests.post",
+        lambda url, **kwargs: posts.append((url, kwargs)) or Response(),
+    )
+    monkeypatch.setattr(
+        _emitter, "inject_span", lambda span: spans.append(span) or True
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    logger = HeliconeManualLogger(api_key="local-helicone-key")
+
+    async def exercise():
+        stream = logger.log_builder(
+            {
+                "model": "stream-model",
+                "messages": [{"role": "user", "content": "stream"}],
+            }
+        )
+        stream.add_chunk(
+            {
+                "model": "stream-model",
+                "choices": [{"delta": {"content": "one "}}],
+            }
+        )
+        stream.add_chunk(
+            {
+                "model": "stream-model",
+                "choices": [{"delta": {"content": "two"}}],
+                "usage": {"prompt_tokens": 2, "completion_tokens": 2},
+            }
+        )
+        await stream.send_log()
+
+        failed = logger.new_builder(
+            {
+                "model": "error-model",
+                "messages": [{"role": "user", "content": "fail"}],
+            }
+        )
+        failed.set_error(RuntimeError("builder exploded"))
+        await failed.send_log()
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        instrumentor.deactivate()
+
+    assert len(posts) == 2
+    assert len(spans) == 2
+    assert spans[0].attributes[SpanAttributes.GEN_AI_IS_STREAMING] is True
+    assert (
+        spans[0].attributes[f"{SpanAttributes.LLM_COMPLETIONS}.0.content"] == "one two"
+    )
+    assert spans[1].status.is_ok is False
+    assert spans[1].attributes[ERROR_MESSAGE] == "builder exploded"
+    assert spans[1].attributes[ERROR_TYPE] == "RuntimeError"
+    assert spans[1].attributes[HTTP_RESPONSE_STATUS_CODE] == 500
+    assert "status_code" not in spans[1].attributes
+
+
+@pytest.mark.integration
+def test_real_121_log_request_error_uses_canonical_otel_status(monkeypatch):
+    posts = []
+    spans = []
+    monkeypatch.setattr(
+        "helicone_helpers.manual_logger.requests.post",
+        lambda url, **kwargs: posts.append((url, kwargs)) or Response(),
+    )
+    monkeypatch.setattr(
+        _emitter, "inject_span", lambda span: spans.append(span) or True
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    logger = HeliconeManualLogger(api_key="local-helicone-key")
+
+    def operation(_recorder):
+        raise ValueError("outer operation failed")
+
+    try:
+        with pytest.raises(ValueError, match="outer operation failed"):
+            logger.log_request(
+                {"model": "failed-model", "messages": []},
+                operation,
+                provider="openai",
+            )
+    finally:
+        instrumentor.deactivate()
+
+    assert posts == []
+    assert len(spans) == 1
+    assert spans[0].status.is_ok is False
+    assert spans[0].attributes[ERROR_MESSAGE] == "outer operation failed"
+    assert spans[0].attributes[ERROR_TYPE] == "ValueError"
+    assert spans[0].attributes[HTTP_RESPONSE_STATUS_CODE] == 500
+    assert "status_code" not in spans[0].attributes
+
+
+@pytest.mark.integration
+def test_real_121_nested_direct_success_and_outer_failure(monkeypatch):
+    posts = []
+    spans = []
+    monkeypatch.setattr(
+        "helicone_helpers.manual_logger.requests.post",
+        lambda url, **kwargs: posts.append((url, kwargs)) or Response(),
+    )
+    monkeypatch.setattr(
+        _emitter, "inject_span", lambda span: spans.append(span) or True
+    )
+    instrumentor = HeliconeInstrumentor()
+    instrumentor.activate()
+    logger = HeliconeManualLogger(api_key="local-helicone-key")
+
+    def operation(_recorder):
+        logger.send_log(
+            "openai",
+            {"model": "nested-model", "messages": []},
+            {"model": "nested-response", "choices": []},
+            {"start_time": 1.0, "end_time": 1.5},
+        )
+        raise RuntimeError("outer failed after nested success")
+
+    try:
+        with pytest.raises(RuntimeError, match="outer failed after nested success"):
+            logger.log_request(
+                {"model": "outer-model", "messages": []},
+                operation,
+                provider="openai",
+            )
+    finally:
+        instrumentor.deactivate()
+
+    assert len(posts) == 1
+    assert len(spans) == 2
+    assert spans[0].status.is_ok is True
+    assert spans[0].attributes[SpanAttributes.LLM_REQUEST_MODEL] == "nested-model"
+    assert spans[1].status.is_ok is False
+    assert spans[1].attributes[SpanAttributes.LLM_REQUEST_MODEL] == "outer-model"


### PR DESCRIPTION
## Summary

- Add the Python `respan-instrumentation-helicone` package for Helicone Manual Logger workflows.
- Translate request, builder, streaming, tool, vector, data, Anthropic, chat, embedding, privacy, cancellation, and error paths into canonical Respan/OpenTelemetry attributes.
- Add focused contract tests, real Helicone helper tests, package documentation, release inventory, and release intent.

## Companion examples

- [Python Helicone examples PR #77](https://github.com/respanai/respan-example-projects/pull/77)

## Release intent

- Version 0.1.0 was manually published to PyPI before this PR.
- The release intent is `none` so merge automation does not republish 0.1.0.

## Validation

- [x] Package tests: 58 passed
- [x] Ruff check and format validation
- [x] Wheel and sdist build
- [x] Clean registry install/import of `respan-instrumentation-helicone==0.1.0`
- [x] Companion examples: 17/17 scenarios
- [x] Respan platform validation: 17 traces, 35 span records, 18 instrumentation spans, no duplicates, and 43/43 semantic assertions
