### PR TITLE
fix(tracing-python): preserve canonical propagated metadata

### DIFF
--- a/.release-intents/20260903-python-tracing.json
+++ b/.release-intents/20260903-python-tracing.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Merge propagated Python tracing metadata into the canonical JSON attribute",
+  "packages": {
+    "respan-tracing": "minor"
+  }
+}

--- a/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/processors/base.py
@@ -16,7 +16,7 @@ from opentelemetry.context import Context
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 from opentelemetry.semconv_ai import SpanAttributes
 
-from respan_sdk.constants.span_attributes import RESPAN_TRACE_GROUP_ID
+from respan_sdk.constants.span_attributes import RESPAN_METADATA, RESPAN_TRACE_GROUP_ID
 from respan_sdk.respan_types.span_types import SpanLink
 from respan_sdk.utils.data_processing.id_processing import format_span_id
 from respan_tracing.contexts.span import span_link_to_otel
@@ -31,7 +31,10 @@ from respan_tracing.constants.context_constants import TRACE_GROUP_ID_KEY, PARAM
 from respan_tracing.filters import evaluate_export_filter
 from respan_tracing.utils.preprocessing.span_processing import is_processable_span
 from respan_tracing.utils.context import get_entity_path
-from respan_tracing.utils.span_factory import read_propagated_attributes
+from respan_tracing.utils.span_factory import (
+    merge_metadata_attributes,
+    read_propagated_attributes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +133,14 @@ class RespanSpanProcessor:
         try:
             propagated = read_propagated_attributes()
             for attr_key, attr_val in propagated.items():
-                if not span.attributes.get(attr_key):
+                if attr_key == RESPAN_METADATA:
+                    span.set_attribute(
+                        attr_key,
+                        merge_metadata_attributes(
+                            span.attributes.get(attr_key), attr_val
+                        ),
+                    )
+                elif not span.attributes.get(attr_key):
                     span.set_attribute(attr_key, attr_val)
         except Exception:
             logger.debug("Failed to bridge propagated attributes", exc_info=True)

--- a/python-sdks/respan-tracing/src/respan_tracing/utils/span_factory.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/utils/span_factory.py
@@ -19,7 +19,7 @@ import json
 import logging
 import time
 from contextlib import contextmanager
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan
@@ -27,8 +27,8 @@ from opentelemetry.trace import SpanContext, SpanKind, TraceFlags
 from opentelemetry.trace.status import Status, StatusCode
 
 from respan_sdk.constants.span_attributes import (
-    RESPAN_PROMPT,
     RESPAN_METADATA,
+    RESPAN_PROMPT,
     RESPAN_SPAN_ATTRIBUTES_MAP,
 )
 from respan_sdk.utils.data_processing.id_processing import (
@@ -45,8 +45,8 @@ logger = logging.getLogger(__name__)
 # Context-propagated attributes
 # ---------------------------------------------------------------------------
 
-_PROPAGATED_ATTRIBUTES: contextvars.ContextVar[Dict[str, Any]] = contextvars.ContextVar(
-    "respan_propagated_attributes", default={}
+_PROPAGATED_ATTRIBUTES: contextvars.ContextVar[Optional[Dict[str, Any]]] = contextvars.ContextVar(
+    "respan_propagated_attributes", default=None
 )
 
 # Keys accepted by propagate_attributes() — derived from the canonical
@@ -78,7 +78,7 @@ def propagate_attributes(**kwargs):
             result = await Runner.run(agent, "Hello")
     """
     # Merge with any already-active attributes (supports nesting)
-    parent = _PROPAGATED_ATTRIBUTES.get()
+    parent = _PROPAGATED_ATTRIBUTES.get() or {}
     merged = {**parent}
     for key, value in kwargs.items():
         if key not in _SUPPORTED_ATTRIBUTE_KEYS:
@@ -109,7 +109,7 @@ def read_propagated_attributes() -> Dict[str, Any]:
 
         {"respan.customer_params.customer_identifier": "user_123",
          "respan.threads.thread_identifier": "conv_abc",
-         "respan.metadata.plan": "pro"}
+         "respan.metadata": "{\"plan\":\"pro\"}"}
     """
     ctx_attrs = _PROPAGATED_ATTRIBUTES.get()
     if not ctx_attrs:
@@ -120,16 +120,52 @@ def read_propagated_attributes() -> Dict[str, Any]:
         if key not in RESPAN_SPAN_ATTRIBUTES_MAP:
             continue
         attr_key = RESPAN_SPAN_ATTRIBUTES_MAP[key]
-        if attr_key == RESPAN_METADATA and isinstance(value, dict):
-            # Metadata is stored as individual respan.metadata.<key> attributes
-            for mk, mv in value.items():
-                result[f"{RESPAN_METADATA}.{mk}"] = str(mv) if not isinstance(mv, str) else mv
+        if attr_key == RESPAN_METADATA:
+            # Structured metadata is one canonical JSON OTEL attribute. Never
+            # manufacture respan.metadata.<key> aliases here.
+            result[RESPAN_METADATA] = _metadata_json(value)
         elif attr_key == RESPAN_PROMPT and isinstance(value, dict):
             # Prompt config: store as JSON string for the exporter to pick up
             result[RESPAN_PROMPT] = json.dumps(value, default=str)
         else:
             result[attr_key] = value
     return result
+
+
+def merge_metadata_attributes(existing: Any, propagated: Any) -> str:
+    """Merge canonical metadata JSON while preserving instrumentation values.
+
+    Nested propagation has already applied its documented inner-scope-wins
+    policy before this function runs. When a vendor instrumentation supplies
+    the same key, its span-local value remains authoritative.
+    """
+
+    return _metadata_json(
+        {
+            **_metadata_mapping(propagated),
+            **_metadata_mapping(existing),
+        }
+    )
+
+
+def _metadata_mapping(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return {"value": value}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    if value is None:
+        return {}
+    return {"value": value}
+
+
+def _metadata_json(value: Any) -> str:
+    return json.dumps(value, default=str, ensure_ascii=False, separators=(",", ":"))
 
 
 # ---------------------------------------------------------------------------
@@ -212,7 +248,10 @@ def build_readable_span(
     if merge_propagated:
         propagated = read_propagated_attributes()
         for k, v in propagated.items():
-            attrs.setdefault(k, v)
+            if k == RESPAN_METADATA:
+                attrs[k] = merge_metadata_attributes(attrs.get(k), v)
+            else:
+                attrs.setdefault(k, v)
 
     # Determine status
     if error_message:

--- a/python-sdks/respan-tracing/tests/test_propagated_metadata.py
+++ b/python-sdks/respan-tracing/tests/test_propagated_metadata.py
@@ -1,0 +1,77 @@
+import json
+
+from respan_sdk.constants.span_attributes import RESPAN_METADATA
+from respan_tracing.processors.base import RespanSpanProcessor
+from respan_tracing.utils.span_factory import (
+    build_readable_span,
+    propagate_attributes,
+    read_propagated_attributes,
+)
+
+
+class _Span:
+    def __init__(self, metadata: dict[str, object]) -> None:
+        self.name = "vendor.call"
+        self.attributes = {RESPAN_METADATA: json.dumps(metadata)}
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+class _Processor:
+    def on_start(self, _span, _parent_context=None) -> None:
+        return None
+
+
+def _assert_single_metadata_attribute(attributes: dict[str, object]) -> None:
+    assert RESPAN_METADATA in attributes
+    assert not any(key.startswith(f"{RESPAN_METADATA}.") for key in attributes)
+
+
+def test_propagated_metadata_is_one_canonical_json_attribute() -> None:
+    with (
+        propagate_attributes(metadata={"run_id": "outer", "outer": True}),
+        propagate_attributes(metadata={"run_id": "inner", "nested": {"ok": True}}),
+    ):
+        attributes = read_propagated_attributes()
+
+    _assert_single_metadata_attribute(attributes)
+    assert json.loads(attributes[RESPAN_METADATA]) == {
+        "nested": {"ok": True},
+        "outer": True,
+        "run_id": "inner",
+    }
+
+
+def test_synthetic_span_merges_propagated_and_instrumentation_metadata() -> None:
+    with propagate_attributes(metadata={"run_id": "run-1", "shared": "propagated"}):
+        span = build_readable_span(
+            "vendor.call",
+            attributes={
+                RESPAN_METADATA: json.dumps(
+                    {"provider_request_id": "request-1", "shared": "instrumentation"}
+                )
+            },
+        )
+
+    _assert_single_metadata_attribute(span.attributes)
+    assert json.loads(span.attributes[RESPAN_METADATA]) == {
+        "provider_request_id": "request-1",
+        "run_id": "run-1",
+        "shared": "instrumentation",
+    }
+
+
+def test_live_span_processor_merges_propagated_metadata_without_aliases() -> None:
+    span = _Span({"provider_request_id": "request-1", "shared": "instrumentation"})
+    processor = RespanSpanProcessor(_Processor())
+
+    with propagate_attributes(metadata={"run_id": "run-1", "shared": "propagated"}):
+        processor.on_start(span)
+
+    _assert_single_metadata_attribute(span.attributes)
+    assert json.loads(span.attributes[RESPAN_METADATA]) == {
+        "provider_request_id": "request-1",
+        "run_id": "run-1",
+        "shared": "instrumentation",
+    }


### PR DESCRIPTION
## Scope

Package: `respan-tracing` only. Split from https://github.com/respanai/respan/pull/400 at `0236995f` under the requested one-package/one-branch/one-PR policy.

Merge propagated metadata into the canonical JSON attribute for live and synthetic Python spans without flat metadata aliases.

## Validation

37 metadata, exporter, context, and OTLP tests passed; wheel built. Existing broad lint diagnostics are unchanged/improved; fatal Ruff checks pass.

- Release inventory and intent validation passed; no missing intent; exactly one changed release-managed package.
- `git diff --check` passed.
- Source batch CI: all 107 checks passed. This PR has its own fresh CI run.

## Merge and release


Release intent: `respan-tracing: minor`. No package is published or merged by this split. Existing release automation can publish after an authorized merge; retain the normal review/release gates.

Examples remain in https://github.com/respanai/respan-example-projects/pull/79, unchanged as requested. Public documentation remains in the user's local review worktree; no docs PR or edits are included.
