### PR TITLE
fix(instrumentation-py): respan-instrumentation-google-adk - support ADK 1.5 for MultiAgentPPT

### DIFF
--- a/.release-intents/20260906-google-adk-1.5-compatibility.json
+++ b/.release-intents/20260906-google-adk-1.5-compatibility.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Support Google ADK 1.5 and correct its output token normalization",
+  "packages": {
+    "respan-instrumentation-google-adk": "patch"
+  }
+}

--- a/python-sdks/instrumentations/respan-instrumentation-google-adk/README.md
+++ b/python-sdks/instrumentations/respan-instrumentation-google-adk/README.md
@@ -32,3 +32,53 @@ respan = Respan(instrumentations=[GoogleADKInstrumentor()])
 
 Any Google ADK runs started after initialization are traced and exported to
 Respan.
+
+## Compatibility
+
+Requires Python 3.11–3.13, Google ADK 1.5.0 or newer, and OpenInference Google
+ADK instrumentation 0.1.12 or newer. Existing projects can keep their ADK pin:
+
+```bash
+pip install respan-instrumentation-google-adk "google-adk==1.5.0"
+```
+
+ADK versions below 1.17 use an iterator bridge around the upstream runner and
+agent hooks. This enters OpenInference's async iterator when legacy parallel
+agents advance it directly. Each iterator runs in its own task, advancing only
+when the consumer requests an event and closing in its original context. It also
+works with custom agents that imported ADK's legacy `_merge_agent_run` helper
+before activation. Deactivation restores the upstream methods.
+
+Activate one Respan Google ADK adapter per process. If another adapter or an
+independently activated OpenInference Google ADK instrumentor already owns the
+hooks, activation logs a warning and leaves that owner in control.
+
+The processor normalizes actual response usage into both modern and legacy
+token fields. This corrects ADK 1.5's native output-token field, which contains
+the total token count. Tool execution stays tool content, including results
+carried into the next model request.
+
+The offline runtime tests exercise installed ADK and OpenInference packages:
+`Runner.run`/`run_async`, session state and model callbacks, sequential and
+parallel agents, custom `BaseAgent` subclasses, sync/async tools, SSE response
+events, errors, suppression, deactivation, and legacy generator cleanup. Model
+responses are deterministic fixtures; no provider credentials are needed.
+
+| Google ADK | OpenInference Google ADK | Validation |
+| --- | --- | --- |
+| 1.5.0 | 0.1.12 and 0.1.25 | Legacy and common runtime tests |
+| 1.17.0 | 0.1.25 | Common runtime tests; legacy-only tests skipped |
+| 2.8.0 | 0.1.25 | Common runtime tests; legacy-only tests skipped |
+
+The legacy fixtures follow the APIs used by
+[MultiAgentPPT](https://github.com/johnson7788/MultiAgentPPT/tree/ce8185cee83092290bdb913a528c6e3a72ee879e)
+and its `google-adk==1.5.0` pin. They cover the ADK execution path; they do not
+validate that application's external services or presentation rendering.
+
+Run the package tests from this directory in an environment with the desired
+ADK version:
+
+```bash
+pip install -e . pytest "google-adk==1.5.0"
+python -m pytest tests -q
+```

--- a/python-sdks/instrumentations/respan-instrumentation-google-adk/pyproject.toml
+++ b/python-sdks/instrumentations/respan-instrumentation-google-adk/pyproject.toml
@@ -13,8 +13,9 @@ packages = [
 python = ">=3.11,<3.14"
 respan-tracing = "^2.16.1"
 respan-instrumentation-openinference = ">=1.2.2"
-google-adk = ">=1.17.0"
+google-adk = ">=1.5.0"
 openinference-instrumentation-google-adk = ">=0.1.12"
+packaging = ">=21.0"
 
 [tool.poetry.plugins."respan.instrumentations"]
 google-adk = "respan_instrumentation_google_adk:GoogleADKInstrumentor"

--- a/python-sdks/instrumentations/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/_compat.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/_compat.py
@@ -1,0 +1,164 @@
+"""Bridge legacy ADK's direct, cross-task advancement of async generators."""
+
+from __future__ import annotations
+
+import asyncio
+from contextvars import ContextVar, copy_context
+from functools import wraps
+from importlib.metadata import version
+from typing import Any, Callable
+
+from packaging.version import Version
+
+_owned_llm_generators: ContextVar[list | None] = ContextVar(
+    "respan_adk_owned_llm_generators", default=None
+)
+
+
+async def _drive_iterator(source, requests):
+    # OI instruments __aiter__, whereas legacy ParallelAgent (and custom
+    # agents importing _merge_agent_run) calls __anext__ directly.
+    iterator = source.__aiter__()
+    llm_generators = []
+    token = _owned_llm_generators.set(llm_generators)
+    try:
+        while True:
+            method, args, result = await requests.get()
+            try:
+                value = await getattr(iterator, method)(*args)
+            except BaseException as exc:
+                if not result.done():
+                    result.set_exception(exc)
+                return
+            else:
+                if not result.done():
+                    result.set_result(value)
+    finally:
+        try:
+            # ADK 1.5 leaves _call_llm_async suspended after yielding a response.
+            # Close those inner span scopes before the outer agent scope, in
+            # the task/context where their context tokens were created.
+            for generator in reversed(llm_generators):
+                await generator.aclose()
+        finally:
+            try:
+                await iterator.aclose()
+            finally:
+                try:
+                    if source is not iterator:
+                        await source.aclose()
+                finally:
+                    _owned_llm_generators.reset(token)
+
+
+class _ContextPreservingIterator:
+    def __init__(self, source: Any) -> None:
+        self._source = source
+        self._context = copy_context()
+        self._requests: asyncio.Queue | None = None
+        self._worker: asyncio.Task | None = None
+        self._closed = False
+        self._advancing = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._advance("__anext__")
+
+    async def asend(self, value):
+        return await self._advance("asend", value)
+
+    async def athrow(self, *args):
+        return await self._advance("athrow", *args)
+
+    async def _advance(self, method, *args):
+        if self._closed:
+            raise StopAsyncIteration
+        if self._advancing:
+            raise RuntimeError("Agent async generator is already running")
+        if self._worker is None:
+            self._requests = asyncio.Queue()
+            # Keep a demand-driven worker alive between events. Besides keeping
+            # context tokens in their original context, this closes generators
+            # in that context when asyncio.run cancels tasks during shutdown.
+            self._worker = asyncio.create_task(
+                _drive_iterator(self._source, self._requests), context=self._context
+            )
+        self._advancing = True
+        result = asyncio.get_running_loop().create_future()
+        self._requests.put_nowait((method, args, result))
+        try:
+            return await result
+        except BaseException:
+            await self.aclose()
+            raise
+        finally:
+            self._advancing = False
+
+    async def aclose(self):
+        self._closed = True
+        if self._worker is not None:
+            if not self._worker.done():
+                self._worker.cancel()
+            await asyncio.gather(self._worker, return_exceptions=True)
+        else:
+            await self._source.aclose()
+
+    def __del__(self):
+        # The worker holds the source, not this adapter, so dropping an iterator
+        # also closes it without scheduling an async-generator finalizer race.
+        worker = self._worker
+        if (
+            worker is not None
+            and not worker.done()
+            and not worker.get_loop().is_closed()
+        ):
+            worker.cancel()
+
+
+def patch_legacy_agent_iterator() -> Callable[[], None] | None:
+    """Return an undo callback; modern ADK keeps its existing upstream path."""
+    if Version(version("google-adk")) >= Version("1.17.0"):
+        return None
+
+    from google.adk import Runner
+    from google.adk.agents import BaseAgent
+    from google.adk.flows.llm_flows.base_llm_flow import BaseLlmFlow
+
+    originals = []
+
+    def wrap(original):
+        @wraps(original)
+        def run_async(self, *args, **kwargs):
+            bound = original.__get__(self, type(self))
+            return _ContextPreservingIterator(bound(*args, **kwargs))
+
+        return run_async
+
+    for cls in (BaseAgent, Runner):
+        original = cls.run_async
+        replacement = wrap(original)
+        cls.run_async = replacement
+        originals.append((cls, "run_async", original, replacement))
+
+    original_llm_call = BaseLlmFlow._call_llm_async
+
+    @wraps(original_llm_call)
+    def call_llm_async(self, *args, **kwargs):
+        generator = original_llm_call(self, *args, **kwargs)
+        if (owned := _owned_llm_generators.get()) is not None:
+            owned.append(generator)
+        return generator
+
+    BaseLlmFlow._call_llm_async = call_llm_async
+    originals.append(
+        (BaseLlmFlow, "_call_llm_async", original_llm_call, call_llm_async)
+    )
+
+    def undo():
+        for cls, name, original, replacement in reversed(originals):
+            if getattr(cls, name) is replacement:
+                setattr(cls, name, original)
+
+    return undo

--- a/python-sdks/instrumentations/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/_instrumentation.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from opentelemetry import trace
+from respan_instrumentation_google_adk._compat import patch_legacy_agent_iterator
 from respan_instrumentation_google_adk._processor import (
     GoogleADKSpanProcessor,
     insert_span_processor_before_export,
@@ -37,6 +38,7 @@ class GoogleADKInstrumentor:
         self._instrumentor_kwargs = dict(instrumentor_kwargs)
         self._instrumentor = None
         self._processor = None
+        self._undo_legacy_iterator = None
         self._is_instrumented = False
 
     @staticmethod
@@ -68,16 +70,35 @@ class GoogleADKInstrumentor:
 
         tracer_provider = trace.get_tracer_provider()
         try:
+            upstream = google_adk_instrumentor_class()
+            if getattr(upstream, "is_instrumented_by_opentelemetry", False):
+                logger.warning(
+                    "Google ADK instrumentation is already active under another "
+                    "owner; deactivate that owner before activating this adapter"
+                )
+                return
             self._processor = GoogleADKSpanProcessor()
             insert_span_processor_before_export(tracer_provider, self._processor)
-            self._instrumentor = google_adk_instrumentor_class()
+            self._instrumentor = upstream
             self._instrumentor.instrument(
                 tracer_provider=tracer_provider,
                 **self._instrumentor_kwargs,
             )
+            # OTel instrumentors may log dependency conflicts and return without
+            # raising. Do not report an active adapter or retain its processor.
+            if not getattr(
+                self._instrumentor, "is_instrumented_by_opentelemetry", True
+            ):
+                raise RuntimeError(
+                    "OpenInference Google ADK instrumentation did not activate"
+                )
+            self._undo_legacy_iterator = patch_legacy_agent_iterator()
             self._is_instrumented = True
             logger.info("Google ADK instrumentation activated")
         except Exception:
+            if self._undo_legacy_iterator is not None:
+                self._undo_legacy_iterator()
+                self._undo_legacy_iterator = None
             if self._instrumentor is not None:
                 try:
                     self._instrumentor.uninstrument()
@@ -93,6 +114,9 @@ class GoogleADKInstrumentor:
     def deactivate(self) -> None:
         """Deactivate the instrumentation."""
         tracer_provider = trace.get_tracer_provider()
+        if self._undo_legacy_iterator is not None:
+            self._undo_legacy_iterator()
+            self._undo_legacy_iterator = None
         if self._is_instrumented and self._instrumentor is not None:
             try:
                 self._instrumentor.uninstrument()

--- a/python-sdks/instrumentations/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/_processor.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-adk/src/respan_instrumentation_google_adk/_processor.py
@@ -505,28 +505,22 @@ def _apply_google_adk_payload_fallbacks(
             if isinstance(usage, dict):
                 prompt_tokens = usage.get("prompt_token_count")
                 if isinstance(prompt_tokens, int):
-                    attrs.setdefault(
-                        TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS,
-                        prompt_tokens,
-                    )
-                    attrs.setdefault(GEN_AI_USAGE_INPUT_TOKENS, prompt_tokens)
+                    attrs[TLSpanAttributes.LLM_USAGE_PROMPT_TOKENS] = prompt_tokens
+                    attrs[GEN_AI_USAGE_INPUT_TOKENS] = prompt_tokens
 
                 completion_tokens = usage.get("candidates_token_count")
                 thoughts_tokens = usage.get("thoughts_token_count")
                 if isinstance(completion_tokens, int):
                     if isinstance(thoughts_tokens, int):
                         completion_tokens += thoughts_tokens
-                    attrs.setdefault(
-                        TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
-                        completion_tokens,
-                    )
-                    attrs.setdefault(GEN_AI_USAGE_OUTPUT_TOKENS, completion_tokens)
+                    # ADK 1.5 writes total_token_count into the modern output
+                    # field. The response usage is authoritative, including 0.
+                    attrs[TLSpanAttributes.LLM_USAGE_COMPLETION_TOKENS] = completion_tokens
+                    attrs[GEN_AI_USAGE_OUTPUT_TOKENS] = completion_tokens
 
                 total_tokens = usage.get("total_token_count")
                 if isinstance(total_tokens, int):
-                    attrs.setdefault(
-                        TLSpanAttributes.LLM_USAGE_TOTAL_TOKENS, total_tokens
-                    )
+                    attrs[TLSpanAttributes.LLM_USAGE_TOTAL_TOKENS] = total_tokens
 
             content = response.get("content")
             if isinstance(content, dict):
@@ -540,9 +534,11 @@ def _apply_google_adk_payload_fallbacks(
     if oi_kind == "TOOL" or attrs.get(RESPAN_LOG_TYPE) == LOG_TYPE_TOOL:
         tool_args = raw_attrs.get(_GOOGLE_ADK_TOOL_CALL_ARGS)
         if tool_args is not None:
-            attrs.setdefault(
-                TLSpanAttributes.TRACELOOP_ENTITY_INPUT,
-                _safe_json_str(tool_args),
+            tool_name = raw_attrs.get(OISpanAttributes.TOOL_NAME) or raw_attrs.get(
+                GEN_AI_TOOL_NAME
+            )
+            attrs[TLSpanAttributes.TRACELOOP_ENTITY_INPUT] = _safe_json_str(
+                {"name": tool_name, "arguments": _parse_json(tool_args)}
             )
         tool_response = raw_attrs.get(_GOOGLE_ADK_TOOL_RESPONSE)
         if tool_response is not None:
@@ -670,7 +666,7 @@ class GoogleADKSpanProcessor(SpanProcessor):
         elif trace_id is not None and log_type in (LOG_TYPE_AGENT, LOG_TYPE_WORKFLOW):
             with self._context_lock:
                 context = self._trace_context.pop(trace_id, {})
-            if translated_attrs.get(TLSpanAttributes.TRACELOOP_ENTITY_INPUT) in (
+            if _parse_json(translated_attrs.get(TLSpanAttributes.TRACELOOP_ENTITY_INPUT)) in (
                 None,
                 "",
             ) and context.get("prompt"):

--- a/python-sdks/instrumentations/respan-instrumentation-google-adk/tests/test_adk_runtime.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-adk/tests/test_adk_runtime.py
@@ -1,0 +1,577 @@
+"""Real ADK compatibility fixtures; only model responses are deterministic.
+
+The Runner/session/RunConfig, Agent callbacks and Sequential/ParallelAgent graph
+mirror johnson7788/MultiAgentPPT at ce8185cee83092290bdb913a528c6e3a72ee879e.
+See backend/simpleOutline/{agent,adk_agent_executor}.py and
+backend/slide_agent/slide_agent. No ADK or OpenInference modules are stubbed.
+"""
+
+import asyncio
+import json
+
+import pytest
+from google.adk import Runner
+from google.adk.agents import Agent, BaseAgent, ParallelAgent, SequentialAgent
+from google.adk.agents.run_config import RunConfig, StreamingMode
+from google.adk.models.base_llm import BaseLlm
+from google.adk.models.llm_response import LlmResponse
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+from opentelemetry import context, trace
+from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+from pydantic import PrivateAttr
+
+from respan_instrumentation_google_adk import GoogleADKInstrumentor
+from respan_instrumentation_google_adk._processor import GOOGLE_ADK_SCOPE_NAME
+
+
+class ScriptedModel(BaseLlm):
+    """Use ADK's actual BaseLlm protocol with provider-shaped response objects."""
+
+    model: str = "gemini-2.0-flash"
+    use_tool: bool = True
+    fail: bool = False
+    _requests: list = PrivateAttr(default_factory=list)
+
+    async def generate_content_async(self, llm_request, stream=False):
+        self._requests.append((llm_request.model_copy(deep=True), stream))
+        if self.fail:
+            raise RuntimeError("model transport failed")
+        if self.use_tool and len(self._requests) == 1:
+            parts = [
+                types.Part(
+                    function_call=types.FunctionCall(
+                        id="search-1", name="document_search", args={"query": "slides"}
+                    )
+                )
+            ]
+        else:
+            if stream:
+                yield LlmResponse(
+                    content=types.Content(
+                        role="model", parts=[types.Part(text="Outline ")]
+                    ),
+                    partial=True,
+                )
+            parts = [types.Part(text="Outline ready")]
+        yield LlmResponse(
+            content=types.Content(role="model", parts=parts),
+            usage_metadata=types.GenerateContentResponseUsageMetadata(
+                prompt_token_count=11, candidates_token_count=3, total_token_count=14
+            ),
+        )
+
+
+class SlideLoopAgent(BaseAgent):
+    """The target also subclasses BaseAgent and delegates through run_async."""
+
+    async def _run_async_impl(self, ctx):
+        for agent in self.sub_agents:
+            async for event in agent.run_async(ctx):
+                yield event
+
+
+@pytest.fixture
+def capture(monkeypatch):
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(trace, "get_tracer_provider", lambda: provider)
+    plugin = GoogleADKInstrumentor()
+    plugin.activate()
+    assert plugin._is_instrumented
+    assert plugin._instrumentor.is_instrumented_by_opentelemetry
+    try:
+        yield plugin, provider, exporter
+    finally:
+        plugin.deactivate()
+        provider.shutdown()
+
+
+def make_agent(*, async_tool=False, fail_tool=False, fail_model=False, use_tool=True):
+    def document_search(query: str) -> dict:
+        """Find sources for an outline."""
+        if fail_tool:
+            raise RuntimeError("document search failed")
+        return {"result": "Sources for " + query}
+
+    async def async_document_search(query: str) -> dict:
+        """Find sources for an outline."""
+        await asyncio.sleep(0)
+        return document_search(query)
+
+    async_document_search.__name__ = "document_search"
+    tool = async_document_search if async_tool else document_search
+    model = ScriptedModel(fail=fail_model, use_tool=use_tool)
+    callback_requests = []
+
+    def before_model(callback_context, llm_request):
+        callback_requests.append(llm_request.model)
+        assert callback_context.state["metadata"] == {"topic": "slides"}
+
+    agent = Agent(
+        name="outline_agent",
+        model=model,
+        instruction="Use document_search.",
+        tools=[tool] if use_tool else [],
+        before_model_callback=before_model,
+    )
+    return agent, model, callback_requests
+
+
+async def run_agent(agent, *, streaming=StreamingMode.NONE, runner_sync=False):
+    sessions = InMemorySessionService()
+    await sessions.create_session(
+        app_name="ppt",
+        user_id="self",
+        session_id="session-1",
+        state={"metadata": {"topic": "slides"}},
+    )
+    runner = Runner(agent=agent, app_name="ppt", session_service=sessions)
+    kwargs = dict(
+        user_id="self",
+        session_id="session-1",
+        new_message=types.Content(role="user", parts=[types.Part(text="Make slides")]),
+        run_config=RunConfig(streaming_mode=streaming),
+    )
+    if runner_sync:
+        # Runner.run drives the real async pipeline from its worker thread.
+        return await asyncio.to_thread(lambda: list(runner.run(**kwargs)))
+    return [event async for event in runner.run_async(**kwargs)]
+
+
+def adk_spans(exporter):
+    return [
+        span
+        for span in exporter.get_finished_spans()
+        if span.instrumentation_scope.name == GOOGLE_ADK_SCOPE_NAME
+    ]
+
+
+@pytest.mark.parametrize("streaming", [StreamingMode.NONE, StreamingMode.SSE])
+@pytest.mark.parametrize("async_tool", [False, True])
+def test_real_runner_agent_tool_roundtrip(capture, streaming, async_tool):
+    _, _, exporter = capture
+    agent, model, callbacks = make_agent(async_tool=async_tool)
+    root = SequentialAgent(name="slides", sub_agents=[agent])
+    events = asyncio.run(run_agent(root, streaming=streaming))
+    assert events[-1].content.parts[0].text == "Outline ready"
+    assert callbacks == [model.model, model.model]
+    assert [stream for _, stream in model._requests] == [
+        streaming == StreamingMode.SSE
+    ] * 2
+    spans = adk_spans(exporter)
+    assert len(spans) == 6
+    by_id = {span.context.span_id: span for span in spans}
+    workflows = [
+        s for s in spans if s.attributes.get("respan.entity.log_type") == "workflow"
+    ]
+    agents = [s for s in spans if s.attributes.get("respan.entity.log_type") == "agent"]
+    chats = [s for s in spans if s.attributes.get("respan.entity.log_type") == "chat"]
+    tools = [s for s in spans if s.attributes.get("respan.entity.log_type") == "tool"]
+    assert len(workflows) == len(tools) == 1
+    assert len(agents) == len(chats) == 2
+    assert workflows[0].parent is None
+    for span in spans:
+        assert span.context.trace_id == workflows[0].context.trace_id
+        assert span.status.status_code == StatusCode.OK
+        assert span.attributes["respan.sessions.session_identifier"] == "session-1"
+        assert "traceloop.span.kind" not in span.attributes
+        assert not any(key.startswith("gcp.vertex.agent.") for key in span.attributes)
+        if span.parent:
+            assert span.parent.span_id in by_id
+        if span in agents or span in workflows or span in tools:
+            assert "gen_ai.request.model" not in span.attributes
+            assert "gen_ai.completion.0.tool_calls" not in span.attributes
+    for chat in chats:
+        attrs = chat.attributes
+        assert by_id[chat.parent.span_id] in agents
+        assert attrs["gen_ai.request.model"] == model.model
+        assert attrs["llm.request.type"] == "chat"
+        assert attrs["gen_ai.system"] == "google"
+        assert (
+            attrs["gen_ai.usage.input_tokens"]
+            == attrs["gen_ai.usage.prompt_tokens"]
+            == 11
+        )
+        assert (
+            attrs["gen_ai.usage.output_tokens"]
+            == attrs["gen_ai.usage.completion_tokens"]
+            == 3
+        )
+        assert attrs["llm.usage.total_tokens"] == 14
+        assert attrs["gen_ai.prompt.1.content"] == "Make slides"
+        assert (
+            json.loads(attrs["llm.request.functions"])[0]["name"] == "document_search"
+        )
+    first, final = chats
+    assert (
+        json.loads(first.attributes["gen_ai.completion.0.tool_calls"])[0]["id"]
+        == "search-1"
+    )
+    assert final.attributes["gen_ai.prompt.2.role"] == "assistant"
+    assert final.attributes["gen_ai.prompt.3.role"] == "tool"
+    assert json.loads(final.attributes["gen_ai.prompt.3.content"])["id"] == "search-1"
+    assert final.attributes["gen_ai.completion.0.content"] == "Outline ready"
+    assert "gen_ai.completion.0.tool_calls" not in final.attributes
+    tool = tools[0]
+    assert by_id[tool.parent.span_id] is first
+    assert json.loads(tool.attributes["traceloop.entity.input"]) == {
+        "name": "document_search",
+        "arguments": {"query": "slides"},
+    }
+    assert json.loads(tool.attributes["traceloop.entity.output"])["response"] == {
+        "result": "Sources for slides"
+    }
+
+
+@pytest.mark.parametrize(
+    "failure,async_tool", [("model", False), ("tool", False), ("tool", True)]
+)
+def test_runtime_errors_propagate_and_close_spans(capture, failure, async_tool):
+    _, _, exporter = capture
+    agent, _, _ = make_agent(
+        fail_model=failure == "model",
+        fail_tool=failure == "tool",
+        async_tool=async_tool,
+    )
+    with pytest.raises(RuntimeError, match="failed"):
+        asyncio.run(run_agent(agent))
+    spans = adk_spans(exporter)
+    assert spans
+    assert all(s.end_time is not None for s in spans)
+    workflow = next(
+        s for s in spans if s.attributes.get("respan.entity.log_type") == "workflow"
+    )
+    assert workflow.status.status_code == StatusCode.ERROR
+    assert any(event.name == "exception" for event in workflow.events)
+    assert not trace.get_current_span().get_span_context().is_valid
+    if failure == "model":
+        assert not any("gen_ai.completion.0.content" in s.attributes for s in spans)
+        assert not any("gen_ai.usage.output_tokens" in s.attributes for s in spans)
+
+
+def test_parallel_custom_agent_preserves_parents(capture):
+    _, _, exporter = capture
+    left, _, _ = make_agent(use_tool=False)
+    right, _, _ = make_agent(use_tool=False)
+    right.name = "slide_agent"
+    parallel = ParallelAgent(name="parallel_slides", sub_agents=[left, right])
+    root = SlideLoopAgent(name="slide_loop", sub_agents=[parallel])
+    asyncio.run(run_agent(root))
+    spans = adk_spans(exporter)
+    assert len(spans) == 7
+    agents = {
+        s.attributes["traceloop.entity.name"]: s
+        for s in spans
+        if s.attributes.get("respan.entity.log_type") == "agent"
+    }
+    assert (
+        agents["parallel_slides"].parent.span_id == agents["slide_loop"].context.span_id
+    )
+    for name in ("outline_agent", "slide_agent"):
+        assert agents[name].parent.span_id == agents["parallel_slides"].context.span_id
+    chat_parent_ids = {
+        s.parent.span_id
+        for s in spans
+        if s.attributes.get("respan.entity.log_type") == "chat"
+    }
+    assert chat_parent_ids == {
+        agents[name].context.span_id for name in ("outline_agent", "slide_agent")
+    }
+
+
+def test_sync_runner(capture):
+    _, _, exporter = capture
+    agent, _, _ = make_agent()
+    events = asyncio.run(run_agent(agent, runner_sync=True))
+    assert events[-1].content.parts[0].text == "Outline ready"
+    assert len(adk_spans(exporter)) == 5
+
+
+def test_suppression_and_deactivation(capture):
+    plugin, provider, exporter = capture
+    agent, _, _ = make_agent()
+    token = context.attach(context.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
+    try:
+        asyncio.run(run_agent(agent))
+    finally:
+        context.detach(token)
+    assert adk_spans(exporter) == []
+    plugin.activate()
+    assert (
+        sum(
+            p is plugin._processor
+            for p in provider._active_span_processor._span_processors
+        )
+        == 1
+    )
+    plugin.deactivate()
+    exporter.clear()
+    agent, _, _ = make_agent()
+    asyncio.run(run_agent(agent))
+    assert adk_spans(exporter) == []
+    assert not any(
+        p.__class__.__name__ == "GoogleADKSpanProcessor"
+        for p in provider._active_span_processor._span_processors
+    )
+    plugin.activate()
+    exporter.clear()
+    agent, _, _ = make_agent()
+    asyncio.run(run_agent(agent))
+    assert len(adk_spans(exporter)) == 5
+
+
+def test_legacy_direct_iterator_alias_and_close(capture, caplog):
+    from importlib.metadata import version
+    from packaging.version import Version
+
+    if Version(version("google-adk")) >= Version("1.17.0"):
+        pytest.skip("Legacy direct iterator bridge is only used below ADK 1.17")
+    # Imported before execution, as in MultiAgentPPT's DynamicParallelSearchAgent.
+    from google.adk.agents.parallel_agent import _merge_agent_run
+    from google.adk.agents.invocation_context import InvocationContext
+    from google.adk.events import Event
+
+    _, provider, exporter = capture
+    closed = []
+    advanced = []
+
+    class YieldingAgent(BaseAgent):
+        async def _run_async_impl(self, ctx):
+            try:
+                advanced.append(self.name)
+                yield Event(
+                    author=self.name,
+                    content=types.Content(
+                        role="model", parts=[types.Part(text=self.name)]
+                    ),
+                )
+                advanced.append(self.name + "_second")
+                yield Event(
+                    author=self.name,
+                    content=types.Content(
+                        role="model", parts=[types.Part(text="second")]
+                    ),
+                )
+            finally:
+                closed.append(self.name)
+
+    async def exercise():
+        sessions = InMemorySessionService()
+        session = await sessions.create_session(app_name="ppt", user_id="self")
+        agents = [YieldingAgent(name="left"), YieldingAgent(name="right")]
+        with provider.get_tracer("test").start_as_current_span("parent") as parent:
+            parent_id = parent.get_span_context().span_id
+            runs = [
+                agent.run_async(
+                    InvocationContext(
+                        invocation_id="test",
+                        agent=agent,
+                        session=session,
+                        session_service=sessions,
+                        run_config=RunConfig(),
+                    )
+                )
+                for agent in agents
+            ]
+            merged = _merge_agent_run(runs)
+            first = await merged.__anext__()
+            assert first.author in {"left", "right"}
+            assert not any(item.endswith("_second") for item in advanced)
+            assert trace.get_current_span().get_span_context().span_id == parent_id
+            await merged.aclose()
+            for run in runs:
+                await run.aclose()
+            assert trace.get_current_span().get_span_context().span_id == parent_id
+        return parent_id
+
+    parent_id = asyncio.run(exercise())
+    assert sorted(closed) == ["left", "right"]
+    assert len(adk_spans(exporter)) == 2
+    assert all(s.parent.span_id == parent_id for s in adk_spans(exporter))
+    assert "Failed to detach context" not in caplog.text
+
+
+def test_legacy_pending_iteration_cancellation(capture, caplog):
+    from importlib.metadata import version
+    from packaging.version import Version
+
+    if Version(version("google-adk")) >= Version("1.17.0"):
+        pytest.skip("Legacy direct iterator bridge is only used below ADK 1.17")
+    from google.adk.agents.invocation_context import InvocationContext
+
+    _, _, exporter = capture
+    closed = []
+
+    async def exercise():
+        started = asyncio.Event()
+
+        class WaitingAgent(BaseAgent):
+            async def _run_async_impl(self, ctx):
+                try:
+                    started.set()
+                    await asyncio.Event().wait()
+                    yield
+                finally:
+                    closed.append(True)
+
+        agent = WaitingAgent(name="waiting")
+        sessions = InMemorySessionService()
+        session = await sessions.create_session(app_name="ppt", user_id="self")
+        run = agent.run_async(
+            InvocationContext(
+                invocation_id="test",
+                agent=agent,
+                session=session,
+                session_service=sessions,
+                run_config=RunConfig(),
+            )
+        )
+        pending = asyncio.create_task(run.__anext__())
+        await started.wait()
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        await run.aclose()
+        assert not trace.get_current_span().get_span_context().is_valid
+
+    asyncio.run(exercise())
+    assert closed == [True]
+    assert len(adk_spans(exporter)) == 1
+    assert "Failed to detach context" not in caplog.text
+
+
+def test_legacy_async_generator_methods(capture, caplog):
+    from importlib.metadata import version
+    from packaging.version import Version
+
+    if Version(version("google-adk")) >= Version("1.17.0"):
+        pytest.skip("Legacy direct iterator bridge is only used below ADK 1.17")
+    from google.adk.agents.invocation_context import InvocationContext
+    from google.adk.events import Event
+
+    _, _, exporter = capture
+
+    class OneEventAgent(BaseAgent):
+        async def _run_async_impl(self, ctx):
+            yield Event(
+                author=self.name,
+                content=types.Content(role="model", parts=[types.Part(text="one")]),
+            )
+
+    async def exercise():
+        agent = OneEventAgent(name="one_event")
+        sessions = InMemorySessionService()
+        session = await sessions.create_session(app_name="ppt", user_id="self")
+        run = agent.run_async(
+            InvocationContext(
+                invocation_id="test",
+                agent=agent,
+                session=session,
+                session_service=sessions,
+                run_config=RunConfig(),
+            )
+        )
+        assert (await run.asend(None)).author == "one_event"
+        with pytest.raises(ValueError, match="consumer failed"):
+            await run.athrow(ValueError("consumer failed"))
+        await run.aclose()
+        with pytest.raises(StopAsyncIteration):
+            await run.__anext__()
+
+    asyncio.run(exercise())
+    assert len(adk_spans(exporter)) == 1
+    assert adk_spans(exporter)[0].status.status_code == StatusCode.ERROR
+    assert "Failed to detach context" not in caplog.text
+
+
+def test_second_adapter_does_not_take_ownership(capture):
+    owner, provider, exporter = capture
+    second = GoogleADKInstrumentor()
+    second.activate()
+    assert not second._is_instrumented
+    assert second._instrumentor is None
+    assert second._processor is None
+    second.deactivate()
+    assert owner._instrumentor.is_instrumented_by_opentelemetry
+    assert (
+        sum(
+            p is owner._processor
+            for p in provider._active_span_processor._span_processors
+        )
+        == 1
+    )
+    agent, _, _ = make_agent()
+    asyncio.run(run_agent(agent))
+    assert len(adk_spans(exporter)) == 5
+
+
+def test_external_upstream_instrumentation_is_preserved(capture):
+    from openinference.instrumentation.google_adk import (
+        GoogleADKInstrumentor as Upstream,
+    )
+
+    plugin, provider, _ = capture
+    plugin.deactivate()
+    external = Upstream()
+    external.instrument(tracer_provider=provider)
+    try:
+        plugin.activate()
+        assert not plugin._is_instrumented
+        assert plugin._instrumentor is None
+        assert plugin._processor is None
+        plugin.deactivate()
+        assert external.is_instrumented_by_opentelemetry
+    finally:
+        external.uninstrument()
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_legacy_abandoned_runner_closes_in_owner_context(capture, caplog, parallel):
+    from importlib.metadata import version
+    from packaging.version import Version
+
+    if Version(version("google-adk")) >= Version("1.17.0"):
+        pytest.skip("Legacy iterator shutdown bridge is only used below ADK 1.17")
+    _, _, exporter = capture
+    left, left_model, _ = make_agent()
+    if parallel:
+        right, _, _ = make_agent()
+        right.name = "slide_agent"
+        root = ParallelAgent(name="slides", sub_agents=[left, right])
+    else:
+        root = left
+
+    async def exercise():
+        sessions = InMemorySessionService()
+        await sessions.create_session(
+            app_name="ppt",
+            user_id="self",
+            session_id="session-1",
+            state={"metadata": {"topic": "slides"}},
+        )
+        runner = Runner(agent=root, app_name="ppt", session_service=sessions)
+        # MultiAgentPPT's executor breaks once it receives its final response.
+        # Also exercise stopping on a tool request, while model spans are open.
+        async for _ in runner.run_async(
+            user_id="self",
+            session_id="session-1",
+            new_message=types.Content(
+                role="user", parts=[types.Part(text="Make slides")]
+            ),
+        ):
+            break
+
+    asyncio.run(exercise())
+    assert len(left_model._requests) == 1
+    spans = adk_spans(exporter)
+    assert len(spans) == (6 if parallel else 3)
+    assert all(s.end_time is not None for s in spans)
+    assert not any(s.attributes.get("respan.entity.log_type") == "tool" for s in spans)
+    assert "Failed to detach context" not in caplog.text
+    assert "Task was destroyed" not in caplog.text

--- a/python-sdks/instrumentations/respan-instrumentation-google-adk/tests/test_instrumentation.py
+++ b/python-sdks/instrumentations/respan-instrumentation-google-adk/tests/test_instrumentation.py
@@ -46,6 +46,8 @@ class FakeSpan:
 
 
 def _install_fake_modules(monkeypatch):
+    monkeypatch.setattr(_instrumentation, "patch_legacy_agent_iterator", lambda: None)
+
     class FakeGoogleADKInstrumentor:
         created = []
 
@@ -138,6 +140,44 @@ def test_activate_passes_custom_openinference_kwargs(monkeypatch, fake_tracer_pr
         "tracer_provider": fake_tracer_provider,
         "trace_content": False,
     }
+
+
+def test_activate_cleans_up_when_upstream_declines(monkeypatch, fake_tracer_provider):
+    fake = _install_fake_modules(monkeypatch)
+    fake.google_adk_instrumentor_class.is_instrumented_by_opentelemetry = False
+    instrumentor = GoogleADKInstrumentor()
+    instrumentor.activate()
+    assert instrumentor._is_instrumented is False
+    assert instrumentor._processor is None
+    assert instrumentor._instrumentor is None
+    assert len(fake_tracer_provider._active_span_processor._span_processors) == 1
+
+
+@pytest.mark.parametrize("completion,thoughts", [(3, 0), (3, 2), (0, 0)])
+def test_processor_replaces_adk15_total_as_output_tokens(completion, thoughts):
+    span = FakeSpan(
+        {
+            "openinference.span.kind": "LLM",
+            "gen_ai.usage.input_tokens": 11,
+            "gen_ai.usage.output_tokens": 11 + completion + thoughts,
+            "gcp.vertex.agent.llm_response": json.dumps(
+                {
+                    "usage_metadata": {
+                        "prompt_token_count": 11,
+                        "candidates_token_count": completion,
+                        "thoughts_token_count": thoughts,
+                        "total_token_count": 11 + completion + thoughts,
+                    }
+                }
+            ),
+        }
+    )
+    GoogleADKSpanProcessor().on_end(span)
+    assert span._attributes["gen_ai.usage.input_tokens"] == 11
+    assert span._attributes["gen_ai.usage.prompt_tokens"] == 11
+    assert span._attributes["gen_ai.usage.output_tokens"] == completion + thoughts
+    assert span._attributes["gen_ai.usage.completion_tokens"] == completion + thoughts
+    assert span._attributes["llm.usage.total_tokens"] == 11 + completion + thoughts
 
 
 def test_activate_is_idempotent(monkeypatch, fake_tracer_provider):
@@ -362,7 +402,10 @@ def test_processor_cleans_google_adk_tool_attrs():
     GoogleADKSpanProcessor().on_end(span)
 
     assert span._attributes["respan.entity.log_type"] == "tool"
-    assert span._attributes["traceloop.entity.input"] == '{"city":"Paris"}'
+    assert json.loads(span._attributes["traceloop.entity.input"]) == {
+        "name": "get_weather",
+        "arguments": {"city": "Paris"},
+    }
     assert span._attributes["traceloop.entity.output"] == '{"result":"sunny"}'
     assert "gen_ai.system" not in span._attributes
     assert "traceloop.span.kind" not in span._attributes


### PR DESCRIPTION
## Summary

MultiAgentPPT pins `google-adk==1.5.0`, while this package required ADK 1.17 or newer. Add real runtime compatibility coverage and a bridge for the legacy runner/agent iterators before lowering the minimum to 1.5. The bridge handles direct iterator advancement across tasks, including custom agents that imported `_merge_agent_run` before activation. It advances only on consumer demand and closes suspended LLM/agent generators in their original context when the consumer stops or cancels.

Correct ADK 1.5's output-token field from authoritative response usage, preserve canonical tool inputs/results, and reject unsuccessful or externally owned instrumentation activation safely.

## Release Intent

Add a `patch` release intent for `respan-instrumentation-google-adk`; no manual manifest version bump.

## Validation

- **33 tests passed** on ADK 1.5.0 with minimum OpenInference 0.1.12 (installed built wheel), and **33 passed** with current OpenInference 0.1.25. ADK 1.17.0 and 2.8.0 each passed **28 tests**, with five legacy-only tests skipped.
- Real `Runner.run`/`run_async`, session state, callbacks, sequential/parallel/custom agents, sync/async tools, SSE events, error propagation, suppression, iterator lifecycle, and parent isolation. Only model responses are deterministic fixtures.
- Independently executed [MultiAgentPPT's unchanged `DocumentSearch` function](https://github.com/johnson7788/MultiAgentPPT/blob/ce8185cee83092290bdb913a528c6e3a72ee879e/backend/simpleOutline/tools.py) through a real ADK 1.5 runner: five spans, two LLM calls, one tool execution, complete document output, unchanged session document IDs, and correct completion counts of 3 and 5.
- Source distribution/wheel build, built-wheel runtime checks, dependency consistency, release metadata validation, and `git diff --check`.

Validation covers the ADK execution path and serialized span payloads; it does not include MultiAgentPPT's external services, presentation rendering, or live Respan ingestion.
