### PR TITLE
fix(tracing-python): respan-tracing - prevent tool output from becoming synthetic chat records

### DIFF
--- a/.release-intents/20260906-tracing-tool-output-provenance.json
+++ b/.release-intents/20260906-tracing-tool-output-provenance.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Require assistant or LLM provenance before exporting synthetic Claude Agent chat children and preserve tool result content.",
+  "packages": {
+    "respan-tracing": "patch"
+  }
+}

--- a/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
+++ b/python-sdks/respan-tracing/src/respan_tracing/exporters/respan.py
@@ -192,16 +192,69 @@ def _derive_synthetic_span_id(*parts: Any) -> int:
     return span_id
 
 
+def _is_tool_execution_span(span: ReadableSpan) -> bool:
+    """Tool execution identity takes precedence over inherited LLM metadata."""
+    attrs = span.attributes or {}
+    return (
+        attrs.get(RESPAN_LOG_TYPE) in {LOG_TYPE_TOOL, LOG_TYPE_FUNCTION}
+        or attrs.get(SpanAttributes.TRACELOOP_SPAN_KIND) == LOG_TYPE_TOOL
+        or attrs.get(GEN_AI_OPERATION_NAME) == "execute_tool"
+        or bool(attrs.get(GEN_AI_TOOL_NAME))
+        or span.name == "execute_tool"
+        or span.name.startswith("execute_tool ")
+    )
+
+
+def _has_llm_response_metadata(attrs: Mapping[str, Any]) -> bool:
+    """Provider/request type alone do not establish an LLM response."""
+    model = attrs.get(SpanAttributes.LLM_REQUEST_MODEL)
+    if isinstance(model, str) and model.strip():
+        return True
+    if any(
+        (key.startswith("gen_ai.usage.") or key.startswith("llm.usage."))
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and value >= 0
+        for key, value in attrs.items()
+    ):
+        return True
+    if attrs.get(f"{SpanAttributes.LLM_COMPLETIONS}.0.role") not in {None, "assistant"}:
+        return False
+    return any(
+        isinstance(tool_calls := _parse_structured_json_attr(attrs.get(key)), list)
+        and bool(tool_calls)
+        for key in (_COMPLETION_TOOL_CALLS_ATTR, RESPAN_SPAN_TOOL_CALLS)
+    )
+
+
 def _is_claude_agent_response_span(span: ReadableSpan) -> bool:
     """Return whether this span is a Claude Agent SDK response-turn parent."""
     scope = getattr(span, "instrumentation_scope", None)
     scope_name = getattr(scope, "name", None)
     attrs = span.attributes or {}
+    if scope_name not in _CLAUDE_AGENT_SCOPE_NAMES or _is_tool_execution_span(span):
+        return False
+    assistant_message = _select_primary_completion_from_attrs(attrs, allow_untyped=False)
+    has_assistant_output = assistant_message is not None and (
+        bool(_extract_text_from_message(assistant_message))
+        or bool(assistant_message.get("tool_calls"))
+    )
     return (
-        scope_name in _CLAUDE_AGENT_SCOPE_NAMES
-        and (
+        (
             attrs.get(RESPAN_LOG_TYPE) == LOG_TYPE_AGENT
             or span.name in _CLAUDE_AGENT_RESPONSE_SPAN_NAMES
+        )
+        and (
+            has_assistant_output
+            or (
+                _has_llm_response_metadata(attrs)
+                and (
+                    span.name in _CLAUDE_AGENT_RESPONSE_SPAN_NAMES
+                    or attrs.get(GEN_AI_OPERATION_NAME) == "invoke_agent"
+                    or span.name == "invoke_agent"
+                    or span.name.startswith("invoke_agent ")
+                )
+            )
         )
     )
 
@@ -214,31 +267,35 @@ def _build_claude_agent_final_chat_span(
         return None
 
     attrs = span.attributes or {}
-    tool_calls = _parse_structured_json_attr(attrs.get(_COMPLETION_TOOL_CALLS_ATTR))
-    if not isinstance(tool_calls, list) or not tool_calls:
-        tool_calls = _parse_structured_json_attr(attrs.get(RESPAN_SPAN_TOOL_CALLS))
-
     primary_completion_message = _select_primary_completion_from_attrs(attrs)
-    has_llm_payload = bool(tool_calls) or any(
-        key in attrs
-        for key in (
-            SpanAttributes.LLM_SYSTEM,
-            SpanAttributes.LLM_REQUEST_MODEL,
-            SpanAttributes.LLM_REQUEST_TYPE,
-        )
-    ) or any(
-        key.startswith("gen_ai.usage.") or key.startswith("llm.usage.")
-        for key in attrs
-    )
     if primary_completion_message is None:
-        if not has_llm_payload:
+        # Missing/redacted output may still carry real model or usage data.
+        # Rejected tool/user output must never become an empty assistant child.
+        if (
+            not _has_llm_response_metadata(attrs)
+            or _parse_json_like(attrs.get(SpanAttributes.TRACELOOP_ENTITY_OUTPUT)) is not None
+            or any(key.startswith(_GEN_AI_COMPLETION_PREFIX) for key in attrs)
+        ):
             return None
         primary_completion_message = {"role": "assistant", "content": ""}
+
+    tool_calls = _parse_structured_json_attr(primary_completion_message.get("tool_calls"))
+    if (
+        (not isinstance(tool_calls, list) or not tool_calls)
+        and attrs.get(f"{SpanAttributes.LLM_COMPLETIONS}.0.role") in {None, "assistant"}
+    ):
+        tool_calls = _parse_structured_json_attr(attrs.get(_COMPLETION_TOOL_CALLS_ATTR))
+        if not isinstance(tool_calls, list) or not tool_calls:
+            tool_calls = _parse_structured_json_attr(attrs.get(RESPAN_SPAN_TOOL_CALLS))
 
     completion_text = _extract_text_from_message(primary_completion_message)
     if completion_text is None:
         completion_text = ""
-    if not completion_text and not has_llm_payload:
+    if (
+        not completion_text
+        and not _has_llm_response_metadata(attrs)
+        and not primary_completion_message.get("tool_calls")
+    ):
         return None
 
     span_context = span.get_span_context()
@@ -362,7 +419,13 @@ def _prepare_spans_for_export(spans: Sequence[ReadableSpan]) -> List[ReadableSpa
             if overrides
             else span
         )
-        synthetic_child = _build_claude_agent_final_chat_span(prepared_span)
+        # Enrichment can infer assistant fields from legacy helper attributes;
+        # response provenance must come from the original instrumentation span.
+        synthetic_child = (
+            _build_claude_agent_final_chat_span(prepared_span)
+            if _is_claude_agent_response_span(span)
+            else None
+        )
         if (
             synthetic_child is not None
             and prepared_span.attributes.get(RESPAN_LOG_TYPE) == LOG_TYPE_AGENT
@@ -899,9 +962,13 @@ def _extract_text_from_message(message: Any) -> Optional[str]:
 
 def _coerce_raw_output_to_completion_message(
     raw_output_payload: Any,
+    *,
+    allow_untyped: bool = False,
 ) -> Optional[Dict[str, Any]]:
-    """Normalize raw output payloads into an assistant message when possible."""
+    """Select assistant output without relabeling tool/user messages."""
     if isinstance(raw_output_payload, str):
+        if not allow_untyped:
+            return None
         return {
             "role": "assistant",
             "content": raw_output_payload,
@@ -909,10 +976,22 @@ def _coerce_raw_output_to_completion_message(
 
     if isinstance(raw_output_payload, Mapping):
         role = raw_output_payload.get("role")
+        if role != "assistant":
+            return None
+        if raw_output_payload.get("type") == "tool_result":
+            return None
         content = raw_output_payload.get("content")
-        tool_calls = raw_output_payload.get("tool_calls")
-        if role is not None or content is not None or tool_calls is not None:
-            return dict(raw_output_payload)
+        if isinstance(content, list):
+            # Tool-result blocks are not assistant-authored, even when wrapped
+            # in an otherwise valid assistant message.
+            assistant_content = [
+                block for block in content
+                if not isinstance(block, Mapping) or block.get("type") != "tool_result"
+            ]
+            if content and not assistant_content:
+                return None
+            raw_output_payload = {**raw_output_payload, "content": assistant_content}
+        return dict(raw_output_payload)
 
     if isinstance(raw_output_payload, list):
         candidates = [
@@ -935,14 +1014,29 @@ def _select_primary_completion_message(
     *,
     completion_messages: Optional[List[Dict[str, Any]]],
     raw_output_payload: Any,
+    allow_untyped: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Choose the assistant completion that best represents the final answer."""
-    raw_output_message = _coerce_raw_output_to_completion_message(raw_output_payload)
+    assistant_messages = [
+        candidate
+        for message in completion_messages or []
+        if (candidate := _coerce_raw_output_to_completion_message(
+            {**message, "role": "assistant"}
+            if allow_untyped and message.get("role") is None
+            else message,
+        )) is not None
+    ]
+    raw_output_message = _coerce_raw_output_to_completion_message(
+        raw_output_payload,
+        # Explicit non-assistant completions cannot be overridden by raw text.
+        allow_untyped=allow_untyped
+        and (not completion_messages or bool(assistant_messages)),
+    )
 
-    if not completion_messages:
+    if not assistant_messages:
         return raw_output_message
 
-    for message in reversed(completion_messages):
+    for message in reversed(assistant_messages):
         message_text = _extract_text_from_message(message)
         if message_text not in {None, ""}:
             return message
@@ -951,11 +1045,13 @@ def _select_primary_completion_message(
     if raw_output_text not in {None, ""}:
         return raw_output_message
 
-    return completion_messages[-1]
+    return assistant_messages[-1]
 
 
 def _select_primary_completion_from_attrs(
     attrs: Mapping[str, Any],
+    *,
+    allow_untyped: Optional[bool] = None,
 ) -> Optional[Dict[str, Any]]:
     """Choose the best completion message using traced attrs plus raw output."""
     return _select_primary_completion_message(
@@ -965,6 +1061,11 @@ def _select_primary_completion_from_attrs(
         ),
         raw_output_payload=_parse_json_like(
             attrs.get(SpanAttributes.TRACELOOP_ENTITY_OUTPUT)
+        ),
+        allow_untyped=(
+            _has_llm_response_metadata(attrs)
+            if allow_untyped is None
+            else allow_untyped
         ),
     )
 
@@ -1172,6 +1273,17 @@ def _get_enrichment_attrs(span: ReadableSpan) -> Dict[str, Any]:
             _RESPAN_TRACING_SDK_VERSION
         )
 
+    if _is_tool_execution_span(span):
+        return extra
+
+    scope = getattr(span, "instrumentation_scope", None)
+    if (
+        getattr(scope, "name", None) in _CLAUDE_AGENT_SCOPE_NAMES
+        and attrs.get(RESPAN_LOG_TYPE) == LOG_TYPE_AGENT
+        and not _is_claude_agent_response_span(span)
+    ):
+        return extra
+
     if attrs.get(SpanAttributes.LLM_SYSTEM) and not attrs.get(SpanAttributes.LLM_REQUEST_TYPE):
         extra[SpanAttributes.LLM_REQUEST_TYPE] = LLMRequestTypeValues.CHAT.value
 
@@ -1189,7 +1301,11 @@ def _get_enrichment_attrs(span: ReadableSpan) -> Dict[str, Any]:
     tool_calls = _parse_structured_json_attr(attrs.get(_COMPLETION_TOOL_CALLS_ATTR))
     if not isinstance(tool_calls, list) or not tool_calls:
         tool_calls = _parse_structured_json_attr(attrs.get(RESPAN_SPAN_TOOL_CALLS))
-    if isinstance(tool_calls, list) and tool_calls:
+    if (
+        isinstance(tool_calls, list)
+        and tool_calls
+        and attrs.get(f"{SpanAttributes.LLM_COMPLETIONS}.0.role") in {None, "assistant"}
+    ):
         if _COMPLETION_TOOL_CALLS_ATTR not in attrs:
             extra[_COMPLETION_TOOL_CALLS_ATTR] = tool_calls
         if f"{SpanAttributes.LLM_COMPLETIONS}.0.role" not in attrs:

--- a/python-sdks/respan-tracing/tests/test_respan_exporter.py
+++ b/python-sdks/respan-tracing/tests/test_respan_exporter.py
@@ -623,6 +623,260 @@ def test_prepare_spans_splits_tool_only_current_claude_agent():
     ) == tool_calls
 
 
+@pytest.mark.parametrize("scope_name", [
+    "opentelemetry.instrumentation.claude_agent_sdk",
+    "openinference.instrumentation.claude_agent_sdk",
+])
+@pytest.mark.parametrize("name, attributes", [
+    ("Grep", {RESPAN_LOG_TYPE: "agent"}),
+    ("Grep", {RESPAN_LOG_TYPE: "agent", "gen_ai.request.model": "claude-sonnet-4-5"}),
+    ("ClaudeAgentSDK.query", {}),
+    ("ClaudeAgentSDK.ClaudeSDKClient.receive_response", {}),
+    ("invoke_agent", {RESPAN_LOG_TYPE: "agent", "gen_ai.system": "anthropic"}),
+    ("invoke_agent", {RESPAN_LOG_TYPE: "agent", "llm.request.type": "chat"}),
+    ("invoke_agent", {RESPAN_LOG_TYPE: "agent", "gen_ai.request.model": ""}),
+    ("invoke_agent", {RESPAN_LOG_TYPE: "agent", "gen_ai.usage.output_tokens": None}),
+])
+def test_export_does_not_turn_unattributed_tool_output_into_chat(
+    scope_name, name, attributes,
+):
+    output = "src/main.py:195: matching Grep result"
+    span = _make_span(
+        name=name,
+        span_id=3100,
+        attributes={**attributes, SpanAttributes.TRACELOOP_ENTITY_OUTPUT: output},
+        scope_name=scope_name,
+    )
+    exporter = RespanSpanExporter(endpoint="https://example.com/api", api_key="test-key")
+    exporter._session = Mock()
+    exporter._session.post.return_value = SimpleNamespace(status_code=200, text="ok")
+
+    assert exporter.export([span]) == SpanExportResult.SUCCESS
+
+    payload = json.loads(exporter._session.post.call_args.kwargs["data"])
+    exported = [
+        item
+        for resource in payload[OTLP_RESOURCE_SPANS_KEY]
+        for scope in resource[OTLP_SCOPE_SPANS_KEY]
+        for item in scope[OTLP_SPANS_KEY]
+    ]
+    assert len(exported) == 1
+    attrs = {item[OTLP_ATTR_KEY]: item[OTLP_ATTR_VALUE] for item in exported[0][OTLP_ATTRIBUTES_KEY]}
+    assert attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT][OTLP_STRING_VALUE] == output
+    assert f"{SpanAttributes.LLM_COMPLETIONS}.0.role" not in attrs
+
+
+@pytest.mark.parametrize("output", [
+    {"role": "tool", "content": "Grep result", "tool_call_id": "call_grep"},
+    {"role": "user", "content": "Grep result"},
+    {"type": "tool_result", "content": "Grep result", "tool_use_id": "call_grep"},
+    [{"role": "tool", "content": "Grep result"}],
+    {"role": "assistant", "content": [{"type": "tool_result", "content": "Grep result"}]},
+    {"content": [{"type": "text", "text": "Grep result"}]},
+    {"tool_call_id": "call_grep", "content": "Grep result"},
+    [{"role": "tool", "content": "Grep result"}, "Grep result"],
+])
+def test_prepare_spans_rejects_non_assistant_output_even_with_llm_metadata(output):
+    span = _make_span(
+        name="ClaudeAgentSDK.query",
+        span_id=3101,
+        attributes={
+            RESPAN_LOG_TYPE: "agent",
+            "gen_ai.request.model": "claude-sonnet-4-5",
+            "gen_ai.usage.output_tokens": 1,
+            SpanAttributes.TRACELOOP_ENTITY_OUTPUT: json.dumps(output),
+        },
+        scope_name="openinference.instrumentation.claude_agent_sdk",
+    )
+
+    prepared = _prepare_spans_for_export([span])
+
+    assert len(prepared) == 1
+    assert prepared[0].attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == json.dumps(output)
+
+
+@pytest.mark.parametrize("tool_attrs, name", [
+    ({RESPAN_LOG_TYPE: "tool"}, "ClaudeAgentSDK.query"),
+    ({"gen_ai.operation.name": "execute_tool"}, "Grep"),
+    ({"gen_ai.tool.name": "Grep"}, "Grep"),
+    ({}, "execute_tool Grep"),
+    ({SpanAttributes.TRACELOOP_SPAN_KIND: "tool"}, "Grep"),
+])
+def test_prepare_spans_does_not_enrich_tool_executions_as_llm(tool_attrs, name):
+    span = _make_span(
+        name=name,
+        span_id=3102,
+        attributes={
+            RESPAN_LOG_TYPE: "agent",
+            "gen_ai.system": "anthropic",
+            "gen_ai.request.model": "claude-sonnet-4-5",
+            RESPAN_SPAN_TOOL_CALLS: json.dumps([{"id": "call_grep"}]),
+            SpanAttributes.TRACELOOP_ENTITY_OUTPUT: "Grep result",
+            **tool_attrs,
+        },
+        scope_name="opentelemetry.instrumentation.claude_agent_sdk",
+    )
+
+    prepared = _prepare_spans_for_export([span])
+
+    assert len(prepared) == 1
+    assert "llm.request.type" not in prepared[0].attributes
+    assert "gen_ai.completion.0.role" not in prepared[0].attributes
+    assert prepared[0].attributes[SpanAttributes.TRACELOOP_ENTITY_OUTPUT] == "Grep result"
+
+
+@pytest.mark.parametrize("attributes", [
+    {SpanAttributes.TRACELOOP_ENTITY_OUTPUT: json.dumps({"role": "assistant", "content": "Done"})},
+    {"gen_ai.completion.0.role": "assistant", "gen_ai.completion.0.content": "Done"},
+    {"gen_ai.request.model": "claude-sonnet-4-5", SpanAttributes.TRACELOOP_ENTITY_OUTPUT: "Done"},
+    {"gen_ai.usage.output_tokens": 0},
+    {"gen_ai.request.model": "claude-sonnet-4-5"},
+])
+def test_prepare_spans_preserves_assistant_response_provenance(attributes):
+    span = _make_span(
+        name="invoke_agent assistant",
+        span_id=3103,
+        attributes={RESPAN_LOG_TYPE: "agent", **attributes},
+        scope_name="opentelemetry.instrumentation.claude_agent_sdk",
+    )
+
+    prepared = _prepare_spans_for_export([span])
+
+    assert len(prepared) == 2
+    assert prepared[1].attributes[RESPAN_LOG_TYPE] == "chat"
+    assert prepared[1].attributes["gen_ai.completion.0.content"] == (
+        "Done" if (
+            SpanAttributes.TRACELOOP_ENTITY_OUTPUT in attributes
+            or "gen_ai.completion.0.content" in attributes
+        ) else ""
+    )
+
+
+@pytest.mark.parametrize("indexed", [False, True])
+def test_prepare_spans_selects_assistant_instead_of_trailing_tool_result(indexed):
+    messages = [
+        {"role": "assistant", "content": "Assistant answer"},
+        {"role": "tool", "content": "Grep result"},
+    ]
+    attrs = {RESPAN_LOG_TYPE: "agent", SpanAttributes.TRACELOOP_ENTITY_OUTPUT: json.dumps(messages)}
+    if indexed:
+        attrs.update({
+            f"{SpanAttributes.LLM_COMPLETIONS}.{i}.{key}": value
+            for i, message in enumerate(messages)
+            for key, value in message.items()
+        })
+    span = _make_span(
+        name="invoke_agent assistant", span_id=3104, attributes=attrs,
+        scope_name="opentelemetry.instrumentation.claude_agent_sdk",
+    )
+
+    prepared = _prepare_spans_for_export([span])
+
+    assert len(prepared) == 2
+    assert prepared[1].attributes["gen_ai.completion.0.content"] == "Assistant answer"
+
+
+def test_prepare_spans_does_not_backfill_assistant_tool_calls_with_tool_results():
+    tool_calls = [{"id": "call_grep", "type": "function", "function": {"name": "Grep", "arguments": "{}"}}]
+    span = _make_span(
+        name="invoke_agent assistant", span_id=3105,
+        attributes={
+            RESPAN_LOG_TYPE: "agent",
+            "gen_ai.completion.0.role": "assistant",
+            "gen_ai.completion.0.content": "",
+            "gen_ai.completion.0.tool_calls": json.dumps(tool_calls),
+            "gen_ai.completion.1.role": "tool",
+            "gen_ai.completion.1.content": "Grep result",
+            SpanAttributes.TRACELOOP_ENTITY_OUTPUT: json.dumps({"role": "tool", "content": "Grep result"}),
+        },
+        scope_name="opentelemetry.instrumentation.claude_agent_sdk",
+    )
+
+    prepared = _prepare_spans_for_export([span])
+
+    assert len(prepared) == 2
+    child_attrs = prepared[1].attributes
+    assert child_attrs["gen_ai.completion.0.content"] == ""
+    assert json.loads(child_attrs["gen_ai.completion.0.tool_calls"]) == tool_calls
+    assert "Grep result" not in child_attrs[SpanAttributes.TRACELOOP_ENTITY_OUTPUT]
+
+
+def test_prepare_spans_rejects_non_assistant_completion_with_untyped_raw_output():
+    span = _make_span(
+        name="ClaudeAgentSDK.query", span_id=3106,
+        attributes={
+            "gen_ai.request.model": "claude-sonnet-4-5",
+            "gen_ai.completion.0.role": "tool",
+            "gen_ai.completion.0.content": "Grep result",
+            SpanAttributes.TRACELOOP_ENTITY_OUTPUT: "Grep result",
+        },
+        scope_name="openinference.instrumentation.claude_agent_sdk",
+    )
+
+    assert len(_prepare_spans_for_export([span])) == 1
+
+
+def test_enrichment_preserves_explicit_tool_completion_content():
+    span = _make_span(
+        name="chat", span_id=3107,
+        attributes={
+            "gen_ai.completion.0.role": "tool",
+            "gen_ai.completion.0.content": "",
+            "gen_ai.completion.0.tool_calls": json.dumps([{"id": "call_grep"}]),
+            "gen_ai.completion.1.role": "assistant",
+            "gen_ai.completion.1.content": "Assistant answer",
+        },
+    )
+
+    attrs = _prepare_spans_for_export([span])[0].attributes
+
+    assert attrs["gen_ai.completion.0.role"] == "tool"
+    assert attrs["gen_ai.completion.0.content"] == ""
+
+
+def test_prepare_spans_does_not_copy_tool_calls_from_a_tool_role_message():
+    span = _make_span(
+        name="invoke_agent assistant", span_id=3109,
+        attributes={
+            RESPAN_LOG_TYPE: "agent",
+            "gen_ai.completion.0.role": "tool",
+            "gen_ai.completion.0.content": "Grep result",
+            "gen_ai.completion.0.tool_calls": json.dumps([{"id": "not_an_assistant_call"}]),
+            "gen_ai.completion.1.role": "assistant",
+            "gen_ai.completion.1.content": "Assistant answer",
+        },
+        scope_name="opentelemetry.instrumentation.claude_agent_sdk",
+    )
+
+    prepared = _prepare_spans_for_export([span])
+
+    assert len(prepared) == 2
+    assert prepared[1].attributes["gen_ai.completion.0.content"] == "Assistant answer"
+    assert "gen_ai.completion.0.tool_calls" not in prepared[1].attributes
+
+
+@pytest.mark.parametrize("attributes", [
+    {"gen_ai.completion.0.role": "assistant", "gen_ai.completion.0.content": ""},
+    {
+        "gen_ai.completion.0.role": "assistant",
+        "gen_ai.completion.0.content": "",
+        "gen_ai.request.model": "claude-sonnet-4-5",
+        SpanAttributes.TRACELOOP_ENTITY_OUTPUT: "Grep result",
+    },
+    {SpanAttributes.TRACELOOP_ENTITY_OUTPUT: json.dumps({
+        "_is_placeholder": True, "role": "assistant", "content": "",
+    })},
+])
+def test_prepare_spans_does_not_treat_empty_assistant_placeholders_as_provenance(attributes):
+    span = _make_span(
+        name="Grep", span_id=3108,
+        attributes={RESPAN_LOG_TYPE: "agent", **attributes},
+        scope_name="opentelemetry.instrumentation.claude_agent_sdk",
+    )
+
+    assert len(_prepare_spans_for_export([span])) == 1
+
+
 def test_prepare_spans_remaps_tool_call_helpers_and_strips_helper_attrs():
     """Exporter remaps helper attrs to completion message fields before OTLP serialization."""
 


### PR DESCRIPTION
## Summary

Claude SDK tool results such as Grep output could be mislabeled as agent responses, coerced into assistant text, and exported as synthetic chat children. Require original assistant output or LLM metadata on a recognized response boundary before creating a child, and give tool execution identity precedence over inherited model/provider fields.

Filter explicit tool/user messages, roleless structured tool results, nested tool-result blocks, and empty placeholders during completion selection. Apply the same rules to enrichment so backfill cannot manufacture provenance or overwrite tool content. Genuine assistant text, emitted tool calls, and responses with content capture disabled remain supported.

## Release Intent

Add a `patch` intent for `respan-tracing`. The release pipeline resolves the final version; no manifest version is manually changed.

## Validation

- [x] Added 43 regression cases, including outgoing OTLP payload checks for unchanged Grep content and no synthetic child.
- [x] Built wheel installed into an isolated target directory; confirmed imports resolve from that wheel. Exporter, structured OTLP, and Claude instrumentation tests against the installed wheel: **95 passed**.
- [x] Source distribution and wheel build, release inventory/intent validation, and `git diff --check` passed.
- [x] Broader tracing tests compared against unchanged upstream `4496befb`: **273 passed / 21 failed** with this change versus **230 passed / the same 21 failed** on upstream. These failures involve existing API/test drift, missing OpenAI instrumentation, and shared tracing state. Three modules were excluded from this comparison after collection failed on removed `span_collector`/`is_root_span_candidate` APIs and the unavailable OpenAI instrumentation dependency.

Validation is local and includes the serialized export payload; no live platform-ingestion validation was performed.
