### PR TITLE
fix(tracing-js): merge canonical metadata and expose span batch transform

### DIFF
--- a/.release-intents/20260903-js-tracing.json
+++ b/.release-intents/20260903-js-tracing.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Preserve canonical propagated metadata and expose readable-span batch transformation",
+  "packages": {
+    "@respan/tracing": "minor"
+  }
+}

--- a/javascript-sdks/respan-tracing/package.json
+++ b/javascript-sdks/respan-tracing/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@ai-sdk/openai": "^4.0.30",
     "@anthropic-ai/sdk": "0.41.0",
+    "@opentelemetry/context-async-hooks": "^2.10.0",
     "@vercel/otel": "^2.1.3",
     "ai": "^7.0.65",
     "dotenv": "^16.4.7",

--- a/javascript-sdks/respan-tracing/src/index.ts
+++ b/javascript-sdks/respan-tracing/src/index.ts
@@ -17,3 +17,4 @@ export type {
   RespanSpanTransformer,
   SpanTransformerRegistration,
 } from "./processor/transformers.js";
+export { transformReadableSpanBatch } from "./processor/spanName.js";

--- a/javascript-sdks/respan-tracing/src/processor/composite.ts
+++ b/javascript-sdks/respan-tracing/src/processor/composite.ts
@@ -10,7 +10,8 @@ import {
 } from "@respan/respan-sdk";
 import { MultiProcessorManager } from "./manager.js";
 import { getEntityPath, getPropagatedAttributes } from "../utils/context.js";
-import { metadataAttributeKey, LOG_PREFIX, LOG_PREFIX_DEBUG, LOG_PREFIX_ERROR } from "../constants/index.js";
+import { LOG_PREFIX, LOG_PREFIX_DEBUG, LOG_PREFIX_ERROR } from "../constants/index.js";
+import { mergeCanonicalMetadata } from "../utils/metadata.js";
 import {
   acquireSpanTransformerHost,
   releaseSpanTransformerHost,
@@ -82,13 +83,11 @@ export class RespanCompositeProcessor implements SpanProcessor {
         const attrKey = RESPAN_SPAN_ATTRIBUTES_MAP[key];
         if (!attrKey) continue;
 
-        if (key === "metadata" && typeof value === "object") {
-          for (const [mk, mv] of Object.entries(value as Record<string, any>)) {
-            span.setAttribute(
-              metadataAttributeKey(mk),
-              typeof mv === "string" ? mv : JSON.stringify(mv)
-            );
-          }
+        if (key === "metadata") {
+          span.setAttribute(
+            attrKey,
+            mergeCanonicalMetadata(readableSpan.attributes[attrKey], value),
+          );
         } else if (key === "prompt" && typeof value === "object") {
           span.setAttribute(attrKey, JSON.stringify(value));
         } else {

--- a/javascript-sdks/respan-tracing/src/utils/metadata.ts
+++ b/javascript-sdks/respan-tracing/src/utils/metadata.ts
@@ -1,0 +1,37 @@
+type MetadataRecord = Record<string, unknown>;
+
+/** Merge canonical metadata JSON without emitting respan.metadata.* aliases. */
+export function mergeCanonicalMetadata(
+  existing: unknown,
+  propagated: unknown,
+): string {
+  return safeJson({
+    ...metadataRecord(propagated),
+    ...metadataRecord(existing),
+  });
+}
+
+function metadataRecord(value: unknown): MetadataRecord {
+  if (isRecord(value)) return { ...value };
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return isRecord(parsed) ? { ...parsed } : { value: parsed };
+    } catch {
+      return { value };
+    }
+  }
+  return value === undefined || value === null ? {} : { value };
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return JSON.stringify({ value: String(value) });
+  }
+}
+
+function isRecord(value: unknown): value is MetadataRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/javascript-sdks/respan-tracing/src/utils/spanFactory.ts
+++ b/javascript-sdks/respan-tracing/src/utils/spanFactory.ts
@@ -10,8 +10,9 @@ import { trace, SpanKind, SpanStatusCode } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { hrTime, hrTimeDuration } from "@opentelemetry/core";
 import { RESPAN_SPAN_ATTRIBUTES_MAP, RespanSpanAttributes } from "@respan/respan-sdk";
-import { RESPAN_PACKAGE_NAME, metadataAttributeKey } from "../constants/index.js";
+import { RESPAN_PACKAGE_NAME } from "../constants/index.js";
 import { getPropagatedAttributes } from "./context.js";
+import { mergeCanonicalMetadata } from "./metadata.js";
 
 // ── ID helpers ──────────────────────────────────────────────────────────────
 
@@ -105,16 +106,11 @@ export function buildReadableSpan(opts: BuildSpanOptions): ReadableSpan {
         if (value === undefined || value === null) continue;
         const attrKey = RESPAN_SPAN_ATTRIBUTES_MAP[key];
         if (!attrKey) continue;
-        // Only set if not already present (caller attrs take precedence)
-        if (attrs[attrKey] !== undefined) continue;
-
-        if (key === "metadata" && typeof value === "object") {
-          for (const [mk, mv] of Object.entries(value as Record<string, any>)) {
-            const fullKey = metadataAttributeKey(mk);
-            if (attrs[fullKey] === undefined) {
-              attrs[fullKey] = typeof mv === "string" ? mv : JSON.stringify(mv);
-            }
-          }
+        if (key === "metadata") {
+          attrs[attrKey] = mergeCanonicalMetadata(attrs[attrKey], value);
+        // Only set non-metadata values when caller attrs do not already exist.
+        } else if (attrs[attrKey] !== undefined) {
+          continue;
         } else if (key === "prompt" && typeof value === "object") {
           attrs[attrKey] = JSON.stringify(value);
         } else {

--- a/javascript-sdks/respan-tracing/tests/propagated-metadata.test.mjs
+++ b/javascript-sdks/respan-tracing/tests/propagated-metadata.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { context } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { RespanSpanAttributes } from "@respan/respan-sdk";
+
+import { propagateAttributes } from "../dist/contexts/propagation.js";
+import { RespanCompositeProcessor } from "../dist/processor/composite.js";
+import { buildReadableSpan } from "../dist/utils/spanFactory.js";
+
+const METADATA = RespanSpanAttributes.RESPAN_METADATA;
+
+function assertSingleMetadataAttribute(attributes) {
+  assert.equal(typeof attributes[METADATA], "string");
+  assert.equal(Object.keys(attributes).some((key) => key.startsWith(`${METADATA}.`)), false);
+}
+
+test("synthetic spans merge propagated metadata into one canonical JSON attribute", () => {
+  const manager = new AsyncLocalStorageContextManager().enable();
+  context.setGlobalContextManager(manager);
+  try {
+    const span = propagateAttributes(
+      { metadata: { run_id: "outer", shared: "outer" } },
+      () => propagateAttributes(
+        { metadata: { run_id: "inner", shared: "propagated" } },
+        () => buildReadableSpan({
+          name: "vendor.call",
+          attributes: {
+            [METADATA]: JSON.stringify({
+              provider_request_id: "request-1",
+              shared: "instrumentation",
+            }),
+          },
+        }),
+      ),
+    );
+
+    assertSingleMetadataAttribute(span.attributes);
+    assert.deepEqual(JSON.parse(span.attributes[METADATA]), {
+      provider_request_id: "request-1",
+      run_id: "inner",
+      shared: "instrumentation",
+    });
+  } finally {
+    context.disable();
+  }
+});
+
+test("live span processing merges propagated metadata without aliases", async () => {
+  const manager = new AsyncLocalStorageContextManager().enable();
+  context.setGlobalContextManager(manager);
+  const forwarded = [];
+  const processor = new RespanCompositeProcessor({
+    onStart(span) {
+      forwarded.push(span);
+    },
+    onEnd() {},
+    forceFlush: async () => {},
+    shutdown: async () => {},
+  });
+  const span = {
+    name: "vendor.call",
+    attributes: {
+      [METADATA]: JSON.stringify({
+        provider_request_id: "request-1",
+        shared: "instrumentation",
+      }),
+    },
+    setAttribute(key, value) {
+      this.attributes[key] = value;
+      return this;
+    },
+  };
+
+  try {
+    propagateAttributes(
+      { metadata: { run_id: "run-1", shared: "propagated" } },
+      () => processor.onStart(span, context.active()),
+    );
+
+    assert.equal(forwarded.length, 1);
+    assertSingleMetadataAttribute(span.attributes);
+    assert.deepEqual(JSON.parse(span.attributes[METADATA]), {
+      provider_request_id: "request-1",
+      run_id: "run-1",
+      shared: "instrumentation",
+    });
+  } finally {
+    await processor.shutdown();
+    context.disable();
+  }
+});

--- a/javascript-sdks/respan-tracing/tests/span-name-style.test.mjs
+++ b/javascript-sdks/respan-tracing/tests/span-name-style.test.mjs
@@ -1,11 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { transformReadableSpanBatch } from "../dist/index.js";
 import {
   resolveSpanNameStyle,
   semanticSpanNameForSpan,
   SpanNameTransformingExporter,
-  transformReadableSpanBatch,
   transformReadableSpanName,
 } from "../dist/processor/spanName.js";
 

--- a/javascript-sdks/yarn.lock
+++ b/javascript-sdks/yarn.lock
@@ -4234,7 +4234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/otlp-transformer@npm:0.205.0":
+"@opentelemetry/otlp-transformer@npm:0.205.0, @opentelemetry/otlp-transformer@npm:^0.205.0":
   version: 0.205.0
   resolution: "@opentelemetry/otlp-transformer@npm:0.205.0"
   dependencies:
@@ -5572,6 +5572,7 @@ __metadata:
     "@ai-sdk/openai": "npm:^4.0.30"
     "@anthropic-ai/sdk": "npm:0.41.0"
     "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/context-async-hooks": "npm:^2.10.0"
     "@opentelemetry/core": "npm:^2.10.0"
     "@opentelemetry/exporter-trace-otlp-http": "npm:^0.221.0"
     "@opentelemetry/resources": "npm:^2.10.0"


### PR DESCRIPTION
## Scope

Package: `@respan/tracing` only. Split from https://github.com/respanai/respan/pull/400 at `0236995f` under the requested one-package/one-branch/one-PR policy.

Merge propagated metadata into the canonical JSON attribute for live and synthetic JavaScript spans; expose the existing readable-span batch transformer for native exporters such as n8n.

## Prerequisite — draft until refreshed

Depends on https://github.com/respanai/respan/pull/401.

Merge the Anthropic test-only compatibility PR first, then refresh this branch onto main. Tracing CI includes dependent packages, so unchanged main still contains the stale Anthropic flat-metadata expectation.

This branch is based directly on upstream `main`; prerequisite package code is deliberately not copied into this PR, preserving one-package scope.

## Validation

Build and 18/18 focused metadata and span-name tests passed on the isolated branch.

- Release inventory and intent validation passed; no missing intent; exactly one changed release-managed package.
- `git diff --check` passed.
- Source batch CI: all 107 checks passed. This PR has its own fresh CI run; prerequisite-dependent failures are not semantic acceptance.

## Merge and release

Release intent: `@respan/tracing: minor`. No package is published or merged by this split. Existing release automation can publish after an authorized merge; retain the normal review/release gates.

Examples remain in https://github.com/respanai/respan-example-projects/pull/79, unchanged as requested. Public documentation remains in the user's local review worktree; no docs PR or edits are included.
