### PR TITLE
feat(instrumentation-py): expand Dify SDK instrumentation

### DIFF
--- a/.release-intents/20260903-python-dify.json
+++ b/.release-intents/20260903-python-dify.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Refresh Python Dify instrumentation for current client APIs and workflow events",
+  "packages": {
+    "respan-instrumentation-dify": "minor"
+  }
+}

--- a/.release-intents/20260903-python-dify.json
+++ b/.release-intents/20260903-python-dify.json
@@ -1,6 +1,7 @@
 {
-  "summary": "Refresh Python Dify instrumentation for current client APIs and workflow events",
+  "summary": "Refresh Python Dify instrumentation and align its explicit facade registration",
   "packages": {
+    "respan-ai": "patch",
     "respan-instrumentation-dify": "minor"
   }
 }

--- a/python-sdks/instrumentations/respan-instrumentation-dify/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/README.md
@@ -1,11 +1,16 @@
 # Respan Dify instrumentation
 
-Trace the `dify-client` Python package with Respan.
+Trace the official `dify-client` Python package with Respan.
+
+Requires Python 3.11 through 3.13 and `dify-client>=0.1.10,<0.2.0`.
 
 This package patches Dify's Service API client methods and emits canonical
 Respan spans for chat, completion, workflow, file, feedback, application, and
 conversation requests. Streaming responses are traced when the returned stream
-is consumed.
+is consumed, closed early, or raises. It supports the released sync-only
+`dify-client` 0.1.10 package and the refreshed 0.1.12 source API, including its
+sync and async Chat, Completion, Workflow, Knowledge Base, and Workspace
+clients.
 
 ## Install
 
@@ -40,6 +45,40 @@ print(response.json()["answer"])
 respan.flush()
 respan.shutdown()
 ```
+
+### Async clients
+
+When the installed Dify SDK exposes its async clients, the same instrumentor
+patches them automatically:
+
+```python
+from dify_client import AsyncChatClient
+
+async with AsyncChatClient(
+    os.environ["DIFY_CHAT_API_KEY"],
+    base_url=os.getenv("DIFY_BASE_URL", "https://api.dify.ai/v1"),
+) as client:
+    response = await client.create_chat_message(
+        inputs={},
+        query="Stream one concise sentence about tracing.",
+        user="respan-example-user",
+        response_mode="streaming",
+    )
+    async for line in response.aiter_lines():
+        print(line)
+```
+
+The span stays open until a streaming response is exhausted, explicitly
+closed, leaves its context manager, or fails. Blocking responses emit when the
+SDK request resolves. `include_content=False` keeps request/response bodies and
+prompt/completion content off spans while retaining operation, status, and
+usage attributes. Credential-like fields are always recursively redacted,
+including Workspace credential-validation requests and echoed responses. When
+multiple instrumentor instances overlap, the first
+active instance's content policy remains in effect until the last instance is
+deactivated; conflicting instances log a warning instead of changing it.
+Deactivation restores only wrappers still owned by this instrumentor, so a
+later patch from another library is left intact.
 
 Use `Respan.propagate_attributes(...)` to attach customer, thread, trace group,
 metadata, or prompt context to Dify spans.

--- a/python-sdks/instrumentations/respan-instrumentation-dify/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.17.0"
 respan-sdk = ">=2.6.1"
-dify-client = ">=0.1.10"
+dify-client = ">=0.1.10,<0.2.0"
 opentelemetry-semantic-conventions-ai = ">=0.4.1"
 
 [tool.poetry.plugins."respan.instrumentations"]

--- a/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/__init__.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/__init__.py
@@ -4,4 +4,4 @@ from respan_instrumentation_dify._instrumentation import DifyInstrumentor
 
 DifyAIInstrumentor = DifyInstrumentor
 
-__all__ = ["DifyInstrumentor", "DifyAIInstrumentor"]
+__all__ = ["DifyAIInstrumentor", "DifyInstrumentor"]

--- a/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_constants.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_constants.py
@@ -8,6 +8,7 @@ from respan_sdk.constants.span_attributes import (
 
 DIFY_INSTRUMENTATION_NAME = "dify"
 DIFY_CLIENT_MODULE = "dify_client.client"
+DIFY_ASYNC_CLIENT_MODULE = "dify_client.async_client"
 DIFY_CHAT_SPAN_NAME = "dify.chat"
 DIFY_COMPLETION_SPAN_NAME = "dify.completion"
 DIFY_WORKFLOW_SPAN_NAME = "dify.workflow"

--- a/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_context.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_context.py
@@ -7,10 +7,9 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from typing import Any
 
-
-_RESPAN_PARAMS: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
+_RESPAN_PARAMS: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
     "respan_dify_params",
-    default={},
+    default=None,
 )
 
 
@@ -24,7 +23,7 @@ def _to_mapping(value: Any) -> Mapping[str, Any] | None:
         if callable(method):
             try:
                 converted = method()
-            except Exception:
+            except Exception:  # noqa: BLE001, S112 -- best-effort vendor hook
                 continue
             if isinstance(converted, Mapping):
                 return converted
@@ -38,7 +37,7 @@ def _to_mapping(value: Any) -> Mapping[str, Any] | None:
 def use_respan_params(value: Any):
     """Temporarily attach optional Respan params to the current Dify call."""
     mapping = _to_mapping(value) or {}
-    parent = _RESPAN_PARAMS.get()
+    parent = _RESPAN_PARAMS.get() or {}
     merged = {**parent, **dict(mapping)}
     token = _RESPAN_PARAMS.set(merged)
     try:
@@ -48,4 +47,4 @@ def use_respan_params(value: Any):
 
 
 def read_respan_params() -> dict[str, Any]:
-    return dict(_RESPAN_PARAMS.get())
+    return dict(_RESPAN_PARAMS.get() or {})

--- a/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_instrumentation.py
@@ -5,25 +5,41 @@ from __future__ import annotations
 import importlib
 import json
 import logging
-from typing import Any
+from collections.abc import Mapping
+from functools import wraps
+from types import TracebackType
+from typing import Any, Self
+
+from respan_tracing.core.tracer import RespanTracer
 
 from respan_instrumentation_dify._constants import (
+    DIFY_ASYNC_CLIENT_MODULE,
     DIFY_CLIENT_MODULE,
     DIFY_INSTRUMENTATION_NAME,
+    RESPONSE_MODE_KEY,
+    STREAMING_RESPONSE_MODE,
 )
 from respan_instrumentation_dify._context import use_respan_params
-from respan_instrumentation_dify._otel_emitter import capture_call_context
-from respan_instrumentation_dify._otel_emitter import emit_dify_span
-from respan_tracing.core.tracer import RespanTracer
+from respan_instrumentation_dify._otel_emitter import (
+    capture_call_context,
+    emit_dify_span,
+)
 
 logger = logging.getLogger(__name__)
 
-_PATCHED_METHODS: dict[tuple[type[Any], str], Any] = {}
+_PATCHED_METHODS: dict[tuple[type[Any], str], tuple[Any, Any]] = {}
 _IS_PATCHED = False
+_ACTIVE_INSTANCES = 0
 _INCLUDE_CONTENT = True
 
 
-def _arg(args: tuple[Any, ...], index: int, kwargs: dict[str, Any], name: str, default: Any = None) -> Any:
+def _arg(
+    args: tuple[Any, ...],
+    index: int,
+    kwargs: dict[str, Any],
+    name: str,
+    default: Any = None,
+) -> Any:
     if len(args) > index:
         return args[index]
     return kwargs.get(name, default)
@@ -48,8 +64,38 @@ def _parse_sse_event(line: Any) -> Any:
         return None
     try:
         return json.loads(text)
-    except Exception:
+    except json.JSONDecodeError:
         return text
+
+
+def _parse_sse_chunks(chunks: list[Any]) -> list[Any]:
+    if not chunks:
+        return []
+    if all(isinstance(chunk, (bytes, bytearray)) for chunk in chunks):
+        text = b"".join(bytes(chunk) for chunk in chunks).decode(
+            "utf-8", errors="replace"
+        )
+    else:
+        text = "".join(
+            chunk.decode("utf-8", errors="replace")
+            if isinstance(chunk, (bytes, bytearray))
+            else str(chunk)
+            for chunk in chunks
+        )
+    events: list[Any] = []
+    for line in text.replace("\r\n", "\n").split("\n"):
+        event = _parse_sse_event(line)
+        if event is not None:
+            events.append(event)
+    return events
+
+
+def _request_uses_streaming(*, stream: bool, request_json: Any) -> bool:
+    if stream:
+        return True
+    if isinstance(request_json, Mapping):
+        return request_json.get(RESPONSE_MODE_KEY) == STREAMING_RESPONSE_MODE
+    return getattr(request_json, RESPONSE_MODE_KEY, None) == STREAMING_RESPONSE_MODE
 
 
 class _InstrumentedStreamingResponse:
@@ -57,20 +103,28 @@ class _InstrumentedStreamingResponse:
         self._response = response
         self._call_context = call_context
         self._events: list[Any] = []
+        self._chunks: list[Any] = []
         self._emitted = False
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._response, name)
 
-    def __enter__(self) -> "_InstrumentedStreamingResponse":
+    def __enter__(self) -> Self:
         enter = getattr(self._response, "__enter__", None)
         if callable(enter):
             enter()
         return self
 
-    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Any:
         if exc is not None:
-            self._emit_once(error=exc if isinstance(exc, Exception) else Exception(str(exc)))
+            self._emit_once(
+                error=exc if isinstance(exc, Exception) else Exception(str(exc))
+            )
         else:
             self._emit_once(error=None)
         exit_method = getattr(self._response, "__exit__", None)
@@ -82,6 +136,9 @@ class _InstrumentedStreamingResponse:
         self._emit_once(error=None)
         return self._response.close()
 
+    def __iter__(self) -> Any:
+        return self._iter_chunks("__iter__")
+
     def iter_lines(self, *args: Any, **kwargs: Any) -> Any:
         try:
             for line in self._response.iter_lines(*args, **kwargs):
@@ -92,22 +149,35 @@ class _InstrumentedStreamingResponse:
         except Exception as exc:
             self._emit_once(error=exc)
             raise
-        else:
+        finally:
             self._emit_once(error=None)
 
     def iter_content(self, *args: Any, **kwargs: Any) -> Any:
-        chunks: list[Any] = []
+        return self._iter_chunks("iter_content", *args, **kwargs)
+
+    def iter_bytes(self, *args: Any, **kwargs: Any) -> Any:
+        return self._iter_chunks("iter_bytes", *args, **kwargs)
+
+    def iter_text(self, *args: Any, **kwargs: Any) -> Any:
+        return self._iter_chunks("iter_text", *args, **kwargs)
+
+    def iter_raw(self, *args: Any, **kwargs: Any) -> Any:
+        return self._iter_chunks("iter_raw", *args, **kwargs)
+
+    def _iter_chunks(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        iterator = (
+            iter(self._response)
+            if method_name == "__iter__"
+            else getattr(self._response, method_name)(*args, **kwargs)
+        )
         try:
-            for chunk in self._response.iter_content(*args, **kwargs):
-                chunks.append(chunk)
+            for chunk in iterator:
+                self._chunks.append(chunk)
                 yield chunk
         except Exception as exc:
             self._emit_once(error=exc)
             raise
-        else:
-            if not self._events:
-                self._events.extend(_parse_sse_event(chunk) for chunk in chunks)
-                self._events = [event for event in self._events if event is not None]
+        finally:
             self._emit_once(error=None)
 
     def _emit_once(self, *, error: Exception | None) -> None:
@@ -117,13 +187,104 @@ class _InstrumentedStreamingResponse:
         emit_dify_span(
             call_context=self._call_context,
             response=self._response,
-            stream_events=self._events,
+            stream_events=self._events or _parse_sse_chunks(self._chunks),
+            error=error,
+            include_content=_INCLUDE_CONTENT,
+        )
+
+
+class _InstrumentedAsyncStreamingResponse:
+    def __init__(self, *, response: Any, call_context: Any) -> None:
+        self._response = response
+        self._call_context = call_context
+        self._events: list[Any] = []
+        self._chunks: list[Any] = []
+        self._emitted = False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._response, name)
+
+    async def __aenter__(self) -> Self:
+        enter = getattr(self._response, "__aenter__", None)
+        if callable(enter):
+            await enter()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Any:
+        if exc is not None:
+            self._emit_once(
+                error=exc if isinstance(exc, Exception) else Exception(str(exc))
+            )
+        else:
+            self._emit_once(error=None)
+        exit_method = getattr(self._response, "__aexit__", None)
+        if callable(exit_method):
+            return await exit_method(exc_type, exc, tb)
+        return None
+
+    async def aclose(self) -> Any:
+        self._emit_once(error=None)
+        close = getattr(self._response, "aclose", None)
+        if callable(close):
+            return await close()
+        return None
+
+    def aiter_lines(self, *args: Any, **kwargs: Any) -> Any:
+        return self._aiter_lines(*args, **kwargs)
+
+    async def _aiter_lines(self, *args: Any, **kwargs: Any) -> Any:
+        try:
+            async for line in self._response.aiter_lines(*args, **kwargs):
+                event = _parse_sse_event(line)
+                if event is not None:
+                    self._events.append(event)
+                yield line
+        except Exception as exc:
+            self._emit_once(error=exc)
+            raise
+        finally:
+            self._emit_once(error=None)
+
+    def aiter_bytes(self, *args: Any, **kwargs: Any) -> Any:
+        return self._aiter_chunks("aiter_bytes", *args, **kwargs)
+
+    def aiter_text(self, *args: Any, **kwargs: Any) -> Any:
+        return self._aiter_chunks("aiter_text", *args, **kwargs)
+
+    def aiter_raw(self, *args: Any, **kwargs: Any) -> Any:
+        return self._aiter_chunks("aiter_raw", *args, **kwargs)
+
+    async def _aiter_chunks(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        try:
+            async for chunk in getattr(self._response, method_name)(*args, **kwargs):
+                self._chunks.append(chunk)
+                yield chunk
+        except Exception as exc:
+            self._emit_once(error=exc)
+            raise
+        finally:
+            self._emit_once(error=None)
+
+    def _emit_once(self, *, error: Exception | None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        emit_dify_span(
+            call_context=self._call_context,
+            response=self._response,
+            stream_events=self._events or _parse_sse_chunks(self._chunks),
             error=error,
             include_content=_INCLUDE_CONTENT,
         )
 
 
 def _wrap_send_request(original: Any) -> Any:
+    @wraps(original)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         respan_params = _pop_respan_params(kwargs=kwargs)
         with use_respan_params(respan_params):
@@ -131,7 +292,10 @@ def _wrap_send_request(original: Any) -> Any:
             endpoint = _arg(args, 1, kwargs, "endpoint", "")
             request_json = _arg(args, 2, kwargs, "json")
             request_params = _arg(args, 3, kwargs, "params")
-            stream = bool(_arg(args, 4, kwargs, "stream", False))
+            stream = _request_uses_streaming(
+                stream=bool(_arg(args, 4, kwargs, "stream", False)),
+                request_json=request_json,
+            )
             call_context = capture_call_context(
                 method=str(method),
                 endpoint=str(endpoint),
@@ -165,6 +329,7 @@ def _wrap_send_request(original: Any) -> Any:
 
 
 def _wrap_send_request_with_files(original: Any) -> Any:
+    @wraps(original)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         respan_params = _pop_respan_params(kwargs=kwargs)
         with use_respan_params(respan_params):
@@ -198,10 +363,100 @@ def _wrap_send_request_with_files(original: Any) -> Any:
 
 
 def _wrap_high_level_method(original: Any) -> Any:
+    @wraps(original)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         respan_params = _pop_respan_params(kwargs=kwargs)
         with use_respan_params(respan_params):
             return original(self, *args, **kwargs)
+
+    return wrapper
+
+
+def _wrap_async_send_request(original: Any) -> Any:
+    @wraps(original)
+    async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        respan_params = _pop_respan_params(kwargs=kwargs)
+        with use_respan_params(respan_params):
+            method = _arg(args, 0, kwargs, "method", "")
+            endpoint = _arg(args, 1, kwargs, "endpoint", "")
+            request_json = _arg(args, 2, kwargs, "json")
+            request_params = _arg(args, 3, kwargs, "params")
+            stream = _request_uses_streaming(
+                stream=bool(_arg(args, 4, kwargs, "stream", False)),
+                request_json=request_json,
+            )
+            call_context = capture_call_context(
+                method=str(method),
+                endpoint=str(endpoint),
+                request_json=request_json,
+                request_params=request_params,
+                stream=stream,
+            )
+            try:
+                response = await original(self, *args, **kwargs)
+            except Exception as exc:
+                emit_dify_span(
+                    call_context=call_context,
+                    error=exc,
+                    include_content=_INCLUDE_CONTENT,
+                )
+                raise
+
+            if stream:
+                return _InstrumentedAsyncStreamingResponse(
+                    response=response,
+                    call_context=call_context,
+                )
+            emit_dify_span(
+                call_context=call_context,
+                response=response,
+                include_content=_INCLUDE_CONTENT,
+            )
+            return response
+
+    return wrapper
+
+
+def _wrap_async_send_request_with_files(original: Any) -> Any:
+    @wraps(original)
+    async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        respan_params = _pop_respan_params(kwargs=kwargs)
+        with use_respan_params(respan_params):
+            method = _arg(args, 0, kwargs, "method", "")
+            endpoint = _arg(args, 1, kwargs, "endpoint", "")
+            request_data = _arg(args, 2, kwargs, "data")
+            files = _arg(args, 3, kwargs, "files")
+            call_context = capture_call_context(
+                method=str(method),
+                endpoint=str(endpoint),
+                request_data=request_data,
+                files=files,
+            )
+            try:
+                response = await original(self, *args, **kwargs)
+            except Exception as exc:
+                emit_dify_span(
+                    call_context=call_context,
+                    error=exc,
+                    include_content=_INCLUDE_CONTENT,
+                )
+                raise
+            emit_dify_span(
+                call_context=call_context,
+                response=response,
+                include_content=_INCLUDE_CONTENT,
+            )
+            return response
+
+    return wrapper
+
+
+def _wrap_async_high_level_method(original: Any) -> Any:
+    @wraps(original)
+    async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        respan_params = _pop_respan_params(kwargs=kwargs)
+        with use_respan_params(respan_params):
+            return await original(self, *args, **kwargs)
 
     return wrapper
 
@@ -213,8 +468,9 @@ def _patch_method(cls: type[Any], method_name: str, wrapper_factory: Any) -> Non
     original = getattr(cls, method_name, None)
     if original is None:
         return
-    _PATCHED_METHODS[key] = original
-    setattr(cls, method_name, wrapper_factory(original))
+    replacement = wrapper_factory(original)
+    _PATCHED_METHODS[key] = (original, replacement)
+    setattr(cls, method_name, replacement)
 
 
 class DifyInstrumentor:
@@ -235,18 +491,20 @@ class DifyInstrumentor:
 
     def activate(self) -> None:
         """Monkey-patch the Dify client."""
-        global _IS_PATCHED, _INCLUDE_CONTENT
+        global _ACTIVE_INSTANCES, _IS_PATCHED, _INCLUDE_CONTENT
         if self._is_instrumented:
             return
         if not self._is_respan_tracing_enabled():
-            logger.info("Dify instrumentation skipped because Respan tracing is disabled")
+            logger.info(
+                "Dify instrumentation skipped because Respan tracing is disabled"
+            )
             return
 
         try:
             module = importlib.import_module(DIFY_CLIENT_MODULE)
-            dify_client_cls = getattr(module, "DifyClient")
-            chat_client_cls = getattr(module, "ChatClient")
-            completion_client_cls = getattr(module, "CompletionClient")
+            dify_client_cls = module.DifyClient
+            chat_client_cls = module.ChatClient
+            completion_client_cls = module.CompletionClient
         except (AttributeError, ImportError) as exc:
             logger.warning(
                 "Failed to activate Dify instrumentation - missing dependency: %s",
@@ -254,7 +512,21 @@ class DifyInstrumentor:
             )
             return
 
-        _INCLUDE_CONTENT = self._include_content
+        try:
+            async_module = importlib.import_module(DIFY_ASYNC_CLIENT_MODULE)
+        except ImportError:
+            # PyPI 0.1.10 is sync-only. Async clients exist in the refreshed
+            # 0.1.12 source line and are patched when available.
+            async_module = None
+
+        if _ACTIVE_INSTANCES == 0:
+            _INCLUDE_CONTENT = self._include_content
+        elif _INCLUDE_CONTENT != self._include_content:
+            logger.warning(
+                "Dify instrumentation is already active with "
+                "include_content=%s; keeping the first active configuration",
+                _INCLUDE_CONTENT,
+            )
 
         if not _IS_PATCHED:
             _patch_method(dify_client_cls, "_send_request", _wrap_send_request)
@@ -281,19 +553,105 @@ class DifyInstrumentor:
                 "create_completion_message",
                 _wrap_high_level_method,
             )
+
+            for class_name, method_names in (
+                ("WorkflowClient", ("run", "run_specific_workflow")),
+                (
+                    "KnowledgeBaseClient",
+                    ("run_datasource_node", "run_rag_pipeline"),
+                ),
+            ):
+                cls = getattr(module, class_name, None)
+                if cls is None:
+                    continue
+                for method_name in method_names:
+                    _patch_method(cls, method_name, _wrap_high_level_method)
+
+            if async_module is not None:
+                async_dify_client_cls = getattr(async_module, "AsyncDifyClient", None)
+                if async_dify_client_cls is not None:
+                    _patch_method(
+                        async_dify_client_cls,
+                        "_send_request",
+                        _wrap_async_send_request,
+                    )
+                    _patch_method(
+                        async_dify_client_cls,
+                        "_send_request_with_files",
+                        _wrap_async_send_request_with_files,
+                    )
+                    for method_name in (
+                        "message_feedback",
+                        "get_application_parameters",
+                        "file_upload",
+                    ):
+                        _patch_method(
+                            async_dify_client_cls,
+                            method_name,
+                            _wrap_async_high_level_method,
+                        )
+
+                for class_name, method_names in (
+                    (
+                        "AsyncChatClient",
+                        (
+                            "create_chat_message",
+                            "get_conversation_messages",
+                            "get_conversations",
+                            "rename_conversation",
+                        ),
+                    ),
+                    (
+                        "AsyncCompletionClient",
+                        ("create_completion_message",),
+                    ),
+                    (
+                        "AsyncWorkflowClient",
+                        ("run", "run_specific_workflow"),
+                    ),
+                    (
+                        "AsyncKnowledgeBaseClient",
+                        ("run_datasource_node", "run_rag_pipeline"),
+                    ),
+                ):
+                    cls = getattr(async_module, class_name, None)
+                    if cls is None:
+                        continue
+                    for method_name in method_names:
+                        _patch_method(
+                            cls,
+                            method_name,
+                            _wrap_async_high_level_method,
+                        )
             _IS_PATCHED = True
 
+        _ACTIVE_INSTANCES += 1
         self._is_instrumented = True
         logger.info("Dify instrumentation activated")
 
     def deactivate(self) -> None:
         """Restore patched Dify client methods."""
-        global _IS_PATCHED
-        for (cls, method_name), original in list(_PATCHED_METHODS.items()):
-            setattr(cls, method_name, original)
+        global _ACTIVE_INSTANCES, _IS_PATCHED
+        if not self._is_instrumented:
+            return
+        _ACTIVE_INSTANCES = max(0, _ACTIVE_INSTANCES - 1)
+        self._is_instrumented = False
+        if _ACTIVE_INSTANCES > 0:
+            return
+        for (cls, method_name), (original, replacement) in list(
+            _PATCHED_METHODS.items()
+        ):
+            if getattr(cls, method_name, None) is replacement:
+                setattr(cls, method_name, original)
+            else:
+                logger.warning(
+                    "Dify method %s.%s changed after activation; "
+                    "leaving the later patch installed",
+                    cls.__name__,
+                    method_name,
+                )
         _PATCHED_METHODS.clear()
         _IS_PATCHED = False
-        self._is_instrumented = False
         logger.info("Dify instrumentation deactivated")
 
 

--- a/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_otel_emitter.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_otel_emitter.py
@@ -2,23 +2,25 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
 from opentelemetry.semconv_ai import SpanAttributes
-
-from respan_instrumentation_dify._context import read_respan_params
-from respan_instrumentation_dify._translator import build_dify_span_data
 from respan_sdk.utils.data_processing.id_processing import (
     format_span_id,
     format_trace_id,
 )
-from respan_tracing.utils.span_factory import build_readable_span
-from respan_tracing.utils.span_factory import inject_span
-from respan_tracing.utils.span_factory import read_propagated_attributes
+from respan_tracing.utils.span_factory import (
+    build_readable_span,
+    inject_span,
+    read_propagated_attributes,
+)
+
+from respan_instrumentation_dify._context import read_respan_params
+from respan_instrumentation_dify._translator import build_dify_span_data
 
 
 @dataclass
@@ -42,7 +44,7 @@ def _current_otel_parent() -> tuple[str | None, str | None]:
     current_span = trace.get_current_span()
     try:
         span_context = current_span.get_span_context()
-    except Exception:
+    except Exception:  # noqa: BLE001 -- defensive OTEL provider boundary
         return None, None
 
     trace_id = getattr(span_context, "trace_id", 0)
@@ -104,6 +106,7 @@ def emit_dify_span(
         respan_params=call_context.respan_params,
         propagated_attributes=call_context.propagated_attributes,
         current_workflow_name=call_context.workflow_name,
+        parent_id=call_context.parent_id,
     )
     status_code = getattr(response, "status_code", 200)
     if not isinstance(status_code, int):

--- a/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_translator.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/src/respan_instrumentation_dify/_translator.py
@@ -9,8 +9,24 @@ from typing import Any
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
-from opentelemetry.semconv_ai import LLMRequestTypeValues
-from opentelemetry.semconv_ai import SpanAttributes
+from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
+from respan_sdk.constants.llm_logging import (
+    LOG_TYPE_CHAT,
+    LOG_TYPE_TASK,
+    LOG_TYPE_TEXT,
+    LOG_TYPE_WORKFLOW,
+    LogMethodChoices,
+)
+from respan_sdk.constants.span_attributes import (
+    RESPAN_CUSTOMER_PARAMS_ID,
+    RESPAN_LOG_METHOD,
+    RESPAN_LOG_TYPE,
+    RESPAN_METADATA,
+    RESPAN_SPAN_ATTRIBUTES_MAP,
+    RESPAN_THREADS_ID,
+    RESPAN_TRACE_GROUP_ID,
+)
+from respan_sdk.utils.serialization import serialize_value
 
 from respan_instrumentation_dify._constants import (
     ANSWER_KEY,
@@ -36,7 +52,6 @@ from respan_instrumentation_dify._constants import (
     MODE_KEY,
     OFF_CONTRACT_ALIASES,
     OUTPUTS_KEY,
-    PARAMS_KEY,
     PROMPT_TOKENS_KEY,
     QUERY_KEY,
     RESPONSE_MODE_KEY,
@@ -47,33 +62,85 @@ from respan_instrumentation_dify._constants import (
     USER_KEY,
     WORKFLOW_RUN_ID_KEY,
 )
-from respan_sdk.constants.llm_logging import LOG_TYPE_CHAT
-from respan_sdk.constants.llm_logging import LOG_TYPE_TASK
-from respan_sdk.constants.llm_logging import LOG_TYPE_TEXT
-from respan_sdk.constants.llm_logging import LOG_TYPE_WORKFLOW
-from respan_sdk.constants.llm_logging import LogMethodChoices
-from respan_sdk.constants.span_attributes import (
-    RESPAN_CUSTOMER_PARAMS_ID,
-    RESPAN_LOG_METHOD,
-    RESPAN_LOG_TYPE,
-    RESPAN_METADATA,
-    RESPAN_SPAN_ATTRIBUTES_MAP,
-    RESPAN_THREADS_ID,
-    RESPAN_TRACE_GROUP_ID,
+
+_REDACTED = "[REDACTED]"
+_SENSITIVE_KEY_FRAGMENTS = (
+    "accesskey",
+    "apikey",
+    "authorization",
+    "cookie",
+    "credential",
+    "password",
+    "passwd",
+    "passphrase",
+    "privatekey",
+    "secret",
+    "token",
 )
-from respan_sdk.utils.serialization import serialize_value
+_NON_SECRET_TOKEN_KEYS = {
+    "cachedtokens",
+    "completiontokens",
+    "inputtokens",
+    "maxtokens",
+    "outputtokens",
+    "prompttokens",
+    "reasoningtokens",
+    "tokencount",
+    "totaltokens",
+}
+
+
+def _normalized_key(key: Any) -> str:
+    return "".join(
+        character for character in str(key).casefold() if character.isalnum()
+    )
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    normalized = _normalized_key(key)
+    if any(normalized.endswith(key) for key in _NON_SECRET_TOKEN_KEYS):
+        return False
+    return any(fragment in normalized for fragment in _SENSITIVE_KEY_FRAGMENTS)
+
+
+def _redact_sensitive(value: Any, seen: set[int] | None = None) -> Any:
+    seen = seen or set()
+    if isinstance(value, Mapping):
+        identity = id(value)
+        if identity in seen:
+            return "[Circular]"
+        seen.add(identity)
+        return {
+            str(key): (
+                _REDACTED if _is_sensitive_key(key) else _redact_sensitive(nested, seen)
+            )
+            for key, nested in value.items()
+        }
+    if isinstance(value, (list, tuple, set)):
+        identity = id(value)
+        if identity in seen:
+            return "[Circular]"
+        seen.add(identity)
+        return [_redact_sensitive(nested, seen) for nested in value]
+    return value
 
 
 def safe_json(value: Any) -> str:
     """Serialize arbitrary Dify values into an OTEL-safe JSON string."""
     try:
+        serialized = serialize_value(value=value)
         return json.dumps(
-            serialize_value(value=value),
-            default=str,
-            separators=(",", ":"),
+            _redact_sensitive(serialized), default=str, separators=(",", ":")
         )
-    except Exception:
-        return json.dumps(str(value), separators=(",", ":"))
+    except Exception:  # noqa: BLE001 -- arbitrary vendor values may fail serialization
+        try:
+            return json.dumps(
+                _redact_sensitive(value),
+                default=lambda _: "[Unserializable]",
+                separators=(",", ":"),
+            )
+        except Exception:  # noqa: BLE001 -- never leak or break on vendor values
+            return json.dumps("[Unserializable]", separators=(",", ":"))
 
 
 def _to_mapping(value: Any) -> Mapping[str, Any] | None:
@@ -85,15 +152,15 @@ def _to_mapping(value: Any) -> Mapping[str, Any] | None:
             continue
         try:
             converted = method()
-        except Exception:
+        except Exception:  # noqa: BLE001, S112 -- best-effort vendor hook
             continue
         if isinstance(converted, Mapping):
             return converted
         if isinstance(converted, str):
             try:
                 parsed = json.loads(converted)
-            except Exception:
-                continue
+            except json.JSONDecodeError:
+                parsed = None
             if isinstance(parsed, Mapping):
                 return parsed
     value_dict = getattr(value, "__dict__", None)
@@ -123,7 +190,7 @@ def _response_json(response: Any) -> Mapping[str, Any]:
     if callable(json_method):
         try:
             value = json_method()
-        except Exception:
+        except Exception:  # noqa: BLE001 -- vendor response parsing is best effort
             return {}
         mapping = _to_mapping(value)
         return mapping or {}
@@ -136,7 +203,11 @@ def _endpoint_kind(endpoint: str) -> str:
         return "chat"
     if endpoint == COMPLETION_MESSAGES_ENDPOINT:
         return "completion"
-    if endpoint.startswith("/workflows/") or endpoint == "/workflows":
+    if (
+        endpoint.startswith("/workflows/")
+        or endpoint == "/workflows"
+        or endpoint.endswith("/pipeline/run")
+    ):
         return "workflow"
     return "api"
 
@@ -149,7 +220,9 @@ def _default_span_name(endpoint: str) -> str:
         return DIFY_COMPLETION_SPAN_NAME
     if kind == "workflow":
         return DIFY_WORKFLOW_SPAN_NAME
-    return f"{DIFY_API_SPAN_NAME}:{endpoint.strip('/') or 'root'}"
+    # Keep endpoint paths (which often contain high-cardinality IDs) in
+    # metadata, never in the span name.
+    return DIFY_API_SPAN_NAME
 
 
 def _log_type(endpoint: str) -> str:
@@ -275,6 +348,15 @@ def _stream_usage(stream_events: Sequence[Any]) -> Mapping[str, Any]:
     return {}
 
 
+def _stream_response_data(stream_events: Sequence[Any]) -> Mapping[str, Any]:
+    merged: dict[str, Any] = {}
+    for event in stream_events:
+        mapping = _to_mapping(event)
+        if mapping is not None:
+            merged.update(mapping)
+    return merged
+
+
 def _int_value(mapping: Mapping[str, Any], key: str) -> int | None:
     value = mapping.get(key)
     if isinstance(value, bool):
@@ -289,12 +371,62 @@ def _int_value(mapping: Mapping[str, Any], key: str) -> int | None:
 def _set_metadata(attributes: dict[str, Any], key: str, value: Any) -> None:
     if value is None:
         return
-    if isinstance(value, bool):
-        attributes[f"{RESPAN_METADATA}.{key}"] = str(value).lower()
-    elif isinstance(value, (str, int, float)):
-        attributes[f"{RESPAN_METADATA}.{key}"] = str(value)
-    else:
-        attributes[f"{RESPAN_METADATA}.{key}"] = safe_json(value=value)
+    canonical = _metadata_mapping(attributes.get(RESPAN_METADATA))
+
+    serialized_value = serialize_value(value=value)
+    canonical[key] = serialized_value
+    attributes[RESPAN_METADATA] = safe_json(value=canonical)
+
+
+def _metadata_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _otel_safe_attribute(value: Any) -> Any:
+    serialized = serialize_value(value=value)
+    if serialized is None or isinstance(serialized, (str, bool, int, float)):
+        return serialized
+    if isinstance(serialized, (list, tuple)) and serialized:
+        item_types = {type(item) for item in serialized}
+        if len(item_types) == 1 and item_types.pop() in {str, bool, int, float}:
+            return list(serialized)
+    return safe_json(value=serialized)
+
+
+def _merge_propagated_attributes(
+    attributes: dict[str, Any],
+    propagated_attributes: Mapping[str, Any],
+) -> None:
+    canonical_metadata = _metadata_mapping(attributes.get(RESPAN_METADATA))
+    metadata_prefix = f"{RESPAN_METADATA}."
+    for key, value in propagated_attributes.items():
+        if key == RESPAN_METADATA:
+            for metadata_key, metadata_value in _metadata_mapping(value).items():
+                canonical_metadata.setdefault(metadata_key, metadata_value)
+            continue
+        if key.startswith(metadata_prefix):
+            metadata_key = key.removeprefix(metadata_prefix)
+            if metadata_key:
+                canonical_metadata.setdefault(
+                    metadata_key,
+                    serialize_value(value=value),
+                )
+            continue
+        attribute_value = _otel_safe_attribute(value)
+        if attribute_value is not None:
+            attributes[key] = attribute_value
+
+    if canonical_metadata:
+        attributes[RESPAN_METADATA] = safe_json(value=canonical_metadata)
 
 
 def _apply_response_metadata(
@@ -468,7 +600,9 @@ def _apply_respan_params(
                     value=metadata_value,
                 )
         else:
-            attributes[attr_key] = value
+            attribute_value = _otel_safe_attribute(value)
+            if attribute_value is not None:
+                attributes[attr_key] = attribute_value
     return span_name
 
 
@@ -487,6 +621,7 @@ def build_dify_span_data(
     respan_params: Mapping[str, Any] | None = None,
     propagated_attributes: Mapping[str, Any] | None = None,
     current_workflow_name: str | None = None,
+    parent_id: str | None = None,
 ) -> tuple[str, dict[str, Any]]:
     """Build canonical span name and attributes from a Dify client call."""
     endpoint = endpoint or ""
@@ -506,7 +641,7 @@ def build_dify_span_data(
         RESPAN_LOG_METHOD: LogMethodChoices.TRACING_INTEGRATION.value,
         RESPAN_LOG_TYPE: _log_type(endpoint=endpoint),
         SpanAttributes.TRACELOOP_ENTITY_NAME: default_span_name,
-        SpanAttributes.TRACELOOP_ENTITY_PATH: default_span_name,
+        SpanAttributes.TRACELOOP_ENTITY_PATH: "",
     }
 
     _set_metadata(attributes=attributes, key=f"dify.{METHOD_KEY}", value=method)
@@ -519,7 +654,13 @@ def build_dify_span_data(
         request_json=request_json_mapping,
         request_params=request_params_mapping,
     )
-    _apply_response_metadata(attributes=attributes, response_data=response_data)
+    semantic_response_data = dict(response_data)
+    if stream_events:
+        semantic_response_data.update(_stream_response_data(stream_events))
+    _apply_response_metadata(
+        attributes=attributes,
+        response_data=semantic_response_data,
+    )
 
     usage = (
         _stream_usage(stream_events=stream_events)
@@ -542,7 +683,7 @@ def build_dify_span_data(
             attributes=attributes,
             endpoint=endpoint,
             request_json=request_json_mapping,
-            response_data=response_data,
+            response_data=semantic_response_data,
             usage=usage,
             output=output,
         )
@@ -554,10 +695,16 @@ def build_dify_span_data(
         default_span_name=default_span_name,
     )
     attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] = span_name
-    attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] = span_name
 
-    for key, value in (propagated_attributes or {}).items():
-        attributes[key] = value
+    _merge_propagated_attributes(
+        attributes,
+        propagated_attributes or {},
+    )
+
+    workflow_name = attributes.get(SpanAttributes.TRACELOOP_WORKFLOW_NAME)
+    attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] = (
+        str(workflow_name) if parent_id and workflow_name else ""
+    )
 
     for alias in OFF_CONTRACT_ALIASES:
         attributes.pop(alias, None)

--- a/python-sdks/instrumentations/respan-instrumentation-dify/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-dify/tests/test_instrumentation.py
@@ -1,12 +1,11 @@
+import asyncio
 import json
 from types import SimpleNamespace
 
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
-from opentelemetry.semconv_ai import LLMRequestTypeValues
-from opentelemetry.semconv_ai import SpanAttributes
-
+from opentelemetry.semconv_ai import LLMRequestTypeValues, SpanAttributes
 from respan_instrumentation_dify import _instrumentation as instrumentation
 from respan_instrumentation_dify._constants import OFF_CONTRACT_ALIASES
 from respan_instrumentation_dify._translator import build_dify_span_data
@@ -15,6 +14,8 @@ from respan_sdk.constants.span_attributes import (
     RESPAN_LOG_METHOD,
     RESPAN_LOG_TYPE,
     RESPAN_METADATA,
+    RESPAN_PROMPT,
+    RESPAN_PROPERTIES,
     RESPAN_THREADS_ID,
     RESPAN_TRACE_GROUP_ID,
 )
@@ -40,6 +41,10 @@ class FakeResponse:
 
     def close(self):
         self.closed = True
+
+
+def _metadata(attributes):
+    return json.loads(attributes[RESPAN_METADATA])
 
 
 def test_build_chat_span_data_sets_canonical_attributes():
@@ -85,8 +90,9 @@ def test_build_chat_span_data_sets_canonical_attributes():
     assert attrs[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 8
     assert attrs[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 2
     assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 10
-    assert attrs[f"{RESPAN_METADATA}.dify.endpoint"] == "/chat-messages"
-    assert attrs[f"{RESPAN_METADATA}.dify.task_id"] == "task-123"
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+    assert _metadata(attrs)["dify.endpoint"] == "/chat-messages"
+    assert _metadata(attrs)["dify.task_id"] == "task-123"
     assert not OFF_CONTRACT_ALIASES.intersection(attrs)
 
 
@@ -169,8 +175,8 @@ def test_build_workflow_span_data_sets_workflow_log_type_without_llm_aliases():
     assert (
         attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == '{"result":"Short summary."}'
     )
-    assert attrs[f"{RESPAN_METADATA}.dify.workflow_run_id"] == "run-123"
-    assert attrs[f"{RESPAN_METADATA}.dify.total_tokens"] == "42"
+    assert _metadata(attrs)["dify.workflow_run_id"] == "run-123"
+    assert _metadata(attrs)["dify.total_tokens"] == 42
     assert not OFF_CONTRACT_ALIASES.intersection(attrs)
 
 
@@ -180,10 +186,25 @@ def test_streaming_events_accumulate_answer_and_usage():
         endpoint="/chat-messages",
         request_json={"query": "Hi", "user": "user-123"},
         stream_events=[
-            {"event": "message", "answer": "Hel"},
-            {"event": "message", "answer": "lo"},
+            {
+                "event": "message",
+                "task_id": "task-stream",
+                "message_id": "message-stream",
+                "conversation_id": "conversation-stream",
+                "answer": "Hel",
+            },
+            {
+                "event": "message",
+                "task_id": "task-stream",
+                "message_id": "message-stream",
+                "conversation_id": "conversation-stream",
+                "answer": "lo",
+            },
             {
                 "event": "message_end",
+                "task_id": "task-stream",
+                "message_id": "message-stream",
+                "conversation_id": "conversation-stream",
                 "metadata": {
                     "usage": {
                         "model": "dify/stream-model",
@@ -200,6 +221,10 @@ def test_streaming_events_accumulate_answer_and_usage():
     assert attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == "Hello"
     assert attrs[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 2
     assert attrs[SpanAttributes.LLM_REQUEST_MODEL] == "dify/stream-model"
+    assert _metadata(attrs)["dify.event"] == "message_end"
+    assert _metadata(attrs)["dify.task_id"] == "task-stream"
+    assert _metadata(attrs)["dify.message_id"] == "message-stream"
+    assert _metadata(attrs)["dify.conversation_id"] == "conversation-stream"
     assert not OFF_CONTRACT_ALIASES.intersection(attrs)
 
 
@@ -221,7 +246,167 @@ def test_respan_params_override_span_context():
     assert attrs[SpanAttributes.TRACELOOP_WORKFLOW_NAME] == "dify_custom.workflow"
     assert attrs[RESPAN_TRACE_GROUP_ID] == "dify_custom.workflow"
     assert attrs[RESPAN_CUSTOMER_PARAMS_ID] == "customer-override"
-    assert attrs[f"{RESPAN_METADATA}.example"] == "params"
+    assert _metadata(attrs)["example"] == "params"
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == ""
+    assert not OFF_CONTRACT_ALIASES.intersection(attrs)
+
+
+def test_metadata_uses_only_the_canonical_json_attribute():
+    _, attrs = build_dify_span_data(
+        method="GET",
+        endpoint="/parameters",
+        request_params={"user": "user-123"},
+        response=FakeResponse({"opening_statement": "Hello"}),
+    )
+
+    metadata = json.loads(attrs[RESPAN_METADATA])
+    assert metadata["dify.method"] == "GET"
+    assert metadata["dify.endpoint"] == "/parameters"
+    assert not any(key.startswith(f"{RESPAN_METADATA}.") for key in attrs)
+
+
+def test_propagated_metadata_merges_into_the_canonical_json_attribute():
+    _, attrs = build_dify_span_data(
+        method="GET",
+        endpoint="/parameters",
+        response=FakeResponse({"opening_statement": "Hello"}),
+        propagated_attributes={
+            f"{RESPAN_METADATA}.run_id": "run-123",
+            f"{RESPAN_METADATA}.example": "dify-loopback",
+            RESPAN_METADATA: json.dumps(
+                {
+                    "suite": "integration",
+                    "dify.endpoint": "must-not-replace-call-metadata",
+                }
+            ),
+        },
+    )
+
+    metadata = _metadata(attrs)
+    assert metadata["dify.endpoint"] == "/parameters"
+    assert metadata["dify.method"] == "GET"
+    assert metadata["run_id"] == "run-123"
+    assert metadata["example"] == "dify-loopback"
+    assert metadata["suite"] == "integration"
+    assert not any(key.startswith(f"{RESPAN_METADATA}.") for key in attrs)
+
+
+def test_child_entity_path_uses_real_parent_workflow_context():
+    _, attrs = build_dify_span_data(
+        method="GET",
+        endpoint="/parameters",
+        response=FakeResponse({"opening_statement": "Hello"}),
+        current_workflow_name="parent.workflow",
+        parent_id="parent-span-id",
+    )
+
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_PATH] == "parent.workflow"
+
+
+def test_structured_respan_params_are_json_serialized_for_otel():
+    _, attrs = build_dify_span_data(
+        method="GET",
+        endpoint="/parameters",
+        response=FakeResponse({"opening_statement": "Hello"}),
+        respan_params={
+            "properties": {"region": "us", "attempts": [1, 2]},
+            "prompt": {"id": "prompt-1", "variables": {"city": "Paris"}},
+        },
+    )
+
+    assert json.loads(attrs[RESPAN_PROPERTIES]) == {
+        "attempts": [1, 2],
+        "region": "us",
+    }
+    assert json.loads(attrs[RESPAN_PROMPT]) == {
+        "id": "prompt-1",
+        "variables": {"city": "Paris"},
+    }
+
+
+def test_include_content_false_omits_request_and_response_content():
+    _, attrs = build_dify_span_data(
+        method="POST",
+        endpoint="/chat-messages",
+        request_json={"query": "private prompt", "user": "user-123"},
+        response=FakeResponse(
+            {
+                "answer": "private answer",
+                "metadata": {"usage": {"prompt_tokens": 2, "completion_tokens": 3}},
+            }
+        ),
+        include_content=False,
+    )
+
+    assert SpanAttributes.TRACELOOP_ENTITY_INPUT not in attrs
+    assert SpanAttributes.TRACELOOP_ENTITY_OUTPUT not in attrs
+    assert f"{SpanAttributes.LLM_PROMPTS}.0.content" not in attrs
+    assert f"{SpanAttributes.LLM_COMPLETIONS}.0.content" not in attrs
+    assert attrs[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 2
+    assert attrs[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 3
+    assert "private prompt" not in json.dumps(attrs, default=str)
+    assert "private answer" not in json.dumps(attrs, default=str)
+
+
+def test_workspace_credentials_are_recursively_redacted_without_mutation():
+    credentials = {
+        "openai_api_key": "python-provider-key",
+        "apiKey": "python-camel-key",
+        "Authorization": "Bearer python-authorization",
+        "nested": {
+            "refresh_token": "python-refresh-token",
+            "password": "python-password",
+            "password_hash": "python-password-hash",
+            "aws_secret_access_key": "python-aws-secret-access-key",
+            "safe_region": "us-east-1",
+        },
+    }
+    _, attrs = build_dify_span_data(
+        method="POST",
+        endpoint=("/workspaces/current/model-providers/openai/credentials/validate"),
+        request_json=credentials,
+        response=FakeResponse(
+            {
+                "result": "success",
+                "provider": {
+                    "credentials": {"access_token": "python-response-access-token"}
+                },
+            }
+        ),
+        respan_params={"metadata": {"session_token": "python-metadata-session-token"}},
+    )
+
+    serialized_attributes = json.dumps(attrs, default=str)
+    for secret in (
+        "python-provider-key",
+        "python-camel-key",
+        "python-authorization",
+        "python-refresh-token",
+        "python-password",
+        "python-password-hash",
+        "python-aws-secret-access-key",
+        "python-response-access-token",
+        "python-metadata-session-token",
+    ):
+        assert secret not in serialized_attributes
+    assert "[REDACTED]" in serialized_attributes
+    assert "us-east-1" in serialized_attributes
+    assert credentials["openai_api_key"] == "python-provider-key"
+    assert credentials["nested"]["refresh_token"] == "python-refresh-token"
+
+
+def test_rag_pipeline_is_classified_as_workflow():
+    span_name, attrs = build_dify_span_data(
+        method="POST",
+        endpoint="/datasets/dataset-1/pipeline/run",
+        request_json={"inputs": {"source": "docs"}, "response_mode": "blocking"},
+        response=FakeResponse(
+            {"data": {"status": "succeeded", "outputs": {"documents": 2}}}
+        ),
+    )
+
+    assert span_name == "dify.workflow"
+    assert attrs[RESPAN_LOG_TYPE] == "workflow"
     assert not OFF_CONTRACT_ALIASES.intersection(attrs)
 
 
@@ -310,3 +495,306 @@ def test_instrumentor_patches_send_request_and_streaming(monkeypatch):
     assert emitted[0]["stream_events"][0]["answer"] == "Hel"
 
     instrumentor.deactivate()
+
+
+def test_concurrent_instrumentors_preserve_first_content_policy(monkeypatch):
+    emitted = []
+
+    class DifyClient:
+        def _send_request(self, method, endpoint, json=None, params=None, stream=False):
+            return FakeResponse({"answer": "private answer"})
+
+        def _send_request_with_files(self, method, endpoint, data, files):
+            return FakeResponse({"id": "file-123"})
+
+    class ChatClient(DifyClient):
+        pass
+
+    class CompletionClient(DifyClient):
+        pass
+
+    fake_module = SimpleNamespace(
+        DifyClient=DifyClient,
+        ChatClient=ChatClient,
+        CompletionClient=CompletionClient,
+    )
+    monkeypatch.setattr(
+        instrumentation.importlib,
+        "import_module",
+        lambda module_name: fake_module,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "emit_dify_span",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    first = instrumentation.DifyInstrumentor(include_content=False)
+    conflicting = instrumentation.DifyInstrumentor(include_content=True)
+    first.activate()
+    conflicting.activate()
+    try:
+        ChatClient()._send_request(
+            "POST",
+            "/chat-messages",
+            {"query": "private prompt", "user": "user-123"},
+        )
+        assert emitted[-1]["include_content"] is False
+
+        conflicting.deactivate()
+        ChatClient()._send_request(
+            "POST",
+            "/chat-messages",
+            {"query": "still private", "user": "user-123"},
+        )
+        assert emitted[-1]["include_content"] is False
+    finally:
+        conflicting.deactivate()
+        first.deactivate()
+
+    replacement = instrumentation.DifyInstrumentor(include_content=True)
+    replacement.activate()
+    try:
+        ChatClient()._send_request(
+            "POST",
+            "/chat-messages",
+            {"query": "visible prompt", "user": "user-123"},
+        )
+        assert emitted[-1]["include_content"] is True
+    finally:
+        replacement.deactivate()
+
+
+def test_deactivation_preserves_a_later_foreign_patch(monkeypatch):
+    class DifyClient:
+        def _send_request(self, method, endpoint, json=None, params=None, stream=False):
+            return FakeResponse({"answer": "original"})
+
+        def _send_request_with_files(self, method, endpoint, data, files):
+            return FakeResponse({"id": "file-123"})
+
+    class ChatClient(DifyClient):
+        pass
+
+    class CompletionClient(DifyClient):
+        pass
+
+    fake_module = SimpleNamespace(
+        DifyClient=DifyClient,
+        ChatClient=ChatClient,
+        CompletionClient=CompletionClient,
+    )
+    monkeypatch.setattr(
+        instrumentation.importlib,
+        "import_module",
+        lambda module_name: fake_module,
+    )
+
+    original = DifyClient._send_request
+    first = instrumentation.DifyInstrumentor()
+    second = instrumentation.DifyInstrumentor()
+    first.activate()
+    second.activate()
+    assert DifyClient._send_request is not original
+
+    def foreign_patch(self, *args, **kwargs):
+        return FakeResponse({"answer": "foreign"})
+
+    DifyClient._send_request = foreign_patch
+    first.deactivate()
+    assert DifyClient._send_request is foreign_patch
+    second.deactivate()
+
+    assert DifyClient._send_request is foreign_patch
+    assert instrumentation._ACTIVE_INSTANCES == 0
+    assert instrumentation._PATCHED_METHODS == {}
+
+
+def test_sync_stream_early_close_emits_partial_events_once(monkeypatch):
+    emitted = []
+    call_context = SimpleNamespace(endpoint="/chat-messages")
+    response = FakeResponse(
+        [
+            {"event": "message", "answer": "partial"},
+            {"event": "message_end"},
+        ]
+    )
+    wrapped = instrumentation._InstrumentedStreamingResponse(
+        response=response,
+        call_context=call_context,
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "emit_dify_span",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    lines = wrapped.iter_lines()
+    assert next(lines)
+    lines.close()
+    wrapped.close()
+
+    assert len(emitted) == 1
+    assert emitted[0]["stream_events"][0]["answer"] == "partial"
+    assert response.closed is True
+
+
+def test_async_clients_are_patched_and_stream_on_response_mode(monkeypatch):
+    emitted = []
+
+    class DifyClient:
+        def _send_request(self, method, endpoint, json=None, params=None, stream=False):
+            return FakeResponse({"result": "success"})
+
+        def _send_request_with_files(self, method, endpoint, data, files):
+            return FakeResponse({"id": "file-sync"})
+
+    class ChatClient(DifyClient):
+        def create_chat_message(self, **kwargs):
+            return self._send_request("POST", "/chat-messages", kwargs)
+
+    class CompletionClient(DifyClient):
+        def create_completion_message(self, **kwargs):
+            return self._send_request("POST", "/completion-messages", kwargs)
+
+    class AsyncResponse:
+        status_code = 200
+
+        def __init__(self, events):
+            self.events = events
+            self.closed = False
+
+        def json(self):
+            return {}
+
+        async def aiter_lines(self):
+            for event in self.events:
+                yield f"data: {json.dumps(event)}"
+
+        async def aclose(self):
+            self.closed = True
+
+    class AsyncDifyClient:
+        async def _send_request(
+            self, method, endpoint, json=None, params=None, stream=False
+        ):
+            return AsyncResponse(
+                [
+                    {"event": "message", "answer": "Hel"},
+                    {"event": "message", "answer": "lo"},
+                ]
+            )
+
+        async def _send_request_with_files(self, method, endpoint, data, files):
+            return AsyncResponse([])
+
+    class AsyncChatClient(AsyncDifyClient):
+        async def create_chat_message(
+            self, inputs, query, user, response_mode="blocking"
+        ):
+            return await self._send_request(
+                "POST",
+                "/chat-messages",
+                {
+                    "inputs": inputs,
+                    "query": query,
+                    "user": user,
+                    "response_mode": response_mode,
+                },
+            )
+
+    class AsyncCompletionClient(AsyncDifyClient):
+        async def create_completion_message(self, inputs, response_mode, user):
+            return await self._send_request(
+                "POST",
+                "/completion-messages",
+                {
+                    "inputs": inputs,
+                    "response_mode": response_mode,
+                    "user": user,
+                },
+            )
+
+    sync_module = SimpleNamespace(
+        DifyClient=DifyClient,
+        ChatClient=ChatClient,
+        CompletionClient=CompletionClient,
+    )
+    async_module = SimpleNamespace(
+        AsyncDifyClient=AsyncDifyClient,
+        AsyncChatClient=AsyncChatClient,
+        AsyncCompletionClient=AsyncCompletionClient,
+    )
+
+    def import_module(name):
+        if name == instrumentation.DIFY_ASYNC_CLIENT_MODULE:
+            return async_module
+        return sync_module
+
+    monkeypatch.setattr(instrumentation.importlib, "import_module", import_module)
+    monkeypatch.setattr(
+        instrumentation,
+        "emit_dify_span",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    async def run():
+        instrumentor = instrumentation.DifyInstrumentor()
+        instrumentor.activate()
+        try:
+            response = await AsyncChatClient().create_chat_message(
+                inputs={},
+                query="Hi",
+                user="user-123",
+                response_mode="streaming",
+                respan_params={"span_name": "custom.async.stream"},
+            )
+            assert emitted == []
+            lines = [line async for line in response.aiter_lines()]
+            assert len(lines) == 2
+            assert len(emitted) == 1
+            assert emitted[0]["call_context"].stream is True
+            assert emitted[0]["call_context"].respan_params["span_name"] == (
+                "custom.async.stream"
+            )
+            assert emitted[0]["stream_events"][1]["answer"] == "lo"
+            await response.aclose()
+            assert len(emitted) == 1
+        finally:
+            instrumentor.deactivate()
+
+    asyncio.run(run())
+
+
+def test_async_stream_error_emits_once(monkeypatch):
+    emitted = []
+
+    class ErrorResponse:
+        status_code = 200
+
+        async def aiter_lines(self):
+            yield 'data: {"event":"message","answer":"partial"}'
+            raise RuntimeError("stream failed")
+
+    wrapped = instrumentation._InstrumentedAsyncStreamingResponse(
+        response=ErrorResponse(),
+        call_context=SimpleNamespace(endpoint="/chat-messages"),
+    )
+    monkeypatch.setattr(
+        instrumentation,
+        "emit_dify_span",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    async def run():
+        try:
+            async for _ in wrapped.aiter_lines():
+                pass
+        except RuntimeError as exc:
+            assert str(exc) == "stream failed"
+        else:
+            raise AssertionError("expected stream error")
+
+    asyncio.run(run())
+    assert len(emitted) == 1
+    assert str(emitted[0]["error"]) == "stream failed"

--- a/python-sdks/respan/src/respan/_auto_instrumentation_registry.py
+++ b/python-sdks/respan/src/respan/_auto_instrumentation_registry.py
@@ -476,14 +476,14 @@ AUTO_INSTRUMENTATION_REGISTRY: Tuple[AutoInstrumentationSpec, ...] = (
     ),
     AutoInstrumentationSpec(
         id="dify",
-        category="agent_framework",
+        category="app_framework",
         provider="Dify",
-        sdk_package="dify",
+        sdk_package="dify-client",
         instrumentation_package="respan-instrumentation-dify",
         entry_point="dify",
         import_path="respan_instrumentation_dify:DifyInstrumentor",
         enabled_by_default=False,
-        auto_disabled_reason=_AGENT_FRAMEWORK_REASON,
+        auto_disabled_reason=_FRAMEWORK_REASON,
     ),
     AutoInstrumentationSpec(
         id="agentspec",

--- a/python-sdks/respan/tests/test_auto_instrumentation_registry.py
+++ b/python-sdks/respan/tests/test_auto_instrumentation_registry.py
@@ -329,6 +329,10 @@ class TestAutoInstrumentationRegistry(unittest.TestCase):
                 "protocol",
                 "respan_instrumentation_cursor_sdk:CursorSDKInstrumentor",
             ),
+            "dify": (
+                "app_framework",
+                "respan_instrumentation_dify:DifyInstrumentor",
+            ),
         }
 
         for spec_id, (category, import_path) in expected.items():
@@ -338,6 +342,8 @@ class TestAutoInstrumentationRegistry(unittest.TestCase):
                 self.assertEqual(specs[spec_id].import_path, import_path)
                 self.assertFalse(specs[spec_id].enabled_by_default)
                 self.assertTrue(specs[spec_id].auto_disabled_reason)
+
+        self.assertEqual(specs["dify"].sdk_package, "dify-client")
 
     def test_respan_auto_mode_does_not_forward_broad_otel_auto(self):
         captured = {}


### PR DESCRIPTION
## Scope

Primary integration package: `respan-instrumentation-dify`.

Refresh Dify Python instrumentation for the current official SDK, workflow/RAG operations, streaming lifecycle, context propagation and privacy.

## Necessary supporting changes

Includes only Dify's facade registry correction (`dify-client`, app-framework category and explicit-only reason) plus its tests. No Exa registry entry and no tracing runtime changes.

This is one of the **five** integration PRs in the Dify/Exa/n8n batch. Registry entries are scoped to the integration being added or updated; necessary runtime fixes and their affected tests are included here instead of separate support PRs. Supersedes the corresponding portions of #400 and the redundant support PRs #401, #403, #405, #407 and #408.

## Validation

Dify 20/20 and facade 15/15 tests passed on this branch. Wheel/sdist builds and Twine checks passed; integration code is unchanged from the tested batch.

- Release inventory and intent validators and `git diff --check` pass.
- One existing release-intent file covers all affected release-managed packages; no standalone support intent/PR is needed.
- New CI runs validate the consolidated branch. Local symlinked dependency caches are not release artifacts.

## Release and related work

Release intent coverage: Dify: minor; facade: patch.

No merge or publication is performed by this consolidation. New-package registry preflight remains a separate release gate; a new instrumentation must not ship against an unpublished required runtime API.

Examples PR https://github.com/respanai/respan-example-projects/pull/79 is unchanged. Documentation remains local for the user's review and is untouched.
