### PR TITLE
fix(release): find published-version artifacts extracted directly into the artifact root

### DIFF
--- a/scripts/release_intents.py
+++ b/scripts/release_intents.py
@@ -349,13 +349,15 @@ def collect_published_versions(artifact_root: Path) -> dict[str, str]:
             )
         versions[package_name] = version
 
-    for payload_path in sorted(artifact_root.glob("*/version.json")):
+    # Artifacts land either as <root>/<artifact-name>/<file> or, when the
+    # download action extracts a single match, directly as <root>/<file>.
+    for payload_path in sorted(artifact_root.rglob("version.json")):
         payload = json.loads(payload_path.read_text())
         if not isinstance(payload, dict):
             raise ValueError(f"invalid published version payload in {payload_path}")
         add_version(payload.get("name"), payload.get("version"), payload_path)
 
-    for payload_path in sorted(artifact_root.glob("*/versions.json")):
+    for payload_path in sorted(artifact_root.rglob("versions.json")):
         payload = json.loads(payload_path.read_text())
         if not isinstance(payload, dict):
             raise ValueError(f"invalid published versions payload in {payload_path}")


### PR DESCRIPTION
## Summary

`sync-manifest-versions` has failed on every publish run (today's three runs and the Aug 26 run) with `no published version artifacts found under .release-sync/artifacts`, so package.json versions on main never get synced after a release.

The download itself succeeds (`Total of 1 artifact(s) downloaded`). The cause is `actions/download-artifact@v8`: when a `pattern` matches a single artifact it is extracted **directly** into `path` (README: *"This change also applies to patterns that only match a single artifact"*), so the file lands at `.release-sync/artifacts/versions.json`, while `collect_published_versions` only globbed one directory down (`*/versions.json`). This switches to a recursive search so both layouts work (verified locally with nested, flat, and Python `version.json` layouts).

No workflow change needed. Releases were unaffected because the pipeline resolves versions with `--prefer-registry`; this only restores the manifest sync commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)