### PR TITLE
feat(instrumentation-py): respan-instrumentation-autogen - support legacy AutoGen for Agent-E and auto-news

### DIFF
--- a/.release-intents/20260906-autogen-legacy-api.json
+++ b/.release-intents/20260906-autogen-legacy-api.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Support legacy autogen chat, reply, and tool APIs alongside AgentChat",
+  "packages": {
+    "respan-instrumentation-autogen": "minor"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/README.md
@@ -1,8 +1,10 @@
 # respan-instrumentation-autogen
 
-Respan instrumentation plugin for AutoGen AgentChat. Wraps OpenInference's
-AutoGen AgentChat instrumentor and translates spans into the Respan tracing
-shape automatically.
+Respan instrumentation for modern AutoGen AgentChat and the legacy `autogen`
+API. The default `AutoGenInstrumentor()` wraps OpenInference's AgentChat
+instrumentor. Select `AutoGenInstrumentor(api="legacy")` for legacy
+`ConversableAgent`, `AssistantAgent`, `UserProxyAgent`, and `GroupChat` workflows.
+Both paths translate OpenInference spans into Respan's canonical attributes.
 
 ## Configuration
 
@@ -66,6 +68,93 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+## Legacy `autogen` (Agent-E and auto-news)
+
+Select the extra matching the application's installed SDK. The distributions
+share the `autogen` import namespace; do not combine the two extras in one
+environment. Modern AgentChat dependencies remain installed for compatibility
+with existing users, but legacy mode does not activate the AgentChat patches.
+
+```bash
+# auto-news's exact pin requires Python 3.11 (pyautogen 0.2.2 requires <3.12).
+pip install respan-ai 'respan-instrumentation-autogen[legacy-pyautogen]' \
+  'pyautogen==0.2.2' 'openai==1.109.1' respan-instrumentation-openai
+
+# In a separate environment, for Agent-E's autogen 0.7 API:
+pip install respan-ai 'respan-instrumentation-autogen[legacy-autogen]' \
+  'autogen==0.7.6' 'openai==1.109.1' respan-instrumentation-openai
+```
+
+`AutoGenInstrumentor()` continues to target modern AgentChat; select
+`api="legacy"` explicitly. Legacy mode records sync and async chat,
+reply, and function execution spans. Add the provider's instrumentor to record
+actual LLM requests, responses, model names, and usage. A function result is
+always tool content, including results containing an `assistant` role.
+
+```python
+import os
+
+from autogen import AssistantAgent, UserProxyAgent
+from respan import Respan
+from respan_instrumentation_autogen import AutoGenInstrumentor
+from respan_instrumentation_openai import OpenAIInstrumentor
+
+respan = Respan(
+    api_key=os.environ["RESPAN_API_KEY"],
+    is_auto_instrument=False,
+    instrumentations=[AutoGenInstrumentor(api="legacy"), OpenAIInstrumentor()],
+)
+assistant = AssistantAgent(
+    "assistant",
+    llm_config={
+        "model": "gpt-4o-mini",
+        "api_key": os.environ["OPENAI_API_KEY"],
+        "cache_seed": None,
+    },
+)
+user = UserProxyAgent(
+    "user",
+    llm_config=False,
+    human_input_mode="NEVER",
+    code_execution_config=False,
+    max_consecutive_auto_reply=0,
+)
+user.initiate_chat(assistant, message="Write one sentence about the news.")
+respan.flush()
+```
+
+The same setup supports `await user.a_initiate_chat(...)`. Respan's runtime
+propagates context into AutoGen's executor threads so provider spans stay under
+their calling agent. Return values remain the SDK's own values, including
+`None` from pyautogen 0.2.2 chats. The adapter also preserves function failure
+results and marks their tool spans as errors.
+
+The legacy dependency contract is `pyautogen>=0.2.2,<0.3` or
+`autogen>=0.7,<0.8`. Real SDK fixtures cover pyautogen 0.2.2 (auto-news) and
+autogen 0.7.6 (Agent-E's API family), with OpenAI 1.109.1 and OpenInference AG2
+0.1.6. These are integration compatibility tests, not full application runs.
+For example, Agent-E's separate `pydantic==2.6.2` pin must still be reconciled
+with the application's Respan SDK dependency before installing the full app.
+
+## Offline compatibility tests
+
+Run each legacy requirements file in its own virtual environment. Use Python
+3.11 for the exact pyautogen 0.2.2 fixture:
+
+```bash
+pip install -e . -r tests/requirements-legacy-pyautogen.txt
+python -m pytest tests -q
+
+# Separate environment:
+pip install -e . -r tests/requirements-legacy-autogen.txt
+python -m pytest tests -q
+```
+
+The fixtures execute the installed SDK's chats, GroupChat dispatch, synchronous
+and asynchronous functions, error paths, suppression, and repeated activation.
+The model roundtrip uses the actual legacy OpenAI wrapper and OpenAI client
+with a deterministic HTTP transport; no API keys or model service are needed.
 
 ## Further Reading
 

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "respan-instrumentation-autogen"
 version = "0.1.1"
-description = "Respan instrumentation plugin for AutoGen AgentChat"
+description = "Respan instrumentation plugin for AutoGen AgentChat and legacy autogen"
 authors = ["Respan <team@respan.ai>"]
 license = "Apache 2.0"
 readme = "README.md"
@@ -17,6 +17,13 @@ respan-instrumentation-openinference = ">=1.2.2"
 autogen-agentchat = ">=0.4.0"
 autogen-ext = { version = ">=0.4.0", extras = ["openai"] }
 openinference-instrumentation-autogen-agentchat = ">=0.1.0"
+openinference-instrumentation-ag2 = ">=0.1.6,<0.2"
+pyautogen = { version = ">=0.2.2,<0.3", optional = true }
+autogen = { version = ">=0.7,<0.8", optional = true }
+
+[tool.poetry.extras]
+legacy-pyautogen = ["pyautogen"]
+legacy-autogen = ["autogen"]
 
 [tool.poetry.plugins."respan.instrumentations"]
 autogen = "respan_instrumentation_autogen:AutoGenInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_instrumentation.py
@@ -165,17 +165,21 @@ def _load_openinference_autogen_agentchat_class() -> type:
 
 
 class AutoGenInstrumentor:
-    """Respan instrumentor for AutoGen AgentChat.
+    """Respan instrumentor for AgentChat or explicit ``api="legacy"`` autogen.
 
     Activates OpenInference's AutoGen AgentChat instrumentor and registers
     Respan's OpenInference translator so AutoGen spans reach the Respan OTLP
     pipeline with the expected ``traceloop.*``, ``gen_ai.*``, and
-    ``respan.*`` fields.
+    ``respan.*`` fields. Legacy mode adapts the upstream AG2 chat, reply and
+    tool wrappers; compose a provider instrumentor for actual LLM spans.
     """
 
     name = AUTOGEN_INSTRUMENTATION_NAME
 
-    def __init__(self, **instrumentor_kwargs: Any) -> None:
+    def __init__(self, *, api: str = "agentchat", **instrumentor_kwargs: Any) -> None:
+        if api not in ("agentchat", "legacy"):
+            raise ValueError("api must be 'agentchat' or 'legacy'")
+        self._api = api
         instrumentor_kwargs.pop(TRACER_PROVIDER_KWARG, None)
         self._instrumentor_kwargs = instrumentor_kwargs
         self._delegate = None
@@ -231,7 +235,7 @@ class AutoGenInstrumentor:
         return bool(getattr(tracer, "is_enabled", True))
 
     def activate(self) -> None:
-        """Instrument AutoGen AgentChat via OpenInference and Respan's translator."""
+        """Activate the selected AutoGen API and Respan's translator."""
         if self._is_instrumented:
             return
 
@@ -239,6 +243,10 @@ class AutoGenInstrumentor:
             logger.info(
                 "AutoGen instrumentation skipped because Respan tracing is disabled"
             )
+            return
+
+        if self._api == "legacy":
+            self._activate_legacy()
             return
 
         try:
@@ -287,6 +295,25 @@ class AutoGenInstrumentor:
             self._delegate = None
             self._is_instrumented = False
             logger.exception("Failed to activate AutoGen instrumentation")
+
+    def _activate_legacy(self) -> None:
+        from respan_instrumentation_autogen._legacy import LegacyAutoGenInstrumentor
+
+        try:
+            self._delegate = OpenInferenceInstrumentor(
+                LegacyAutoGenInstrumentor, **self._instrumentor_kwargs
+            )
+            self._delegate.activate()
+            if not LegacyAutoGenInstrumentor().is_instrumented_by_opentelemetry:
+                raise RuntimeError("Install a supported legacy-pyautogen or legacy-autogen extra")
+            self._is_instrumented = True
+            logger.info("Legacy AutoGen instrumentation activated")
+        except Exception:
+            if self._delegate is not None:
+                self._delegate.deactivate()
+            self._delegate = None
+            self._is_instrumented = False
+            logger.exception("Failed to activate legacy AutoGen instrumentation")
 
     def deactivate(self) -> None:
         """Deactivate the instrumentation."""

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_legacy.py
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/src/respan_instrumentation_autogen/_legacy.py
@@ -1,0 +1,162 @@
+"""Adapt OpenInference's AG2 wrappers to the earlier ``autogen`` APIs."""
+
+from __future__ import annotations
+
+from functools import wraps
+from importlib.metadata import PackageNotFoundError, version
+from inspect import getattr_static
+from typing import Any
+
+from openinference.instrumentation import OITracer, TraceConfig
+from openinference.instrumentation.ag2 import AG2Instrumentor
+from openinference.instrumentation.ag2._wrappers import (
+    _ChatWrapper,
+    _ReplyWrapper,
+    _ToolWrapper,
+)
+from opentelemetry import trace
+from opentelemetry.instrumentation.dependencies import get_dependency_conflicts
+from wrapt import wrap_function_wrapper
+
+
+class _ChatResult:
+    def __init__(self, result: Any, agent: Any, recipient: Any) -> None:
+        self.result = result
+        self.chat_history = agent.chat_messages.get(recipient, [])
+
+
+class _LegacyChatWrapper(_ChatWrapper):
+    def _span(self, instance: Any, method: str, bound: Any) -> Any:
+        # pyautogen 0.2.2 accepts message inside **context and returns None.
+        bound = {**bound.get("context", {}), **bound}
+        return super()._span(instance, method, bound)
+
+    def __call__(self, wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:
+        @wraps(wrapped)
+        def with_result(*call_args: Any, **call_kwargs: Any) -> Any:
+            result = wrapped(*call_args, **call_kwargs)
+            recipient = call_kwargs.get("recipient", call_args[0] if call_args else None)
+            return _ChatResult(result, instance, recipient) if result is None else result
+
+        result = super().__call__(with_result, instance, args, kwargs)
+        return result.result if isinstance(result, _ChatResult) else result
+
+    async def async_call(self, wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:
+        @wraps(wrapped)
+        async def with_result(*call_args: Any, **call_kwargs: Any) -> Any:
+            result = await wrapped(*call_args, **call_kwargs)
+            recipient = call_kwargs.get("recipient", call_args[0] if call_args else None)
+            return _ChatResult(result, instance, recipient) if result is None else result
+
+        result = await super().async_call(with_result, instance, args, kwargs)
+        return result.result if isinstance(result, _ChatResult) else result
+
+
+class _LegacyReplyWrapper(_ReplyWrapper):
+    def _span(self, instance: Any, method: str, bound: Any) -> Any:
+        if bound.get("messages") is None:
+            bound = {**bound, "messages": instance.chat_messages.get(bound.get("sender"), [])}
+        return super()._span(instance, method, bound)
+
+
+class _LegacyToolWrapper(_ToolWrapper):
+    @staticmethod
+    def _normalized_call(args: Any, kwargs: Any) -> Any:
+        # The traced and suppressed paths must retain the SDK's validation,
+        # including its rejection of a bare string instead of a function dict.
+        return args, kwargs
+
+
+def _gate(wrapper: Any, generation: dict[str, bool]) -> Any:
+    def call(wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:
+        if not generation["enabled"]:
+            return wrapped(*args, **kwargs)
+        return wrapper(wrapped, instance, args, kwargs)
+
+    return call
+
+
+class LegacyAutoGenInstrumentor(AG2Instrumentor):
+    """Use the upstream lifecycle and wrappers with verified legacy contracts.
+
+    AG2's default dependency check excludes pyautogen 0.2. These versions share
+    the six ConversableAgent methods but differ in chat arguments and results.
+    """
+
+    # BaseInstrumentor is a per-class singleton; never inherit an already
+    # constructed AG2Instrumentor instance from the parent class.
+    _instance = None
+
+    def _check_dependency_conflicts(self) -> Any:
+        requirements = ("pyautogen>=0.2.2,<0.3", "autogen>=0.7,<0.8")
+        conflicts = [get_dependency_conflicts([requirement]) for requirement in requirements]
+        return None if any(conflict is None for conflict in conflicts) else conflicts[0]
+
+    def _instrument(self, **kwargs: Any) -> None:
+        import autogen
+        from autogen import ConversableAgent
+
+        if AG2Instrumentor().is_instrumented_by_opentelemetry:
+            raise RuntimeError("Deactivate the existing AG2 instrumentor before activating legacy AutoGen")
+
+        installed = []
+        for distribution in ("pyautogen", "autogen", "ag2"):
+            try:
+                installed.append((distribution, version(distribution)))
+            except PackageNotFoundError:
+                pass
+        # autogen 0.7 is a metapackage for pyautogen of the same version.
+        if not installed or any(item[1] != autogen.__version__ for item in installed):
+            raise RuntimeError(
+                "Legacy AutoGen requires matching autogen distribution versions; "
+                "install either pyautogen 0.2.x or autogen 0.7.x in a clean environment"
+            )
+
+        config = kwargs.get("config") or TraceConfig()
+        if not isinstance(config, TraceConfig):
+            raise TypeError("config must be an instance of TraceConfig")
+        self._tracer = OITracer(
+            trace.get_tracer(
+                "openinference.instrumentation.ag2",
+                tracer_provider=kwargs.get("tracer_provider"),
+            ),
+            config=config,
+        )
+        chat, reply, tool = (
+            _LegacyChatWrapper(self._tracer),
+            _LegacyReplyWrapper(self._tracer),
+            _LegacyToolWrapper(self._tracer),
+        )
+        wrappers = {
+            "initiate_chat": chat,
+            "a_initiate_chat": chat.async_call,
+            "generate_reply": reply,
+            "a_generate_reply": reply.async_call,
+            "execute_function": tool,
+            "a_execute_function": tool.async_call,
+        }
+        self._original_methods = {name: getattr_static(ConversableAgent, name) for name in wrappers}
+        self._installed_methods = {}
+        self._generation = {"enabled": False}
+        try:
+            for name, wrapper in wrappers.items():
+                wrap_function_wrapper(ConversableAgent, name, _gate(wrapper, self._generation))
+                self._installed_methods[name] = getattr_static(ConversableAgent, name)
+            self._generation["enabled"] = True
+        except BaseException:
+            self._uninstrument()
+            raise
+
+    def _uninstrument(self, **kwargs: Any) -> None:
+        from autogen import ConversableAgent
+
+        # Another library may wrap our method after activation. Retain that
+        # wrapper and disable our captured generation so it becomes inert,
+        # including after a later activation creates a new generation.
+        if generation := getattr(self, "_generation", None):
+            generation["enabled"] = False
+        for name, original in getattr(self, "_original_methods", {}).items():
+            if getattr_static(ConversableAgent, name) is self._installed_methods.get(name):
+                setattr(ConversableAgent, name, original)
+        self._original_methods = {}
+        self._installed_methods = {}

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/tests/requirements-legacy-autogen.txt
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/tests/requirements-legacy-autogen.txt
@@ -1,0 +1,6 @@
+# Agent-E uses autogen~=0.7; pin a reproducible representative of that API.
+autogen==0.7.6
+openai==1.109.1
+httpx==0.28.1
+respan-instrumentation-openai==1.2.2
+pytest>=8

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/tests/requirements-legacy-pyautogen.txt
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/tests/requirements-legacy-pyautogen.txt
@@ -1,0 +1,6 @@
+# Python 3.11: auto-news pins this SDK, which requires Python <3.12.
+pyautogen==0.2.2
+openai==1.109.1
+httpx==0.28.1
+respan-instrumentation-openai==1.2.2
+pytest>=8

--- a/python-sdks/instrumentations/respan-instrumentation-autogen/tests/test_legacy_integration.py
+++ b/python-sdks/instrumentations/respan-instrumentation-autogen/tests/test_legacy_integration.py
@@ -1,0 +1,292 @@
+"""Real legacy SDK fixtures; only the OpenAI HTTP transport is deterministic.
+
+Run in separate environments with tests/requirements-legacy-*.txt. No AutoGen
+classes or methods are mocked: chats, reply dispatch, functions and GroupChat
+all execute the installed library.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+autogen = pytest.importorskip("autogen")
+
+from opentelemetry import context as context_api, trace
+from opentelemetry.instrumentation.threading import ThreadingInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from respan_instrumentation_autogen import AutoGenInstrumentor
+from respan_tracing.core.tracer import RespanTracer
+
+
+@pytest.fixture
+def tracing(monkeypatch):
+    RespanTracer.reset_instance()
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: provider)
+    plugin = AutoGenInstrumentor(api="legacy")
+    plugin.activate()
+    assert plugin._is_instrumented
+    yield provider, exporter, plugin
+    plugin.deactivate()
+    provider.shutdown()
+    RespanTracer.reset_instance()
+
+
+def agent(name, **kwargs):
+    return autogen.ConversableAgent(
+        name, llm_config=False, human_input_mode="NEVER",
+        code_execution_config=False, max_consecutive_auto_reply=1, **kwargs,
+    )
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_real_chat_preserves_return_value_and_history(tracing, asynchronous):
+    provider, exporter, _ = tracing
+    sender = agent("sender", default_auto_reply="sender reply")
+    recipient = agent("recipient", default_auto_reply="recipient reply")
+    with provider.get_tracer("test").start_as_current_span("parent") as parent:
+        if asynchronous:
+            result = asyncio.run(sender.a_initiate_chat(recipient, message="hello", silent=True))
+        else:
+            result = sender.initiate_chat(recipient, message="hello", silent=True)
+    if autogen.__version__ == "0.2.2":
+        assert result is None
+    else:
+        assert isinstance(result, autogen.ChatResult)
+        assert result.chat_history == sender.chat_messages[recipient]
+    spans = [span for span in exporter.get_finished_spans() if span.name != "parent"]
+    chat = next(span for span in spans if "initiate_chat" in span.name)
+    assert chat.parent.span_id == parent.get_span_context().span_id
+    assert json.loads(chat.attributes["traceloop.entity.input"])["message"] == "hello"
+    assert json.loads(chat.attributes["traceloop.entity.output"]) == sender.chat_messages[recipient][-1]["content"]
+    replies = [span for span in spans if "generate_reply" in span.name]
+    assert replies
+    assert json.loads(replies[0].attributes["traceloop.entity.input"])[0]["content"] == "hello"
+    assert all(span.parent.span_id == chat.context.span_id for span in replies)
+    assert {span.attributes["respan.entity.log_type"] for span in spans} == {"agent"}
+    assert not any(key.startswith("gen_ai.") for span in spans for key in span.attributes)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("failure", [False, True])
+def test_real_tool_outputs_and_failure_status(tracing, asynchronous, failure):
+    _, exporter, _ = tracing
+
+    def search(query):
+        if failure:
+            raise ValueError("search failed")
+        return {"role": "assistant", "content": "ordinary tool result", "query": query}
+
+    async def async_search(query):
+        return search(query)
+
+    executor = agent("executor", function_map={"search": async_search if asynchronous else search})
+    call = {"name": "search", "arguments": '{"query":"legacy"}'}
+    result = asyncio.run(executor.a_execute_function(call)) if asynchronous else executor.execute_function(call)
+    assert result[0] is not failure
+    span, = exporter.get_finished_spans()
+    assert span.attributes["respan.entity.log_type"] == "tool"
+    assert json.loads(span.attributes["traceloop.entity.input"]) == call
+    output = json.loads(span.attributes["traceloop.entity.output"])
+    assert output[0] is not failure
+    assert "search failed" in str(output) if failure else "ordinary tool result" in str(output)
+    assert span.status.status_code is (trace.StatusCode.ERROR if failure else trace.StatusCode.OK)
+    assert not any(key.startswith("gen_ai.") for key in span.attributes)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_suppression_preserves_results_without_spans(tracing, asynchronous):
+    _, exporter, _ = tracing
+    speaker = agent("speaker", default_auto_reply="reply", function_map={"echo": lambda: "tool"})
+    token = context_api.attach(context_api.set_value(context_api._SUPPRESS_INSTRUMENTATION_KEY, True))
+    try:
+        if asynchronous:
+            from respan_instrumentation_autogen._legacy import LegacyAutoGenInstrumentor
+            original = LegacyAutoGenInstrumentor()._original_methods["a_generate_reply"]
+            expected = asyncio.run(original(agent("control", default_auto_reply="reply"), messages=[{"role": "user", "content": "hi"}]))
+            assert asyncio.run(speaker.a_generate_reply(messages=[{"role": "user", "content": "hi"}])) == expected
+            assert asyncio.run(speaker.a_execute_function({"name": "echo", "arguments": "{}"}))[1]["content"] == "tool"
+        else:
+            assert speaker.generate_reply(messages=[{"role": "user", "content": "hi"}]) == "reply"
+            assert speaker.execute_function({"name": "echo", "arguments": "{}"})[1]["content"] == "tool"
+    finally:
+        context_api.detach(token)
+    assert not exporter.get_finished_spans()
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_reply_exception_propagates_once_and_context_is_restored(tracing, asynchronous):
+    _, exporter, _ = tracing
+    speaker = agent("speaker")
+
+    def fail(*args, **kwargs):
+        raise ValueError("reply failed")
+
+    speaker.register_reply([autogen.Agent, None], fail, position=0)
+    with pytest.raises(ValueError, match="reply failed"):
+        if asynchronous:
+            asyncio.run(speaker.a_generate_reply(messages=[{"role": "user", "content": "hi"}]))
+        else:
+            speaker.generate_reply(messages=[{"role": "user", "content": "hi"}])
+    span, = exporter.get_finished_spans()
+    assert span.status.status_code is trace.StatusCode.ERROR
+    assert len([event for event in span.events if event.name == "exception"]) == 1
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+def test_legacy_plugins_share_and_restore_all_six_methods(tracing):
+    _, exporter, first = tracing
+    from respan_instrumentation_autogen._legacy import LegacyAutoGenInstrumentor
+    originals = dict(LegacyAutoGenInstrumentor()._original_methods)
+    second = AutoGenInstrumentor(api="legacy")
+    second.activate()
+    first.deactivate()
+    agent("speaker", default_auto_reply="reply").generate_reply(messages=[{"role": "user", "content": "hi"}])
+    assert len(exporter.get_finished_spans()) == 1
+    second.deactivate()
+    assert all(getattr(autogen.ConversableAgent, name) is method for name, method in originals.items())
+    second.deactivate()
+    first.activate()
+    first.deactivate()
+    assert all(getattr(autogen.ConversableAgent, name) is method for name, method in originals.items())
+
+
+@pytest.mark.parametrize("suppressed", [False, True])
+def test_invalid_tool_call_keeps_sdk_validation_without_executing(tracing, suppressed):
+    _, exporter, _ = tracing
+    calls = []
+    executor = agent("executor", function_map={"ping": lambda: calls.append("executed")})
+    token = context_api.attach(context_api.set_value(context_api._SUPPRESS_INSTRUMENTATION_KEY, suppressed))
+    try:
+        with pytest.raises(AttributeError):
+            executor.execute_function("ping")
+    finally:
+        context_api.detach(token)
+    assert not calls
+    assert len(exporter.get_finished_spans()) == (0 if suppressed else 1)
+
+
+def test_teardown_preserves_later_wrappers_and_reactivation_does_not_duplicate(tracing):
+    _, exporter, plugin = tracing
+    from respan_instrumentation_autogen._legacy import LegacyAutoGenInstrumentor
+    original = LegacyAutoGenInstrumentor()._original_methods["generate_reply"]
+    installed = autogen.ConversableAgent.generate_reply
+    seen = []
+
+    def external(self, *args, **kwargs):
+        seen.append(self.name)
+        return installed(self, *args, **kwargs)
+
+    autogen.ConversableAgent.generate_reply = external
+    try:
+        plugin.deactivate()
+        assert autogen.ConversableAgent.generate_reply is external
+        agent("inactive", default_auto_reply="reply").generate_reply(messages=[{"role": "user", "content": "hi"}])
+        assert not exporter.get_finished_spans()
+        plugin.activate()
+        agent("active", default_auto_reply="reply").generate_reply(messages=[{"role": "user", "content": "hi"}])
+        assert len(exporter.get_finished_spans()) == 1
+        plugin.deactivate()
+        assert autogen.ConversableAgent.generate_reply is external
+        assert seen == ["inactive", "active"]
+    finally:
+        plugin.deactivate()
+        autogen.ConversableAgent.generate_reply = original
+
+
+def test_real_group_chat_dispatch(tracing):
+    _, exporter, _ = tracing
+    writer = agent("writer", default_auto_reply="draft")
+    editor = agent("editor", default_auto_reply="approved")
+    group = autogen.GroupChat(agents=[writer, editor], messages=[], max_round=3, speaker_selection_method="round_robin")
+    manager = autogen.GroupChatManager(groupchat=group, llm_config=False, human_input_mode="NEVER", code_execution_config=False)
+    writer.initiate_chat(manager, message="write news", silent=True)
+    assert [item["content"] for item in group.messages] == ["write news", "approved", "draft"]
+    spans = exporter.get_finished_spans()
+    chat = next(span for span in spans if span.name == "writer.initiate_chat")
+    manager_span = next(span for span in spans if span.name == "chat_manager.generate_reply")
+    assert manager_span.parent.span_id == chat.context.span_id
+    assert {span.attributes["traceloop.entity.name"] for span in spans} >= {"writer", "editor", "chat_manager"}
+
+
+def test_modern_agentchat_can_run_alongside_legacy(tracing):
+    from autogen_agentchat.agents import AssistantAgent
+    from autogen_ext.models.replay import ReplayChatCompletionClient
+
+    _, exporter, legacy = tracing
+    modern = AutoGenInstrumentor()
+    modern.activate()
+    assert modern._is_instrumented
+    try:
+        model_client = ReplayChatCompletionClient(["modern answer"])
+        assistant = AssistantAgent("modern", model_client=model_client)
+        result = asyncio.run(assistant.run(task="modern question"))
+        assert result.messages[-1].content == "modern answer"
+        modern_spans = exporter.get_finished_spans()
+        assert any("modern answer" in span.attributes.get("traceloop.entity.output", "") for span in modern_spans)
+        modern.deactivate()
+        exporter.clear()
+        assert legacy._is_instrumented
+        agent("legacy", default_auto_reply="legacy answer").generate_reply(messages=[{"role": "user", "content": "legacy question"}])
+        span, = exporter.get_finished_spans()
+        assert json.loads(span.attributes["traceloop.entity.output"]) == "legacy answer"
+    finally:
+        modern.deactivate()
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_real_llm_function_roundtrip_composes_with_provider_instrumentation(tracing, asynchronous):
+    httpx = pytest.importorskip("httpx")
+    provider_module = pytest.importorskip("respan_instrumentation_openai")
+    _, exporter, _ = tracing
+    requests = []
+
+    def transport(request):
+        body = json.loads(request.content)
+        requests.append(body)
+        message = ({"role": "assistant", "content": None, "function_call": {"name": "search", "arguments": '{"query":"news"}'}}
+                   if len(requests) == 1 else {"role": "assistant", "content": "done"})
+        return httpx.Response(200, json={"id": f"chatcmpl-{len(requests)}", "object": "chat.completion", "created": 1,
+            "model": "gpt-4o-mini", "choices": [{"index": 0, "message": message, "finish_reason": "function_call" if len(requests) == 1 else "stop"}],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}})
+
+    class FixtureClient(httpx.Client):
+        def __deepcopy__(self, memo):
+            return self
+
+    client = FixtureClient(transport=httpx.MockTransport(transport))
+    provider_plugin = provider_module.OpenAIInstrumentor()
+    provider_plugin.activate()
+    # RespanTracer normally installs this bridge for run_in_executor itself.
+    threading = ThreadingInstrumentor()
+    threading.instrument()
+    try:
+        assistant = autogen.AssistantAgent("assistant", llm_config={"model": "gpt-4o-mini", "api_key": "fixture-key",
+            "base_url": "http://fixture.invalid/v1", "http_client": client, "cache_seed": None,
+            "functions": [{"name": "search", "description": "Search news", "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]}}]})
+        user = autogen.UserProxyAgent("user", llm_config=False, human_input_mode="NEVER", code_execution_config=False,
+            max_consecutive_auto_reply=3, is_termination_msg=lambda message: message.get("content") == "done",
+            function_map={"search": lambda query: "tool-only news"})
+        result = asyncio.run(user.a_initiate_chat(assistant, message="find news", silent=True)) if asynchronous else user.initiate_chat(assistant, message="find news", silent=True)
+        assert result is None if autogen.__version__ == "0.2.2" else isinstance(result, autogen.ChatResult)
+    finally:
+        threading.uninstrument()
+        provider_plugin.deactivate()
+        client.close()
+    assert len(requests) == 2
+    assert any(item.get("role") == "function" and item["content"] == "tool-only news" for item in requests[1]["messages"])
+    spans = exporter.get_finished_spans()
+    llms = [span for span in spans if span.attributes.get("respan.entity.log_type") == "chat"]
+    tools = [span for span in spans if span.attributes.get("respan.entity.log_type") == "tool"]
+    assert len(llms) == 2
+    assert len(tools) == 1
+    assert {span.attributes["gen_ai.request.model"] for span in llms} == {"gpt-4o-mini"}
+    assert all(span.attributes["gen_ai.usage.input_tokens"] == 11 for span in llms)
+    by_id = {span.context.span_id: span for span in spans}
+    assert all(by_id[span.parent.span_id].attributes["respan.entity.log_type"] == "agent" for span in llms + tools)
+    assert len({span.context.trace_id for span in spans}) == 1


### PR DESCRIPTION
## Summary

`respan-instrumentation-autogen` only instrumented modern AgentChat, leaving legacy `autogen` applications such as Agent-E and auto-news untraced. Add explicit `AutoGenInstrumentor(api="legacy")` support using OpenInference AG2 wrappers adapted to the older chat arguments, implicit message history, and return values. The default remains modern AgentChat.

Separate `legacy-pyautogen` and `legacy-autogen` extras declare the supported namespace owners. Legacy mode preserves sync/async chat, reply, and tool behavior, including pyautogen 0.2.2's `None` chat return, suppression, failures, and teardown ownership. The README shows explicit provider instrumentation for actual LLM spans.

## Release Intent

Add a `minor` release intent for `respan-instrumentation-autogen`; no manual manifest version bump.

## Validation

- **36 tests passed in each environment:** built-wheel `pyautogen==0.2.2` on Python 3.11, `autogen==0.7.6` on Python 3.12, and `pyautogen==0.2.35`. Covers sync/async conversations, GroupChat, tool results/errors, suppression, activation/teardown, and modern AgentChat 0.7.5 coexistence.
- Actual legacy OpenAI wrapper and client with deterministic HTTP transport: two LLM calls, one function execution, matching model/usage, and connected agent parents. No AutoGen modules are stubbed.
- Independently executed [Agent-E's unchanged sequential tool executor](https://github.com/EmergenceAI/Agent-E/blob/f218c3cb4b2b3e33ed08ea12da5514ab1e89cdd7/ae/utils/autogen_sequential_function_call.py): navigation executes once, the subsequent tool remains skipped, async tool output is preserved, and exactly two canonical tool spans are exported.
- Source distribution/wheel build, built-wheel import and runtime checks, dependency consistency, release metadata validation, and `git diff --check`.

These are package and bounded target-method checks, not full application runs or live Respan ingestion tests. Agent-E's separate `pydantic==2.6.2` application pin still needs reconciliation with its Respan SDK dependency.
