### PR TITLE
test(anthropic): support legacy and canonical propagated metadata

### DIFF
--- a/.release-intents/20260903-anthropic-canonical-metadata.json
+++ b/.release-intents/20260903-anthropic-canonical-metadata.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Align Anthropic regression tests with canonical propagated metadata",
+  "packages": {
+    "@respan/instrumentation-anthropic": "none"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-anthropic/tests/anthropic_instrumentation_internal.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-anthropic/tests/anthropic_instrumentation_internal.test.mjs
@@ -432,8 +432,14 @@ test("rejecting create calls preserve status and propagated audit attributes", a
   assert.equal(span.attributes["error.message"], "Error: Anthropic model was not found");
   assert.equal(span.attributes["respan.span_params.custom_identifier"], "anthropic-error-case");
   assert.equal(span.attributes["respan.trace.trace_group_identifier"], "anthropic-error-group");
-  assert.equal(span.attributes["respan.metadata.run_id"], "anthropic-error-marker");
-  assert.equal(span.attributes["respan.metadata.case_id"], "failure");
+  assert.deepEqual(JSON.parse(span.attributes["respan.metadata"]), {
+    run_id: "anthropic-error-marker",
+    case_id: "failure",
+  });
+  assert.equal(
+    Object.keys(span.attributes).some((key) => key.startsWith("respan.metadata.")),
+    false,
+  );
   assert.deepEqual(JSON.parse(span.attributes["gen_ai.prompt.0.tool_calls"]), [
     {
       id: "toolu_history",
@@ -449,8 +455,14 @@ test("rejecting create calls preserve status and propagated audit attributes", a
   assert.equal(span.attributes["gen_ai.prompt.1.tool_call_id"], "toolu_history");
   assert.equal(span.attributes["gen_ai.completion.0.tool_calls"], undefined);
   assert.equal(span.instrumentationScope?.version, "1.1.2");
-  assert.equal(toolSpan.attributes["respan.metadata.run_id"], "anthropic-error-marker");
-  assert.equal(toolSpan.attributes["respan.metadata.case_id"], "failure");
+  assert.deepEqual(JSON.parse(toolSpan.attributes["respan.metadata"]), {
+    run_id: "anthropic-error-marker",
+    case_id: "failure",
+  });
+  assert.equal(
+    Object.keys(toolSpan.attributes).some((key) => key.startsWith("respan.metadata.")),
+    false,
+  );
   assert.equal(toolSpan.instrumentationScope?.version, "1.1.2");
 
   messagesPrototype.create = patchedTarget.originalCreate;

--- a/javascript-sdks/instrumentations/respan-instrumentation-anthropic/tests/anthropic_instrumentation_internal.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-anthropic/tests/anthropic_instrumentation_internal.test.mjs
@@ -20,6 +20,27 @@ import {
 const captureState = { spans: [] };
 const originalGetTracerProvider = trace.getTracerProvider.bind(trace);
 const contextStorage = new AsyncLocalStorage();
+
+function assertPropagatedAuditMetadata(attributes, expected) {
+  const prefix = "respan.metadata.";
+  const flatEntries = Object.entries(attributes).filter(([key]) =>
+    key.startsWith(prefix),
+  );
+  const canonical = attributes["respan.metadata"];
+  if (canonical !== undefined) {
+    assert.equal(typeof canonical, "string");
+    assert.deepEqual(flatEntries, []);
+    assert.deepEqual(JSON.parse(canonical), expected);
+  } else {
+    assert.deepEqual(
+      Object.fromEntries(
+        flatEntries.map(([key, value]) => [key.slice(prefix.length), value]),
+      ),
+      expected,
+    );
+  }
+}
+
 const contextManager = {
   active() {
     return contextStorage.getStore() ?? ROOT_CONTEXT;
@@ -432,14 +453,10 @@ test("rejecting create calls preserve status and propagated audit attributes", a
   assert.equal(span.attributes["error.message"], "Error: Anthropic model was not found");
   assert.equal(span.attributes["respan.span_params.custom_identifier"], "anthropic-error-case");
   assert.equal(span.attributes["respan.trace.trace_group_identifier"], "anthropic-error-group");
-  assert.deepEqual(JSON.parse(span.attributes["respan.metadata"]), {
+  assertPropagatedAuditMetadata(span.attributes, {
     run_id: "anthropic-error-marker",
     case_id: "failure",
   });
-  assert.equal(
-    Object.keys(span.attributes).some((key) => key.startsWith("respan.metadata.")),
-    false,
-  );
   assert.deepEqual(JSON.parse(span.attributes["gen_ai.prompt.0.tool_calls"]), [
     {
       id: "toolu_history",
@@ -455,14 +472,10 @@ test("rejecting create calls preserve status and propagated audit attributes", a
   assert.equal(span.attributes["gen_ai.prompt.1.tool_call_id"], "toolu_history");
   assert.equal(span.attributes["gen_ai.completion.0.tool_calls"], undefined);
   assert.equal(span.instrumentationScope?.version, "1.1.2");
-  assert.deepEqual(JSON.parse(toolSpan.attributes["respan.metadata"]), {
+  assertPropagatedAuditMetadata(toolSpan.attributes, {
     run_id: "anthropic-error-marker",
     case_id: "failure",
   });
-  assert.equal(
-    Object.keys(toolSpan.attributes).some((key) => key.startsWith("respan.metadata.")),
-    false,
-  );
   assert.equal(toolSpan.instrumentationScope?.version, "1.1.2");
 
   messagesPrototype.create = patchedTarget.originalCreate;


### PR DESCRIPTION
## Scope

Package: `@respan/instrumentation-anthropic` only. Split from https://github.com/respanai/respan/pull/400 at `0236995f` under the requested one-package/one-branch/one-PR policy.

Keep Anthropic propagation checks compatible with both supported tracing metadata representations while rejecting mixed envelopes, missing/extra keys, and malformed canonical JSON. No runtime changes.

## Validation

Anthropic tests: 5/5 with isolated base tracing and 5/5 with canonical tracing. Assertion helper: 2 valid representations accepted, 9 invalid cases rejected.

- Release inventory and intent validation passed; no missing intent; exactly one changed release-managed package.
- `git diff --check` passed.
- Source batch CI: all 107 checks passed. This PR has its own fresh CI run.

## Merge and release


Release intent: `@respan/instrumentation-anthropic: none`. No package is published or merged by this split. Existing release automation can publish after an authorized merge; retain the normal review/release gates.

Examples remain in https://github.com/respanai/respan-example-projects/pull/79, unchanged as requested. Public documentation remains in the user's local review worktree; no docs PR or edits are included.
