### PR TITLE
chore(release): retry openrouter republish (provenance) and publish instrumentation-pi as patch

### DIFF
--- a/.release-intents/20260903-pi-instrumentation.json
+++ b/.release-intents/20260903-pi-instrumentation.json
@@ -1,7 +1,7 @@
 {
-  "summary": "Add Pi coding agent TypeScript instrumentation (@respan/instrumentation-pi) with a pi extension entry, a `respan integrate pi` CLI command, a Respan facade registry entry, and tracing skill guidance",
+  "summary": "Add Pi coding agent TypeScript instrumentation (@respan/instrumentation-pi) with a pi extension entry, a `respan integrate pi` CLI command, a Respan facade registry entry, and tracing skill guidance Follow-up: 0.1.0 of @respan/instrumentation-pi was published by hand before this merged, so the pipeline publishes 0.1.1 (patch) instead of 'new'.",
   "packages": {
-    "@respan/instrumentation-pi": "new",
+    "@respan/instrumentation-pi": "patch",
     "@respan/cli": "minor",
     "@respan/respan": "minor"
   }

--- a/.release-intents/20260904-republish-openrouter-followup.json
+++ b/.release-intents/20260904-republish-openrouter-followup.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Retry the @respan/instrumentation-openrouter republish from 20260904-republish-workspace-leaks: the first attempt failed npm's provenance check (E422) because package.json had no repository field; the other four packages in that intent were published.",
+  "packages": {
+    "@respan/instrumentation-openrouter": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-openrouter/package.json
+++ b/javascript-sdks/instrumentations/respan-instrumentation-openrouter/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@respan/instrumentation-openrouter",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/respanai/respan",
+    "directory": "javascript-sdks/instrumentations/respan-instrumentation-openrouter"
+  },
   "description": "Respan tracing instrumentation for the OpenRouter TypeScript SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Both publish runs on main today failed; this fixes the two causes.

1. **`@respan/instrumentation-openrouter` E422 on publish** (run 33859326862). npm's provenance verification requires `package.json` `repository.url` to match `https://github.com/respanai/respan`; openrouter was the only release-managed JS package without a `repository` field. Added it (same shape as its siblings) and re-queued the republish as a patch. The other four packages from #412 (aws-bedrock 1.0.1, codex-sdk 1.0.1, cursor 0.1.1, llama-index 0.1.1) are already published without `workspace:` ranges.
2. **`@respan/instrumentation-pi` 'new' intent rejected** (run 33860587676): 0.1.0 was published by hand before #411 merged, and `resolve-versions` refuses `new` for a package that already exists in the registry, which failed the run before `@respan/cli` and `@respan/respan` were released. Switched the intent to `patch` (→ 0.1.1).

Verified locally: `release_intents.py validate`, `plan` and `resolve-versions --prefer-registry` against the registry all pass for origin/main..HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)