### PR TITLE
chore(release): republish 5 packages whose npm manifests leak workspace: ranges (fixes npm install @respan/respan)

### DIFF
--- a/.release-intents/20260904-republish-workspace-leaks.json
+++ b/.release-intents/20260904-republish-workspace-leaks.json
@@ -1,0 +1,10 @@
+{
+  "summary": "Republish five packages whose npm manifests still carry literal workspace: ranges and are therefore uninstallable (this also breaks `npm install @respan/respan`, which lists aws-bedrock and openrouter as optional dependencies). No source change; the yarn-pack publish flow rewrites the ranges.",
+  "packages": {
+    "@respan/instrumentation-aws-bedrock": "patch",
+    "@respan/instrumentation-openrouter": "patch",
+    "@respan/instrumentation-codex-sdk": "patch",
+    "@respan/instrumentation-cursor": "patch",
+    "@respan/instrumentation-llama-index": "patch"
+  }
+}


### PR DESCRIPTION
## Summary

Five published packages still carry literal `workspace:^` dependency ranges on npm, which npm rejects (`EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"`):

- `@respan/instrumentation-aws-bedrock@1.0.0`
- `@respan/instrumentation-openrouter@0.1.0`
- `@respan/instrumentation-codex-sdk@1.0.0`
- `@respan/instrumentation-cursor@0.1.0`
- `@respan/instrumentation-llama-index@0.1.0`

Because `@respan/respan@2.4.1` lists aws-bedrock and openrouter as optional dependencies, a plain `npm install @respan/respan` in a clean project currently fails with that error (reproduced today). This intent bumps the five packages to `patch` with no source change so the yarn-pack publish flow (already on main) republishes them with real version ranges.

Verify after publish: `npm view <pkg> dependencies --json | grep workspace` returns nothing, and `npm install @respan/respan` succeeds in an empty directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)