### PR TITLE
feat(instrumentation-js): add Helicone Manual Logger instrumentation

### DIFF
--- a/.github/release-packages.json
+++ b/.github/release-packages.json
@@ -623,6 +623,12 @@
       "name": "respan-instrumentation-restate",
       "path": "python-sdks/instrumentations/respan-instrumentation-restate",
       "registry": "pypi"
+    },
+    {
+      "ecosystem": "javascript",
+      "name": "@respan/instrumentation-helicone",
+      "path": "javascript-sdks/instrumentations/respan-instrumentation-helicone",
+      "registry": "npm"
     }
   ]
 }

--- a/.release-intents/20260829-helicone-javascript-instrumentation.json
+++ b/.release-intents/20260829-helicone-javascript-instrumentation.json
@@ -1,6 +1,6 @@
 {
-  "summary": "Add JavaScript instrumentation for Helicone Manual Logger workflows",
+  "summary": "Add JavaScript instrumentation for Helicone Manual Logger workflows; version 0.1.0 was published manually before this PR",
   "packages": {
-    "@respan/instrumentation-helicone": "new"
+    "@respan/instrumentation-helicone": "none"
   }
 }

--- a/.release-intents/20260829-helicone-javascript-instrumentation.json
+++ b/.release-intents/20260829-helicone-javascript-instrumentation.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Add JavaScript instrumentation for Helicone Manual Logger workflows",
+  "packages": {
+    "@respan/instrumentation-helicone": "new"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-helicone/README.md
+++ b/javascript-sdks/instrumentations/respan-instrumentation-helicone/README.md
@@ -1,0 +1,78 @@
+# @respan/instrumentation-helicone
+
+Respan instrumentation for `@helicone/helpers`. It captures calls made through
+`HeliconeManualLogger` as canonical Respan spans while leaving Helicone's own
+logging behavior unchanged.
+
+The tested compatibility range is `@helicone/helpers >=1.8.3 <1.9.0` because
+the adapter patches the 1.8.x `HeliconeManualLogger` call surface directly.
+
+The integration covers `logRequest`, `logStream`, `logSingleStream`,
+`logSingleRequest`, `HeliconeLogBuilder`, direct `sendLog` calls, and Helicone's
+custom `tool`, `vector_db`, and `data` events. Successful calls are captured at
+the shared `sendLog` chokepoint. Operations that fail before `sendLog` still
+produce one error span, without a duplicate success/error pair.
+
+## Installation
+
+```bash
+npm install @respan/respan @respan/instrumentation-helicone @helicone/helpers@~1.8.3
+```
+
+## Usage
+
+```ts
+import { HeliconeManualLogger } from "@helicone/helpers";
+import { HeliconeInstrumentor } from "@respan/instrumentation-helicone";
+import { Respan } from "@respan/respan";
+
+const respan = new Respan({
+  apiKey: process.env.RESPAN_API_KEY,
+  instrumentations: [new HeliconeInstrumentor()],
+});
+await respan.initialize();
+
+const helicone = new HeliconeManualLogger({
+  apiKey: process.env.HELICONE_API_KEY!,
+});
+
+await helicone.logRequest(
+  {
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: "Say hello." }],
+  },
+  async (recorder) => {
+    const response = {
+      choices: [{ message: { role: "assistant", content: "Hello!" } }],
+      usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+    };
+    recorder.appendResults(response);
+    return response;
+  },
+  { "Helicone-Session-Id": "session-123" },
+  "openai",
+);
+
+await respan.shutdown();
+```
+
+For manual activation, `await instrumentor.activate()` before the first
+Helicone call. The `instrumentHelicone(options)` convenience function is also
+async and resolves only after its patches are installed.
+
+`traceContent` defaults to `true`. Set it to `false` on the instrumentor to
+omit request and response bodies while retaining operation, model, provider,
+usage, status, and safe correlation attributes:
+
+```ts
+new HeliconeInstrumentor({ traceContent: false });
+```
+
+The instrumentation does not record the Helicone logger API key or copy
+authorization/unknown headers into spans. It maps only Helicone
+user/session/property headers with explicit semantics, and redacts structured
+sensitive fields and error strings. With `traceContent: true`, ordinary user
+prompt and response text is intentionally captured.
+
+This integration is explicit-only because Helicone is an observability bridge;
+automatic activation could duplicate provider or framework instrumentation.

--- a/javascript-sdks/instrumentations/respan-instrumentation-helicone/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-helicone/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@respan/instrumentation-helicone",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Respan instrumentation plugin for the Helicone TypeScript helpers",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "author": "Respan <team@respan.ai>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/instrumentations/respan-instrumentation-helicone"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node --test tests/*.test.mjs",
+    "publish:package": "yarn npm publish",
+    "release": "yarn build && yarn version patch && yarn publish:package"
+  },
+  "keywords": [
+    "respan",
+    "opentelemetry",
+    "helicone",
+    "instrumentation"
+  ],
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^2.10.0",
+    "@opentelemetry/semantic-conventions": "^1.43.0",
+    "@respan/respan-sdk": "^1.1.7",
+    "@respan/tracing": "^1.1.6",
+    "@traceloop/ai-semantic-conventions": "^0.13.0"
+  },
+  "peerDependencies": {
+    "@helicone/helpers": ">=1.8.3 <1.9.0"
+  },
+  "peerDependenciesMeta": {
+    "@helicone/helpers": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@helicone/helpers": "1.8.3",
+    "@opentelemetry/context-async-hooks": "^2.10.0",
+    "@types/node": "^22.15.29",
+    "openai": "^5.10.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-helicone/src/_constants.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-helicone/src/_constants.ts
@@ -1,0 +1,36 @@
+/** Helicone-owned payload and header names stay local to this adapter. */
+export const HeliconeFields = {
+  EVENT_TYPE: "_type",
+  TOOL_NAME: "toolName",
+  OPERATION: "operation",
+  NAME: "name",
+  INPUT: "input",
+  ARGUMENTS: "arguments",
+  TOP_K: "topK",
+  DATABASE_NAME: "databaseName",
+  META: "meta",
+} as const;
+
+export const HeliconeEventTypes = {
+  TOOL: "tool",
+  VECTOR_DB: "vector_db",
+  DATA: "data",
+} as const;
+
+export const HeliconeHeaders = {
+  USER_ID: "helicone-user-id",
+  SESSION_ID: "helicone-session-id",
+  PROPERTY_PREFIX: "helicone-property-",
+} as const;
+
+export const MAX_SERIALIZED_BYTES = 1_000_000;
+export const MAX_ERROR_MESSAGE_CHARS = 8_192;
+export const MAX_INDEXED_PROMPT_MESSAGES = 128;
+
+/**
+ * Required by Respan's published span contract. The installed Traceloop
+ * semantic-conventions package does not yet export a constant for this key.
+ */
+export const TraceloopCompatibilityFields = {
+  LLM_USAGE_CACHE_READ_INPUT_TOKENS: "llm.usage.cache_read_input_tokens",
+} as const;

--- a/javascript-sdks/instrumentations/respan-instrumentation-helicone/src/_translator.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-helicone/src/_translator.ts
@@ -1,0 +1,1208 @@
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  ATTR_ERROR_TYPE,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+} from "@opentelemetry/semantic-conventions";
+import {
+  ATTR_ERROR_MESSAGE,
+  ATTR_GEN_AI_REQUEST_STREAM,
+  ATTR_GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK,
+  ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+} from "@opentelemetry/semantic-conventions/incubating";
+import {
+  RESPAN_SPAN_ATTRIBUTES_MAP,
+  RespanLogType,
+  RespanSpanAttributes,
+} from "@respan/respan-sdk";
+import { buildReadableSpan } from "@respan/tracing";
+import {
+  LLMRequestTypeValues,
+  SpanAttributes,
+} from "@traceloop/ai-semantic-conventions";
+import {
+  HeliconeEventTypes,
+  HeliconeFields,
+  HeliconeHeaders,
+  MAX_ERROR_MESSAGE_CHARS,
+  MAX_INDEXED_PROMPT_MESSAGES,
+  MAX_SERIALIZED_BYTES,
+  TraceloopCompatibilityFields,
+} from "./_constants.js";
+
+export interface HeliconeParentContext {
+  traceId?: string;
+  parentId?: string;
+  entityPath?: string;
+}
+
+export interface HeliconeCapture {
+  request: unknown;
+  response?: unknown;
+  options?: unknown;
+  loggerHeaders?: unknown;
+  propagatedAttributes?: unknown;
+  error?: unknown;
+  parent: HeliconeParentContext;
+  fallbackOperation?: string;
+  traceContent: boolean;
+  instrumentationScope: {
+    name: string;
+    version: string;
+  };
+}
+
+type AnyRecord = Record<string, any>;
+type Attributes = Record<string, string | number | boolean | Array<string | number | boolean>>;
+
+interface ParsedResponse {
+  raw: unknown;
+  record?: AnyRecord;
+  text?: string;
+  message?: AnyRecord;
+  toolCalls?: AnyRecord[];
+  usage?: AnyRecord;
+}
+
+interface OperationShape {
+  logType: RespanLogType;
+  entityName: string;
+  requestType?: LLMRequestTypeValues;
+}
+
+const TRACE_METHOD = "ts_tracing";
+
+export function buildHeliconeSpan(capture: HeliconeCapture): ReadableSpan {
+  const request = asRecord(capture.request);
+  const options = asRecord(capture.options);
+  const parsedResponse = parseResponse(capture.response);
+  const shape = resolveOperationShape(request, capture.fallbackOperation);
+  const resolvedErrorMessage = resolveErrorMessage(
+    capture.error,
+    parsedResponse,
+    options.status,
+  );
+  const errorMessage = resolvedErrorMessage
+    ? redactSensitiveText(resolvedErrorMessage)
+    : undefined;
+  const attributes: Attributes = {
+    [SpanAttributes.TRACELOOP_ENTITY_NAME]: shape.entityName,
+    [SpanAttributes.TRACELOOP_ENTITY_PATH]: capture.parent.entityPath ?? "",
+    [RespanSpanAttributes.RESPAN_LOG_METHOD]: TRACE_METHOD,
+    [RespanSpanAttributes.RESPAN_LOG_TYPE]: shape.logType,
+  };
+
+  if (request[HeliconeFields.EVENT_TYPE] === HeliconeEventTypes.TOOL) {
+    attachToolEvent(attributes, request, parsedResponse, capture.traceContent);
+  } else if (request[HeliconeFields.EVENT_TYPE] === HeliconeEventTypes.VECTOR_DB) {
+    attachVectorEvent(attributes, request, parsedResponse, capture.traceContent);
+  } else if (request[HeliconeFields.EVENT_TYPE] === HeliconeEventTypes.DATA) {
+    attachDataEvent(attributes, request, parsedResponse, capture.traceContent);
+  } else {
+    attachLlmAttributes(
+      attributes,
+      request,
+      parsedResponse,
+      options,
+      shape,
+      capture.traceContent,
+    );
+    const streaming = resolveStreaming(
+      request,
+      options,
+      capture.fallbackOperation,
+    );
+    if (streaming !== undefined) {
+      attributes[ATTR_GEN_AI_REQUEST_STREAM] = streaming;
+    }
+  }
+
+  attachSafeHeliconeHeaders(
+    attributes,
+    capture.loggerHeaders,
+    options.additionalHeaders,
+  );
+  attachOperationalMetadata(
+    attributes,
+    options,
+    capture.fallbackOperation,
+    capture.propagatedAttributes,
+  );
+  if (errorMessage) {
+    const statusCode = errorStatusCode(options.status);
+    attributes[ATTR_ERROR_TYPE] = errorType(capture.error, options.status);
+    attributes[ATTR_HTTP_RESPONSE_STATUS_CODE] = statusCode;
+    attributes[ATTR_ERROR_MESSAGE] = errorMessage;
+    attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson({
+      error: errorMessage,
+    });
+    removeCompletionAttributes(attributes);
+  }
+
+  const { startTimeIso, endTimeIso } = resolveTimes(options);
+  const span = buildReadableSpan({
+    name: shape.entityName,
+    traceId: capture.parent.traceId,
+    parentId: capture.parent.parentId,
+    startTimeIso,
+    endTimeIso,
+    attributes,
+    statusCode: errorMessage ? 500 : 200,
+    errorMessage,
+    mergePropagated: capture.propagatedAttributes === undefined,
+  }) as ReadableSpan & {
+    instrumentationScope?: { name: string; version?: string };
+  };
+  span.instrumentationScope = capture.instrumentationScope;
+  return span;
+}
+
+function resolveOperationShape(
+  request: AnyRecord,
+  fallbackOperation?: string,
+): OperationShape {
+  if (request[HeliconeFields.EVENT_TYPE] === HeliconeEventTypes.TOOL) {
+    return {
+      logType: RespanLogType.TOOL,
+      entityName: stringValue(request[HeliconeFields.TOOL_NAME]) || "helicone.tool",
+    };
+  }
+
+  if (request[HeliconeFields.EVENT_TYPE] === HeliconeEventTypes.VECTOR_DB) {
+    const operation = sanitizeNamePart(request[HeliconeFields.OPERATION]) || "operation";
+    return {
+      logType: RespanLogType.TASK,
+      entityName: `helicone.vector_db.${operation}`,
+    };
+  }
+
+  if (request[HeliconeFields.EVENT_TYPE] === HeliconeEventTypes.DATA) {
+    const name = sanitizeNamePart(request[HeliconeFields.NAME]) || "event";
+    return {
+      logType: RespanLogType.TASK,
+      entityName: `helicone.data.${name}`,
+    };
+  }
+
+  if (Array.isArray(request.messages) || Array.isArray(request.contents)) {
+    return {
+      logType: RespanLogType.CHAT,
+      entityName: "helicone.chat",
+      requestType: LLMRequestTypeValues.CHAT,
+    };
+  }
+
+  if (request.prompt !== undefined || request.input !== undefined) {
+    return {
+      logType: RespanLogType.TEXT,
+      entityName: "helicone.text",
+      requestType: LLMRequestTypeValues.CHAT,
+    };
+  }
+
+  const fallback = sanitizeNamePart(fallbackOperation);
+  return {
+    logType: RespanLogType.CHAT,
+    entityName: fallback ? `helicone.${fallback}` : "helicone.chat",
+    requestType: LLMRequestTypeValues.CHAT,
+  };
+}
+
+function attachLlmAttributes(
+  attributes: Attributes,
+  request: AnyRecord,
+  response: ParsedResponse,
+  options: AnyRecord,
+  shape: OperationShape,
+  traceContent: boolean,
+): void {
+  const requestModel = request.model;
+  const responseModel = firstDefined(
+    response.record?.model,
+    response.record?.response?.model,
+  );
+  if (requestModel !== undefined) {
+    attributes[SpanAttributes.LLM_REQUEST_MODEL] = String(requestModel);
+  }
+  if (responseModel !== undefined) {
+    attributes[SpanAttributes.LLM_RESPONSE_MODEL] = String(responseModel);
+  }
+
+  const provider = resolveProvider(
+    options.provider,
+    request,
+    firstDefined(requestModel, responseModel),
+  );
+  if (provider) attributes[SpanAttributes.LLM_SYSTEM] = provider;
+  if (shape.requestType) {
+    attributes[SpanAttributes.LLM_REQUEST_TYPE] = shape.requestType;
+  }
+
+  attachRequestSettings(attributes, request);
+  attachUsage(attributes, response.usage);
+
+  if (!traceContent) return;
+
+  attachToolDefinitions(attributes, request.tools ?? request.functions);
+
+  const requestMessages = normalizeRequestMessages(request);
+  if (requestMessages) {
+    const systemContent = firstDefined(
+      request.system,
+      asRecord(request.systemInstruction).parts,
+      request.systemInstruction,
+    );
+    const promptMessages = systemContent !== undefined
+      ? [{ role: "system", content: systemContent }, ...requestMessages]
+      : requestMessages;
+    attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(promptMessages);
+    attachPromptMessages(attributes, promptMessages);
+  } else {
+    const scalarPrompt = firstDefined(request.prompt, request.input);
+    if (scalarPrompt !== undefined) {
+      const promptMessages = [
+        ...(request.system !== undefined
+          ? [{ role: "system", content: request.system }]
+          : []),
+        { role: "user", content: scalarPrompt },
+      ];
+      attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(promptMessages);
+      attachPromptMessages(attributes, promptMessages);
+    } else {
+      attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(request);
+    }
+  }
+
+  const output = response.message ?? response.raw ?? null;
+  attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson(output);
+  attachCompletion(attributes, response);
+}
+
+function normalizeRequestMessages(request: AnyRecord): AnyRecord[] | undefined {
+  if (Array.isArray(request.messages)) {
+    return request.messages.map((value: unknown) => {
+      const message = asRecord(value);
+      return {
+        ...message,
+        role: String(message.role ?? "user"),
+      };
+    });
+  }
+  if (!Array.isArray(request.contents)) return undefined;
+  return request.contents.map((value: unknown) => {
+    const content = asRecord(value);
+    return {
+      role: content.role === "model" ? "assistant" : String(content.role ?? "user"),
+      content: firstDefined(content.parts, content.content, []),
+    };
+  });
+}
+
+function attachRequestSettings(attributes: Attributes, request: AnyRecord): void {
+  setPrimitive(attributes, SpanAttributes.LLM_REQUEST_MAX_TOKENS, request.max_tokens ?? request.maxTokens);
+  setPrimitive(attributes, SpanAttributes.LLM_REQUEST_TEMPERATURE, request.temperature);
+  setPrimitive(attributes, SpanAttributes.LLM_REQUEST_TOP_P, request.top_p ?? request.topP);
+  setPrimitive(attributes, SpanAttributes.LLM_TOP_K, request.top_k ?? request.topK);
+  setPrimitive(
+    attributes,
+    SpanAttributes.LLM_FREQUENCY_PENALTY,
+    request.frequency_penalty ?? request.frequencyPenalty,
+  );
+  setPrimitive(
+    attributes,
+    SpanAttributes.LLM_PRESENCE_PENALTY,
+    request.presence_penalty ?? request.presencePenalty,
+  );
+  if (request.stop !== undefined || request.stopSequences !== undefined) {
+    attributes[SpanAttributes.LLM_CHAT_STOP_SEQUENCES] = safeJson(
+      request.stop ?? request.stopSequences,
+    );
+  }
+}
+
+function attachToolDefinitions(attributes: Attributes, value: unknown): void {
+  const tools = normalizeToolDefinitions(value);
+  if (tools.length > 0) {
+    attributes[SpanAttributes.LLM_REQUEST_FUNCTIONS] = safeJson(tools);
+  }
+}
+
+function normalizeToolDefinitions(value: unknown): AnyRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    const record = asRecord(item);
+    if (Array.isArray(record.functionDeclarations)) {
+      return normalizeToolDefinitions(record.functionDeclarations);
+    }
+    if (isRecord(record.function)) {
+      return [{
+        type: String(record.type ?? "function"),
+        function: {
+          name: String(record.function.name ?? ""),
+          ...(record.function.description !== undefined
+            ? { description: String(record.function.description) }
+            : {}),
+          ...(record.function.parameters !== undefined
+            ? { parameters: record.function.parameters }
+            : {}),
+        },
+      }];
+    }
+
+    if (record.name !== undefined) {
+      const parameters = firstDefined(record.parameters, record.input_schema);
+      return [{
+        type: "function",
+        function: {
+          name: String(record.name),
+          ...(record.description !== undefined
+            ? { description: String(record.description) }
+            : {}),
+          ...(parameters !== undefined
+            ? { parameters }
+            : {}),
+        },
+      }];
+    }
+    return [];
+  });
+}
+
+function normalizeToolCalls(value: unknown): AnyRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    const record = asRecord(item);
+    const fn = asRecord(record.function);
+    const functionCall = asRecord(record.functionCall);
+    const name = firstDefined(fn.name, functionCall.name, record.name);
+    if (name === undefined) return [];
+    const rawArguments = firstDefined(
+      fn.arguments,
+      functionCall.args,
+      record.input,
+      record.arguments,
+      {},
+    );
+    return [{
+      ...(record.id !== undefined ? { id: String(record.id) } : {}),
+      type: "function",
+      function: {
+        name: String(name),
+        arguments: normalizeToolArguments(rawArguments),
+      },
+    }];
+  });
+}
+
+function normalizeToolArguments(value: unknown): string {
+  if (typeof value !== "string") return safeJson(value);
+  const parsed = parseJson(value);
+  return parsed === undefined ? redactSensitiveText(value) : safeJson(parsed);
+}
+
+function toolCallsFromContent(value: unknown): AnyRecord[] {
+  if (!Array.isArray(value)) return [];
+  return normalizeToolCalls(
+    value.filter((item) => {
+      const record = asRecord(item);
+      return record.type === "tool_use" || isRecord(record.functionCall);
+    }),
+  );
+}
+
+function attachPromptMessages(attributes: Attributes, messages: unknown): void {
+  if (!Array.isArray(messages)) return;
+  messages.slice(0, MAX_INDEXED_PROMPT_MESSAGES).forEach((rawMessage, index) => {
+    const message = asRecord(rawMessage);
+    const prefix = `${SpanAttributes.LLM_PROMPTS}.${index}`;
+    attributes[`${prefix}.role`] = String(message.role ?? "user");
+    if (message.content !== undefined) {
+      attributes[`${prefix}.content`] = contentString(message.content);
+    }
+    const explicitToolCalls = normalizeToolCalls(firstDefined(
+      message.tool_calls,
+      message.toolCalls,
+    ));
+    const toolCalls = explicitToolCalls.length > 0
+      ? explicitToolCalls
+      : toolCallsFromContent(message.content);
+    if (toolCalls.length > 0) {
+      attributes[`${prefix}.tool_calls`] = safeJson(toolCalls);
+    }
+  });
+}
+
+function attachCompletion(attributes: Attributes, response: ParsedResponse): void {
+  const message = response.message;
+  const hasOutput =
+    response.text !== undefined ||
+    message?.content !== undefined ||
+    (response.toolCalls?.length ?? 0) > 0;
+  if (!hasOutput) return;
+
+  const prefix = `${SpanAttributes.LLM_COMPLETIONS}.0`;
+  attributes[`${prefix}.role`] = String(message?.role ?? "assistant");
+  attributes[`${prefix}.content`] = contentString(
+    firstDefined(message?.content, response.text, ""),
+  );
+  if (response.toolCalls && response.toolCalls.length > 0) {
+    attributes[`${prefix}.tool_calls`] = safeJson(response.toolCalls);
+  }
+}
+
+function attachUsage(attributes: Attributes, usageValue: unknown): void {
+  const usage = asRecord(usageValue);
+  const input = integerValue(firstDefined(
+    usage.input_tokens,
+    usage.prompt_tokens,
+    usage.inputTokens,
+    usage.promptTokens,
+    usage.promptTokenCount,
+  ));
+  const output = integerValue(firstDefined(
+    usage.output_tokens,
+    usage.completion_tokens,
+    usage.outputTokens,
+    usage.completionTokens,
+    usage.candidatesTokenCount,
+  ));
+  const explicitTotal = integerValue(firstDefined(
+    usage.total_tokens,
+    usage.totalTokens,
+    usage.totalTokenCount,
+  ));
+  const cacheRead = integerValue(firstDefined(
+    usage.cache_read_input_tokens,
+    usage.cacheReadInputTokens,
+    usage.cache_read_tokens,
+    usage.cacheReadTokens,
+    usage.cachedContentTokenCount,
+  ));
+
+  if (input !== undefined) {
+    attributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = input;
+    attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] = input;
+  }
+  if (output !== undefined) {
+    attributes[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] = output;
+    attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = output;
+  }
+  if (cacheRead !== undefined) {
+    attributes[ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] = cacheRead;
+    attributes[
+      TraceloopCompatibilityFields.LLM_USAGE_CACHE_READ_INPUT_TOKENS
+    ] = cacheRead;
+  }
+  const total = explicitTotal ??
+    (input !== undefined || output !== undefined ? (input ?? 0) + (output ?? 0) : undefined);
+  if (total !== undefined) {
+    attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] = total;
+  }
+}
+
+function attachToolEvent(
+  attributes: Attributes,
+  request: AnyRecord,
+  response: ParsedResponse,
+  traceContent: boolean,
+): void {
+  if (!traceContent) return;
+  const args = firstDefined(
+    request[HeliconeFields.INPUT],
+    request[HeliconeFields.ARGUMENTS],
+    omitKeys(request, [HeliconeFields.EVENT_TYPE, HeliconeFields.TOOL_NAME]),
+  );
+  attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson({
+    name: String(request[HeliconeFields.TOOL_NAME] ?? "tool"),
+    arguments: args ?? {},
+  });
+  attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson(response.raw ?? null);
+}
+
+function attachVectorEvent(
+  attributes: Attributes,
+  request: AnyRecord,
+  response: ParsedResponse,
+  traceContent: boolean,
+): void {
+  setPrimitive(
+    attributes,
+    SpanAttributes.VECTOR_DB_QUERY_TOP_K,
+    request[HeliconeFields.TOP_K],
+  );
+  setPrimitive(
+    attributes,
+    SpanAttributes.VECTOR_DB_TABLE_NAME,
+    request[HeliconeFields.DATABASE_NAME],
+  );
+  if (!traceContent) return;
+  attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(request);
+  attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson(response.raw ?? null);
+}
+
+function attachDataEvent(
+  attributes: Attributes,
+  request: AnyRecord,
+  response: ParsedResponse,
+  traceContent: boolean,
+): void {
+  if (!traceContent) return;
+  attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] = safeJson(
+    firstDefined(
+      request[HeliconeFields.META],
+      omitKeys(request, [HeliconeFields.EVENT_TYPE, HeliconeFields.NAME]),
+    ),
+  );
+  attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] = safeJson(response.raw ?? null);
+}
+
+function attachSafeHeliconeHeaders(
+  attributes: Attributes,
+  ...headerSources: unknown[]
+): void {
+  const headers = new Map<string, string>();
+  for (const source of headerSources) {
+    for (const [key, value] of normalizeHeaders(source)) headers.set(key, value);
+  }
+  const userId = headers.get(HeliconeHeaders.USER_ID);
+  const sessionId = headers.get(HeliconeHeaders.SESSION_ID);
+  if (userId) {
+    attributes[RespanSpanAttributes.RESPAN_CUSTOMER_PARAMS_ID] = userId;
+  }
+  if (sessionId) {
+    attributes[RespanSpanAttributes.RESPAN_THREADS_ID] = sessionId;
+  }
+
+  const properties: Record<string, string> = {};
+  for (const [key, value] of headers.entries()) {
+    if (!key.startsWith(HeliconeHeaders.PROPERTY_PREFIX)) continue;
+    const propertyName = key.slice(HeliconeHeaders.PROPERTY_PREFIX.length);
+    if (propertyName && value) properties[propertyName] = value;
+  }
+  if (Object.keys(properties).length > 0) {
+    attributes[SpanAttributes.TRACELOOP_ASSOCIATION_PROPERTIES] = safeJson(properties);
+  }
+}
+
+function attachOperationalMetadata(
+  attributes: Attributes,
+  options: AnyRecord,
+  fallbackOperation?: string,
+  propagatedAttributes?: unknown,
+): void {
+  const propagated = asRecord(propagatedAttributes);
+  const propagatedMetadata = asRecord(propagated.metadata);
+  const status = finiteNumber(options.status);
+  const timeToFirstToken = finiteNumber(options.timeToFirstToken);
+  if (timeToFirstToken !== undefined) {
+    attributes[ATTR_GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK] =
+      timeToFirstToken / 1_000;
+  }
+  const heliconeMetadata: AnyRecord = {
+    ...(status !== undefined ? { status } : {}),
+    ...(timeToFirstToken !== undefined
+      ? { time_to_first_token_ms: timeToFirstToken }
+      : {}),
+    ...(fallbackOperation ? { operation: fallbackOperation } : {}),
+    ...(
+      timeToFirstToken !== undefined ||
+      fallbackOperation?.toLowerCase().includes("stream")
+        ? { streaming: true }
+        : {}
+    ),
+  };
+  const metadata = {
+    ...propagatedMetadata,
+    helicone: heliconeMetadata,
+  };
+  attributes[RespanSpanAttributes.RESPAN_METADATA] = safeJson(metadata);
+
+  if (propagatedAttributes !== undefined) {
+    attachPropagatedSnapshot(attributes, propagated);
+  }
+}
+
+function attachPropagatedSnapshot(
+  attributes: Attributes,
+  propagated: AnyRecord,
+): void {
+  for (const [key, value] of Object.entries(propagated)) {
+    if (key === "metadata" || value === undefined || value === null) continue;
+    const attributeKey = (RESPAN_SPAN_ATTRIBUTES_MAP as Record<string, string>)[key];
+    if (!attributeKey || attributes[attributeKey] !== undefined) continue;
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      attributes[attributeKey] = value;
+    } else {
+      attributes[attributeKey] = safeJson(value);
+    }
+  }
+}
+
+function resolveStreaming(
+  request: AnyRecord,
+  options: AnyRecord,
+  fallbackOperation?: string,
+): boolean | undefined {
+  if (typeof request.stream === "boolean") return request.stream;
+  if (options.timeToFirstToken !== undefined) return true;
+  if (fallbackOperation?.toLowerCase().includes("stream")) return true;
+  return undefined;
+}
+
+function parseResponse(value: unknown): ParsedResponse {
+  if (typeof value !== "string") {
+    const record = asRecord(value);
+    if (isGoogleResponse(record)) return aggregateGoogleChunks([record], value);
+    const message = extractMessage(record);
+    return {
+      raw: value,
+      record,
+      text: extractText(record),
+      message,
+      toolCalls: extractToolCalls(record, message),
+      usage: findUsage(record),
+    };
+  }
+
+  const parsedWhole = parseJson(value);
+  if (parsedWhole !== undefined) return parseResponse(parsedWhole);
+
+  const chunks = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.startsWith("data:") ? line.slice(5).trim() : line)
+    .filter((line) => line !== "[DONE]")
+    .map(parseJson)
+    .filter((item): item is unknown => item !== undefined);
+  if (chunks.length === 0) {
+    return { raw: value, text: value };
+  }
+  return aggregateChunks(chunks, value);
+}
+
+function aggregateChunks(chunks: unknown[], raw: unknown): ParsedResponse {
+  if (chunks.some((chunk) => isAnthropicStreamChunk(asRecord(chunk)))) {
+    return aggregateAnthropicChunks(chunks, raw);
+  }
+  if (chunks.some((chunk) => isGoogleResponse(asRecord(chunk)))) {
+    return aggregateGoogleChunks(chunks, raw);
+  }
+
+  const textParts: string[] = [];
+  const toolCalls = new Map<string, AnyRecord>();
+  let usage: AnyRecord | undefined;
+  let role = "assistant";
+  let model: unknown;
+
+  chunks.forEach((chunkValue) => {
+    const chunk = asRecord(chunkValue);
+    model = chunk.model ?? model;
+    usage = isRecord(chunk.usage) ? chunk.usage : usage;
+    const choice = asRecord(Array.isArray(chunk.choices) ? chunk.choices[0] : undefined);
+    const message = asRecord(choice.delta ?? choice.message);
+    if (message.role) role = String(message.role);
+    if (message.content !== undefined) textParts.push(contentString(message.content));
+    mergeStreamingToolCalls(toolCalls, message.tool_calls ?? message.toolCalls);
+  });
+
+  const mergedTools = normalizeToolCalls([...toolCalls.values()]);
+  const text = textParts.join("");
+  const message: AnyRecord = { role, content: text };
+  if (mergedTools.length > 0) message.tool_calls = mergedTools;
+  return {
+    raw,
+    record: { model, usage, choices: [{ message }] },
+    text,
+    message,
+    toolCalls: mergedTools,
+    usage,
+  };
+}
+
+function isAnthropicStreamChunk(chunk: AnyRecord): boolean {
+  return typeof chunk.type === "string" && (
+    chunk.type.startsWith("message_") ||
+    chunk.type.startsWith("content_block_")
+  );
+}
+
+function aggregateAnthropicChunks(
+  chunks: unknown[],
+  raw: unknown,
+): ParsedResponse {
+  const blocks = new Map<number, AnyRecord>();
+  const partialToolInputs = new Map<number, string>();
+  let role = "assistant";
+  let model: unknown;
+  let usage: AnyRecord = {};
+
+  for (const chunkValue of chunks) {
+    const chunk = asRecord(chunkValue);
+    if (chunk.type === "message_start") {
+      const message = asRecord(chunk.message);
+      role = String(message.role ?? role);
+      model = firstDefined(message.model, model);
+      usage = mergeUsage(usage, message.usage);
+      if (Array.isArray(message.content)) {
+        message.content.forEach((block: unknown, index: number) => {
+          blocks.set(index, { ...asRecord(block) });
+        });
+      }
+      continue;
+    }
+    if (chunk.type === "content_block_start") {
+      const index = integerValue(chunk.index) ?? blocks.size;
+      const block = { ...asRecord(chunk.content_block) };
+      blocks.set(index, block);
+      if (block.type === "tool_use" && block.input !== undefined) {
+        if (typeof block.input === "string" && block.input) {
+          partialToolInputs.set(index, block.input);
+        } else if (isRecord(block.input) && Object.keys(block.input).length > 0) {
+          partialToolInputs.set(index, safeJson(block.input));
+        }
+      }
+      continue;
+    }
+    if (chunk.type === "content_block_delta") {
+      const index = integerValue(chunk.index) ?? 0;
+      const delta = asRecord(chunk.delta);
+      const block = blocks.get(index) ?? {
+        type: delta.type === "input_json_delta" ? "tool_use" : "text",
+      };
+      if (delta.type === "text_delta" || delta.text !== undefined) {
+        block.text = String(block.text ?? "") + String(delta.text ?? "");
+      }
+      if (delta.type === "input_json_delta" || delta.partial_json !== undefined) {
+        partialToolInputs.set(
+          index,
+          (partialToolInputs.get(index) ?? "") + String(delta.partial_json ?? ""),
+        );
+      }
+      blocks.set(index, block);
+      continue;
+    }
+    if (chunk.type === "message_delta") {
+      usage = mergeUsage(usage, chunk.usage);
+    }
+  }
+
+  const content = [...blocks.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([index, rawBlock]) => {
+      const block = { ...rawBlock };
+      if (block.type === "tool_use" && partialToolInputs.has(index)) {
+        const rawInput = partialToolInputs.get(index) ?? "";
+        block.input = parseJson(rawInput) ?? rawInput;
+      }
+      return block;
+    });
+  const message: AnyRecord = { role, content };
+  const toolCalls = toolCallsFromContent(content);
+  return {
+    raw,
+    record: { model, usage, role, content },
+    text: contentString(content),
+    message,
+    toolCalls,
+    usage,
+  };
+}
+
+function isGoogleResponse(record: AnyRecord): boolean {
+  return Array.isArray(record.candidates) ||
+    isRecord(record.usageMetadata) ||
+    record.modelVersion !== undefined;
+}
+
+function aggregateGoogleChunks(
+  chunks: unknown[],
+  raw: unknown,
+): ParsedResponse {
+  const parts: AnyRecord[] = [];
+  let role = "assistant";
+  let model: unknown;
+  let usage: AnyRecord = {};
+
+  for (const chunkValue of chunks) {
+    const chunk = asRecord(chunkValue);
+    model = firstDefined(chunk.modelVersion, chunk.model, model);
+    usage = mergeUsage(usage, chunk.usageMetadata ?? chunk.usage);
+    const candidate = asRecord(
+      Array.isArray(chunk.candidates) ? chunk.candidates[0] : undefined,
+    );
+    const content = asRecord(candidate.content);
+    if (content.role) role = content.role === "model" ? "assistant" : String(content.role);
+    if (!Array.isArray(content.parts)) continue;
+    for (const rawPart of content.parts) {
+      const part = { ...asRecord(rawPart) };
+      const previous = parts.at(-1);
+      if (
+        typeof part.text === "string" &&
+        previous &&
+        typeof previous.text === "string" &&
+        Object.keys(part).length === 1 &&
+        Object.keys(previous).length === 1
+      ) {
+        previous.text += part.text;
+      } else {
+        parts.push(part);
+      }
+    }
+  }
+
+  const message: AnyRecord = { role, content: parts };
+  const toolCalls = toolCallsFromContent(parts);
+  return {
+    raw,
+    record: { model, usage, candidates: [{ content: { role, parts } }] },
+    text: contentString(parts),
+    message,
+    toolCalls,
+    usage,
+  };
+}
+
+function mergeUsage(current: AnyRecord, next: unknown): AnyRecord {
+  return isRecord(next) ? { ...current, ...next } : current;
+}
+
+function mergeStreamingToolCalls(target: Map<string, AnyRecord>, value: unknown): void {
+  if (!Array.isArray(value)) return;
+  value.forEach((rawCall, index) => {
+    const call = asRecord(rawCall);
+    const fn = asRecord(call.function);
+    const key = String(call.index ?? call.id ?? index);
+    const existing = target.get(key) ?? {
+      ...(call.id !== undefined ? { id: String(call.id) } : {}),
+      type: String(call.type ?? "function"),
+      function: { name: "", arguments: "" },
+    };
+    if (call.id !== undefined) existing.id = String(call.id);
+    if (fn.name !== undefined) existing.function.name += String(fn.name);
+    if (fn.arguments !== undefined) existing.function.arguments += String(fn.arguments);
+    target.set(key, existing);
+  });
+}
+
+function extractMessage(record: AnyRecord): AnyRecord | undefined {
+  const choice = asRecord(Array.isArray(record.choices) ? record.choices[0] : undefined);
+  const message = asRecord(firstDefined(
+    choice.message,
+    record.message,
+    record.output,
+    record.role !== undefined || record.content !== undefined ? record : undefined,
+  ));
+  if (Object.keys(message).length > 0) return message;
+  if (choice.text !== undefined || record.text !== undefined) {
+    return {
+      role: "assistant",
+      content: String(choice.text ?? record.text),
+    };
+  }
+  return undefined;
+}
+
+function extractText(record: AnyRecord): string | undefined {
+  const message = extractMessage(record);
+  const value = firstDefined(
+    message?.content,
+    asRecord(Array.isArray(record.choices) ? record.choices[0] : undefined).text,
+    record.text,
+  );
+  return value === undefined ? undefined : contentString(value);
+}
+
+function extractToolCalls(record: AnyRecord, message?: AnyRecord): AnyRecord[] {
+  const explicitToolCalls = normalizeToolCalls(firstDefined(
+    message?.tool_calls,
+    message?.toolCalls,
+    record.tool_calls,
+    record.toolCalls,
+  ));
+  return explicitToolCalls.length > 0
+    ? explicitToolCalls
+    : toolCallsFromContent(message?.content);
+}
+
+function findUsage(record: AnyRecord): AnyRecord | undefined {
+  const candidates = [
+    record.usage,
+    record.metrics?.usage,
+    record.response?.usage,
+  ];
+  return candidates.find(isRecord) as AnyRecord | undefined;
+}
+
+function resolveProvider(
+  provider: unknown,
+  request: AnyRecord,
+  model: unknown,
+): string | undefined {
+  const explicit = firstDefined(provider, request.provider);
+  if (explicit !== undefined) return normalizeProvider(String(explicit));
+  const modelName = String(model ?? "").toLowerCase();
+  if (modelName.includes("claude")) return "anthropic";
+  if (modelName.includes("gemini")) return "google";
+  if (modelName.includes("command")) return "cohere";
+  if (modelName.includes("gpt") || /^o[134](?:-|$)/.test(modelName)) return "openai";
+  return undefined;
+}
+
+function resolveErrorMessage(
+  error: unknown,
+  response: ParsedResponse,
+  statusValue: unknown,
+): string | undefined {
+  if (error !== undefined && error !== null) return errorMessage(error);
+  const status = Number(statusValue);
+  if (Number.isFinite(status) && (status >= 400 || status < 0)) {
+    const responseError = firstDefined(
+      response.record?.error?.message,
+      response.record?.error,
+      response.record?.message,
+    );
+    if (responseError !== undefined) return errorMessage(responseError);
+    if (response.text) return response.text.split(/\r?\n/, 1)[0];
+    if (status < 0) return "Helicone operation cancelled";
+    return `Helicone operation failed with status ${status}`;
+  }
+  return undefined;
+}
+
+function errorType(error: unknown, status: unknown): string {
+  if (error instanceof Error && error.name) return error.name;
+  if (error !== undefined && error !== null) return typeof error;
+  const numericStatus = Number(status);
+  if (numericStatus < 0) return "cancelled";
+  if (Number.isFinite(numericStatus)) return `status_${numericStatus}`;
+  return "error";
+}
+
+function errorStatusCode(status: unknown): number {
+  const numericStatus = Number(status);
+  if (Number.isFinite(numericStatus) && numericStatus >= 400) {
+    return Math.trunc(numericStatus);
+  }
+  if (Number.isFinite(numericStatus) && numericStatus < 0) return 499;
+  return 500;
+}
+
+function removeCompletionAttributes(attributes: Attributes): void {
+  const prefix = `${SpanAttributes.LLM_COMPLETIONS}.0.`;
+  for (const key of Object.keys(attributes)) {
+    if (key.startsWith(prefix)) delete attributes[key];
+  }
+}
+
+function resolveTimes(options: AnyRecord): {
+  startTimeIso: string;
+  endTimeIso: string;
+} {
+  const now = Date.now();
+  const start = finiteNumber(options.startTime) ?? now;
+  const end = Math.max(start, finiteNumber(options.endTime) ?? now);
+  return {
+    startTimeIso: new Date(start).toISOString(),
+    endTimeIso: new Date(end).toISOString(),
+  };
+}
+
+function normalizeHeaders(value: unknown): Map<string, string> {
+  const out = new Map<string, string>();
+  if (value instanceof Headers) {
+    value.forEach((headerValue, key) => out.set(key.toLowerCase(), headerValue));
+    return out;
+  }
+  if (!isRecord(value)) return out;
+  Object.entries(value).forEach(([key, headerValue]) => {
+    if (headerValue !== undefined && headerValue !== null) {
+      out.set(key.toLowerCase(), String(headerValue));
+    }
+  });
+  return out;
+}
+
+function contentString(value: unknown): string {
+  if (typeof value === "string") {
+    const parsed = parseJson(value);
+    return isRecord(parsed) || Array.isArray(parsed) ? safeJson(parsed) : value;
+  }
+  // The span contract requires every structured content value to remain JSON,
+  // including arrays made only of text blocks; concatenating loses boundaries.
+  return value === undefined || value === null ? "" : safeJson(value);
+}
+
+function errorMessage(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  if (isRecord(value) && value.message !== undefined) return String(value.message);
+  return safeJson(value);
+}
+
+function redactSensitiveText(value: string): string {
+  const parsed = parseJson(value);
+  if (isRecord(parsed) || Array.isArray(parsed)) {
+    return safeJson(parsed).slice(0, MAX_ERROR_MESSAGE_CHARS);
+  }
+  return value
+    .replace(
+      /((?:"|')?(?:authorization|api[_ -]?key|access[_ -]?token|refresh[_ -]?token|auth[_ -]?token|bearer[_ -]?token|id[_ -]?token|session[_ -]?token|private[_ -]?key|client[_ -]?secret|credential|credentials|helicone[_ -]?auth|token|password|secret|cookie)(?:"|')?\s*[:=]\s*)(?:(?:bearer|basic)\s+)?(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
+      "$1[REDACTED]",
+    )
+    .replace(/\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
+    .replace(/\bsk-(?:proj-)?[A-Za-z0-9_-]{8,}\b/g, "[REDACTED]")
+    .slice(0, MAX_ERROR_MESSAGE_CHARS);
+}
+
+function normalizeProvider(value: string): string | undefined {
+  const normalized = value.toLowerCase().trim().replace(/^@/, "");
+  return normalized.replace(/[^a-z0-9._-]+/g, "_") || undefined;
+}
+
+function sanitizeNamePart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function setPrimitive(attributes: Attributes, key: string, value: unknown): void {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    attributes[key] = value;
+  }
+}
+
+function integerValue(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.trunc(number) : undefined;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function parseJson(value: string): unknown | undefined {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+export function safeJson(value: unknown): string {
+  const sanitized = sanitizeForSerialization(value);
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(sanitized);
+  } catch {
+    serialized = JSON.stringify(String(sanitized));
+  }
+  const bytes = new TextEncoder().encode(serialized).byteLength;
+  if (bytes <= MAX_SERIALIZED_BYTES) return serialized;
+  return JSON.stringify({
+    truncated: true,
+    original_bytes: bytes,
+    preview: serialized.slice(0, Math.floor(MAX_SERIALIZED_BYTES / 2)),
+  });
+}
+
+function sanitizeForSerialization(value: unknown): unknown {
+  const seen = new WeakSet<object>();
+  let visited = 0;
+
+  const visit = (current: unknown, depth: number, key?: string): unknown => {
+    visited += 1;
+    if (visited > 50_000 || depth > 32) return "[Truncated]";
+    if (key && isSensitiveKey(key)) return "[REDACTED]";
+    if (typeof current === "string") {
+      const parsed = parseJson(current);
+      if (isRecord(parsed) || Array.isArray(parsed)) {
+        try {
+          return JSON.stringify(visit(parsed, depth + 1));
+        } catch {
+          return "[Truncated]";
+        }
+      }
+      return current;
+    }
+    if (
+      current === null ||
+      typeof current === "number" ||
+      typeof current === "boolean"
+    ) return current;
+    if (typeof current === "bigint") return current.toString();
+    if (current === undefined) return null;
+    if (current instanceof Date) return current.toISOString();
+    if (current instanceof Error) {
+      return {
+        name: current.name,
+        message: redactSensitiveText(current.message),
+      };
+    }
+    if (ArrayBuffer.isView(current)) {
+      return Array.from(current as unknown as ArrayLike<number>);
+    }
+    if (Array.isArray(current)) {
+      return current.map((item) => visit(item, depth + 1));
+    }
+    if (typeof current !== "object") return String(current);
+    if (seen.has(current)) return "[Circular]";
+    seen.add(current);
+    return Object.fromEntries(
+      Object.entries(current as AnyRecord).map(([childKey, childValue]) => [
+        childKey,
+        visit(childValue, depth + 1, childKey),
+      ]),
+    );
+  };
+
+  return visit(value, 0);
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (normalized === "token" || normalized.endsWith("_token")) return true;
+  return /(?:^|_)(?:authorization|api_key|access_token|refresh_token|auth_token|bearer|bearer_token|id_token|session_token|private_key|client_secret|credential|credentials|helicone_auth|password|secret|cookie)(?:_|$)/.test(
+    normalized,
+  );
+}
+
+function omitKeys(record: AnyRecord, keys: string[]): AnyRecord {
+  const omitted = new Set(keys);
+  return Object.fromEntries(
+    Object.entries(record).filter(([key]) => !omitted.has(key)),
+  );
+}
+
+function firstDefined(...values: unknown[]): any {
+  return values.find((value) => value !== undefined && value !== null);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return value === undefined || value === null ? undefined : String(value);
+}
+
+function isRecord(value: unknown): value is AnyRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): AnyRecord {
+  return isRecord(value) ? value : {};
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-helicone/src/index.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-helicone/src/index.ts
@@ -1,0 +1,502 @@
+/**
+ * Respan instrumentation for `@helicone/helpers`.
+ *
+ * `HeliconeManualLogger.sendLog()` is the common successful-call chokepoint for
+ * direct sends, builders, request helpers, and stream helpers. This package
+ * patches it once and adds narrow outer wrappers solely to capture operations
+ * that reject before `sendLog()` is reached.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+import { context, trace } from "@opentelemetry/api";
+import {
+  getEntityPath,
+  getPropagatedAttributes,
+  injectSpan,
+} from "@respan/tracing";
+import {
+  buildHeliconeSpan,
+  type HeliconeCapture,
+  type HeliconeParentContext,
+} from "./_translator.js";
+
+type AnyFunction = (this: any, ...args: any[]) => any;
+type AnyRecord = Record<string, any>;
+
+interface HeliconeHelpersModule {
+  HeliconeManualLogger?: {
+    prototype?: any;
+  };
+}
+
+interface InvocationState {
+  parent?: InvocationState;
+  captureReached: boolean;
+  callbackDepth: number;
+  parentContext: HeliconeParentContext;
+  startedAt: number;
+  operation: string;
+  request: unknown;
+  additionalHeaders?: unknown;
+  propagatedAttributes?: unknown;
+  provider?: unknown;
+}
+
+interface InstalledPatch {
+  target: Record<string, AnyFunction>;
+  method: string;
+  original: AnyFunction;
+  wrapped: AnyFunction;
+}
+
+export interface HeliconeInstrumentorOptions {
+  /** Application-resolved module override, primarily useful for tests/loaders. */
+  sdkModule?: HeliconeHelpersModule;
+  /** Capture request/response bodies. Defaults to true. */
+  traceContent?: boolean;
+}
+
+const INSTRUMENTATION_NAME = "@respan/instrumentation-helicone";
+const packageRequire = createRequire(import.meta.url);
+const { version: INSTRUMENTATION_VERSION } = packageRequire("../package.json") as {
+  version: string;
+};
+const instrumentationScope = {
+  name: INSTRUMENTATION_NAME,
+  version: INSTRUMENTATION_VERSION,
+};
+
+const invocationStorage = new AsyncLocalStorage<InvocationState>();
+const OUTER_ERROR_METHODS = [
+  "logRequest",
+  "logStream",
+  "logSingleStream",
+  "logSingleRequest",
+] as const;
+
+const sharedState = {
+  activeInstances: 0,
+  contentCaptureDisabledInstances: 0,
+  patches: [] as InstalledPatch[],
+  activation: undefined as Promise<boolean> | undefined,
+};
+
+export class HeliconeInstrumentor {
+  public readonly name = "helicone";
+
+  private readonly sdkModule?: HeliconeHelpersModule;
+  private readonly traceContent: boolean;
+  private active = false;
+  private activation?: Promise<void>;
+
+  constructor(options: HeliconeInstrumentorOptions = {}) {
+    this.sdkModule = options.sdkModule;
+    this.traceContent = options.traceContent ?? true;
+  }
+
+  async activate(): Promise<void> {
+    if (this.active) return;
+    if (!this.activation) this.activation = this.acquireActivation();
+    const activation = this.activation;
+    try {
+      await activation;
+    } finally {
+      if (this.activation === activation) this.activation = undefined;
+    }
+  }
+
+  deactivate(): void {
+    if (!this.active) return;
+    const shared = sharedState;
+    shared.activeInstances = Math.max(0, shared.activeInstances - 1);
+    if (!this.traceContent) {
+      shared.contentCaptureDisabledInstances = Math.max(
+        0,
+        shared.contentCaptureDisabledInstances - 1,
+      );
+    }
+    this.active = false;
+    if (shared.activeInstances === 0) restorePatches();
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  enable(): void {
+    void this.activate().catch(() => undefined);
+  }
+
+  disable(): void {
+    this.deactivate();
+  }
+
+  private async acquireActivation(): Promise<void> {
+    const shared = sharedState;
+    let installed: boolean;
+    if (shared.activation) {
+      installed = await shared.activation;
+    } else if (shared.patches.length > 0) {
+      installed = true;
+    } else {
+      const activation = installPatches(this.sdkModule);
+      shared.activation = activation;
+      try {
+        installed = await activation;
+      } finally {
+        if (shared.activation === activation) shared.activation = undefined;
+      }
+    }
+
+    if (!installed || this.active) return;
+    shared.activeInstances += 1;
+    if (!this.traceContent) shared.contentCaptureDisabledInstances += 1;
+    this.active = true;
+  }
+}
+
+export async function instrumentHelicone(
+  options: HeliconeInstrumentorOptions = {},
+): Promise<HeliconeInstrumentor> {
+  const instrumentor = new HeliconeInstrumentor(options);
+  await instrumentor.activate();
+  return instrumentor;
+}
+
+export { buildHeliconeSpan } from "./_translator.js";
+export default HeliconeInstrumentor;
+
+async function installPatches(
+  suppliedModule?: HeliconeHelpersModule,
+): Promise<boolean> {
+  const helpers = suppliedModule ?? await importHeliconeHelpers();
+  const prototype = helpers.HeliconeManualLogger?.prototype;
+  if (!prototype || typeof prototype.sendLog !== "function") {
+    throw new Error(
+      "@respan/instrumentation-helicone requires @helicone/helpers " +
+      ">=1.8.3 <2 with HeliconeManualLogger.sendLog().",
+    );
+  }
+
+  try {
+    patchSendLog(prototype);
+    patchLogBuilder(prototype);
+    for (const method of OUTER_ERROR_METHODS) patchOuterErrorPath(prototype, method);
+  } catch (error) {
+    restorePatches();
+    throw error;
+  }
+  return sharedState.patches.length > 0;
+}
+
+function patchSendLog(prototype: Record<string, AnyFunction>): void {
+  const original = prototype.sendLog;
+  if (typeof original !== "function") return;
+
+  const wrapped: AnyFunction = async function respanHeliconeSendLog(
+    this: unknown,
+    request: unknown,
+    response: unknown,
+    options: unknown,
+  ) {
+    if (sharedState.activeInstances === 0) {
+      return await original.apply(this, arguments as any);
+    }
+
+    const state = invocationStorage.getStore();
+    const callbackOwnedSend = (state?.callbackDepth ?? 0) > 0;
+    if (!callbackOwnedSend) markCaptureReached(state);
+    const parent = callbackOwnedSend
+      ? activeParentContext()
+      : state?.parentContext ?? activeParentContext();
+    const propagatedAttributes =
+      callbackOwnedSend
+        ? snapshotPropagatedAttributes()
+        : state?.propagatedAttributes ?? snapshotPropagatedAttributes();
+    let thrown: unknown;
+    try {
+      return await original.apply(this, arguments as any);
+    } catch (error) {
+      thrown = error;
+      throw error;
+    } finally {
+      emitCapture({
+        request,
+        response,
+        options,
+        loggerHeaders: asRecord(this).headers,
+        error: thrown,
+        parent,
+        fallbackOperation: callbackOwnedSend ? undefined : state?.operation,
+        propagatedAttributes,
+        traceContent: shouldCaptureContent(),
+        instrumentationScope,
+      });
+    }
+  };
+
+  installMethodPatch(prototype, "sendLog", original, wrapped);
+}
+
+function patchLogBuilder(prototype: Record<string, AnyFunction>): void {
+  const original = prototype.logBuilder;
+  if (typeof original !== "function") return;
+
+  const wrapped: AnyFunction = function respanHeliconeLogBuilder(
+    this: unknown,
+    request: unknown,
+    additionalHeaders?: unknown,
+  ) {
+    const builder = original.apply(this, arguments as any);
+    if (sharedState.activeInstances === 0 || !builder) return builder;
+
+    const builderRecord = asRecord(builder);
+    const originalSendLog = builderRecord.sendLog;
+    if (typeof originalSendLog !== "function") return builder;
+    const parentState = invocationStorage.getStore();
+    const snapshot = {
+      parent: parentState,
+      parentContext: activeParentContext(),
+      propagatedAttributes: snapshotPropagatedAttributes(),
+      request,
+      additionalHeaders,
+      loggerHeaders: asRecord(this).headers,
+    };
+
+    builderRecord.sendLog = async function respanHeliconeBuilderSendLog(
+      this: unknown,
+      ...args: unknown[]
+    ) {
+      if (sharedState.activeInstances === 0) {
+        return await originalSendLog.apply(this, args);
+      }
+      const state: InvocationState = {
+        parent: snapshot.parent,
+        captureReached: false,
+        callbackDepth: 0,
+        parentContext: snapshot.parentContext,
+        propagatedAttributes: snapshot.propagatedAttributes,
+        startedAt: Date.now(),
+        operation: "logBuilder",
+        request: snapshot.request,
+        additionalHeaders: snapshot.additionalHeaders,
+      };
+      return await invocationStorage.run(state, async () => {
+        try {
+          return await originalSendLog.apply(this, args);
+        } catch (error) {
+          if (!state.captureReached) {
+            markCaptureReached(state);
+            emitCapture({
+              request: state.request,
+              options: {
+                startTime: state.startedAt,
+                endTime: Date.now(),
+                status: 500,
+                additionalHeaders: state.additionalHeaders,
+              },
+              loggerHeaders: snapshot.loggerHeaders,
+              error,
+              parent: state.parentContext,
+              fallbackOperation: state.operation,
+              propagatedAttributes: state.propagatedAttributes,
+              traceContent: shouldCaptureContent(),
+              instrumentationScope,
+            });
+          }
+          throw error;
+        }
+      });
+    };
+    return builder;
+  };
+
+  installMethodPatch(prototype, "logBuilder", original, wrapped);
+}
+
+function patchOuterErrorPath(
+  prototype: Record<string, AnyFunction>,
+  method: typeof OUTER_ERROR_METHODS[number],
+): void {
+  const original = prototype[method];
+  if (typeof original !== "function") return;
+
+  const wrapped: AnyFunction = async function respanHeliconeOuterCall(
+    this: unknown,
+    ...args: unknown[]
+  ) {
+    if (sharedState.activeInstances === 0) {
+      return await original.apply(this, args);
+    }
+
+    const parentState = invocationStorage.getStore();
+    const state: InvocationState = {
+      parent: parentState,
+      captureReached: false,
+      callbackDepth: 0,
+      parentContext: activeParentContext(),
+      propagatedAttributes: snapshotPropagatedAttributes(),
+      startedAt: Date.now(),
+      operation: method,
+      request: args[0],
+      ...outerCorrelation(method, args),
+    };
+
+    return await invocationStorage.run(state, async () => {
+      const operationArgs = wrapUserCallback(method, args, state);
+      try {
+        return await original.apply(this, operationArgs);
+      } catch (error) {
+        if (!state.captureReached) {
+          markCaptureReached(state);
+          emitCapture({
+            request: state.request,
+            response: undefined,
+            options: {
+              startTime: state.startedAt,
+              endTime: Date.now(),
+              status: 500,
+              additionalHeaders: state.additionalHeaders,
+              provider: state.provider,
+            },
+            loggerHeaders: asRecord(this).headers,
+            error,
+            parent: state.parentContext,
+            fallbackOperation: state.operation,
+            propagatedAttributes: state.propagatedAttributes,
+            traceContent: shouldCaptureContent(),
+            instrumentationScope,
+          });
+        }
+        throw error;
+      }
+    });
+  };
+
+  installMethodPatch(prototype, method, original, wrapped);
+}
+
+function wrapUserCallback(
+  method: typeof OUTER_ERROR_METHODS[number],
+  args: unknown[],
+  state: InvocationState,
+): unknown[] {
+  if (method !== "logRequest" && method !== "logStream") return args;
+  const callback = args[1];
+  if (typeof callback !== "function") return args;
+  const wrapped = async function respanHeliconeUserCallback(
+    this: unknown,
+    ...callbackArgs: unknown[]
+  ) {
+    state.callbackDepth += 1;
+    try {
+      return await callback.apply(this, callbackArgs);
+    } finally {
+      state.callbackDepth = Math.max(0, state.callbackDepth - 1);
+    }
+  };
+  const operationArgs = [...args];
+  operationArgs[1] = wrapped;
+  return operationArgs;
+}
+
+function outerCorrelation(
+  method: typeof OUTER_ERROR_METHODS[number],
+  args: unknown[],
+): Pick<InvocationState, "additionalHeaders" | "provider"> {
+  if (method === "logRequest") {
+    return { additionalHeaders: args[2], provider: args[3] };
+  }
+  if (method === "logStream" || method === "logSingleStream") {
+    return { additionalHeaders: args[2] };
+  }
+  const options = asRecord(args[2]);
+  return { additionalHeaders: options.additionalHeaders };
+}
+
+function installMethodPatch(
+  target: Record<string, AnyFunction>,
+  method: string,
+  original: AnyFunction,
+  wrapped: AnyFunction,
+): void {
+  target[method] = wrapped;
+  sharedState.patches.push({ target, method, original, wrapped });
+}
+
+function restorePatches(): void {
+  const shared = sharedState;
+  for (const patch of [...shared.patches].reverse()) {
+    if (patch.target[patch.method] === patch.wrapped) {
+      patch.target[patch.method] = patch.original;
+    }
+  }
+  shared.patches = [];
+  shared.contentCaptureDisabledInstances = 0;
+}
+
+function markCaptureReached(state: InvocationState | undefined): void {
+  if (state) state.captureReached = true;
+}
+
+function shouldCaptureContent(): boolean {
+  const shared = sharedState;
+  return shared.activeInstances > 0 && shared.contentCaptureDisabledInstances === 0;
+}
+
+function emitCapture(capture: HeliconeCapture): void {
+  try {
+    injectSpan(buildHeliconeSpan(capture));
+  } catch {
+    // Instrumentation must never alter Helicone application behavior.
+  }
+}
+
+function activeParentContext(): HeliconeParentContext {
+  const activeContext = context.active();
+  const spanContext = trace.getSpan(activeContext)?.spanContext();
+  let entityPath: string | undefined;
+  try {
+    entityPath = getEntityPath(activeContext);
+  } catch {
+    entityPath = undefined;
+  }
+  return {
+    traceId: spanContext?.traceId,
+    parentId: spanContext?.spanId,
+    entityPath,
+  };
+}
+
+function snapshotPropagatedAttributes(): unknown {
+  const propagated = asRecord(getPropagatedAttributes());
+  if (Object.keys(propagated).length === 0) return {};
+  return {
+    ...propagated,
+    ...(isPlainRecord(propagated.metadata)
+      ? { metadata: { ...propagated.metadata } }
+      : {}),
+  };
+}
+
+async function importHeliconeHelpers(): Promise<HeliconeHelpersModule> {
+  try {
+    const hostRequire = createRequire(`${process.cwd()}/package.json`);
+    const resolved = hostRequire.resolve("@helicone/helpers");
+    return await import(pathToFileURL(resolved).href) as HeliconeHelpersModule;
+  } catch {
+    return await import("@helicone/helpers") as HeliconeHelpersModule;
+  }
+}
+
+function asRecord(value: unknown): AnyRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as AnyRecord
+    : {};
+}
+
+function isPlainRecord(value: unknown): value is AnyRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-helicone/tests/helicone_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-helicone/tests/helicone_instrumentor.test.mjs
@@ -1,0 +1,1308 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import * as HeliconeHelpers from "@helicone/helpers";
+import { context, trace } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  ENTITY_NAME_KEY,
+  propagateAttributes,
+} from "@respan/tracing";
+
+import {
+  HeliconeInstrumentor,
+  instrumentHelicone,
+} from "../dist/index.js";
+
+const captureState = { spans: [] };
+const fetchState = { calls: [] };
+const originalFetch = globalThis.fetch;
+const originalGetTracerProvider = trace.getTracerProvider.bind(trace);
+const originalConsoleError = console.error;
+const contextManager = new AsyncLocalStorageContextManager();
+
+test.before(() => {
+  context.setGlobalContextManager(contextManager.enable());
+  Object.defineProperty(trace, "getTracerProvider", {
+    configurable: true,
+    writable: true,
+    value() {
+      return {
+        activeSpanProcessor: {
+          onEnd(span) {
+            captureState.spans.push(span);
+          },
+        },
+      };
+    },
+  });
+  console.error = () => {};
+});
+
+test.after(() => {
+  Object.defineProperty(trace, "getTracerProvider", {
+    configurable: true,
+    writable: true,
+    value: originalGetTracerProvider,
+  });
+  globalThis.fetch = originalFetch;
+  console.error = originalConsoleError;
+  contextManager.disable();
+});
+
+test.beforeEach(() => {
+  captureState.spans = [];
+  fetchState.calls = [];
+  globalThis.fetch = async (input, init) => {
+    fetchState.calls.push({ input: String(input), init });
+    return new Response(null, { status: 204 });
+  };
+});
+
+function createLogger(headers = {
+  Authorization: "Bearer provider-secret",
+  "X-Internal-Token": "another-secret",
+  "Helicone-User-Id": "constructor-user",
+  "Helicone-Session-Id": "constructor-session",
+  "Helicone-Property-service": "constructor-service",
+}) {
+  return new HeliconeHelpers.HeliconeManualLogger({
+    apiKey: "helicone-secret-that-must-not-be-traced",
+    headers,
+    loggingEndpoint: "http://127.0.0.1:43199",
+  });
+}
+
+async function withInstrumentor(fn, options = {}) {
+  const instrumentor = new HeliconeInstrumentor({
+    sdkModule: HeliconeHelpers,
+    ...options,
+  });
+  await instrumentor.activate();
+  try {
+    return await fn(createLogger(), instrumentor);
+  } finally {
+    instrumentor.deactivate();
+  }
+}
+
+function attributesAt(index = 0) {
+  assert.ok(captureState.spans[index], `missing captured span at index ${index}`);
+  return captureState.spans[index].attributes;
+}
+
+function assertNoOffContractAliases(attrs) {
+  for (const key of [
+    "respan.span.tools",
+    "respan.span.tool_calls",
+    "respan.span.handoffs",
+    "tools",
+    "tool_calls",
+    "model",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_request_tokens",
+    "span_tools",
+    "has_tool_calls",
+    "parallel_tool_calls",
+  ]) {
+    assert.equal(attrs[key], undefined, `${key} must not be emitted`);
+  }
+}
+
+test("logRequest emits one canonical chat span with tools, usage, and safe correlations", async () => {
+  await withInstrumentor(async (logger) => {
+    const request = {
+      model: "gpt-4o-mini",
+      api_key: "request-secret",
+      messages: [
+        { role: "system", content: "Use the weather tool." },
+        { role: "user", content: "Weather in Tokyo?" },
+      ],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "Look up weather.",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" }, apiKey: { type: "string" } },
+            },
+          },
+        },
+      ],
+    };
+    const response = {
+      id: "chatcmpl-helicone-1",
+      model: "gpt-4o-mini-2026-08-01",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "Calling the weather tool.",
+            tool_calls: [
+              {
+                id: "call_weather",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: JSON.stringify({ city: "Tokyo" }),
+                },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 14, completion_tokens: 6, total_tokens: 20 },
+    };
+
+    const result = await logger.logRequest(
+      request,
+      async (recorder) => {
+        recorder.appendResults(response);
+        return response;
+      },
+      {
+        "Helicone-User-Id": "user-42",
+        "Helicone-Session-Id": "session-42",
+        "Helicone-Property-environment": "test",
+        Authorization: "Bearer must-not-leak",
+      },
+      "openai",
+    );
+    assert.equal(result, response);
+  });
+
+  assert.equal(captureState.spans.length, 1, "success path must not duplicate");
+  assert.equal(fetchState.calls.length, 1, "Helicone logging behavior must remain intact");
+  const span = captureState.spans[0];
+  const attrs = span.attributes;
+  assert.equal(span.instrumentationScope.name, "@respan/instrumentation-helicone");
+  assert.equal(attrs["respan.entity.log_type"], "chat");
+  assert.equal(attrs["respan.entity.log_method"], "ts_tracing");
+  assert.equal(attrs["gen_ai.system"], "openai");
+  assert.equal(attrs["gen_ai.request.model"], "gpt-4o-mini");
+  assert.equal(attrs["gen_ai.response.model"], "gpt-4o-mini-2026-08-01");
+  assert.equal(attrs["llm.request.type"], "chat");
+  assert.equal(attrs["gen_ai.prompt.1.role"], "user");
+  assert.equal(attrs["gen_ai.prompt.1.content"], "Weather in Tokyo?");
+  assert.equal(attrs["gen_ai.completion.0.role"], "assistant");
+  assert.equal(attrs["gen_ai.completion.0.content"], "Calling the weather tool.");
+  assert.deepEqual(JSON.parse(attrs["gen_ai.completion.0.tool_calls"]), [
+    responseToolCall("call_weather", "get_weather", { city: "Tokyo" }),
+  ]);
+  const definitions = JSON.parse(attrs["llm.request.functions"]);
+  assert.equal(definitions[0].function.name, "get_weather");
+  assert.equal(
+    definitions[0].function.parameters.properties.apiKey,
+    "[REDACTED]",
+  );
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 14);
+  assert.equal(attrs["gen_ai.usage.output_tokens"], 6);
+  assert.equal(attrs["gen_ai.usage.prompt_tokens"], 14);
+  assert.equal(attrs["gen_ai.usage.completion_tokens"], 6);
+  assert.equal(attrs["llm.usage.total_tokens"], 20);
+  assert.equal(attrs["respan.customer_params.customer_identifier"], "user-42");
+  assert.equal(attrs["respan.threads.thread_identifier"], "session-42");
+  assert.deepEqual(JSON.parse(attrs["traceloop.association.properties"]), {
+    service: "constructor-service",
+    environment: "test",
+  });
+  assert.equal(attrs.authorization, undefined);
+  assert.equal(attrs["x-internal-token"], undefined);
+  assert.ok(!JSON.stringify(attrs).includes("provider-secret"));
+  assert.ok(!JSON.stringify(attrs).includes("must-not-leak"));
+  assertNoOffContractAliases(attrs);
+});
+
+test("Anthropic content blocks, tools, tool use, and cache usage map canonically", async () => {
+  const multimodalPrompt = [
+    { type: "text", text: "Inspect this order label." },
+    {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "sample-image-data" },
+    },
+  ];
+  const historicalToolUse = {
+    type: "tool_use",
+    id: "toolu_history",
+    name: "lookup_order",
+    input: { order_id: "H-1024" },
+  };
+  const twoTextBlocks = [
+    { type: "text", text: "Keep this boundary. " },
+    { type: "text", text: "And this one." },
+  ];
+  const responseContent = [
+    { type: "text", text: "I will check that order." },
+    {
+      type: "tool_use",
+      id: "toolu_current",
+      name: "lookup_order",
+      input: { order_id: "H-2048" },
+    },
+  ];
+
+  await withInstrumentor(async (logger) => {
+    await logger.sendLog(
+      {
+        model: "claude-sonnet-4-20250514",
+        system: "Be concise.",
+        messages: [
+          { role: "user", content: multimodalPrompt },
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "I need the lookup tool." },
+              historicalToolUse,
+            ],
+          },
+          {
+            role: "user",
+            content: [{
+              type: "tool_result",
+              tool_use_id: "toolu_history",
+              content: "Order found.",
+            }],
+          },
+          { role: "user", content: twoTextBlocks },
+        ],
+        tools: [{
+          name: "lookup_order",
+          description: "Look up an order.",
+          input_schema: {
+            type: "object",
+            properties: { order_id: { type: "string" } },
+            required: ["order_id"],
+          },
+        }],
+      },
+      {
+        id: "msg_anthropic_1",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-20250514-rev1",
+        content: responseContent,
+        usage: {
+          input_tokens: 21,
+          output_tokens: 8,
+          cache_read_input_tokens: 13,
+        },
+      },
+      { startTime: Date.now() - 10, endTime: Date.now(), status: 200 },
+    );
+  });
+
+  const attrs = attributesAt();
+  assert.equal(attrs["gen_ai.system"], "anthropic");
+  assert.equal(attrs["gen_ai.request.model"], "claude-sonnet-4-20250514");
+  assert.equal(attrs["gen_ai.response.model"], "claude-sonnet-4-20250514-rev1");
+  assert.equal(attrs["llm.request.type"], "chat");
+  assert.equal(attrs["gen_ai.prompt.0.role"], "system");
+  assert.equal(attrs["gen_ai.prompt.0.content"], "Be concise.");
+  assert.deepEqual(JSON.parse(attrs["gen_ai.prompt.1.content"]), multimodalPrompt);
+  assert.deepEqual(
+    JSON.parse(attrs["gen_ai.prompt.2.tool_calls"]),
+    [responseToolCall("toolu_history", "lookup_order", { order_id: "H-1024" })],
+  );
+  assert.deepEqual(JSON.parse(attrs["gen_ai.prompt.4.content"]), twoTextBlocks);
+  const entityInput = JSON.parse(attrs["traceloop.entity.input"]);
+  assert.deepEqual(entityInput[0], { role: "system", content: "Be concise." });
+  const tools = JSON.parse(attrs["llm.request.functions"]);
+  assert.equal(tools[0].function.name, "lookup_order");
+  assert.equal(tools[0].function.parameters.type, "object");
+  assert.deepEqual(JSON.parse(attrs["gen_ai.completion.0.content"]), responseContent);
+  assert.deepEqual(
+    JSON.parse(attrs["gen_ai.completion.0.tool_calls"]),
+    [responseToolCall("toolu_current", "lookup_order", { order_id: "H-2048" })],
+  );
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 21);
+  assert.equal(attrs["gen_ai.usage.output_tokens"], 8);
+  assert.equal(attrs["gen_ai.usage.cache_read.input_tokens"], 13);
+  assert.equal(attrs["llm.usage.cache_read_input_tokens"], 13);
+  assert.equal(attrs["llm.usage.total_tokens"], 29);
+  assertNoOffContractAliases(attrs);
+});
+
+test("prompt indexing is capped, missing roles default, and JSON strings redact", async () => {
+  const serializedPrompt = JSON.stringify({
+    privateKey: "serialized-private-secret",
+    nested: { authToken: "serialized-auth-secret" },
+    promptTokens: 12,
+    tokenizer: "cl100k_base",
+  });
+  const serializedCompletion = JSON.stringify({
+    clientSecret: "serialized-client-secret",
+    completionTokens: 4,
+    tokenCount: 16,
+  });
+  const messages = Array.from({ length: 130 }, (_, index) => ({
+    content: index === 0 ? serializedPrompt : `message-${index}`,
+  }));
+
+  await withInstrumentor(async (logger) => {
+    const now = Date.now();
+    await logger.sendLog(
+      { model: "bounded-history-model", messages },
+      {
+        choices: [{ message: { content: serializedCompletion } }],
+        usage: { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 },
+      },
+      { startTime: now - 2, endTime: now, status: 200 },
+    );
+  });
+
+  const attrs = attributesAt();
+  assert.equal(attrs["gen_ai.prompt.0.role"], "user");
+  assert.deepEqual(JSON.parse(attrs["gen_ai.prompt.0.content"]), {
+    privateKey: "[REDACTED]",
+    nested: { authToken: "[REDACTED]" },
+    promptTokens: 12,
+    tokenizer: "cl100k_base",
+  });
+  assert.equal(attrs["gen_ai.prompt.127.role"], "user");
+  assert.equal(attrs["gen_ai.prompt.127.content"], "message-127");
+  assert.equal(attrs["gen_ai.prompt.128.role"], undefined);
+  assert.equal(attrs["gen_ai.prompt.128.content"], undefined);
+
+  const entityInput = JSON.parse(attrs["traceloop.entity.input"]);
+  assert.equal(entityInput.length, 130);
+  assert.equal(entityInput[0].role, "user");
+  assert.deepEqual(JSON.parse(entityInput[0].content), {
+    privateKey: "[REDACTED]",
+    nested: { authToken: "[REDACTED]" },
+    promptTokens: 12,
+    tokenizer: "cl100k_base",
+  });
+  assert.deepEqual(JSON.parse(attrs["gen_ai.completion.0.content"]), {
+    clientSecret: "[REDACTED]",
+    completionTokens: 4,
+    tokenCount: 16,
+  });
+  const entityOutput = JSON.parse(attrs["traceloop.entity.output"]);
+  assert.deepEqual(JSON.parse(entityOutput.content), {
+    clientSecret: "[REDACTED]",
+    completionTokens: 4,
+    tokenCount: 16,
+  });
+  assert.ok(!JSON.stringify(attrs).includes("serialized-private-secret"));
+  assert.ok(!JSON.stringify(attrs).includes("serialized-auth-secret"));
+  assert.ok(!JSON.stringify(attrs).includes("serialized-client-secret"));
+});
+
+test("direct sendLog maps text completions and logical timing", async () => {
+  const startTime = Date.now() - 250;
+  const endTime = startTime + 100;
+  await withInstrumentor(async (logger) => {
+    await logger.sendLog(
+      { model: "text-model-1", prompt: "Write one line." },
+      {
+        model: "text-model-1",
+        choices: [{ text: "One traced line." }],
+        usage: { input_tokens: 5, output_tokens: 4 },
+      },
+      {
+        startTime,
+        endTime,
+        status: 200,
+        timeToFirstToken: 18,
+        provider: "custom-provider",
+      },
+    );
+  });
+
+  assert.equal(captureState.spans.length, 1);
+  const span = captureState.spans[0];
+  const attrs = span.attributes;
+  assert.equal(attrs["respan.entity.log_type"], "text");
+  assert.equal(attrs["llm.request.type"], "chat");
+  assert.equal(attrs["gen_ai.system"], "custom-provider");
+  assert.equal(attrs["gen_ai.prompt.0.role"], "user");
+  assert.equal(attrs["gen_ai.prompt.0.content"], "Write one line.");
+  assert.deepEqual(JSON.parse(attrs["traceloop.entity.input"]), [
+    { role: "user", content: "Write one line." },
+  ]);
+  assert.equal(attrs["gen_ai.completion.0.content"], "One traced line.");
+  assert.deepEqual(JSON.parse(attrs["respan.metadata"]).helicone, {
+    status: 200,
+    time_to_first_token_ms: 18,
+    streaming: true,
+  });
+  assert.equal(attrs["respan.metadata.helicone_status"], undefined);
+  assert.equal(attrs["respan.metadata.helicone_time_to_first_token_ms"], undefined);
+  assert.equal(attrs["respan.metadata.helicone_streaming"], undefined);
+  assert.equal(attrs["gen_ai.response.time_to_first_chunk"], 0.018);
+  assert.equal(span.startTime[0], Math.trunc(startTime / 1000));
+  assert.equal(span.endTime[0], Math.trunc(endTime / 1000));
+});
+
+test("single request, builder, and direct send each emit exactly once", async () => {
+  await withInstrumentor(async (logger) => {
+    await logger.logSingleRequest(
+      { model: "single-model", messages: [{ role: "user", content: "single" }] },
+      JSON.stringify({
+        choices: [{ message: { role: "assistant", content: "single response" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      }),
+      { latencyMs: 25 },
+    );
+
+    const builder = logger.logBuilder({
+      model: "builder-model",
+      messages: [{ role: "user", content: "builder" }],
+    });
+    builder.setResponse(JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "builder response" } }],
+      usage: { prompt_tokens: 3, completion_tokens: 4 },
+    }));
+    await builder.sendLog();
+
+    const attachedBuilder = logger.logBuilder({
+      model: "builder-attach-model",
+      messages: [{ role: "user", content: "builder attach" }],
+    });
+    await attachedBuilder.attachStream(heliconeValueStream([
+      { choices: [{ delta: { role: "assistant", content: "attached" } }] },
+    ]));
+    await attachedBuilder.sendLog();
+
+    const readableBuilder = logger.logBuilder({
+      model: "builder-readable-model",
+      messages: [{ role: "user", content: "builder readable" }],
+    });
+    const readable = readableBuilder.toReadableStream(heliconeValueStream([
+      { choices: [{ delta: { role: "assistant", content: "readable" } }] },
+    ]));
+    const reader = readable.getReader();
+    while (!(await reader.read()).done) {
+      // Drain the public readable stream so the builder captures its chunks.
+    }
+    await readableBuilder.sendLog();
+
+    await logger.sendLog(
+      { model: "direct-model", messages: [{ role: "user", content: "direct" }] },
+      { choices: [{ message: { role: "assistant", content: "direct response" } }] },
+      { startTime: Date.now() - 1, endTime: Date.now(), status: 200 },
+    );
+  });
+
+  assert.equal(captureState.spans.length, 5);
+  assert.equal(fetchState.calls.length, 5);
+  assert.deepEqual(
+    captureState.spans.map((span) => span.attributes["gen_ai.request.model"]),
+    [
+      "single-model",
+      "builder-model",
+      "builder-attach-model",
+      "builder-readable-model",
+      "direct-model",
+    ],
+  );
+  assert.equal(
+    captureState.spans[1].attributes["gen_ai.system"],
+    undefined,
+    "unknown builder providers must be omitted",
+  );
+});
+
+test("delayed builders retain creation parent and every propagated correlation", async () => {
+  await withInstrumentor(async () => {
+    const logger = createLogger({});
+    const parentA = trace.wrapSpanContext({
+      traceId: "a".repeat(32),
+      spanId: "b".repeat(16),
+      traceFlags: 1,
+    });
+    const parentB = trace.wrapSpanContext({
+      traceId: "c".repeat(32),
+      spanId: "d".repeat(16),
+      traceFlags: 1,
+    });
+    const contextA = trace
+      .setSpan(context.active(), parentA)
+      .setValue(ENTITY_NAME_KEY, "workflow.creation_a");
+    const contextB = trace
+      .setSpan(context.active(), parentB)
+      .setValue(ENTITY_NAME_KEY, "workflow.send_b");
+    let builder;
+
+    context.with(contextA, () => propagateAttributes(
+      {
+        custom_identifier: "custom-a",
+        trace_group_identifier: "trace-group-a",
+        customer_identifier: "customer-a",
+        thread_identifier: "thread-a",
+        metadata: { run_id: "run-a", example_run_id: "run-a" },
+      },
+      () => {
+        builder = logger.logBuilder({
+          model: "delayed-builder-model",
+          messages: [{ role: "user", content: "created in A" }],
+        });
+      },
+    ));
+
+    assert.ok(builder);
+    builder.setResponse(JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "sent in B" } }],
+    }));
+    await context.with(contextB, () => propagateAttributes(
+      {
+        custom_identifier: "custom-b",
+        trace_group_identifier: "trace-group-b",
+        customer_identifier: "customer-b",
+        thread_identifier: "thread-b",
+        metadata: { run_id: "run-b", example_run_id: "run-b" },
+      },
+      () => builder.sendLog(),
+    ));
+  });
+
+  assert.equal(captureState.spans.length, 1);
+  const span = captureState.spans[0];
+  assert.equal(span.spanContext().traceId, "a".repeat(32));
+  assert.equal(span.parentSpanContext?.spanId, "b".repeat(16));
+  assert.equal(span.attributes["traceloop.entity.path"], "workflow.creation_a");
+  assert.equal(span.attributes["respan.span_params.custom_identifier"], "custom-a");
+  assert.equal(span.attributes["respan.trace.trace_group_identifier"], "trace-group-a");
+  assert.equal(span.attributes["respan.customer_params.customer_identifier"], "customer-a");
+  assert.equal(span.attributes["respan.threads.thread_identifier"], "thread-a");
+  assert.deepEqual(JSON.parse(span.attributes["respan.metadata"]), {
+    run_id: "run-a",
+    example_run_id: "run-a",
+    helicone: { status: 200, operation: "logBuilder" },
+  });
+  assert.equal(span.attributes["respan.metadata.run_id"], undefined);
+  assert.equal(span.attributes["respan.metadata.example_run_id"], undefined);
+  const serializedAttributes = JSON.stringify(span.attributes);
+  for (const value of ["custom-b", "trace-group-b", "customer-b", "thread-b", "run-b"]) {
+    assert.ok(!serializedAttributes.includes(value), `${value} leaked from send context`);
+  }
+});
+
+test("logStream and logSingleStream aggregate streamed content and usage", async () => {
+  const chunks = [
+    { choices: [{ delta: { role: "assistant", content: "streamed " } }] },
+    { choices: [{ delta: { content: "answer" } }] },
+    { choices: [{ delta: {} }], usage: { prompt_tokens: 8, completion_tokens: 3 } },
+  ];
+
+  await withInstrumentor(async (logger) => {
+    const result = await logger.logStream(
+      { model: "stream-model", messages: [{ role: "user", content: "stream" }] },
+      async (recorder) => {
+        recorder.attachStream(jsonLineStream(chunks));
+        return "stream-result";
+      },
+      { "Helicone-Property-mode": "logStream" },
+    );
+    assert.equal(result, "stream-result");
+
+    await logger.logSingleStream(
+      { model: "single-stream-model", messages: [{ role: "user", content: "stream2" }] },
+      jsonLineStream(chunks),
+      { "Helicone-Property-mode": "logSingleStream" },
+    );
+  });
+
+  assert.equal(captureState.spans.length, 2);
+  for (const [index, span] of captureState.spans.entries()) {
+    const attrs = span.attributes;
+    assert.equal(attrs["gen_ai.completion.0.content"], "streamed answer");
+    assert.equal(attrs["gen_ai.request.stream"], true);
+    assert.equal(attrs["gen_ai.usage.input_tokens"], 8);
+    assert.equal(attrs["gen_ai.usage.output_tokens"], 3);
+    assert.equal(JSON.parse(attrs["respan.metadata"]).helicone.streaming, true);
+    assert.equal(attrs["respan.metadata.helicone_streaming"], undefined);
+    assert.equal(JSON.parse(attrs["respan.metadata"]).helicone.operation,
+      index === 0 ? "logStream" : "logSingleStream");
+  }
+});
+
+test("Anthropic, Google, and fragmented OpenAI stream payloads aggregate canonically", async () => {
+  const anthropicChunks = [
+    {
+      type: "message_start",
+      message: {
+        role: "assistant",
+        model: "claude-sonnet-4-stream-rev",
+        content: [],
+        usage: { input_tokens: 12, cache_read_input_tokens: 4 },
+      },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    },
+    { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Anthropic " } },
+    { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "streamed." } },
+    {
+      type: "content_block_start",
+      index: 1,
+      content_block: {
+        type: "tool_use",
+        id: "toolu_stream",
+        name: "lookup_order",
+        input: {},
+      },
+    },
+    {
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "input_json_delta", partial_json: '{"order_id":' },
+    },
+    {
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "input_json_delta", partial_json: '"H-2048"}' },
+    },
+    { type: "message_delta", usage: { output_tokens: 7 } },
+  ];
+  const googleChunks = [
+    {
+      modelVersion: "gemini-2.5-flash-rev",
+      candidates: [{ content: { role: "model", parts: [{ text: "Google " }] } }],
+    },
+    {
+      candidates: [{ content: { role: "model", parts: [{ text: "streamed." }] } }],
+    },
+    {
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [{ functionCall: { name: "lookup_order", args: { order_id: "G-42" } } }],
+        },
+      }],
+      usageMetadata: {
+        promptTokenCount: 10,
+        candidatesTokenCount: 5,
+        totalTokenCount: 15,
+        cachedContentTokenCount: 3,
+      },
+    },
+  ];
+  const openAiChunks = [
+    {
+      model: "gpt-4o-mini-stream-rev",
+      choices: [{ delta: {
+        role: "assistant",
+        tool_calls: [{
+          index: 0,
+          id: "call_stream",
+          type: "function",
+          function: { name: "lookup_order", arguments: "" },
+        }],
+      } }],
+    },
+    {
+      choices: [{ delta: {
+        tool_calls: [{ index: 0, function: { arguments: '{"order_id":' } }],
+      } }],
+    },
+    {
+      choices: [{ delta: {
+        tool_calls: [{ index: 0, function: { arguments: '"O-42"}' } }],
+      } }],
+      usage: { prompt_tokens: 9, completion_tokens: 4, total_tokens: 13 },
+    },
+  ];
+
+  await withInstrumentor(async (logger) => {
+    const now = Date.now();
+    await logger.sendLog(
+      {
+        model: "claude-sonnet-4-stream",
+        messages: [{ role: "user", content: "Stream with Anthropic." }],
+        tools: [{ name: "lookup_order", input_schema: { type: "object" } }],
+      },
+      anthropicChunks.map((chunk) => `data: ${JSON.stringify(chunk)}`).join("\n"),
+      { startTime: now - 20, endTime: now, status: 200, timeToFirstToken: 2 },
+    );
+    await logger.sendLog(
+      {
+        model: "gemini-2.5-flash",
+        contents: [{ role: "user", parts: [{ text: "Stream with Google." }] }],
+        tools: [{ functionDeclarations: [{
+          name: "lookup_order",
+          description: "Look up an order.",
+          parameters: { type: "object" },
+        }] }],
+      },
+      googleChunks.map((chunk) => JSON.stringify(chunk)).join("\n"),
+      { startTime: now - 15, endTime: now, status: 200, timeToFirstToken: 3 },
+    );
+    await logger.sendLog(
+      {
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "Stream one tool call." }],
+      },
+      openAiChunks.map((chunk) => `data: ${JSON.stringify(chunk)}`).join("\n"),
+      { startTime: now - 10, endTime: now, status: 200, timeToFirstToken: 1 },
+    );
+  });
+
+  assert.equal(captureState.spans.length, 3);
+  const [anthropic, google, openai] = captureState.spans.map((span) => span.attributes);
+  assert.equal(anthropic["gen_ai.system"], "anthropic");
+  assert.equal(anthropic["gen_ai.response.model"], "claude-sonnet-4-stream-rev");
+  assert.deepEqual(JSON.parse(anthropic["gen_ai.completion.0.content"]), [
+    { type: "text", text: "Anthropic streamed." },
+    {
+      type: "tool_use",
+      id: "toolu_stream",
+      name: "lookup_order",
+      input: { order_id: "H-2048" },
+    },
+  ]);
+  assert.deepEqual(JSON.parse(anthropic["gen_ai.completion.0.tool_calls"]), [
+    responseToolCall("toolu_stream", "lookup_order", { order_id: "H-2048" }),
+  ]);
+  assert.equal(anthropic["gen_ai.usage.input_tokens"], 12);
+  assert.equal(anthropic["gen_ai.usage.output_tokens"], 7);
+  assert.equal(anthropic["llm.usage.cache_read_input_tokens"], 4);
+
+  assert.equal(google["gen_ai.system"], "google");
+  assert.equal(google["gen_ai.response.model"], "gemini-2.5-flash-rev");
+  assert.deepEqual(JSON.parse(google["gen_ai.prompt.0.content"]), [
+    { text: "Stream with Google." },
+  ]);
+  assert.deepEqual(JSON.parse(google["gen_ai.completion.0.content"]), [
+    { text: "Google streamed." },
+    { functionCall: { name: "lookup_order", args: { order_id: "G-42" } } },
+  ]);
+  assert.deepEqual(JSON.parse(google["gen_ai.completion.0.tool_calls"]), [{
+    type: "function",
+    function: { name: "lookup_order", arguments: JSON.stringify({ order_id: "G-42" }) },
+  }]);
+  assert.equal(JSON.parse(google["llm.request.functions"])[0].function.name, "lookup_order");
+  assert.equal(google["gen_ai.usage.input_tokens"], 10);
+  assert.equal(google["gen_ai.usage.output_tokens"], 5);
+  assert.equal(google["llm.usage.cache_read_input_tokens"], 3);
+
+  assert.deepEqual(JSON.parse(openai["gen_ai.completion.0.tool_calls"]), [
+    responseToolCall("call_stream", "lookup_order", { order_id: "O-42" }),
+  ]);
+  assert.equal(openai["gen_ai.usage.input_tokens"], 9);
+  assert.equal(openai["gen_ai.usage.output_tokens"], 4);
+});
+
+test("Google non-stream response objects map candidates, parts, tools, and usage", async () => {
+  await withInstrumentor(async (logger) => {
+    const now = Date.now();
+    await logger.sendLog(
+      {
+        model: "gemini-2.5-pro",
+        contents: [{ role: "user", parts: [{ text: "Call the lookup function." }] }],
+        tools: [{ functionDeclarations: [{
+          name: "lookup_order",
+          parameters: { type: "object", properties: { id: { type: "string" } } },
+        }] }],
+      },
+      {
+        modelVersion: "gemini-2.5-pro-rev",
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [
+              { text: "Calling lookup." },
+              { functionCall: { name: "lookup_order", args: { id: "G-99" } } },
+            ],
+          },
+        }],
+        usageMetadata: {
+          promptTokenCount: 8,
+          candidatesTokenCount: 4,
+          totalTokenCount: 12,
+          cachedContentTokenCount: 2,
+        },
+      },
+      { startTime: now - 4, endTime: now, status: 200 },
+    );
+  });
+
+  const attrs = attributesAt();
+  assert.equal(attrs["gen_ai.system"], "google");
+  assert.equal(attrs["gen_ai.response.model"], "gemini-2.5-pro-rev");
+  assert.deepEqual(JSON.parse(attrs["gen_ai.prompt.0.content"]), [
+    { text: "Call the lookup function." },
+  ]);
+  assert.equal(JSON.parse(attrs["llm.request.functions"])[0].function.name, "lookup_order");
+  assert.deepEqual(JSON.parse(attrs["gen_ai.completion.0.tool_calls"]), [{
+    type: "function",
+    function: { name: "lookup_order", arguments: JSON.stringify({ id: "G-99" }) },
+  }]);
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 8);
+  assert.equal(attrs["gen_ai.usage.output_tokens"], 4);
+  assert.equal(attrs["llm.usage.total_tokens"], 12);
+  assert.equal(attrs["llm.usage.cache_read_input_tokens"], 2);
+});
+
+test("synthetic bare usage.tokens is not reported as provider usage", async () => {
+  await withInstrumentor(async (logger) => {
+    const now = Date.now();
+    await logger.sendLog(
+      { model: "synthetic-usage-model", messages: [{ role: "user", content: "usage" }] },
+      {
+        choices: [{ message: { role: "assistant", content: "ignored synthetic usage" } }],
+        usage: { tokens: 999 },
+      },
+      { startTime: now - 1, endTime: now, status: 200 },
+    );
+  });
+
+  const attrs = attributesAt();
+  assert.equal(attrs["gen_ai.usage.input_tokens"], undefined);
+  assert.equal(attrs["gen_ai.usage.output_tokens"], undefined);
+  assert.equal(attrs["gen_ai.usage.prompt_tokens"], undefined);
+  assert.equal(attrs["gen_ai.usage.completion_tokens"], undefined);
+  assert.equal(attrs["llm.usage.total_tokens"], undefined);
+});
+
+test("outer operation failures emit one error span and preserve the original error", async () => {
+  const leakedCredential = "sk-proj-this-must-not-leak";
+  await withInstrumentor(async (logger) => {
+    await assert.rejects(
+      logger.logRequest(
+        { model: "failed-model", messages: [{ role: "user", content: "fail" }] },
+        async () => {
+          throw new TypeError(
+            `provider operation failed Authorization: Bearer ${leakedCredential}`,
+          );
+        },
+        { "Helicone-Session-Id": "failed-session" },
+        "openai",
+      ),
+      /provider operation failed/,
+    );
+
+    await assert.rejects(
+      logger.logStream(
+        { model: "failed-stream-model", messages: [{ role: "user", content: "fail stream" }] },
+        async () => {
+          throw new Error("stream setup failed");
+        },
+      ),
+      /stream setup failed/,
+    );
+  });
+
+  assert.equal(captureState.spans.length, 2);
+  assert.equal(fetchState.calls.length, 0, "failed operations never reached Helicone sendLog");
+  assert.equal(captureState.spans[0].status.code, 2);
+  assert.equal(
+    captureState.spans[0].status.message,
+    "provider operation failed Authorization: [REDACTED]",
+  );
+  assert.equal(attributesAt(0)["error.type"], "TypeError");
+  assert.equal(attributesAt(0)["status_code"], undefined);
+  assert.equal(attributesAt(0)["http.response.status_code"], 500);
+  assert.equal(
+    attributesAt(0)["error.message"],
+    "provider operation failed Authorization: [REDACTED]",
+  );
+  assert.deepEqual(JSON.parse(attributesAt(0)["traceloop.entity.output"]), {
+    error: "provider operation failed Authorization: [REDACTED]",
+  });
+  assert.ok(!JSON.stringify(captureState.spans[0]).includes(leakedCredential));
+  assert.equal(attributesAt(0)["gen_ai.completion.0.content"], undefined);
+  assert.equal(attributesAt(0)["respan.threads.thread_identifier"], "failed-session");
+  assert.equal(captureState.spans[1].status.message, "stream setup failed");
+});
+
+test("nested and direct callback sends do not suppress the outer failure", async () => {
+  await withInstrumentor(async (logger) => {
+    const parentA = trace.wrapSpanContext({
+      traceId: "1".repeat(32),
+      spanId: "2".repeat(16),
+      traceFlags: 1,
+    });
+    const parentB = trace.wrapSpanContext({
+      traceId: "3".repeat(32),
+      spanId: "4".repeat(16),
+      traceFlags: 1,
+    });
+    const contextA = trace
+      .setSpan(context.active(), parentA)
+      .setValue(ENTITY_NAME_KEY, "workflow.a");
+    const contextB = trace
+      .setSpan(context.active(), parentB)
+      .setValue(ENTITY_NAME_KEY, "workflow.b");
+    const inA = (fn) => context.with(contextA, () => propagateAttributes(
+      { metadata: { run_id: "run-a" } },
+      fn,
+    ));
+    const inB = (fn) => context.with(contextB, () => propagateAttributes(
+      { metadata: { run_id: "run-b" } },
+      fn,
+    ));
+
+    await assert.rejects(inA(() => logger.logRequest(
+      { model: "outer-nested-model", messages: [{ role: "user", content: "outer" }] },
+      async () => {
+        await inB(() => logger.logRequest(
+          { model: "inner-model", messages: [{ role: "user", content: "inner" }] },
+          async (recorder) => {
+            const response = {
+              choices: [{ message: { role: "assistant", content: "inner success" } }],
+            };
+            recorder.appendResults(response);
+            return response;
+          },
+        ));
+        throw new Error("outer failed after inner helper");
+      },
+    )), /outer failed after inner helper/);
+
+    await assert.rejects(inA(() => logger.logRequest(
+      { model: "outer-direct-model", messages: [{ role: "user", content: "outer direct" }] },
+      async () => {
+        const now = Date.now();
+        await inB(() => logger.sendLog(
+          { model: "callback-direct-model", messages: [{ role: "user", content: "direct" }] },
+          { choices: [{ message: { role: "assistant", content: "direct success" } }] },
+          { startTime: now - 1, endTime: now, status: 200 },
+        ));
+        throw new Error("outer failed after direct send");
+      },
+    )), /outer failed after direct send/);
+  });
+
+  assert.equal(captureState.spans.length, 4);
+  assert.equal(fetchState.calls.length, 2);
+  assert.deepEqual(
+    captureState.spans.map((span) => ({
+      model: span.attributes["gen_ai.request.model"],
+      status: span.status.code,
+    })),
+    [
+      { model: "inner-model", status: 1 },
+      { model: "outer-nested-model", status: 2 },
+      { model: "callback-direct-model", status: 1 },
+      { model: "outer-direct-model", status: 2 },
+    ],
+  );
+  assert.deepEqual(
+    captureState.spans.map((span) => ({
+      traceId: span.spanContext().traceId,
+      parentId: span.parentSpanContext?.spanId,
+      entityPath: span.attributes["traceloop.entity.path"],
+      runId: JSON.parse(span.attributes["respan.metadata"]).run_id,
+    })),
+    [
+      {
+        traceId: "3".repeat(32),
+        parentId: "4".repeat(16),
+        entityPath: "workflow.b",
+        runId: "run-b",
+      },
+      {
+        traceId: "1".repeat(32),
+        parentId: "2".repeat(16),
+        entityPath: "workflow.a",
+        runId: "run-a",
+      },
+      {
+        traceId: "3".repeat(32),
+        parentId: "4".repeat(16),
+        entityPath: "workflow.b",
+        runId: "run-b",
+      },
+      {
+        traceId: "1".repeat(32),
+        parentId: "2".repeat(16),
+        entityPath: "workflow.a",
+        runId: "run-a",
+      },
+    ],
+  );
+});
+
+test("builder error status produces one failed span with its response context", async () => {
+  await withInstrumentor(async (logger) => {
+    const builder = logger.logBuilder({
+      model: "builder-error-model",
+      messages: [{ role: "user", content: "builder error" }],
+    });
+    builder.setError(new Error("builder failed"));
+    await builder.sendLog();
+  });
+
+  assert.equal(captureState.spans.length, 1);
+  const span = captureState.spans[0];
+  assert.equal(span.status.code, 2);
+  assert.match(span.status.message, /builder failed/);
+  assert.equal(span.attributes.status_code, undefined);
+  assert.equal(span.attributes["http.response.status_code"], 500);
+  assert.match(span.attributes["error.message"], /builder failed/);
+  assert.equal(span.attributes["gen_ai.completion.0.content"], undefined);
+  assert.equal(JSON.parse(span.attributes["respan.metadata"]).helicone.status, 500);
+});
+
+test("JSON-shaped error messages redact nested secrets everywhere", async () => {
+  const unsafeMessage = JSON.stringify({
+    password: "hunter2",
+    token: "plain-secret",
+  });
+  const safeMessage = JSON.stringify({
+    password: "[REDACTED]",
+    token: "[REDACTED]",
+  });
+
+  await withInstrumentor(async (logger) => {
+    const now = Date.now();
+    await logger.sendLog(
+      { model: "failed-json-model", messages: [{ role: "user", content: "fail" }] },
+      { error: { message: unsafeMessage } },
+      { startTime: now - 1, endTime: now, status: 500 },
+    );
+  });
+
+  const span = captureState.spans[0];
+  assert.equal(span.status.message, safeMessage);
+  assert.equal(span.attributes["error.message"], safeMessage);
+  assert.deepEqual(JSON.parse(span.attributes["traceloop.entity.output"]), {
+    error: safeMessage,
+  });
+  assert.ok(!JSON.stringify({
+    status: span.status,
+    attributes: span.attributes,
+  }).includes("hunter2"));
+  assert.ok(!JSON.stringify(span.attributes).includes("plain-secret"));
+});
+
+test("custom tool, vector_db, and data events map to canonical span types", async () => {
+  await withInstrumentor(async (logger) => {
+    const now = Date.now();
+    await logger.sendLog(
+      { _type: "tool", toolName: "lookup_order", input: { orderId: "O-42" } },
+      { eta: "tomorrow" },
+      { startTime: now - 4, endTime: now, status: 200 },
+    );
+    await logger.sendLog(
+      {
+        _type: "vector_db",
+        operation: "search",
+        text: "respan tracing",
+        vector: [0.1, 0.2, 0.3],
+        topK: 3,
+        databaseName: "docs",
+      },
+      { matches: [{ id: "doc-1", score: 0.99 }] },
+      { startTime: now - 3, endTime: now, status: 200 },
+    );
+    await logger.sendLog(
+      { _type: "data", name: "quality_score", meta: { score: 0.98 } },
+      { accepted: true },
+      { startTime: now - 2, endTime: now, status: 200 },
+    );
+  });
+
+  assert.equal(captureState.spans.length, 3);
+  const [tool, vector, data] = captureState.spans;
+  assert.equal(tool.attributes["respan.entity.log_type"], "tool");
+  assert.equal(tool.attributes["traceloop.entity.name"], "lookup_order");
+  assert.deepEqual(JSON.parse(tool.attributes["traceloop.entity.input"]), {
+    name: "lookup_order",
+    arguments: { orderId: "O-42" },
+  });
+  assertNoOffContractAliases(tool.attributes);
+
+  assert.equal(vector.attributes["respan.entity.log_type"], "task");
+  assert.equal(vector.attributes["db.system"], undefined);
+  assert.equal(vector.attributes["db.vector.query.top_k"], 3);
+  assert.equal(vector.attributes["db.vector.table_name"], "docs");
+  assert.deepEqual(JSON.parse(vector.attributes["traceloop.entity.input"]).vector, [0.1, 0.2, 0.3]);
+
+  assert.equal(data.attributes["respan.entity.log_type"], "task");
+  assert.deepEqual(JSON.parse(data.attributes["traceloop.entity.input"]), { score: 0.98 });
+});
+
+test("traceContent=false redacts bodies while retaining model, usage, status, and correlations", async () => {
+  await withInstrumentor(async (logger) => {
+    await logger.sendLog(
+      {
+        model: "private-model",
+        messages: [{ role: "user", content: "private prompt" }],
+        tools: [{
+          name: "private_tool",
+          description: "private tool description",
+          parameters: { type: "object", properties: { secret: { default: "private" } } },
+        }],
+      },
+      {
+        choices: [{ message: { role: "assistant", content: "private response" } }],
+        usage: { prompt_tokens: 2, completion_tokens: 3 },
+      },
+      {
+        startTime: Date.now() - 1,
+        endTime: Date.now(),
+        status: 200,
+        additionalHeaders: { "Helicone-User-Id": "private-user" },
+      },
+    );
+  }, { traceContent: false });
+
+  const attrs = attributesAt();
+  assert.equal(attrs["traceloop.entity.input"], undefined);
+  assert.equal(attrs["traceloop.entity.output"], undefined);
+  assert.equal(attrs["gen_ai.prompt.0.content"], undefined);
+  assert.equal(attrs["gen_ai.completion.0.content"], undefined);
+  assert.equal(attrs["llm.request.functions"], undefined);
+  assert.equal(attrs["gen_ai.request.model"], "private-model");
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 2);
+  assert.equal(attrs["respan.customer_params.customer_identifier"], "private-user");
+});
+
+test("serialization redacts secret keys, preserves ordinary vectors, and bounds oversized payloads", async () => {
+  await withInstrumentor(async (logger) => {
+    const now = Date.now();
+    await logger.sendLog(
+      {
+        _type: "data",
+        name: "redaction",
+        meta: {
+          apiKey: "top-secret",
+          nested: {
+            password: "hidden",
+            authToken: "auth-token-sentinel",
+            bearerToken: "bearer-token-sentinel",
+            idToken: "id-token-sentinel",
+            sessionToken: "session-token-sentinel",
+            privateKey: "private-key-sentinel",
+            clientSecret: "client-secret-sentinel",
+            credential: "credential-sentinel",
+            credentials: "credentials-sentinel",
+            heliconeAuth: "helicone-auth-sentinel",
+            promptTokens: 12,
+            completionTokens: 4,
+            tokenCount: 16,
+            tokenizer: "cl100k_base",
+            vector: [0.01, 0.02, 0.03],
+          },
+        },
+      },
+      { ok: true },
+      { startTime: now - 1, endTime: now, status: 200 },
+    );
+    await logger.sendLog(
+      { _type: "data", name: "oversized", meta: { text: "x".repeat(1_100_000) } },
+      { ok: true },
+      { startTime: now - 1, endTime: now, status: 200 },
+    );
+  });
+
+  const redacted = JSON.parse(attributesAt(0)["traceloop.entity.input"]);
+  assert.equal(redacted.apiKey, "[REDACTED]");
+  assert.equal(redacted.nested.password, "[REDACTED]");
+  for (const key of [
+    "authToken",
+    "bearerToken",
+    "idToken",
+    "sessionToken",
+    "privateKey",
+    "clientSecret",
+    "credential",
+    "credentials",
+    "heliconeAuth",
+  ]) {
+    assert.equal(redacted.nested[key], "[REDACTED]", `${key} must be redacted`);
+  }
+  assert.equal(redacted.nested.promptTokens, 12);
+  assert.equal(redacted.nested.completionTokens, 4);
+  assert.equal(redacted.nested.tokenCount, 16);
+  assert.equal(redacted.nested.tokenizer, "cl100k_base");
+  assert.deepEqual(redacted.nested.vector, [0.01, 0.02, 0.03]);
+  assert.ok(!JSON.stringify(attributesAt(0)).includes("top-secret"));
+  const oversized = attributesAt(1)["traceloop.entity.input"];
+  assert.ok(Buffer.byteLength(oversized, "utf8") < 600_000);
+  assert.equal(JSON.parse(oversized).truncated, true);
+});
+
+test("patch ownership is reference-counted and methods restore after the last owner", async () => {
+  const prototype = HeliconeHelpers.HeliconeManualLogger.prototype;
+  const originalSendLog = prototype.sendLog;
+  const first = new HeliconeInstrumentor({ sdkModule: HeliconeHelpers });
+  const second = new HeliconeInstrumentor({ sdkModule: HeliconeHelpers });
+  await first.activate();
+  const patchedSendLog = prototype.sendLog;
+  await second.activate();
+  assert.notStrictEqual(patchedSendLog, originalSendLog);
+  assert.strictEqual(prototype.sendLog, patchedSendLog);
+
+  first.deactivate();
+  await createLogger().sendLog(
+    { model: "still-active", messages: [{ role: "user", content: "hi" }] },
+    { choices: [{ message: { role: "assistant", content: "hello" } }] },
+    { startTime: Date.now() - 1, endTime: Date.now(), status: 200 },
+  );
+  assert.equal(captureState.spans.length, 1);
+  assert.strictEqual(prototype.sendLog, patchedSendLog);
+
+  second.deactivate();
+  assert.strictEqual(prototype.sendLog, originalSendLog);
+  await createLogger().sendLog(
+    { model: "inactive", messages: [{ role: "user", content: "hi" }] },
+    { choices: [{ message: { role: "assistant", content: "hello" } }] },
+    { startTime: Date.now() - 1, endTime: Date.now(), status: 200 },
+  );
+  assert.equal(captureState.spans.length, 1);
+});
+
+test("activation rejects incompatible helper module surfaces", async () => {
+  const instrumentor = new HeliconeInstrumentor({
+    sdkModule: { HeliconeManualLogger: class UnsupportedLogger {} },
+  });
+  await assert.rejects(
+    instrumentor.activate(),
+    /HeliconeManualLogger\.sendLog/,
+  );
+  assert.equal(instrumentor.isActive(), false);
+  await assert.rejects(
+    instrumentHelicone({
+      sdkModule: { HeliconeManualLogger: class UnsupportedConvenienceLogger {} },
+    }),
+    /HeliconeManualLogger\.sendLog/,
+  );
+});
+
+function responseToolCall(id, name, args) {
+  return {
+    id,
+    type: "function",
+    function: { name, arguments: JSON.stringify(args) },
+  };
+}
+
+function jsonLineStream(chunks) {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(`${JSON.stringify(chunk)}\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+function heliconeValueStream(values) {
+  const create = () => ({
+    async *[Symbol.asyncIterator]() {
+      for (const value of values) yield value;
+    },
+    tee() {
+      return [create(), create()];
+    },
+    toReadableStream() {
+      return new ReadableStream({
+        start(controller) {
+          for (const value of values) controller.enqueue(value);
+          controller.close();
+        },
+      });
+    },
+  });
+  return create();
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-helicone/tsconfig.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-helicone/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es2022",
+    "outDir": "./dist",
+    "declaration": true,
+    "lib": ["DOM", "DOM.Iterable", "es2022"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "sourceMap": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/javascript-sdks/package.json
+++ b/javascript-sdks/package.json
@@ -16,6 +16,7 @@
     "instrumentations/respan-instrumentation-codex-sdk",
     "instrumentations/respan-instrumentation-cursor",
     "instrumentations/respan-instrumentation-flue",
+    "instrumentations/respan-instrumentation-helicone",
     "instrumentations/respan-instrumentation-langchain",
     "instrumentations/respan-instrumentation-llama-index",
     "instrumentations/respan-instrumentation-google-adk",

--- a/javascript-sdks/yarn.lock
+++ b/javascript-sdks/yarn.lock
@@ -2177,6 +2177,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@helicone/helpers@npm:1.8.3":
+  version: 1.8.3
+  resolution: "@helicone/helpers@npm:1.8.3"
+  peerDependencies:
+    openai: ^5.10.2
+  checksum: 10c0/13a674e6a819b81e285801db13e97d0e5c38630cd0eb6f5415d94670aa51a5cfc17fb128edcfbc537138bf1691b1d1f5ac157459d82232c8d7bb089523c700ae
+  languageName: node
+  linkType: hard
+
 "@hono/node-server@npm:2.1.0":
   version: 2.1.0
   resolution: "@hono/node-server@npm:2.1.0"
@@ -4234,7 +4243,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/otlp-transformer@npm:0.205.0":
+"@opentelemetry/otlp-transformer@npm:0.205.0, @opentelemetry/otlp-transformer@npm:^0.205.0":
   version: 0.205.0
   resolution: "@opentelemetry/otlp-transformer@npm:0.205.0"
   dependencies:
@@ -5168,6 +5177,29 @@ __metadata:
     "@google/adk": ">=1.2.0"
   peerDependenciesMeta:
     "@google/adk":
+      optional: false
+  languageName: unknown
+  linkType: soft
+
+"@respan/instrumentation-helicone@workspace:instrumentations/respan-instrumentation-helicone":
+  version: 0.0.0-use.local
+  resolution: "@respan/instrumentation-helicone@workspace:instrumentations/respan-instrumentation-helicone"
+  dependencies:
+    "@helicone/helpers": "npm:1.8.3"
+    "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/context-async-hooks": "npm:^2.10.0"
+    "@opentelemetry/sdk-trace-base": "npm:^2.10.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.43.0"
+    "@respan/respan-sdk": "npm:^1.1.7"
+    "@respan/tracing": "npm:^1.1.6"
+    "@traceloop/ai-semantic-conventions": "npm:^0.13.0"
+    "@types/node": "npm:^22.15.29"
+    openai: "npm:^5.10.2"
+    typescript: "npm:^5.7.3"
+  peerDependencies:
+    "@helicone/helpers": ">=1.8.3 <1.9.0"
+  peerDependenciesMeta:
+    "@helicone/helpers":
       optional: false
   languageName: unknown
   linkType: soft
@@ -11419,6 +11451,23 @@ __metadata:
   bin:
     openai: bin/cli
   checksum: 10c0/c4f2e837684ed96b8cec58c65a584646d667c69918f29052775e2e8c05ff5c860d8b58214a7770bc6895ca8602480420c1db6a5392dd250179eb0b91c2b19a2f
+  languageName: node
+  linkType: hard
+
+"openai@npm:^5.10.2":
+  version: 5.23.2
+  resolution: "openai@npm:5.23.2"
+  peerDependencies:
+    ws: ^8.18.0
+    zod: ^3.23.8
+  peerDependenciesMeta:
+    ws:
+      optional: true
+    zod:
+      optional: true
+  bin:
+    openai: bin/cli
+  checksum: 10c0/8ee37f37c64fd04a61622c4782d231e8f0245e2d85956d833e43d30946edbf07d5276cd74e09aa5d23006de8da43dad312246a9dd7ca6ca6d65d983fc976ffa6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add the JavaScript `@respan/instrumentation-helicone` package for Helicone Manual Logger workflows.
- Translate request, builder, streaming, custom-event, Anthropic, privacy, delayed, cancellation, and error paths into canonical Respan/OpenTelemetry attributes.
- Add contract tests, package documentation, workspace registration, release inventory, and release intent.

## Companion examples

- [JavaScript Helicone examples PR #78](https://github.com/respanai/respan-example-projects/pull/78)

## Release

- Version 0.1.0 was manually published to [npm](https://www.npmjs.com/package/@respan/instrumentation-helicone/v/0.1.0) before this PR.
- The release intent is `none` so merge automation does not republish 0.1.0.

## Validation

- [x] Package tests: 19 passed
- [x] TypeScript build
- [x] Published tarball SHA-1: `21da67fc01fdab3e1609a555d54d99e87e0fb38b`
- [x] Public npm metadata and `latest: 0.1.0` verified
- [x] Clean unauthenticated registry install passed
- [x] Registry-installed public API import passed
- [x] Release inventory and release-intent validation passed
- [x] Companion examples: 10/10 scenarios
- [x] Respan platform validation: 11 traces, 30 span records, 19 instrumentation spans, and no duplicates
