### PR TITLE
chore(release): publish instrumentation-pi 0.1.1 + respan 2.5.0 (after npm Trusted Publisher is configured)

### DIFF
--- a/.release-intents/20260904-pi-respan-after-trusted-publisher.json
+++ b/.release-intents/20260904-pi-respan-after-trusted-publisher.json
@@ -1,0 +1,7 @@
+{
+  "summary": "Publish @respan/instrumentation-pi 0.1.1 and @respan/respan 2.5.0, which run 33861301643 left unpublished: npm returned E404 on the pi publish because @respan/instrumentation-pi (first published by hand) had no Trusted Publisher configured for this repository's publish.yml. Merge only after the Trusted Publisher is configured on npmjs.com. @respan/cli 0.14.0 and @respan/instrumentation-openrouter 0.1.1 were published by that run and are not repeated here.",
+  "packages": {
+    "@respan/instrumentation-pi": "patch",
+    "@respan/respan": "minor"
+  }
+}


### PR DESCRIPTION
## Summary

Publish run 33861301643 published `@respan/cli@0.14.0` and `@respan/instrumentation-openrouter@0.1.1`, then failed on `@respan/instrumentation-pi@0.1.1` with npm **E404 on PUT**. The pipeline publishes with OIDC Trusted Publishing (`id-token: write`, no token), and per `contribution/cicd.md` every npm package needs this repository + `publish.yml` configured as a Trusted Publisher. `@respan/instrumentation-pi` was first published by hand today, so it has none yet. `@respan/respan@2.5.0` never ran because the loop aborted.

This intent re-plans exactly those two packages (resolve-versions against the registry: pi 0.1.0 → 0.1.1, respan 2.4.1 → 2.5.0).

**Do not merge until** the Trusted Publisher for `@respan/instrumentation-pi` is configured on npmjs.com (package → Settings → Trusted Publisher → GitHub Actions: organization `respanai`, repository `respan`, workflow `publish.yml`, environment `npm`). Otherwise the run fails again with the same E404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)