### PR TITLE
fix(instrumentation-py): respan-instrumentation-claude-agent-sdk - preserve tool correlation and failure outcomes

### DIFF
--- a/.release-intents/20260906-claude-agent-sdk-tool-correlation.json
+++ b/.release-intents/20260906-claude-agent-sdk-tool-correlation.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Preserve Claude Agent SDK tool invocation IDs, deduplicate canonical calls by ID and normalized arguments, and make repeated instrumentation safe",
+  "packages": {
+    "respan-instrumentation-claude-agent-sdk": "patch"
+  }
+}

--- a/.release-intents/20260906-claude-agent-sdk-tool-correlation.json
+++ b/.release-intents/20260906-claude-agent-sdk-tool-correlation.json
@@ -1,5 +1,5 @@
 {
-  "summary": "Preserve Claude Agent SDK tool invocation IDs, deduplicate canonical calls by ID and normalized arguments, and make repeated instrumentation safe",
+  "summary": "Preserve Claude Agent SDK tool correlation and failure results, reconcile terminal tool outcomes, and make repeated instrumentation safe",
   "packages": {
     "respan-instrumentation-claude-agent-sdk": "patch"
   }

--- a/contribution/span-contract.md
+++ b/contribution/span-contract.md
@@ -97,10 +97,13 @@ If you find these in existing code, that's debt to remove, not a pattern to copy
 | `traceloop.entity.name` | string | tool name |
 | `traceloop.entity.input` | string (JSON) | `{name, arguments}` |
 | `traceloop.entity.output` | string (JSON) | tool result |
+| `gen_ai.tool.call.id` | string | invocation ID, when available; matches the model's tool-call ID and identifies the execution/result |
 
 The span's existence + `respan.entity.log_type=tool` IS the tool call.
 Do NOT additionally set `tool_calls`, `respan.span.tool_calls`, or
-`gen_ai.tool.*` on tool execution spans.
+other `gen_ai.tool.*` attributes on tool execution spans. Preserve
+`gen_ai.tool.call.id` for correlation with the model call and tool result; it
+does not represent an additional tool call.
 
 "Was a tool used in this trace?" is answered by *"any
 `log_type=tool` child span exists?"* — not by summing tool_call fields

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/README.md
@@ -6,6 +6,22 @@ This package enables the Claude Agent SDK's native OpenTelemetry emission and
 normalizes those spans into the Respan/Traceloop conventions used by the OTLP
 pipeline.
 
+Tool execution spans preserve `gen_ai.tool.call.id` so their inputs and results
+can be matched to the agent's canonical tool calls. Repeated observations of the
+same invocation ID produce one canonical call, with JSON argument formatting and
+object-key order ignored during comparison. If the same ID has conflicting names
+or arguments, the processor logs a warning and keeps the first call. Missing
+fields are filled from later observations of the same ID. Calls without an ID
+are compared by name and normalized arguments.
+
+Repeated activation on the same tracer provider shares one normalization
+processor. Deactivating one instrumentor keeps that processor active until its
+last owner deactivates. Normalization also preserves already-normalized tool
+types, names, inputs, and results.
+The upstream SDK patches are global: the first active instance's provider,
+`agent_name`, and `capture_content` settings remain in effect until all instances
+deactivate.
+
 ## Configuration
 
 ### 1. Install

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/README.md
@@ -22,6 +22,15 @@ The upstream SDK patches are global: the first active instance's provider,
 `agent_name`, and `capture_content` settings remain in effect until all instances
 deactivate.
 
+Failed-tool hooks retain their error result when content capture is enabled.
+For both `query()` and `ClaudeSDKClient`, terminal SDK tool results also close
+matching spans when a post-tool hook is missing. Explicit permission denials
+are recorded as SDK denial outcomes, not fabricated tool stderr. Repeated
+results and late post-tool hooks cannot close the same span twice. Unmatched
+tool or subagent spans still report genuine cleanup errors.
+This compatibility handling is provided by Respan; it does not require a fork
+or changes to the installed upstream instrumentation package.
+
 ## Configuration
 
 ### 1. Install

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
@@ -6,6 +6,8 @@ import importlib
 import json
 import logging
 from collections.abc import Mapping
+from dataclasses import dataclass
+from threading import RLock
 from typing import Any
 
 from opentelemetry import trace
@@ -17,6 +19,31 @@ from respan_instrumentation_claude_agent_sdk._processor import (  # type: ignore
 from respan_sdk.constants.span_attributes import RESPAN_METADATA
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _ProcessorRegistration:
+    tracer_provider: Any
+    processor: ClaudeAgentSDKSpanProcessor
+    owners: int = 0
+
+
+@dataclass
+class _UpstreamRegistration:
+    instrumentor: Any
+    patched_modules: list[tuple[Any, str, Any]]
+    owns_instrumentation: bool
+    processor_registration: _ProcessorRegistration
+    owners: int = 0
+
+
+# Upstream instrumentation patches SDK methods globally, while span processors
+# belong to providers. Keep their lifetimes separate and serialize ownership
+# changes so simultaneous initialization cannot install duplicate normalizers.
+_ownership_lock = RLock()
+_processor_registrations: dict[int, _ProcessorRegistration] = {}
+_upstream_registrations: dict[type[Any], _UpstreamRegistration] = {}
+
 
 def _get_span_attr_value(span: Any, key: str) -> Any:
     attributes = getattr(span, "attributes", None)
@@ -62,6 +89,8 @@ class ClaudeAgentSDKInstrumentor:
         self._capture_content = capture_content
         self._otel_instrumentor = None
         self._processor = None
+        self._tracer_provider = None
+        self._upstream_instrumentor_class = None
         self._is_instrumented = False
         self._patched_modules: list[tuple[Any, str, Any]] = []
 
@@ -94,7 +123,7 @@ class ClaudeAgentSDKInstrumentor:
     def _unregister_processor(
         tracer_provider: Any,
         processor: ClaudeAgentSDKSpanProcessor,
-    ) -> None:
+    ) -> bool:
         active_span_processor = getattr(tracer_provider, "_active_span_processor", None)
         processors = (
             getattr(active_span_processor, "_span_processors", None)
@@ -102,12 +131,49 @@ class ClaudeAgentSDKInstrumentor:
             else None
         )
         if active_span_processor is None or processors is None:
-            return
+            return False
         active_span_processor._span_processors = tuple(
             existing_processor
             for existing_processor in processors
             if existing_processor is not processor
         )
+        return True
+
+    def _acquire_processor(self, tracer_provider: Any) -> None:
+        registration = _processor_registrations.get(id(tracer_provider))
+        if registration is None:
+            processor = ClaudeAgentSDKSpanProcessor()
+            try:
+                self._register_processor(tracer_provider, processor)
+            except Exception:
+                self._unregister_processor(tracer_provider, processor)
+                raise
+            registration = _ProcessorRegistration(tracer_provider, processor)
+            _processor_registrations[id(tracer_provider)] = registration
+        registration.owners += 1
+        self._tracer_provider = tracer_provider
+        self._processor = registration.processor
+
+    @staticmethod
+    def _release_processor_registration(registration: _ProcessorRegistration) -> None:
+        registration.owners -= 1
+        if registration.owners == 0:
+            removed = ClaudeAgentSDKInstrumentor._unregister_processor(
+                registration.tracer_provider, registration.processor
+            )
+            if removed:
+                del _processor_registrations[id(registration.tracer_provider)]
+                registration.processor.shutdown()
+            # Providers exposing only add_span_processor cannot detach processors.
+            # Keep their registration available for reuse on the next activation.
+
+    def _release_processor(self) -> None:
+        if self._tracer_provider is None:
+            return
+        registration = _processor_registrations[id(self._tracer_provider)]
+        self._tracer_provider = None
+        self._processor = None
+        self._release_processor_registration(registration)
 
     def _patch_upstream_helpers(self) -> bool:
         if self._patched_modules:
@@ -316,10 +382,14 @@ class ClaudeAgentSDKInstrumentor:
 
         return True
 
-    def _restore_upstream_helpers(self) -> None:
-        while self._patched_modules:
-            module, attr_name, original = self._patched_modules.pop()
+    @staticmethod
+    def _restore_helper_patches(patches: list[tuple[Any, str, Any]]) -> None:
+        while patches:
+            module, attr_name, original = patches.pop()
             setattr(module, attr_name, original)
+
+    def _restore_upstream_helpers(self) -> None:
+        self._restore_helper_patches(self._patched_modules)
 
     def _patch_standalone_query_seam(self, *, strip_module_query_wrap: bool) -> None:
         """Make ``from claude_agent_sdk import query`` traceable (issue A6).
@@ -387,83 +457,124 @@ class ClaudeAgentSDKInstrumentor:
             claude_agent_sdk.query = module_query.__wrapped__
 
     def activate(self) -> None:
-        if self._is_instrumented:
-            return
+        with _ownership_lock:
+            if self._is_instrumented:
+                return
 
-        try:
-            upstream_instrumentor_class = _load_upstream_instrumentor_class()
-        except (AttributeError, ImportError) as exc:
-            logger.warning(
-                "Failed to activate Claude Agent SDK instrumentation — missing dependency: %s",
-                exc,
-            )
-            return
+            try:
+                upstream_instrumentor_class = _load_upstream_instrumentor_class()
+            except (AttributeError, ImportError) as exc:
+                logger.warning(
+                    "Failed to activate Claude Agent SDK instrumentation — missing dependency: %s",
+                    exc,
+                )
+                return
 
-        if not self._patch_upstream_helpers():
-            return
+            upstream = _upstream_registrations.get(upstream_instrumentor_class)
+            instrument_attempted = False
+            try:
+                tracer_provider = trace.get_tracer_provider()
+                self._acquire_processor(tracer_provider)
+                if upstream is None:
+                    if not self._patch_upstream_helpers():
+                        self._restore_upstream_helpers()
+                        self._release_processor()
+                        return
 
-        tracer_provider = trace.get_tracer_provider()
-        if self._processor is None:
-            self._processor = ClaudeAgentSDKSpanProcessor()
-        self._register_processor(tracer_provider=tracer_provider, processor=self._processor)
+                    self._otel_instrumentor = upstream_instrumentor_class()
+                    already_instrumented = bool(
+                        getattr(
+                            self._otel_instrumentor,
+                            "is_instrumented_by_opentelemetry",
+                            False,
+                        )
+                    )
+                    # Preserve pre-existing query wrappers, including wrappers
+                    # owned by instrumentation activated outside this plugin.
+                    import claude_agent_sdk
 
-        self._otel_instrumentor = upstream_instrumentor_class()
+                    module_query_prewrapped = hasattr(
+                        getattr(claude_agent_sdk, "query", None), "__wrapped__"
+                    )
+                    if not already_instrumented:
+                        instrument_attempted = True
+                        self._otel_instrumentor.instrument(
+                            tracer_provider=tracer_provider,
+                            agent_name=self._agent_name,
+                            capture_content=self._capture_content,
+                        )
 
-        # Note whether a module-level `query` wrap already exists *before* we
-        # instrument, so the seam patch below only strips a wrap our own
-        # instrument() adds — never a user's or another vendor's pre-existing wrap.
-        try:
-            import claude_agent_sdk as _claude_agent_sdk
+                    self._patch_standalone_query_seam(
+                        strip_module_query_wrap=(
+                            instrument_attempted and not module_query_prewrapped
+                        )
+                    )
+                    upstream = _UpstreamRegistration(
+                        self._otel_instrumentor,
+                        self._patched_modules,
+                        owns_instrumentation=instrument_attempted,
+                        processor_registration=_processor_registrations[
+                            id(tracer_provider)
+                        ],
+                    )
+                    # The global upstream tracer keeps using this provider even
+                    # if its original owner deactivates before owners on other
+                    # providers. Retain normalization until the global wrap ends.
+                    upstream.processor_registration.owners += 1
+                    _upstream_registrations[upstream_instrumentor_class] = upstream
+                else:
+                    # Upstream patches are global. Its first active owner's
+                    # provider, agent name, and content settings remain in effect.
+                    self._otel_instrumentor = upstream.instrumentor
+                    self._patched_modules = upstream.patched_modules
+            except Exception as exc:
+                if instrument_attempted and self._otel_instrumentor is not None:
+                    try:
+                        self._otel_instrumentor.uninstrument()
+                    except Exception:
+                        logger.debug(
+                            "Failed to roll back Claude Agent SDK instrumentation",
+                            exc_info=True,
+                        )
+                self._restore_upstream_helpers()
+                self._otel_instrumentor = None
+                self._release_processor()
+                logger.warning(
+                    "Failed to activate Claude Agent SDK instrumentation: %s", exc
+                )
+                return
 
-            module_query_prewrapped = hasattr(
-                getattr(_claude_agent_sdk, "query", None), "__wrapped__"
-            )
-        except Exception:
-            module_query_prewrapped = False
-
-        try:
-            self._otel_instrumentor.instrument(
-                tracer_provider=tracer_provider,
-                agent_name=self._agent_name,
-                capture_content=self._capture_content,
-            )
-        except Exception as exc:
-            self._unregister_processor(
-                tracer_provider=tracer_provider,
-                processor=self._processor,
-            )
-            self._otel_instrumentor = None
-            self._restore_upstream_helpers()
-            logger.warning(
-                "Failed to activate Claude Agent SDK instrumentation: %s",
-                exc,
-            )
-            return
-
-        # Cover `from claude_agent_sdk import query` (A6) by instrumenting the
-        # internal seam instead of the bypassable module-level `query` attribute.
-        self._patch_standalone_query_seam(
-            strip_module_query_wrap=not module_query_prewrapped
-        )
-
-        self._is_instrumented = True
-        logger.info("Claude Agent SDK instrumentation activated")
+            upstream.owners += 1
+            self._upstream_instrumentor_class = upstream_instrumentor_class
+            self._is_instrumented = True
+            logger.info("Claude Agent SDK instrumentation activated")
 
     def deactivate(self) -> None:
-        if not self._is_instrumented:
-            return
+        with _ownership_lock:
+            if not self._is_instrumented:
+                return
 
-        try:
-            if self._otel_instrumentor is not None:
-                self._otel_instrumentor.uninstrument()
-        finally:
-            self._otel_instrumentor = None
-            self._restore_upstream_helpers()
-            if self._processor is not None:
-                self._unregister_processor(
-                    tracer_provider=trace.get_tracer_provider(),
-                    processor=self._processor,
-                )
+            upstream_class = self._upstream_instrumentor_class
+            upstream = _upstream_registrations[upstream_class]
+            upstream.owners -= 1
+            try:
+                if upstream.owners == 0:
+                    del _upstream_registrations[upstream_class]
+                    try:
+                        if upstream.owns_instrumentation:
+                            upstream.instrumentor.uninstrument()
+                    finally:
+                        try:
+                            self._restore_helper_patches(upstream.patched_modules)
+                        finally:
+                            self._release_processor_registration(
+                                upstream.processor_registration
+                            )
+            finally:
+                self._otel_instrumentor = None
+                self._patched_modules = []
+                self._upstream_instrumentor_class = None
+                self._is_instrumented = False
+                self._release_processor()
 
-        self._is_instrumented = False
-        logger.info("Claude Agent SDK instrumentation deactivated")
+            logger.info("Claude Agent SDK instrumentation deactivated")

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_instrumentation.py
@@ -11,6 +11,7 @@ from threading import RLock
 from typing import Any
 
 from opentelemetry import trace
+from opentelemetry.trace import StatusCode
 
 from respan_instrumentation_claude_agent_sdk._processor import (  # type: ignore[reportMissingImports]
     ClaudeAgentSDKSpanProcessor,
@@ -194,12 +195,23 @@ class ClaudeAgentSDKInstrumentor:
             spans_module = importlib.import_module(
                 "opentelemetry.instrumentation.claude_agent_sdk._spans"
             )
+            hooks_module = importlib.import_module(
+                "opentelemetry.instrumentation.claude_agent_sdk._hooks"
+            )
+            from ._tool_lifecycle import (
+                _InvocationMessageStream,
+                _capture_failure_output,
+                _reconcile_sdk_message,
+            )
+
             instrumentor_class = _load_upstream_instrumentor_class()
+            original_set_tool_error_attributes = hooks_module.set_tool_error_attributes
 
             # Read the upstream constant names inside the guarded block so a version
             # that renames or drops one degrades to a logged no-op instead of an
             # uncaught AttributeError out of activate().
             output_messages_attr = constants_module.GEN_AI_OUTPUT_MESSAGES
+            error_type_attr = constants_module.ERROR_TYPE
             usage_input_tokens_attr = constants_module.GEN_AI_USAGE_INPUT_TOKENS
             usage_output_tokens_attr = constants_module.GEN_AI_USAGE_OUTPUT_TOKENS
             usage_cache_creation_tokens_attr = (
@@ -224,6 +236,37 @@ class ClaudeAgentSDKInstrumentor:
             instrumentor_class._instrumented_receive_response
         )
         original_handle_control_request = Query._handle_control_request
+        original_instrumented_query = getattr(instrumentor_class, "_instrumented_query", None)
+
+        def patched_set_tool_error_attributes(span: Any, error: str) -> None:
+            ctx = context_module.get_invocation_context()
+            capture_content = bool(getattr(ctx, "capture_content", False))
+            _capture_failure_output(
+                span, error, capture_content=capture_content,
+            )
+            original_set_tool_error_attributes(
+                span, error if capture_content else "Tool execution failed",
+            )
+
+        async def patched_instrumented_query(
+            instrumentor: Any, wrapped: Any, args: tuple[Any, ...], kwargs: dict[str, Any],
+        ) -> Any:
+            from claude_agent_sdk import ResultMessage
+
+            previous_invocation_ctx = context_module.get_invocation_context()
+            source = _InvocationMessageStream(wrapped)
+            messages = original_instrumented_query(instrumentor, source, args, kwargs)
+            after_result = False
+            try:
+                async for message in messages:
+                    _reconcile_sdk_message(context_module.get_invocation_context(), message)
+                    after_result = isinstance(message, ResultMessage)
+                    yield message
+            finally:
+                try:
+                    await source.close(messages, after_result=after_result)
+                finally:
+                    context_module.set_invocation_context(previous_invocation_ctx)
 
         def patched_set_response_content(span: Any, content: Any) -> None:
             if content is None:
@@ -252,6 +295,11 @@ class ClaudeAgentSDKInstrumentor:
 
         def patched_set_result_attributes(span: Any, result_message: Any) -> None:
             original_set_result_attributes(span, result_message)
+            if getattr(result_message, "is_error", False) is True:
+                # A caller can stop at this result before the SDK raises its later
+                # exception. Classify the observed failure without exposing content.
+                span.set_attribute(error_type_attr, "claude_agent_sdk_error")
+                span.set_status(StatusCode.ERROR, "Claude Agent SDK invocation failed")
 
             usage = getattr(result_message, "usage", None)
             if isinstance(usage, dict):
@@ -314,27 +362,40 @@ class ClaudeAgentSDKInstrumentor:
             args: tuple[Any, ...],
             kwargs: dict[str, Any],
         ) -> Any:
+            from claude_agent_sdk import ResultMessage
+
             previous_invocation_ctx = context_module.get_invocation_context()
             invocation_ctx = getattr(instance, "_otel_invocation_ctx", None)
             query = getattr(instance, "_query", None)
+            terminal_result = None
+            source = _InvocationMessageStream(wrapped)
+            messages = original_instrumented_receive_response(
+                instrumentor, source, instance, args, kwargs,
+            )
             if invocation_ctx is not None:
                 context_module.set_invocation_context(invocation_ctx)
                 if query is not None:
                     query._otel_invocation_ctx = invocation_ctx
 
             try:
-                async for message in original_instrumented_receive_response(
-                    instrumentor,
-                    wrapped,
-                    instance,
-                    args,
-                    kwargs,
-                ):
-                    yield message
+                async for message in messages:
+                    if terminal_result is not None:
+                        yield terminal_result
+                        terminal_result = None
+                    _reconcile_sdk_message(invocation_ctx, message)
+                    if isinstance(message, ResultMessage):
+                        terminal_result = message
+                    else:
+                        yield message
             finally:
-                if query is not None:
-                    query._otel_invocation_ctx = None
-                context_module.set_invocation_context(previous_invocation_ctx)
+                try:
+                    await source.close(messages, after_result=False)
+                finally:
+                    if query is not None:
+                        query._otel_invocation_ctx = None
+                    context_module.set_invocation_context(previous_invocation_ctx)
+            if terminal_result is not None:
+                yield terminal_result
 
         async def patched_handle_control_request(query: Any, request: Any) -> Any:
             previous_invocation_ctx = context_module.get_invocation_context()
@@ -379,6 +440,16 @@ class ClaudeAgentSDKInstrumentor:
             (Query, "_handle_control_request", getattr(Query, "_handle_control_request"))
         )
         Query._handle_control_request = patched_handle_control_request
+
+        self._patched_modules.append(
+            (hooks_module, "set_tool_error_attributes", original_set_tool_error_attributes)
+        )
+        hooks_module.set_tool_error_attributes = patched_set_tool_error_attributes
+        if original_instrumented_query is not None:
+            self._patched_modules.append(
+                (instrumentor_class, "_instrumented_query", original_instrumented_query)
+            )
+            instrumentor_class._instrumented_query = patched_instrumented_query
 
         return True
 

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_processor.py
@@ -470,10 +470,28 @@ def _build_tool_call_from_tool_span_attrs(
     }
 
 
+def _normalized_tool_arguments(arguments: Any) -> str:
+    """Compare structured arguments without depending on JSON formatting."""
+    if isinstance(arguments, str):
+        try:
+            parsed_arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            # Match the Python-literal compatibility supported by _json_string.
+            parsed_arguments = _safe_json_loads(arguments)
+            if parsed_arguments is None:
+                return f"raw:{arguments}"
+    else:
+        parsed_arguments = arguments
+    return "json:" + json.dumps(
+        serialize_value(parsed_arguments), sort_keys=True, separators=(",", ":"),
+        default=str,
+    )
+
+
 def _tool_call_signature(tool_call: Mapping[str, Any]) -> tuple[str, str, str]:
     function_payload = tool_call.get("function")
     if not isinstance(function_payload, Mapping):
-        return ("", "", "")
+        function_payload = {}
 
     tool_call_id = tool_call.get("id")
     tool_name = function_payload.get("name")
@@ -481,7 +499,7 @@ def _tool_call_signature(tool_call: Mapping[str, Any]) -> tuple[str, str, str]:
     return (
         str(tool_call_id or ""),
         str(tool_name or ""),
-        str(tool_arguments or ""),
+        _normalized_tool_arguments(tool_arguments),
     )
 
 
@@ -489,7 +507,8 @@ def _merge_tool_calls(
     *tool_call_lists: list[dict[str, Any]] | None,
 ) -> list[dict[str, Any]] | None:
     merged_tool_calls = []
-    seen_signatures = set()
+    calls_by_id: dict[str, dict[str, Any]] = {}
+    anonymous_signatures: set[tuple[str, str, str]] = set()
 
     for tool_call_list in tool_call_lists:
         if not isinstance(tool_call_list, list):
@@ -498,12 +517,60 @@ def _merge_tool_calls(
             if not isinstance(tool_call, Mapping):
                 continue
             signature = _tool_call_signature(tool_call)
-            if signature in seen_signatures:
-                continue
-            seen_signatures.add(signature)
-            merged_tool_calls.append(dict(tool_call))
+            tool_call_id = signature[0]
+            if tool_call_id:
+                existing_call = calls_by_id.get(tool_call_id)
+                if existing_call is not None:
+                    _merge_tool_call_observation(existing_call, tool_call)
+                    continue
+            else:
+                if signature in anonymous_signatures:
+                    continue
+                anonymous_signatures.add(signature)
+            merged_call = dict(tool_call)
+            if tool_call_id:
+                calls_by_id[tool_call_id] = merged_call
+            merged_tool_calls.append(merged_call)
 
     return merged_tool_calls or None
+
+
+def _merge_tool_call_observation(
+    existing_call: dict[str, Any], incoming_call: Mapping[str, Any],
+) -> None:
+    """Fill absent fields without replacing the first populated observation."""
+    incoming_function = incoming_call.get("function")
+    if not isinstance(incoming_function, Mapping):
+        return
+    existing_function = existing_call.get("function")
+    merged_function = (
+        dict(existing_function) if isinstance(existing_function, Mapping) else {}
+    )
+    conflicting = False
+    for field in ("name", "arguments"):
+        incoming_value = incoming_function.get(field)
+        existing_value = merged_function.get(field)
+        if incoming_value is None or incoming_value == "":
+            continue
+        if existing_value is None or existing_value == "":
+            merged_function[field] = incoming_value
+        elif field == "arguments":
+            conflicting |= (
+                _normalized_tool_arguments(existing_value)
+                != _normalized_tool_arguments(incoming_value)
+            )
+        else:
+            conflicting |= existing_value != incoming_value
+    if conflicting:
+        logger.warning(
+            "Conflicting Claude Agent SDK tool call for invocation ID %s "
+            "(name or arguments differ); keeping the first call",
+            existing_call.get("id"),
+        )
+    else:
+        existing_call["function"] = merged_function
+        if not existing_call.get("type") and incoming_call.get("type"):
+            existing_call["type"] = incoming_call["type"]
 
 
 def _extract_function_name(payload: Mapping[str, Any]) -> str | None:
@@ -667,10 +734,22 @@ def enrich_claude_agent_sdk_span(span: ReadableSpan) -> None:
     if isinstance(session_id, str) and session_id:
         _set_if_missing(attrs, RESPAN_SESSION_ID, session_id)
 
-    if operation_name == _CLAUDE_TOOL_OPERATION_NAME or attrs.get(CLAUDE_AGENT_SDK_TOOL_NAME_ATTR):
+    if (
+        operation_name == _CLAUDE_TOOL_OPERATION_NAME
+        or attrs.get(CLAUDE_AGENT_SDK_TOOL_NAME_ATTR)
+        or attrs.get(RESPAN_LOG_TYPE) == LOG_TYPE_TOOL
+        or span.name.startswith(f"{_CLAUDE_TOOL_OPERATION_NAME} ")
+    ):
         tool_name = _extract_tool_span_name(span, attrs)
-        tool_input = _json_string(attrs.get(CLAUDE_AGENT_SDK_TOOL_CALL_ARGUMENTS_ATTR))
-        tool_output = _json_string(attrs.get(CLAUDE_AGENT_SDK_TOOL_CALL_RESULT_ATTR))
+        # A previous normalizer may already have removed the native attributes.
+        tool_input = attrs.get(CLAUDE_AGENT_SDK_TOOL_CALL_ARGUMENTS_ATTR)
+        if tool_input is None:
+            tool_input = attrs.get(SpanAttributes.TRACELOOP_ENTITY_INPUT)
+        tool_input = _json_string(tool_input)
+        tool_output = attrs.get(CLAUDE_AGENT_SDK_TOOL_CALL_RESULT_ATTR)
+        if tool_output is None:
+            tool_output = attrs.get(SpanAttributes.TRACELOOP_ENTITY_OUTPUT)
+        tool_output = _json_string(tool_output)
 
         attrs[RESPAN_LOG_TYPE] = LOG_TYPE_TOOL
         attrs[SpanAttributes.TRACELOOP_ENTITY_NAME] = tool_name
@@ -704,7 +783,9 @@ def enrich_claude_agent_sdk_span(span: ReadableSpan) -> None:
         input_value, output_value = _extract_input_output(attrs)
         input_messages = _extract_normalized_input_messages(attrs)
         output_messages = _extract_messages(attrs, CLAUDE_AGENT_SDK_OUTPUT_MESSAGES_ATTR)
-        tool_calls = _extract_tool_calls(attrs)
+        tool_calls = _merge_tool_calls(
+            _extract_existing_tool_calls(attrs), _extract_tool_calls(attrs),
+        )
         tools = _reconcile_tools_with_tool_calls(
             tools=_extract_tools(attrs),
             tool_calls=tool_calls,
@@ -764,7 +845,13 @@ def enrich_claude_agent_sdk_span(span: ReadableSpan) -> None:
         key: value
         for key, value in attrs.items()
         if key not in CLAUDE_AGENT_SDK_STRIP_ATTRS
-        and not key.startswith("gen_ai.tool.")
+        and (
+            not key.startswith("gen_ai.tool.")
+            or (
+                key == CLAUDE_AGENT_SDK_TOOL_CALL_ID_ATTR
+                and attrs.get(RESPAN_LOG_TYPE) == LOG_TYPE_TOOL
+            )
+        )
     }
     _set_if_unset_span_status(span, span._attributes)
 
@@ -830,9 +917,6 @@ class ClaudeAgentSDKSpanProcessor(SpanProcessor):
 
     def on_end(self, span: ReadableSpan) -> None:
         try:
-            original_attrs = getattr(span, "_attributes", None)
-            if isinstance(original_attrs, Mapping):
-                original_attrs = dict(original_attrs)
             enrich_claude_agent_sdk_span(span)
 
             attrs = getattr(span, "_attributes", None)
@@ -841,19 +925,9 @@ class ClaudeAgentSDKSpanProcessor(SpanProcessor):
                 return
 
             if attrs.get(RESPAN_LOG_TYPE) == LOG_TYPE_TOOL:
-                # Correlate with the upstream call ID before helper attributes
-                # are stripped, while using the normalized canonical name and
-                # arguments from the exported tool span.
-                pending_attrs = dict(attrs)
-                if isinstance(original_attrs, Mapping):
-                    tool_call_id = original_attrs.get(
-                        CLAUDE_AGENT_SDK_TOOL_CALL_ID_ATTR
-                    )
-                    if tool_call_id:
-                        pending_attrs[CLAUDE_AGENT_SDK_TOOL_CALL_ID_ATTR] = (
-                            tool_call_id
-                        )
-                self._store_pending_tool_call(span, pending_attrs)
+                # The exported tool keeps its invocation ID so the parent call
+                # and the tool's result remain correlated after normalization.
+                self._store_pending_tool_call(span, attrs)
                 # Only agent spans merge queued tool calls into their final attrs.
                 # Drop any child calls queued against non-agent parents on span end.
                 self._consume_pending_tool_calls(span)

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_tool_lifecycle.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/src/respan_instrumentation_claude_agent_sdk/_tool_lifecycle.py
@@ -1,0 +1,135 @@
+"""Reconcile SDK tool outcomes before upstream's unmatched-span cleanup."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from opentelemetry.instrumentation.claude_agent_sdk._constants import (
+    ERROR_TYPE,
+    GEN_AI_TOOL_CALL_RESULT,
+)
+from opentelemetry.trace import StatusCode
+
+logger = logging.getLogger(__name__)
+
+
+class _InvocationMessageStream:
+    """Allow a completed standalone turn to stop upstream without GeneratorExit.
+
+    Streaming prompts can wait for the caller to consume a ResultMessage before
+    supplying more input. Never read ahead or delay that result. When the caller
+    closes at a result, stop the source iterator and resume upstream just enough
+    for its async-for loop to finish normally, then close the SDK source.
+    """
+
+    def __init__(self, wrapped: Any) -> None:
+        self._wrapped = wrapped
+        self._source: Any = None
+        self._stop = False
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self._source = aiter(self._wrapped(*args, **kwargs))
+        return self
+
+    def __aiter__(self) -> Any:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._stop:
+            raise StopAsyncIteration
+        return await anext(self._source)
+
+    async def close(self, upstream: Any, *, after_result: bool) -> None:
+        try:
+            if after_result:
+                self._stop = True
+                try:
+                    await anext(upstream)
+                except StopAsyncIteration:
+                    pass
+        finally:
+            try:
+                await upstream.aclose()
+            finally:
+                close_source = getattr(self._source, "aclose", None)
+                if close_source is not None:
+                    await close_source()
+
+
+def _capture_failure_output(span: Any, error: str, *, capture_content: bool) -> None:
+    """Annotate only: the original failure hook still owns its pop and end."""
+    if capture_content:
+        _set_result_content(span, {"error": error})
+
+
+def _set_result_content(span: Any, content: Any) -> None:
+    try:
+        span.set_attribute(GEN_AI_TOOL_CALL_RESULT, json.dumps(content, default=str))
+    except (TypeError, ValueError):
+        logger.debug("Could not serialize Claude tool result", exc_info=True)
+
+
+def _finish_tool_span(
+    ctx: Any,
+    tool_use_id: str,
+    *,
+    content: Any,
+    is_error: bool,
+    permission_denied: bool = False,
+) -> None:
+    # No await between pop and end: a late hook or repeated result sees no
+    # pending span and cannot finish the same invocation twice.
+    span = ctx.active_tool_spans.pop(tool_use_id, None)
+    if span is None:
+        return
+    try:
+        if is_error:
+            span.set_attribute(
+                ERROR_TYPE, "permission_denied" if permission_denied else "tool_error"
+            )
+            span.set_status(
+                StatusCode.ERROR,
+                "Tool permission denied" if permission_denied else "Tool execution failed",
+            )
+        if ctx.capture_content:
+            _set_result_content(span, content)
+    finally:
+        span.end()
+
+
+def _reconcile_sdk_message(ctx: Any, message: Any) -> None:
+    """Close only tool IDs for which the SDK supplies a terminal outcome.
+
+    Unknown tool/subagent spans remain pending so upstream can report genuine
+    cancellation or lifecycle errors. Never infer success from agent completion.
+    """
+    if ctx is None or not getattr(ctx, "active_tool_spans", None):
+        return
+
+    from claude_agent_sdk import ResultMessage, ToolResultBlock, UserMessage
+
+    if isinstance(message, UserMessage) and isinstance(message.content, list):
+        for block in message.content:
+            if isinstance(block, ToolResultBlock) and block.tool_use_id:
+                _finish_tool_span(
+                    ctx, block.tool_use_id, content=block.content,
+                    is_error=block.is_error is True,
+                )
+
+    if isinstance(message, ResultMessage):
+        # Some CLI permission failures have no post-hook or ToolResultBlock.
+        # This is an explicit SDK denial record, not fabricated tool stderr.
+        denials = getattr(message, "permission_denials", None)
+        if not isinstance(denials, list):
+            return
+        for denial in denials:
+            tool_use_id = denial.get("tool_use_id") if isinstance(denial, Mapping) else None
+            if isinstance(tool_use_id, str) and tool_use_id:
+                _finish_tool_span(
+                    ctx, tool_use_id,
+                    content={"error": "permission_denied", "source": "ResultMessage.permission_denials"},
+                    is_error=True, permission_denied=True,
+                )

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_instrumentation.py
@@ -1054,7 +1054,10 @@ def test_span_processor_on_end_merges_pending_tool_calls_into_parent_agent_span(
     processor.on_end(tool_span)
     processor.on_end(agent_span)
 
-    assert not any(key.startswith("gen_ai.tool.") for key in tool_span._attributes)
+    assert tool_span._attributes["gen_ai.tool.call.id"] == "toolu_123"
+    assert {
+        key for key in tool_span._attributes if key.startswith("gen_ai.tool.")
+    } == {"gen_ai.tool.call.id"}
     assert json.loads(agent_span._attributes[_COMPLETION_TOOL_CALLS_ATTR]) == [
         {
             "id": "toolu_123",

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_instrumentation.py
@@ -166,6 +166,8 @@ def _install_fake_claude_agent_sdk_modules(
         "opentelemetry.instrumentation.claude_agent_sdk._constants"
     )
     constants_module.GEN_AI_OUTPUT_MESSAGES = output_messages_attr
+    constants_module.ERROR_TYPE = "error.type"
+    constants_module.GEN_AI_TOOL_CALL_RESULT = "gen_ai.tool.call.result"
     constants_module.GEN_AI_USAGE_INPUT_TOKENS = usage_input_tokens_attr
     constants_module.GEN_AI_USAGE_OUTPUT_TOKENS = usage_output_tokens_attr
     constants_module.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = (
@@ -201,6 +203,9 @@ def _install_fake_claude_agent_sdk_modules(
     instrumentor_module.ClaudeAgentSdkInstrumentor = FakeClaudeAgentSdkInstrumentor
     instrumentor_module.set_response_content = _original_set_response_content
     instrumentor_module.set_result_attributes = _original_set_result_attributes
+
+    hooks_module = ModuleType("opentelemetry.instrumentation.claude_agent_sdk._hooks")
+    hooks_module.set_tool_error_attributes = lambda span, error: None
 
     claude_sdk_module = ModuleType("claude_agent_sdk")
     claude_sdk_module.__path__ = []
@@ -260,6 +265,11 @@ def _install_fake_claude_agent_sdk_modules(
         sys.modules,
         "opentelemetry.instrumentation.claude_agent_sdk._instrumentor",
         instrumentor_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "opentelemetry.instrumentation.claude_agent_sdk._hooks",
+        hooks_module,
     )
     monkeypatch.setitem(sys.modules, "claude_agent_sdk", claude_sdk_module)
     monkeypatch.setitem(sys.modules, "claude_agent_sdk._internal", internal_module)

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_processor_ownership.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_processor_ownership.py
@@ -1,0 +1,262 @@
+"""Lifecycle regressions for independent Respan instrumentor instances."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from opentelemetry import trace
+
+from respan_instrumentation_claude_agent_sdk import ClaudeAgentSDKInstrumentor
+from test_instrumentation import (
+    _install_fake_claude_agent_sdk_modules,
+    _make_fake_tracer_provider,
+)
+
+
+@pytest.fixture
+def lifecycle(monkeypatch):
+    provider = _make_fake_tracer_provider()
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: provider)
+    fake = _install_fake_claude_agent_sdk_modules(monkeypatch)
+    owners = []
+
+    def make_owner(**kwargs):
+        owner = ClaudeAgentSDKInstrumentor(**kwargs)
+        owners.append(owner)
+        return owner
+
+    yield provider, fake, make_owner
+
+    for owner in reversed(owners):
+        owner.deactivate()
+
+
+@pytest.mark.parametrize("first_to_deactivate", [0, 1])
+def test_owners_share_processor_and_keep_helpers_until_last_deactivation(
+    lifecycle, first_to_deactivate
+):
+    provider, fake, make_owner = lifecycle
+    exporter = object()
+    provider._active_span_processor._span_processors = (exporter,)
+    original_seam = fake.internal_client.process_query
+    owners = [make_owner(agent_name="first"), make_owner(agent_name="second")]
+    owners[0].activate()
+    upstream = owners[0]._otel_instrumentor
+    processor = owners[0]._processor
+    patched_response = fake.spans_module.set_response_content
+    patched_result = fake.spans_module.set_result_attributes
+    patched_seam = vars(fake.internal_client)["process_query"]
+    owners[1].activate()
+
+    assert owners[1]._processor is processor
+    assert owners[1]._otel_instrumentor is upstream
+    assert upstream.instrument_kwargs["agent_name"] == "first"
+    assert provider._active_span_processor._span_processors == (processor, exporter)
+    assert fake.spans_module.set_response_content is patched_response
+    assert fake.spans_module.set_result_attributes is patched_result
+    assert vars(fake.internal_client)["process_query"] is patched_seam
+
+    owners[first_to_deactivate].deactivate()
+    owners[first_to_deactivate].deactivate()
+
+    assert upstream.uninstrument_calls == 0
+    assert provider._active_span_processor._span_processors == (processor, exporter)
+    assert fake.spans_module.set_response_content is patched_response
+    assert vars(fake.internal_client)["process_query"] is patched_seam
+
+    owners[1 - first_to_deactivate].deactivate()
+
+    assert upstream.uninstrument_calls == 1
+    assert provider._active_span_processor._span_processors == (exporter,)
+    assert fake.spans_module.set_response_content is fake.original_set_response_content
+    assert fake.spans_module.set_result_attributes is fake.original_set_result_attributes
+    assert fake.internal_client.process_query is original_seam
+    assert fake.claude_sdk_module.query is fake.standalone_query
+
+
+def test_owner_can_reactivate_while_peer_is_active(lifecycle):
+    provider, fake, make_owner = lifecycle
+    first, second = make_owner(), make_owner()
+    first.activate()
+    second.activate()
+    upstream = first._otel_instrumentor
+    processor = first._processor
+    first.deactivate()
+    first.activate()
+    first.activate()
+    second.deactivate()
+
+    assert first._otel_instrumentor is upstream
+    assert first._processor is processor
+    assert provider._active_span_processor._span_processors == (processor,)
+    assert upstream.uninstrument_calls == 0
+
+    first.deactivate()
+    assert upstream.uninstrument_calls == 1
+    assert provider._active_span_processor._span_processors == ()
+    assert fake.spans_module.set_response_content is fake.original_set_response_content
+
+
+def test_deactivation_uses_captured_provider(lifecycle, monkeypatch):
+    provider, _, make_owner = lifecycle
+    owner = make_owner()
+    owner.activate()
+    other_provider = _make_fake_tracer_provider()
+    unrelated_processor = object()
+    other_provider._active_span_processor._span_processors = (unrelated_processor,)
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: other_provider)
+
+    owner.deactivate()
+
+    assert provider._active_span_processor._span_processors == ()
+    assert other_provider._active_span_processor._span_processors == (unrelated_processor,)
+
+
+def test_global_upstream_retains_first_provider_until_last_owner(lifecycle, monkeypatch):
+    first_provider, _, make_owner = lifecycle
+    first, second = make_owner(), make_owner()
+    first.activate()
+    first_processor = first._processor
+    upstream = first._otel_instrumentor
+    second_provider = _make_fake_tracer_provider()
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: second_provider)
+    second.activate()
+    second_processor = second._processor
+
+    assert second_processor is not first_processor
+    assert second._otel_instrumentor is upstream
+    assert upstream.instrument_kwargs["tracer_provider"] is first_provider
+    first.deactivate()
+    assert first_provider._active_span_processor._span_processors == (first_processor,)
+    assert second_provider._active_span_processor._span_processors == (second_processor,)
+    assert upstream.uninstrument_calls == 0
+
+    second.deactivate()
+    assert first_provider._active_span_processor._span_processors == ()
+    assert second_provider._active_span_processor._span_processors == ()
+    assert upstream.uninstrument_calls == 1
+
+
+def test_simultaneous_owners_register_once(lifecycle):
+    provider, _, make_owner = lifecycle
+    owners = [make_owner() for _ in range(8)]
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda owner: owner.activate(), owners))
+
+    processor = owners[0]._processor
+    upstream = owners[0]._otel_instrumentor
+    assert all(owner._processor is processor for owner in owners)
+    assert all(owner._otel_instrumentor is upstream for owner in owners)
+    assert provider._active_span_processor._span_processors == (processor,)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda owner: owner.deactivate(), owners))
+    assert provider._active_span_processor._span_processors == ()
+    assert upstream.uninstrument_calls == 1
+
+
+def test_partial_activation_rolls_back_upstream_and_can_retry(lifecycle, monkeypatch):
+    provider, fake, make_owner = lifecycle
+    instrument = fake.instrumentor_class.instrument
+    attempted = []
+
+    def fail_after_wrapping(instance, **kwargs):
+        attempted.append(instance)
+        instrument(instance, **kwargs)
+        raise RuntimeError("failed after wrapping")
+
+    monkeypatch.setattr(fake.instrumentor_class, "instrument", fail_after_wrapping)
+    owner = make_owner()
+    owner.activate()
+
+    assert owner._is_instrumented is False
+    assert owner._otel_instrumentor is None
+    assert provider._active_span_processor._span_processors == ()
+    assert attempted[0].uninstrument_calls == 1
+    assert fake.spans_module.set_response_content is fake.original_set_response_content
+    assert fake.claude_sdk_module.query is fake.standalone_query
+
+    monkeypatch.setattr(fake.instrumentor_class, "instrument", instrument)
+    owner.activate()
+    assert owner._is_instrumented is True
+    assert len(provider._active_span_processor._span_processors) == 1
+
+
+def test_failed_peer_activation_preserves_existing_owner(lifecycle, monkeypatch):
+    provider, fake, make_owner = lifecycle
+    first, second = make_owner(), make_owner()
+    first.activate()
+    upstream = first._otel_instrumentor
+    processor = first._processor
+    patched_response = fake.spans_module.set_response_content
+    other_provider = _make_fake_tracer_provider()
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: other_provider)
+
+    def fail_registration(*args, **kwargs):
+        raise RuntimeError("registration failed")
+
+    monkeypatch.setattr(second, "_register_processor", fail_registration)
+    second.activate()
+
+    assert second._is_instrumented is False
+    assert first._is_instrumented is True
+    assert provider._active_span_processor._span_processors == (processor,)
+    assert other_provider._active_span_processor._span_processors == ()
+    assert fake.spans_module.set_response_content is patched_response
+    assert upstream.uninstrument_calls == 0
+
+
+def test_uninstrument_failure_still_releases_ownership(lifecycle, monkeypatch):
+    provider, fake, make_owner = lifecycle
+    owner = make_owner()
+    owner.activate()
+    uninstrument = fake.instrumentor_class.uninstrument
+
+    def fail_after_uninstrument(instance):
+        uninstrument(instance)
+        raise RuntimeError("uninstrument failed")
+
+    monkeypatch.setattr(fake.instrumentor_class, "uninstrument", fail_after_uninstrument)
+    with pytest.raises(RuntimeError, match="uninstrument failed"):
+        owner.deactivate()
+
+    assert owner._is_instrumented is False
+    assert provider._active_span_processor._span_processors == ()
+    assert fake.spans_module.set_response_content is fake.original_set_response_content
+    monkeypatch.setattr(fake.instrumentor_class, "uninstrument", uninstrument)
+    owner.activate()
+    assert owner._is_instrumented is True
+
+
+def test_add_only_provider_reuses_processor_after_reactivation(lifecycle, monkeypatch):
+    _, _, make_owner = lifecycle
+    provider = _make_fake_tracer_provider(composite=False)
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: provider)
+    owner = make_owner()
+    owner.activate()
+    processor = owner._processor
+    owner.deactivate()
+    owner.activate()
+
+    assert owner._processor is processor
+    assert provider.added_processors == [processor]
+
+
+def test_external_upstream_instrumentation_is_not_uninstrumented(lifecycle, monkeypatch):
+    provider, fake, make_owner = lifecycle
+    external = fake.instrumentor_class()
+    external.instrument(tracer_provider=provider)
+    external_query = fake.claude_sdk_module.query
+    monkeypatch.setattr(
+        fake.instrumentor_class, "is_instrumented_by_opentelemetry", True, raising=False
+    )
+    owner = make_owner()
+    owner.activate()
+    upstream = owner._otel_instrumentor
+    owner.deactivate()
+
+    assert upstream.instrument_kwargs is None
+    assert upstream.uninstrument_calls == 0
+    assert fake.claude_sdk_module.query is external_query
+    assert fake.spans_module.set_response_content is fake.original_set_response_content
+    assert provider._active_span_processor._span_processors == ()
+    external.uninstrument()

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_tool_correlation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_tool_correlation.py
@@ -1,0 +1,302 @@
+"""Regression coverage for exported Claude tool invocation identity."""
+
+import json
+import logging
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.semconv_ai import SpanAttributes
+
+from respan_instrumentation_claude_agent_sdk import _processor
+from respan_instrumentation_claude_agent_sdk._constants import (
+    CLAUDE_AGENT_SDK_TOOL_CALL_ID_ATTR,
+)
+from respan_sdk.constants.llm_logging import LOG_TYPE_AGENT, LOG_TYPE_CHAT, LOG_TYPE_TOOL
+from respan_sdk.constants.span_attributes import RESPAN_LOG_TYPE
+from respan_tracing.exporters.respan import (
+    _build_otlp_payload,
+    _prepare_spans_for_export,
+)
+
+
+_TOOL_CALLS_ATTR = f"{SpanAttributes.LLM_COMPLETIONS}.0.tool_calls"
+
+
+def _call(arguments, *, call_id="toolu_grep", name="Grep"):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+@pytest.mark.parametrize("call_id", ["toolu_grep", ""])
+def test_equivalent_json_arguments_merge_without_warning(call_id, caplog):
+    first = _call(
+        '{"pattern":"TODO","options":{"paths":["src","tests"],"case":true}}',
+        call_id=call_id,
+    )
+    reordered = _call(
+        '{ "options": { "case": true, "paths": ["src", "tests"] }, '
+        '"pattern": "TODO" }',
+        call_id=call_id,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=_processor.__name__):
+        merged = _processor._merge_tool_calls([first], [reordered, first])
+
+    assert merged == [first]
+    assert not caplog.records
+
+
+def test_distinct_invocation_ids_with_identical_arguments_stay_separate():
+    first = _call('{"pattern":"TODO"}', call_id="toolu_first")
+    second = _call('{"pattern":"TODO"}', call_id="toolu_second")
+
+    assert _processor._merge_tool_calls([first, second], [first]) == [first, second]
+
+
+def test_synthetic_102_observations_merge_to_76_invocations(caplog):
+    # Mirrors the reported duplicate counts with synthetic content; this is not
+    # a replay of the original trace or its tool inputs.
+    model_calls = [
+        _call(
+            json.dumps({"pattern": f"TODO-{index}", "path": "src"}),
+            call_id=f"toolu_{index}",
+        )
+        for index in range(76)
+    ]
+    repeated_tool_calls = [
+        _call(
+            json.dumps({"path": "src", "pattern": f"TODO-{index}"}, separators=(",", ":")),
+            call_id=f"toolu_{index}",
+        )
+        for index in range(26)
+    ]
+
+    with caplog.at_level(logging.WARNING, logger=_processor.__name__):
+        merged = _processor._merge_tool_calls(model_calls, repeated_tool_calls)
+
+    assert len(model_calls) + len(repeated_tool_calls) == 102
+    assert merged == model_calls
+    assert len({call["id"] for call in merged}) == 76
+    assert not caplog.records
+
+
+@pytest.mark.parametrize(
+    "conflicting_call",
+    [
+        _call('{"pattern":"FIXME"}'),
+        _call('{"pattern":"TODO"}', name="Search"),
+        _call("unparseable arguments"),
+    ],
+    ids=["arguments", "name", "malformed-arguments"],
+)
+def test_conflicting_invocation_keeps_first_call_and_warns(conflicting_call, caplog):
+    first = _call('{"pattern":"TODO"}')
+
+    with caplog.at_level(logging.WARNING, logger=_processor.__name__):
+        merged = _processor._merge_tool_calls([first], [conflicting_call])
+
+    assert merged == [first]
+    warnings = [record.getMessage() for record in caplog.records]
+    assert any("toolu_grep" in message and "conflict" in message.lower() for message in warnings)
+
+
+@pytest.mark.parametrize(
+    "partial_function",
+    [
+        None,
+        {},
+        {"name": "Grep"},
+        {"name": "Grep", "arguments": None},
+        {"name": "Grep", "arguments": ""},
+        {"arguments": '{"pattern":"TODO"}'},
+        {"name": "", "arguments": '{"pattern":"TODO"}'},
+    ],
+)
+@pytest.mark.parametrize("partial_first", [True, False])
+def test_partial_observation_merges_with_complete_invocation(
+    partial_function, partial_first, caplog
+):
+    complete = _call('{"pattern":"TODO"}')
+    partial = {"id": "toolu_grep", "type": "function"}
+    if partial_function is not None:
+        partial["function"] = partial_function
+    observations = [partial, complete] if partial_first else [complete, partial]
+
+    with caplog.at_level(logging.WARNING, logger=_processor.__name__):
+        merged = _processor._merge_tool_calls(observations)
+
+    assert merged == [complete]
+    assert not caplog.records
+
+
+@pytest.mark.parametrize(
+    ("first_arguments", "second_arguments"),
+    [
+        ("{broken: one", "{broken: two"),
+        ("first raw value", "second raw value"),
+        ("null", '"null"'),
+        ("null", "not JSON"),
+        ('{"value":true}', '{"value":1}'),
+        ('{"paths":["src","tests"]}', '{"paths":["tests","src"]}'),
+    ],
+)
+def test_calls_without_ids_keep_distinct_arguments(first_arguments, second_arguments):
+    first = _call(first_arguments, call_id="")
+    second = _call(second_arguments, call_id="")
+
+    assert _processor._merge_tool_calls([first, second, first]) == [first, second]
+
+
+@pytest.mark.parametrize(("raw_value", "canonical_value"), [("", ""), ([], "[]")])
+def test_repeated_normalization_keeps_empty_tool_input_and_result(
+    raw_value, canonical_value
+):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(shutdown_on_exit=False)
+    provider.add_span_processor(_processor.ClaudeAgentSDKSpanProcessor())
+    provider.add_span_processor(_processor.ClaudeAgentSDKSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    try:
+        tracer = provider.get_tracer("opentelemetry.instrumentation.claude_agent_sdk")
+        with tracer.start_as_current_span(
+            "execute_tool Grep",
+            attributes={
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": "Grep",
+                "gen_ai.tool.call.arguments": raw_value,
+                "gen_ai.tool.call.result": raw_value,
+                CLAUDE_AGENT_SDK_TOOL_CALL_ID_ATTR: "toolu_grep",
+            },
+        ):
+            pass
+        span = exporter.get_finished_spans()[0]
+    finally:
+        provider.shutdown()
+
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT] == canonical_value
+    assert span.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == canonical_value
+    normalized = dict(span.attributes)
+    _processor.enrich_claude_agent_sdk_span(span)
+    assert dict(span.attributes) == normalized
+
+
+@pytest.mark.parametrize("processor_count", [1, 2])
+@pytest.mark.parametrize("tool_span_name", ["execute_tool Grep", "Grep"])
+def test_real_export_preserves_tool_identity_result_and_parent_calls(
+    processor_count, tool_span_name, caplog
+):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(shutdown_on_exit=False)
+    for _ in range(processor_count):
+        provider.add_span_processor(_processor.ClaudeAgentSDKSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("opentelemetry.instrumentation.claude_agent_sdk")
+    arguments = {"path": "src", "pattern": "TODO"}
+    result = {"content": [{"type": "text", "text": "src/main.py:7: TODO"}]}
+    input_messages = [{"role": "user", "content": "Find TODO comments in src"}]
+    output_messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "toolu_grep", "name": "Grep", "input": arguments},
+                {"type": "text", "text": "Found one TODO comment."},
+            ],
+        }
+    ]
+    try:
+        with tracer.start_as_current_span(
+            "invoke_agent code_search",
+            attributes={
+                "gen_ai.operation.name": "invoke_agent",
+                "gen_ai.agent.name": "code_search",
+                "gen_ai.input.messages": json.dumps(input_messages),
+                "gen_ai.output.messages": json.dumps(output_messages),
+                "gen_ai.tool.definitions": '[{"name":"Grep"}]',
+                "gen_ai.response.model": "claude-sonnet-4-5",
+                "gen_ai.usage.input_tokens": 30,
+                "gen_ai.usage.output_tokens": 7,
+                SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS: 10,
+                SpanAttributes.LLM_USAGE_CACHE_CREATION_INPUT_TOKENS: 4,
+            },
+        ):
+            with tracer.start_as_current_span(
+                tool_span_name,
+                attributes={
+                    "gen_ai.operation.name": "execute_tool",
+                    "gen_ai.tool.name": "Grep",
+                    CLAUDE_AGENT_SDK_TOOL_CALL_ID_ATTR: "toolu_grep",
+                    # Same invocation as the model output, with changed JSON
+                    # formatting and key order as produced by the SDK tool path.
+                    "gen_ai.tool.call.arguments": '{"pattern":"TODO","path":"src"}',
+                    "gen_ai.tool.call.result": json.dumps(result),
+                },
+            ):
+                pass
+        finished = exporter.get_finished_spans()
+    finally:
+        provider.shutdown()
+
+    assert len(finished) == 2
+    tool, agent = finished
+    assert tool.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_TOOL
+    assert tool.attributes[SpanAttributes.TRACELOOP_ENTITY_NAME] == "Grep"
+    assert tool.attributes[SpanAttributes.TRACELOOP_ENTITY_PATH] == "Grep"
+    assert tool.attributes[CLAUDE_AGENT_SDK_TOOL_CALL_ID_ATTR] == "toolu_grep"
+    assert json.loads(tool.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == arguments
+    assert json.loads(tool.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == result
+    assert {key for key in tool.attributes if key.startswith("gen_ai.tool.")} == {
+        CLAUDE_AGENT_SDK_TOOL_CALL_ID_ATTR
+    }
+    assert agent.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_AGENT
+    assert json.loads(agent.attributes[SpanAttributes.TRACELOOP_ENTITY_INPUT]) == input_messages
+    assert json.loads(agent.attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]) == output_messages
+    assert agent.attributes[SpanAttributes.LLM_USAGE_PROMPT_TOKENS] == 16
+    assert agent.attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] == 7
+    assert agent.attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] == 23
+    assert agent.attributes[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] == 10
+    assert agent.attributes[SpanAttributes.LLM_USAGE_CACHE_CREATION_INPUT_TOKENS] == 4
+    assert json.loads(agent.attributes[_TOOL_CALLS_ATTR]) == [_call(json.dumps(arguments))]
+
+    # Explicit re-normalization must preserve all canonical fields after the
+    # upstream role and content helper attributes have already been removed.
+    for span in finished:
+        normalized = dict(span.attributes)
+        _processor.enrich_claude_agent_sdk_span(span)
+        _processor.enrich_claude_agent_sdk_span(span)
+        assert dict(span.attributes) == normalized
+
+    prepared = _prepare_spans_for_export(finished)
+    assert len(prepared) == 3
+    exported_tool, exported_agent, exported_chat = prepared
+    assert exported_chat.attributes[RESPAN_LOG_TYPE] == LOG_TYPE_CHAT
+    assert json.loads(exported_chat.attributes[_TOOL_CALLS_ATTR]) == [
+        _call(json.dumps(arguments))
+    ]
+    assert exported_chat.attributes[SpanAttributes.LLM_USAGE_CACHE_READ_INPUT_TOKENS] == 10
+    assert exported_chat.attributes[SpanAttributes.LLM_USAGE_CACHE_CREATION_INPUT_TOKENS] == 4
+    assert exported_tool.parent == exported_agent.get_span_context()
+    assert exported_chat.parent == exported_agent.get_span_context()
+
+    wire_spans = [
+        span
+        for resource in _build_otlp_payload(prepared)["resourceSpans"]
+        for scope in resource["scopeSpans"]
+        for span in scope["spans"]
+    ]
+    wire_tool, wire_agent, wire_chat = wire_spans
+    wire_tool_attrs = {item["key"]: item["value"] for item in wire_tool["attributes"]}
+    wire_chat_attrs = {item["key"]: item["value"] for item in wire_chat["attributes"]}
+    invocation_id = wire_tool_attrs[CLAUDE_AGENT_SDK_TOOL_CALL_ID_ATTR]["stringValue"]
+    assert invocation_id == "toolu_grep"
+    assert json.loads(wire_chat_attrs[_TOOL_CALLS_ATTR]["stringValue"])[0]["id"] == invocation_id
+    assert json.loads(
+        wire_tool_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]["stringValue"]
+    ) == result
+    assert wire_tool["traceId"] == wire_agent["traceId"] == wire_chat["traceId"]
+    assert wire_tool["parentSpanId"] == wire_chat["parentSpanId"] == wire_agent["spanId"]
+    assert not [record for record in caplog.records if record.name == _processor.__name__]

--- a/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_tool_lifecycle.py
+++ b/python-sdks/instrumentations/respan-instrumentation-claude-agent-sdk/tests/test_tool_lifecycle.py
@@ -1,0 +1,490 @@
+"""Offline lifecycle regressions using real SDK messages and upstream OTel hooks."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+from claude_agent_sdk import ClaudeAgentOptions, ResultError, ResultMessage, ToolResultBlock, UserMessage
+from opentelemetry.instrumentation.claude_agent_sdk import _context, _hooks
+from opentelemetry.instrumentation.claude_agent_sdk._constants import (
+    ERROR_TYPE,
+    GEN_AI_TOOL_CALL_ID,
+    GEN_AI_TOOL_CALL_RESULT,
+)
+from opentelemetry.instrumentation.claude_agent_sdk._context import InvocationContext
+from opentelemetry.instrumentation.claude_agent_sdk._instrumentor import (
+    ClaudeAgentSdkInstrumentor as UpstreamInstrumentor,
+)
+from opentelemetry.metrics import NoOpMeterProvider
+from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
+from opentelemetry.trace import StatusCode
+
+from respan_instrumentation_claude_agent_sdk import ClaudeAgentSDKInstrumentor, _instrumentation
+from respan_instrumentation_claude_agent_sdk._tool_lifecycle import (
+    _capture_failure_output,
+    _reconcile_sdk_message,
+)
+
+
+class _Recorder(SpanProcessor):
+    def __init__(self):
+        self.spans = []
+
+    def on_end(self, span):
+        self.spans.append(span)
+
+
+@pytest.fixture
+def otel():
+    provider = TracerProvider(shutdown_on_exit=False)
+    recorder = _Recorder()
+    provider.add_span_processor(recorder)
+    tracer = provider.get_tracer("offline-claude-lifecycle")
+    prior = _context.get_invocation_context()
+    contexts = []
+
+    def context(*, capture_content=True):
+        value = InvocationContext(tracer.start_span("invocation"), capture_content=capture_content)
+        contexts.append(value)
+        return value
+
+    yield SimpleNamespace(provider=provider, recorder=recorder, tracer=tracer, context=context)
+    for value in contexts:
+        value.cleanup_unclosed_spans()
+        if value.invocation_span.is_recording():
+            value.invocation_span.end()
+    _context.set_invocation_context(prior)
+    provider.shutdown()
+
+
+@pytest.fixture
+def patched_helpers():
+    owner = ClaudeAgentSDKInstrumentor()
+    assert owner._patch_upstream_helpers()
+    try:
+        yield owner
+    finally:
+        owner._restore_upstream_helpers()
+
+
+async def _hook(otel, ctx, event, tool_id, data):
+    prior = _context.get_invocation_context()
+    _context.set_invocation_context(ctx)
+    try:
+        hooks = _hooks.build_instrumentation_hooks(otel.tracer, capture_content=ctx.capture_content)
+        return await hooks[event][0].hooks[0](data, tool_id, None)
+    finally:
+        _context.set_invocation_context(prior)
+
+
+async def _start_tool(otel, ctx, tool_id="toolu_pending"):
+    await _hook(otel, ctx, "PreToolUse", tool_id, {"tool_name": "Bash", "tool_input": {"command": "offline fixture"}})
+    return ctx.active_tool_spans[tool_id]
+
+
+def _result(**kwargs):
+    fields = dict(subtype="success", duration_ms=1, duration_api_ms=1,
+                  is_error=False, num_turns=1, session_id="offline-session")
+    fields.update(kwargs)
+    return ResultMessage(**fields)
+
+
+def _tool_result(tool_id, *, is_error=False, content="SDK result"):
+    return UserMessage(content=[ToolResultBlock(tool_use_id=tool_id, content=content, is_error=is_error)])
+
+
+def _end_counter(monkeypatch, span):
+    calls = []
+    original = span.end
+
+    def end(*args, **kwargs):
+        calls.append(True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(span, "end", end)
+    return calls
+
+
+def test_failure_annotation_does_not_take_hook_end_ownership(otel):
+    span = otel.tracer.start_span("tool")
+    _capture_failure_output(span, "tool failed", capture_content=True)
+    assert json.loads(span.attributes[GEN_AI_TOOL_CALL_RESULT]) == {"error": "tool failed"}
+    assert span.is_recording()
+    assert span.status.status_code is StatusCode.UNSET
+    assert not otel.recorder.spans
+    span.end()
+
+
+def test_real_failure_hook_records_error_output_and_closes_once(otel, patched_helpers, monkeypatch):
+    async def scenario():
+        ctx = otel.context()
+        span = await _start_tool(otel, ctx)
+        endings = _end_counter(monkeypatch, span)
+        await _hook(otel, ctx, "PostToolUseFailure", "toolu_pending", {"error": "command rejected"})
+        assert not ctx.active_tool_spans
+        assert json.loads(span.attributes[GEN_AI_TOOL_CALL_RESULT]) == {"error": "command rejected"}
+        assert span.status.status_code is StatusCode.ERROR
+        ctx.cleanup_unclosed_spans()
+        assert len(endings) == 1
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("is_error", [False, True])
+def test_sdk_tool_result_closes_missing_post_hook_before_cleanup(otel, is_error):
+    async def scenario():
+        ctx = otel.context()
+        span = await _start_tool(otel, ctx)
+        content = [{"type": "text", "text": "explicit SDK outcome"}]
+        _reconcile_sdk_message(ctx, _tool_result("toolu_pending", is_error=is_error, content=content))
+        assert not ctx.active_tool_spans
+        assert not span.is_recording()
+        assert span.attributes[GEN_AI_TOOL_CALL_ID] == "toolu_pending"
+        assert json.loads(span.attributes[GEN_AI_TOOL_CALL_RESULT]) == content
+        assert (span.status.status_code is StatusCode.ERROR) is is_error
+        if is_error:
+            assert span.attributes[ERROR_TYPE] == "tool_error"
+        ctx.cleanup_unclosed_spans()
+        assert span.status.description != "Span not properly closed"
+    asyncio.run(scenario())
+
+
+def test_permission_denials_are_explicit_outcomes_for_matching_tools_only(otel):
+    async def scenario():
+        ctx = otel.context()
+        denied = await _start_tool(otel, ctx, "toolu_denied")
+        orphan = await _start_tool(otel, ctx, "toolu_orphan")
+        subagent = otel.tracer.start_span("subagent")
+        ctx.active_subagent_spans["toolu_subagent"] = subagent
+        _reconcile_sdk_message(ctx, _result(permission_denials=[
+            {"tool_use_id": "toolu_denied", "tool_name": "Bash", "tool_input": {"command": "not stderr"}},
+            {"tool_use_id": "toolu_subagent"}, {"tool_use_id": "unknown"}, {"tool_use_id": 7}, "invalid",
+        ]))
+        assert not denied.is_recording()
+        assert denied.attributes[ERROR_TYPE] == "permission_denied"
+        assert denied.status.status_code is StatusCode.ERROR
+        assert json.loads(denied.attributes[GEN_AI_TOOL_CALL_RESULT]) == {
+            "error": "permission_denied", "source": "ResultMessage.permission_denials",
+        }
+        assert orphan.is_recording() and subagent.is_recording()
+        assert list(ctx.active_tool_spans) == ["toolu_orphan"]
+        assert list(ctx.active_subagent_spans) == ["toolu_subagent"]
+        ctx.cleanup_unclosed_spans()
+        for span in (orphan, subagent):
+            assert span.status.status_code is StatusCode.ERROR
+            assert span.status.description == "Span not properly closed"
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("first", ["hook", "result"])
+@pytest.mark.parametrize("is_error", [False, True])
+def test_hook_result_duplicate_and_late_hook_end_each_invocation_once(otel, patched_helpers, monkeypatch, first, is_error):
+    async def scenario():
+        ctx = otel.context()
+        span = await _start_tool(otel, ctx)
+        endings = _end_counter(monkeypatch, span)
+        event = "PostToolUseFailure" if is_error else "PostToolUse"
+        hook_data = {"error": "hook failure"} if is_error else {"tool_response": "hook result"}
+        message = _tool_result("toolu_pending", is_error=is_error)
+        if first == "hook":
+            await _hook(otel, ctx, event, "toolu_pending", hook_data)
+            original_attrs = dict(span.attributes)
+            _reconcile_sdk_message(ctx, message)
+        else:
+            _reconcile_sdk_message(ctx, message)
+            original_attrs = dict(span.attributes)
+            await _hook(otel, ctx, event, "toolu_pending", hook_data)
+        _reconcile_sdk_message(ctx, message)
+        _reconcile_sdk_message(ctx, _result(permission_denials=[{"tool_use_id": "toolu_pending"}]))
+        await _hook(otel, ctx, "PostToolUseFailure", "toolu_pending", {"error": "late contradictory error"})
+        ctx.cleanup_unclosed_spans()
+        assert len(endings) == 1
+        assert dict(span.attributes) == original_attrs
+        assert (span.status.status_code is StatusCode.ERROR) is is_error
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("outcome", ["success", "tool_error", "permission_denied", "failure_hook"])
+def test_structure_only_keeps_status_without_sensitive_result_content(otel, patched_helpers, outcome):
+    async def scenario():
+        ctx = otel.context(capture_content=False)
+        span = await _start_tool(otel, ctx)
+        sentinel = "sensitive-failure-sentinel"
+        if outcome == "failure_hook":
+            await _hook(otel, ctx, "PostToolUseFailure", "toolu_pending", {"error": sentinel})
+        elif outcome == "permission_denied":
+            _reconcile_sdk_message(ctx, _result(permission_denials=[{"tool_use_id": "toolu_pending", "tool_input": {"command": sentinel}}]))
+        else:
+            _reconcile_sdk_message(ctx, _tool_result("toolu_pending", is_error=outcome == "tool_error", content=sentinel))
+        assert not span.is_recording()
+        assert GEN_AI_TOOL_CALL_RESULT not in span.attributes
+        assert sentinel not in json.dumps(dict(span.attributes))
+        assert sentinel not in (span.status.description or "")
+        assert (span.status.status_code is StatusCode.ERROR) is (outcome != "success")
+    asyncio.run(scenario())
+
+
+def test_successful_agent_result_does_not_invent_outcomes_for_orphans(otel):
+    async def scenario():
+        ctx = otel.context()
+        span = await _start_tool(otel, ctx)
+        _reconcile_sdk_message(ctx, UserMessage(content="Tool permission denied, but no explicit tool result"))
+        _reconcile_sdk_message(ctx, _result())
+        assert span.is_recording()
+        assert GEN_AI_TOOL_CALL_RESULT not in span.attributes
+        ctx.cleanup_unclosed_spans()
+        ctx.cleanup_unclosed_spans()
+        assert span.status.description == "Span not properly closed"
+        assert len(otel.recorder.spans) == 1
+    asyncio.run(scenario())
+
+
+def test_identical_tool_ids_in_separate_invocations_are_isolated(otel):
+    async def scenario():
+        first, second = otel.context(), otel.context()
+        first_span = await _start_tool(otel, first, "toolu_reused")
+        second_span = await _start_tool(otel, second, "toolu_reused")
+        _context.set_invocation_context(second)
+        _reconcile_sdk_message(first, _tool_result("toolu_reused"))
+        assert not first_span.is_recording()
+        assert second_span.is_recording()
+        assert _context.get_invocation_context() is second
+        _reconcile_sdk_message(second, _tool_result("toolu_reused", is_error=True))
+        assert first_span.status.status_code is StatusCode.UNSET
+        assert second_span.status.status_code is StatusCode.ERROR
+    asyncio.run(scenario())
+
+
+def _configure_upstream(monkeypatch, otel):
+    upstream = UpstreamInstrumentor()
+    meter = NoOpMeterProvider().get_meter("offline-claude")
+    for name, value in {"_tracer": otel.tracer, "_agent_name": "offline", "_capture_content": True,
+                        "_token_histogram": meter.create_histogram("tokens"), "_duration_histogram": meter.create_histogram("duration")}.items():
+        monkeypatch.setattr(upstream, name, value, raising=False)
+    return upstream
+
+
+@pytest.mark.parametrize("mode", ["standalone", "client"])
+@pytest.mark.parametrize("is_error", [False, True])
+def test_real_wrapper_reconciles_tool_result_before_upstream_cleanup(otel, patched_helpers, monkeypatch, mode, is_error):
+    async def scenario():
+        upstream = _configure_upstream(monkeypatch, otel)
+        previous = otel.context()
+        client = SimpleNamespace(_otel_invocation_ctx=otel.context(), _query=SimpleNamespace(_otel_invocation_ctx=None))
+        _context.set_invocation_context(previous)
+        seen = {}
+        message = _tool_result("toolu_missing_hook", is_error=is_error)
+        terminal = _result()
+
+        async def messages(*args, **kwargs):
+            ctx = _context.get_invocation_context()
+            seen["ctx"] = ctx
+            seen["tool"] = await _start_tool(otel, ctx, "toolu_missing_hook")
+            yield message
+            yield terminal
+
+        iterator = (upstream._instrumented_query(messages, (), {"prompt": "offline", "options": ClaudeAgentOptions()})
+                    if mode == "standalone" else upstream._instrumented_receive_response(messages, client, (), {}))
+        assert await anext(iterator) is message
+        assert not seen["tool"].is_recording()
+        assert not seen["ctx"].active_tool_spans
+        assert (seen["tool"].status.status_code is StatusCode.ERROR) is is_error
+        assert json.loads(seen["tool"].attributes[GEN_AI_TOOL_CALL_RESULT]) == "SDK result"
+        assert await anext(iterator) is terminal
+        await iterator.aclose()
+        assert _context.get_invocation_context() is previous
+        assert seen["tool"].status.description != "Span not properly closed"
+        assert seen["ctx"].invocation_span.status.status_code is not StatusCode.ERROR
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("mode", ["standalone", "client"])
+@pytest.mark.parametrize("terminal", [False, True])
+def test_wrapper_aclose_finalizes_upstream_and_restores_prior_context(otel, patched_helpers, monkeypatch, mode, terminal):
+    async def scenario():
+        upstream = _configure_upstream(monkeypatch, otel)
+        previous = otel.context()
+        invocation = otel.context() if mode == "client" else None
+        client = SimpleNamespace(_otel_invocation_ctx=invocation, _query=SimpleNamespace(_otel_invocation_ctx=None))
+        _context.set_invocation_context(previous)
+        seen = {}
+
+        async def messages(*args, **kwargs):
+            ctx = _context.get_invocation_context()
+            seen["ctx"] = ctx
+            try:
+                await _start_tool(otel, ctx, "toolu_orphan")
+                if terminal:
+                    yield _result(permission_denials=[{"tool_use_id": "toolu_orphan"}])
+                else:
+                    yield UserMessage(content="stream is still active")
+            finally:
+                seen["source_closed"] = True
+
+        iterator = (upstream._instrumented_query(messages, (), {"prompt": "offline", "options": ClaudeAgentOptions()})
+                    if mode == "standalone" else upstream._instrumented_receive_response(messages, client, (), {}))
+        await anext(iterator)
+        ctx = seen["ctx"]
+        assert ctx is not previous
+        await iterator.aclose()
+        assert _context.get_invocation_context() is previous
+        assert seen["source_closed"]
+        assert not ctx.invocation_span.is_recording()  # Actual upstream finally ran.
+        assert not ctx.active_tool_spans
+        if mode == "client":
+            assert client._otel_invocation_ctx is None
+            assert client._query._otel_invocation_ctx is None
+        if terminal:
+            assert ctx.invocation_span.status.status_code is not StatusCode.ERROR
+        else:
+            assert ctx.invocation_span.status.status_code is StatusCode.ERROR
+            tool = next(span for span in otel.recorder.spans if span.attributes.get(GEN_AI_TOOL_CALL_ID) == "toolu_orphan")
+            assert tool.status.description == "Span not properly closed"
+    asyncio.run(scenario())
+
+
+def test_standalone_streaming_prompt_receives_result_before_next_input(otel, patched_helpers, monkeypatch):
+    async def scenario():
+        upstream = _configure_upstream(monkeypatch, otel)
+        previous = otel.context()
+        _context.set_invocation_context(previous)
+        acknowledged = asyncio.Event()
+        events = []
+        seen = {}
+        first, second = _result(num_turns=1), _result(num_turns=2)
+
+        async def prompt():
+            yield {"type": "user", "message": {"role": "user", "content": "turn one"}}
+            await acknowledged.wait()
+            events.append("second_input")
+            yield {"type": "user", "message": {"role": "user", "content": "turn two"}}
+
+        async def messages(*args, **kwargs):
+            seen["ctx"] = _context.get_invocation_context()
+            inputs = kwargs["prompt"]
+            try:
+                await anext(inputs)
+                events.append("first_result")
+                yield first
+                await anext(inputs)
+                events.append("second_result")
+                yield second
+            finally:
+                await inputs.aclose()
+                events.append("source_closed")
+
+        iterator = upstream._instrumented_query(messages, (), {"prompt": prompt(), "options": ClaudeAgentOptions()})
+        # Timeout stays in this task so it does not alter the ContextVar scope.
+        async with asyncio.timeout(2):
+            try:
+                assert await anext(iterator) is first
+                assert events == ["first_result"]
+                events.append("caller_acknowledged")
+                acknowledged.set()
+                assert await anext(iterator) is second
+                with pytest.raises(StopAsyncIteration):
+                    await anext(iterator)
+            finally:
+                await iterator.aclose()
+        assert events == ["first_result", "caller_acknowledged", "second_input", "second_result", "source_closed"]
+        assert _context.get_invocation_context() is previous
+        assert not seen["ctx"].invocation_span.is_recording()
+        assert seen["ctx"].invocation_span.status.status_code is not StatusCode.ERROR
+    asyncio.run(scenario())
+
+
+def test_standalone_delivers_error_result_before_sdk_result_error(otel, patched_helpers, monkeypatch):
+    async def scenario():
+        upstream = _configure_upstream(monkeypatch, otel)
+        previous = otel.context()
+        _context.set_invocation_context(previous)
+        terminal = _result(subtype="error_during_execution", is_error=True)
+        failure = ResultError("offline terminal failure", data={"is_error": True}, exit_code=1)
+        events = []
+        seen = {}
+
+        async def messages(*args, **kwargs):
+            seen["ctx"] = _context.get_invocation_context()
+            try:
+                yield terminal
+                events.append("source_raised")
+                raise failure
+            finally:
+                events.append("source_closed")
+
+        iterator = upstream._instrumented_query(messages, (), {"prompt": "offline", "options": ClaudeAgentOptions()})
+        async with asyncio.timeout(2):
+            try:
+                assert await anext(iterator) is terminal
+                assert events == []
+                events.append("caller_received")
+                with pytest.raises(ResultError) as raised:
+                    await anext(iterator)
+                assert raised.value is failure
+            finally:
+                await iterator.aclose()
+        assert events == ["caller_received", "source_raised", "source_closed"]
+        assert _context.get_invocation_context() is previous
+        assert not seen["ctx"].invocation_span.is_recording()
+        assert seen["ctx"].invocation_span.status.status_code is StatusCode.ERROR
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("mode", ["standalone", "client"])
+@pytest.mark.parametrize("capture_content", [False, True])
+def test_error_result_then_immediate_close_preserves_failure_without_tools(otel, patched_helpers, monkeypatch, mode, capture_content):
+    async def scenario():
+        upstream = _configure_upstream(monkeypatch, otel)
+        monkeypatch.setattr(upstream, "_capture_content", capture_content)
+        previous = otel.context()
+        invocation = otel.context(capture_content=capture_content) if mode == "client" else None
+        client = SimpleNamespace(_otel_invocation_ctx=invocation, _query=SimpleNamespace(_otel_invocation_ctx=None))
+        _context.set_invocation_context(previous)
+        sentinel = "sensitive-terminal-error-sentinel"
+        terminal = _result(subtype="error_during_execution", is_error=True, errors=[sentinel], result=sentinel)
+        seen = {}
+
+        async def messages(*args, **kwargs):
+            seen["ctx"] = _context.get_invocation_context()
+            try:
+                yield terminal
+            finally:
+                seen["source_closed"] = True
+
+        iterator = (upstream._instrumented_query(messages, (), {"prompt": "offline", "options": ClaudeAgentOptions()})
+                    if mode == "standalone" else upstream._instrumented_receive_response(messages, client, (), {}))
+        assert await anext(iterator) is terminal
+        await iterator.aclose()
+        assert seen["source_closed"]
+        assert _context.get_invocation_context() is previous
+        span = seen["ctx"].invocation_span
+        assert not span.is_recording()
+        assert span.status.status_code is StatusCode.ERROR
+        if not capture_content:
+            assert sentinel not in json.dumps(dict(span.attributes))
+            assert sentinel not in (span.status.description or "")
+    asyncio.run(scenario())
+
+
+def test_shared_owners_keep_compatibility_wrappers_until_last_deactivation(otel, monkeypatch):
+    originals = (UpstreamInstrumentor._instrumented_query, UpstreamInstrumentor._instrumented_receive_response,
+                 _hooks.set_tool_error_attributes)
+    monkeypatch.setattr(_instrumentation.trace, "get_tracer_provider", lambda: otel.provider)
+    first, second = ClaudeAgentSDKInstrumentor(), ClaudeAgentSDKInstrumentor()
+    try:
+        first.activate()
+        assert first._is_instrumented
+        wrapped = (UpstreamInstrumentor._instrumented_query, UpstreamInstrumentor._instrumented_receive_response,
+                   _hooks.set_tool_error_attributes)
+        assert all(actual is not original for actual, original in zip(wrapped, originals))
+        second.activate()
+        assert second._is_instrumented
+        first.deactivate()
+        assert (UpstreamInstrumentor._instrumented_query, UpstreamInstrumentor._instrumented_receive_response,
+                _hooks.set_tool_error_attributes) == wrapped
+        second.deactivate()
+        assert (UpstreamInstrumentor._instrumented_query, UpstreamInstrumentor._instrumented_receive_response,
+                _hooks.set_tool_error_attributes) == originals
+    finally:
+        second.deactivate()
+        first.deactivate()


### PR DESCRIPTION
## Summary

Claude Agent SDK traces lose tool invocation IDs, duplicate equivalent calls, and can reclassify tools during repeated normalization. Upstream instrumentation 0.1.4 also drops failed-hook results and leaves tool spans open when the SDK reports an outcome without a post-tool hook.

- Preserve `gen_ai.tool.call.id` through OTLP export. Merge calls primarily by ID, normalize JSON arguments, fill missing fields from later observations, and preserve distinct IDs and genuine conflicts.
- Keep tool classification and content stable across repeated normalization. Share processors and reference-count global instrumentation so the first active owner's settings remain in effect until the last owner deactivates.
- Add compatibility handling in the Respan adapter: retain failed-hook output when content capture is enabled, reconcile `ToolResultBlock` and explicit permission-denial records with matching pending tool IDs, and close each span once. Unknown tool/subagent spans still reach upstream cleanup as errors; agent completion alone never invents a tool outcome.
- Preserve immediate standalone streaming results and subsequent SDK exceptions, finalize SDK iterators on closure, restore invocation context, and mark error results as failures even when callers stop immediately. Structure-only capture excludes failure content.

The new handling reuses #418's shared patch ownership. It requires no upstream fork or edits to installed upstream files. README and span-contract changes remain scoped to the implemented behavior.

## Release Intent

Updated `.release-intents/20260906-claude-agent-sdk-tool-correlation.json` with the existing `patch` intent for `respan-instrumentation-claude-agent-sdk`. No manual version bump or new runtime dependency.

## Validation

- Package suite plus shared exporter suite: **125 passed, 1 skipped**, including **30 new offline lifecycle regressions** using real upstream 0.1.4 hooks/wrappers, SDK 0.2.149 message types, and real OTel spans.
- Rebuilt wheel and sdist; installed-wheel lifecycle, correlation, and ownership tests: **74 passed**. All five installed adapter source files match the checkout; all eight upstream Python source files retain their original hashes. `pip check` passes.
- Synthetic correlation regression: 102 observations collapse to 76 invocation IDs. This is not a replay of the original Scira trace. Real OTel tests check correlation after Respan OTLP serialization and repeated normalization.
- Release inventory, intent validation, changed-range release plan, and `git diff --check` pass.
- The skipped test is the opt-in live gateway test. No live gateway call or Respan platform trace validation was performed for this change.
