### PR TITLE
fix(instrumentation-pi): report the package version from package.json

### DIFF
--- a/.release-intents/20260904-pi-version-from-manifest.json
+++ b/.release-intents/20260904-pi-version-from-manifest.json
@@ -1,0 +1,6 @@
+{
+  "summary": "@respan/instrumentation-pi: read PACKAGE_VERSION (telemetry.sdk.version on every span) from package.json at runtime instead of a hardcoded \"0.1.0\", so pipeline version bumps are reflected (0.1.1 reported itself as 0.1.0).",
+  "packages": {
+    "@respan/instrumentation-pi": "patch"
+  }
+}

--- a/javascript-sdks/instrumentations/respan-instrumentation-pi/src/_otel_emitter.ts
+++ b/javascript-sdks/instrumentations/respan-instrumentation-pi/src/_otel_emitter.ts
@@ -22,6 +22,7 @@
  * idle time in either scope.
  */
 
+import { createRequire } from "node:module";
 import { createHash } from "node:crypto";
 
 import { context, isSpanContextValid, trace, type HrTime } from "@opentelemetry/api";
@@ -44,7 +45,12 @@ import { SpanAttributes } from "@traceloop/ai-semantic-conventions";
 
 import type { PiModelLike, PiToolDefinitionLike } from "./_pi_types.js";
 
-export const PACKAGE_VERSION = "0.1.0";
+const packageManifest = createRequire(import.meta.url)("../package.json") as {
+  version?: string;
+};
+
+/** Version of this package as published (read from package.json, so pipeline bumps are reflected). */
+export const PACKAGE_VERSION: string = packageManifest.version ?? "unknown";
 export const PI_INSTRUMENTATION_NAME = "@respan/instrumentation-pi";
 
 const RESPAN_LOG_METHOD_TS_TRACING = "ts_tracing";

--- a/javascript-sdks/instrumentations/respan-instrumentation-pi/tests/pi_instrumentor.test.mjs
+++ b/javascript-sdks/instrumentations/respan-instrumentation-pi/tests/pi_instrumentor.test.mjs
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
@@ -287,7 +288,10 @@ class SyncContextManager {
 function assertCommonContract(span) {
   assert.equal(span.attributes["respan.entity.log_method"], "ts_tracing");
   assert.equal(span.attributes["telemetry.sdk.name"], "@respan/instrumentation-pi");
-  assert.equal(span.attributes["telemetry.sdk.version"], "0.1.0");
+  assert.equal(
+    span.attributes["telemetry.sdk.version"],
+    JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version,
+  );
   assert.equal(span.instrumentationScope.name, "@respan/instrumentation-pi");
   assert.equal(typeof span.attributes["traceloop.entity.name"], "string");
   assert.equal(typeof span.attributes["traceloop.entity.path"], "string");


### PR DESCRIPTION
## Summary

`PACKAGE_VERSION` in `@respan/instrumentation-pi` was a hardcoded `"0.1.0"`, so the 0.1.1 release published by the pipeline still stamps `telemetry.sdk.version=0.1.0` on every span. This reads the version from `package.json` at runtime (the pattern `@respan/instrumentation-anthropic` already uses) and makes the test assert against the manifest. Includes a `patch` release intent (→ 0.1.2).

Verified: 42/42 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)